### PR TITLE
Add golang 1.21.4 image

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -26,7 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.21","1.21.5","1.20","1.20.4","1.20.5"]
+        go-version:
+        - "1.21"
+        - "1.21.5"
+        - "1.20"
+        - "1.20.4"
+        - "1.20.5"
+        - "1.21.4"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This adds the generation of a golang 1.21.4 image for use in https://github.com/NVIDIA/k8s-kata-manager/pull/4