### PR TITLE
Remove CLIENT_GEN_VERSION and CONTROLLER_GEN_VERSION from devel image

### DIFF
--- a/images/devel/Dockerfile
+++ b/images/devel/Dockerfile
@@ -15,17 +15,12 @@
 ARG GOLANG_VERSION=x.x.x
 FROM golang:${GOLANG_VERSION}
 
-ARG CLIENT_GEN_VERSION=v0.26.1
-ARG CONTROLLER_GEN_VERSION=v0.9.2
 ARG GOLANGCI_LINT_VERSION=v1.52.0
 ARG MOQ_VERSION=v0.3.3
 
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION} \
-    && go install github.com/matryer/moq@${MOQ_VERSION} \
-    && go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION} \
-    && go install k8s.io/code-generator/cmd/client-gen@${CLIENT_GEN_VERSION}
+    && go install github.com/matryer/moq@${MOQ_VERSION}
 
 # We need to set the /work directory as a safe directory.
 # This allows git commands to run in the container.
 RUN git config --file=/.gitconfig --add safe.directory /work
-


### PR DESCRIPTION
It is better to leave each repo to set CLIENT_GEN_VERSION and CONTROLLER_GEN_VERSION and simply use `k8s-test-infra` as a base image 