### PR TITLE
Add mock GPU Helm chart with Kind E2E CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 NVIDIA CORPORATION
+# Copyright 2025 NVIDIA CORPORATION
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/gpu-mock-e2e.yaml
+++ b/.github/workflows/gpu-mock-e2e.yaml
@@ -1,0 +1,118 @@
+# Copyright 2026 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: GPU Mock E2E
+
+on:
+  workflow_call:
+    inputs:
+      golang_version:
+        required: true
+        type: string
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ inputs.golang_version }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Create Kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: gpu-mock-e2e
+
+      - name: Build gpu-mock image
+        run: |
+          docker build -t gpu-mock:e2e -f deployments/gpu-mock/Dockerfile \
+            --build-arg GOLANG_VERSION=${{ inputs.golang_version }} .
+
+      - name: Load image into Kind
+        run: |
+          kind load docker-image gpu-mock:e2e --name gpu-mock-e2e
+
+      - name: Install gpu-mock Helm chart
+        run: |
+          helm install gpu-mock deployments/gpu-mock/helm/gpu-mock \
+            --set image.repository=gpu-mock \
+            --set image.tag=e2e \
+            --set gpu.count=2 \
+            --wait --timeout 120s
+
+      - name: Verify DaemonSet is ready
+        run: |
+          kubectl rollout status daemonset -l app.kubernetes.io/name=gpu-mock --timeout=60s
+
+      - name: Verify node labels
+        run: |
+          NODE=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+          LABEL=$(kubectl get node "$NODE" -o jsonpath='{.metadata.labels.nvidia\.com/gpu\.present}')
+          echo "nvidia.com/gpu.present=$LABEL"
+          [ "$LABEL" = "true" ] || (echo "FAIL: node label not set" && exit 1)
+
+      - name: Verify mock files on node
+        run: |
+          NODE_CONTAINER=gpu-mock-e2e-control-plane
+          # Check library
+          docker exec "$NODE_CONTAINER" sh -c "ls /var/lib/nvidia-mock/driver/usr/lib64/libnvidia-ml.so.* | head -1"
+          docker exec "$NODE_CONTAINER" test -L /var/lib/nvidia-mock/driver/usr/lib64/libnvidia-ml.so.1
+          # Check device files
+          docker exec "$NODE_CONTAINER" test -e /var/lib/nvidia-mock/dev/nvidia0
+          docker exec "$NODE_CONTAINER" test -e /var/lib/nvidia-mock/dev/nvidia1
+          docker exec "$NODE_CONTAINER" test -e /var/lib/nvidia-mock/dev/nvidiactl
+          # Check config at both locations
+          docker exec "$NODE_CONTAINER" test -f /var/lib/nvidia-mock/config/config.yaml
+          docker exec "$NODE_CONTAINER" test -f /var/lib/nvidia-mock/driver/config/config.yaml
+          echo "All mock files verified"
+
+      - name: Deploy NVIDIA device plugin
+        run: |
+          kubectl apply -f tests/e2e/device-plugin-mock.yaml
+          kubectl -n kube-system wait --for=condition=ready \
+            pod -l name=nvidia-device-plugin-mock --timeout=120s
+
+      - name: Verify allocatable GPUs
+        run: |
+          NODE=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+          # Wait for kubelet to update allocatable (may take a few seconds)
+          for i in $(seq 1 30); do
+            GPUS=$(kubectl get node "$NODE" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}')
+            if [ "$GPUS" = "2" ]; then
+              echo "PASS: Node reports $GPUS allocatable GPUs"
+              exit 0
+            fi
+            echo "Attempt $i: allocatable GPUs=$GPUS (expected 2), waiting..."
+            sleep 2
+          done
+          echo "FAIL: Expected 2 allocatable GPUs, got $GPUS"
+          exit 1
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== gpu-mock pod logs ==="
+          kubectl logs -l app.kubernetes.io/name=gpu-mock --tail=50 || true
+          echo "=== device plugin logs ==="
+          kubectl -n kube-system logs -l name=nvidia-device-plugin-mock --tail=50 || true
+          echo "=== pod status ==="
+          kubectl get pods -A || true
+          echo "=== node describe ==="
+          kubectl describe nodes || true

--- a/.github/workflows/gpu-mock-e2e.yaml
+++ b/.github/workflows/gpu-mock-e2e.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Verify DaemonSet is ready
         run: |
-          kubectl rollout status daemonset -l app.kubernetes.io/name=gpu-mock --timeout=60s
+          kubectl rollout status daemonset/gpu-mock --timeout=60s
 
       - name: Verify node labels
         run: |

--- a/deployments/gpu-mock/Dockerfile
+++ b/deployments/gpu-mock/Dockerfile
@@ -22,9 +22,19 @@ RUN cd pkg/gpu/mocknvml && make clean && make
 
 FROM debian:bookworm-slim
 ARG KUBECTL_VERSION=v1.32.0
-ARG TARGETARCH
+ARG TARGETARCH=amd64
 COPY --from=builder /src/pkg/gpu/mocknvml/libnvidia-ml.so.* /usr/local/lib/
-ADD https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl /usr/local/bin/kubectl
-RUN chmod +x /usr/local/bin/kubectl
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends curl ca-certificates; \
+    rm -rf /var/lib/apt/lists/*; \
+    curl -fsSLo /usr/local/bin/kubectl \
+      "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl"; \
+    curl -fsSLo /tmp/kubectl.sha256 \
+      "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl.sha256"; \
+    echo "$(cat /tmp/kubectl.sha256)  /usr/local/bin/kubectl" | sha256sum --check; \
+    chmod +x /usr/local/bin/kubectl; \
+    rm /tmp/kubectl.sha256; \
+    apt-get purge -y --auto-remove curl ca-certificates
 COPY deployments/gpu-mock/scripts/ /scripts/
 RUN chmod +x /scripts/*.sh

--- a/deployments/gpu-mock/Dockerfile
+++ b/deployments/gpu-mock/Dockerfile
@@ -11,21 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: CI Pipeline
 
-on:
-  push:
-    branches:
-      - "pull-request/[0-9]+"
-      - main
-      - release-*
-  
-jobs:
-  basic:
-    uses: ./.github/workflows/basic-checks.yaml
+ARG GOLANG_VERSION=1.25
+FROM golang:${GOLANG_VERSION}-bookworm AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+COPY vendor/ vendor/
+COPY pkg/gpu/mocknvml/ pkg/gpu/mocknvml/
+RUN cd pkg/gpu/mocknvml && make clean && make
 
-  gpu-mock-e2e:
-    needs: [basic]
-    uses: ./.github/workflows/gpu-mock-e2e.yaml
-    with:
-      golang_version: ${{ needs.basic.outputs.golang_version }}
+FROM debian:bookworm-slim
+ARG KUBECTL_VERSION=v1.32.0
+ARG TARGETARCH
+COPY --from=builder /src/pkg/gpu/mocknvml/libnvidia-ml.so.* /usr/local/lib/
+ADD https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl /usr/local/bin/kubectl
+RUN chmod +x /usr/local/bin/kubectl
+COPY deployments/gpu-mock/scripts/ /scripts/
+RUN chmod +x /scripts/*.sh

--- a/deployments/gpu-mock/helm/gpu-mock/Chart.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/Chart.yaml
@@ -1,0 +1,15 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: gpu-mock
+description: Mock GPU infrastructure for Kubernetes testing
+type: application
+version: 0.1.0
+appVersion: "550.163.01"
+keywords:
+  - gpu
+  - nvidia
+  - mock
+  - testing
+maintainers:
+  - name: NVIDIA

--- a/deployments/gpu-mock/helm/gpu-mock/profiles/a100.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/profiles/a100.yaml
@@ -1,0 +1,381 @@
+# Mock NVML Configuration: DGX A100
+# Full configuration for nvidia-smi -x -q compatibility
+# Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
+
+version: "1.0"
+
+# =============================================================================
+# System-level configuration
+# =============================================================================
+system:
+  driver_version: "550.163.01"
+  nvml_version: "12.550.163.01"
+  cuda_version: "12.4"
+  cuda_version_major: 12
+  cuda_version_minor: 4
+
+# =============================================================================
+# Default device configuration (applied to all devices unless overridden)
+# =============================================================================
+device_defaults:
+  # ---------------------------------------------------------------------------
+  # Basic identification
+  # ---------------------------------------------------------------------------
+  name: "NVIDIA A100-SXM4-40GB"
+  brand: "nvidia"                    # nvidia, tesla, quadro, geforce, etc.
+  serial: "1324821083812"
+  board_part_number: "692-2G506-0200-002"
+  vbios_version: "92.00.45.00.03"
+
+  # ---------------------------------------------------------------------------
+  # Architecture
+  # ---------------------------------------------------------------------------
+  architecture: "ampere"
+  compute_capability:
+    major: 8
+    minor: 0
+  num_gpu_cores: 6912               # CUDA cores
+
+  # ---------------------------------------------------------------------------
+  # InfoROM versions
+  # ---------------------------------------------------------------------------
+  inforom:
+    image_version: "G506.0200.00.04"
+    oem_object: "2.0"
+    ecc_object: "6.16"
+    pwr_object: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Memory configuration
+  # ---------------------------------------------------------------------------
+  memory:
+    total_bytes: 42949672960        # 40 GiB HBM2e
+    reserved_bytes: 611319808       # ~583 MiB reserved
+    free_bytes: 42338353152         # total - reserved at idle
+    used_bytes: 0
+
+  bar1_memory:
+    total_bytes: 68719476736        # 64 GiB
+    free_bytes: 68719476736
+    used_bytes: 0
+
+  # ---------------------------------------------------------------------------
+  # PCI configuration
+  # ---------------------------------------------------------------------------
+  pci:
+    device_id: 0x20B010DE           # A100 SXM4 40GB
+    subsystem_id: 0x134710DE
+    # bus_id is auto-generated per device if not specified
+
+  pcie:
+    max_link_gen: 4                 # PCIe Gen4
+    current_link_gen: 4
+    max_link_width: 16              # x16
+    current_link_width: 16
+    replay_counter: 0
+    tx_throughput_kbps: 0           # KB/s
+    rx_throughput_kbps: 0
+
+  # ---------------------------------------------------------------------------
+  # Power configuration
+  # ---------------------------------------------------------------------------
+  power:
+    management_supported: true
+    management_mode: "enabled"
+    default_limit_mw: 400000        # 400W
+    enforced_limit_mw: 400000
+    min_limit_mw: 100000            # 100W
+    max_limit_mw: 400000            # 400W
+    current_draw_mw: 72000          # 72W idle
+    power_state: "P0"               # P0-P12
+
+  # ---------------------------------------------------------------------------
+  # Thermal configuration
+  # ---------------------------------------------------------------------------
+  thermal:
+    temperature_gpu_c: 33           # Idle temperature
+    temperature_memory_c: 31
+    shutdown_threshold_c: 92
+    slowdown_threshold_c: 87
+    max_operating_c: 83
+    target_temperature_c: 83        # For auto fan control
+
+  # ---------------------------------------------------------------------------
+  # Fan configuration (N/A for SXM form factor)
+  # ---------------------------------------------------------------------------
+  fan:
+    count: 0                        # SXM has no fans (liquid cooled)
+    speed_percent: "N/A"
+    target_speed_percent: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Clock speeds (MHz)
+  # ---------------------------------------------------------------------------
+  clocks:
+    graphics_current: 210           # Idle
+    graphics_max: 1410
+    graphics_app: 1410              # Application clock setting
+    graphics_app_default: 1410
+    sm_current: 210
+    sm_max: 1410
+    memory_current: 1215
+    memory_max: 1215
+    memory_app: 1215
+    memory_app_default: 1215
+    video_current: 585
+    video_max: 1290
+
+  # ---------------------------------------------------------------------------
+  # Clocks throttle reasons (bitmask reasons)
+  # ---------------------------------------------------------------------------
+  clocks_throttle_reasons:
+    gpu_idle: true                  # Clock is idle
+    applications_clocks_setting: false
+    sw_power_cap: false
+    hw_slowdown: false
+    hw_thermal_slowdown: false
+    hw_power_brake_slowdown: false
+    sync_boost: false
+    sw_thermal_slowdown: false
+    display_clocks_setting: false
+
+  # ---------------------------------------------------------------------------
+  # Supported clocks (for nvidia-smi -q -d SUPPORTED_CLOCKS)
+  # ---------------------------------------------------------------------------
+  supported_clocks:
+    memory_clocks:
+      - freq_mhz: 1215
+        graphics_clocks: [210, 420, 630, 840, 1050, 1215, 1275, 1335, 1410]
+
+  # ---------------------------------------------------------------------------
+  # Performance state
+  # ---------------------------------------------------------------------------
+  performance_state: "P0"           # P0 = max performance
+
+  # ---------------------------------------------------------------------------
+  # Utilization (percentage, 0-100)
+  # ---------------------------------------------------------------------------
+  utilization:
+    gpu: 0
+    memory: 0
+    encoder: 0
+    decoder: 0
+    jpeg: 0
+    ofa: 0                          # Optical flow accelerator
+
+  # ---------------------------------------------------------------------------
+  # Encoder/Decoder statistics
+  # ---------------------------------------------------------------------------
+  encoder_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  fbc_stats:                        # Frame buffer capture
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  # ---------------------------------------------------------------------------
+  # ECC configuration
+  # ---------------------------------------------------------------------------
+  ecc:
+    mode_current: "enabled"
+    mode_pending: "enabled"
+    default_mode: "enabled"
+    # Error counts (all zeros for clean GPU)
+    errors:
+      volatile:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+      aggregate:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+
+  # ---------------------------------------------------------------------------
+  # Retired pages
+  # ---------------------------------------------------------------------------
+  retired_pages:
+    single_bit_retirement:
+      count: 0
+      addresses: []
+    double_bit_retirement:
+      count: 0
+      addresses: []
+    pending_blacklist: false
+    pending_retirement: false
+
+  # ---------------------------------------------------------------------------
+  # Remapped rows
+  # ---------------------------------------------------------------------------
+  remapped_rows:
+    correctable: 0
+    uncorrectable: 0
+    pending: false
+    failure_occurred: false
+
+  # ---------------------------------------------------------------------------
+  # Display configuration
+  # ---------------------------------------------------------------------------
+  display:
+    mode: "disabled"                # No display output on A100
+    active: "disabled"
+
+  # ---------------------------------------------------------------------------
+  # Persistence mode
+  # ---------------------------------------------------------------------------
+  persistence_mode: "enabled"       # Typically enabled on servers
+
+  # ---------------------------------------------------------------------------
+  # Compute mode
+  # ---------------------------------------------------------------------------
+  compute_mode: "default"           # default, exclusive_thread, prohibited, exclusive_process
+
+  # ---------------------------------------------------------------------------
+  # MIG configuration
+  # ---------------------------------------------------------------------------
+  mig:
+    mode_current: "disabled"
+    mode_pending: "disabled"
+    max_gpu_instances: 7            # A100 supports up to 7 MIG instances
+    # GPU instances would be defined here if MIG enabled
+
+  # ---------------------------------------------------------------------------
+  # GPU operation mode (GOM)
+  # ---------------------------------------------------------------------------
+  gpu_operation_mode:
+    current: "all_on"               # all_on, compute, low_dp
+    pending: "all_on"
+
+  # ---------------------------------------------------------------------------
+  # Driver model (Windows only)
+  # ---------------------------------------------------------------------------
+  driver_model:
+    current: "N/A"                  # Linux: N/A, Windows: WDDM or TCC
+    pending: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Accounting mode
+  # ---------------------------------------------------------------------------
+  accounting:
+    mode: "disabled"
+    buffer_size: 4000               # Max PIDs tracked
+
+  # ---------------------------------------------------------------------------
+  # Virtualization
+  # ---------------------------------------------------------------------------
+  virtualization:
+    mode: "none"                    # none, passthrough, vgpu
+    host_vgpu_mode: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # GSP Firmware
+  # ---------------------------------------------------------------------------
+  gsp_firmware:
+    mode: "enabled"                 # GSP enabled on newer drivers
+    version: "550.54.15"
+
+  # ---------------------------------------------------------------------------
+  # Processes (empty at idle)
+  # ---------------------------------------------------------------------------
+  processes: []
+
+# =============================================================================
+# Device-specific overrides (indexed 0-7 for DGX A100)
+# Only specify fields that differ from device_defaults
+# =============================================================================
+devices:
+  - index: 0
+    uuid: "GPU-12345678-1234-1234-1234-123456780000"
+    serial: "1324821083800"
+    pci:
+      bus_id: "00000000:07:00.0"
+    minor_number: 0
+
+  - index: 1
+    uuid: "GPU-12345678-1234-1234-1234-123456780001"
+    serial: "1324821083801"
+    pci:
+      bus_id: "00000000:0F:00.0"
+    minor_number: 1
+
+  - index: 2
+    uuid: "GPU-12345678-1234-1234-1234-123456780002"
+    serial: "1324821083802"
+    pci:
+      bus_id: "00000000:47:00.0"
+    minor_number: 2
+
+  - index: 3
+    uuid: "GPU-12345678-1234-1234-1234-123456780003"
+    serial: "1324821083803"
+    pci:
+      bus_id: "00000000:4E:00.0"
+    minor_number: 3
+
+  - index: 4
+    uuid: "GPU-12345678-1234-1234-1234-123456780004"
+    serial: "1324821083804"
+    pci:
+      bus_id: "00000000:87:00.0"
+    minor_number: 4
+
+  - index: 5
+    uuid: "GPU-12345678-1234-1234-1234-123456780005"
+    serial: "1324821083805"
+    pci:
+      bus_id: "00000000:90:00.0"
+    minor_number: 5
+
+  - index: 6
+    uuid: "GPU-12345678-1234-1234-1234-123456780006"
+    serial: "1324821083806"
+    pci:
+      bus_id: "00000000:B7:00.0"
+    minor_number: 6
+
+  - index: 7
+    uuid: "GPU-12345678-1234-1234-1234-123456780007"
+    serial: "1324821083807"
+    pci:
+      bus_id: "00000000:BD:00.0"
+    minor_number: 7
+
+# =============================================================================
+# NVLink topology
+# =============================================================================
+nvlink:
+  version: 3
+  links_per_gpu: 12
+  bandwidth_per_link_gbps: 50       # 50 GB/s per link = 600 GB/s total per GPU
+  # NVLink state per link (12 links)
+  links:
+    - link: 0
+      state: "active"
+      remote_device_type: "gpu"
+      remote_pci_bus_id: "00000000:0F:00.0"
+    # ... define all 12 links for full topology

--- a/deployments/gpu-mock/helm/gpu-mock/profiles/gb200.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/profiles/gb200.yaml
@@ -46,7 +46,7 @@ device_defaults:
     pwr_object: "1.0"
 
   # ---------------------------------------------------------------------------
-  # Memory configuration - 192GB HBM3e per GPU
+  # Memory configuration - 192 GiB HBM3e per GPU
   # ---------------------------------------------------------------------------
   memory:
     total_bytes: 206158430208       # 192 GiB HBM3e

--- a/deployments/gpu-mock/helm/gpu-mock/profiles/gb200.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/profiles/gb200.yaml
@@ -1,0 +1,415 @@
+# Mock NVML Configuration: GB200 NVL (Grace-Blackwell Superchip)
+# Full configuration for nvidia-smi -x -q compatibility
+# Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
+
+version: "1.0"
+
+# =============================================================================
+# System-level configuration
+# =============================================================================
+system:
+  driver_version: "560.35.03"
+  nvml_version: "12.560.35.03"
+  cuda_version: "12.6"
+  cuda_version_major: 12
+  cuda_version_minor: 6
+
+# =============================================================================
+# Default device configuration (applied to all devices unless overridden)
+# =============================================================================
+device_defaults:
+  # ---------------------------------------------------------------------------
+  # Basic identification
+  # ---------------------------------------------------------------------------
+  name: "NVIDIA GB200 NVL"
+  brand: "nvidia"
+  serial: "1562849103750"
+  board_part_number: "699-2G530-0200-000"
+  vbios_version: "96.00.9E.00.01"
+
+  # ---------------------------------------------------------------------------
+  # Architecture
+  # ---------------------------------------------------------------------------
+  architecture: "blackwell"
+  compute_capability:
+    major: 10
+    minor: 0
+  num_gpu_cores: 18432              # Blackwell has more CUDA cores
+
+  # ---------------------------------------------------------------------------
+  # InfoROM versions
+  # ---------------------------------------------------------------------------
+  inforom:
+    image_version: "G530.0200.00.01"
+    oem_object: "2.1"
+    ecc_object: "7.16"
+    pwr_object: "1.0"
+
+  # ---------------------------------------------------------------------------
+  # Memory configuration - 192GB HBM3e per GPU
+  # ---------------------------------------------------------------------------
+  memory:
+    total_bytes: 206158430208       # 192 GiB HBM3e
+    reserved_bytes: 1073741824      # ~1 GiB reserved
+    free_bytes: 205084688384        # total - reserved at idle
+    used_bytes: 0
+
+  bar1_memory:
+    total_bytes: 549755813888       # 512 GiB (unified memory with Grace)
+    free_bytes: 549755813888
+    used_bytes: 0
+
+  # ---------------------------------------------------------------------------
+  # PCI configuration
+  # ---------------------------------------------------------------------------
+  pci:
+    device_id: 0x233010DE           # GB200 (placeholder - check real ID)
+    subsystem_id: 0x181710DE
+
+  pcie:
+    max_link_gen: 6                 # PCIe Gen6 (or NVLink-C2C to Grace)
+    current_link_gen: 6
+    max_link_width: 16              # x16
+    current_link_width: 16
+    replay_counter: 0
+    tx_throughput_kbps: 0
+    rx_throughput_kbps: 0
+
+  # ---------------------------------------------------------------------------
+  # Power configuration - GB200 is much higher power
+  # ---------------------------------------------------------------------------
+  power:
+    management_supported: true
+    management_mode: "enabled"
+    default_limit_mw: 1000000       # 1000W (full superchip)
+    enforced_limit_mw: 1000000
+    min_limit_mw: 400000            # 400W minimum
+    max_limit_mw: 1200000           # 1200W boost
+    current_draw_mw: 145000         # 145W idle
+    power_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Thermal configuration
+  # ---------------------------------------------------------------------------
+  thermal:
+    temperature_gpu_c: 36           # Idle temperature (liquid cooled)
+    temperature_memory_c: 34
+    shutdown_threshold_c: 95
+    slowdown_threshold_c: 90
+    max_operating_c: 85
+    target_temperature_c: 85
+
+  # ---------------------------------------------------------------------------
+  # Fan configuration (N/A - liquid cooled)
+  # ---------------------------------------------------------------------------
+  fan:
+    count: 0                        # Liquid cooled, no fans
+    speed_percent: "N/A"
+    target_speed_percent: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Clock speeds (MHz) - Blackwell has higher clocks
+  # ---------------------------------------------------------------------------
+  clocks:
+    graphics_current: 345           # Idle
+    graphics_max: 2100              # Boost
+    graphics_app: 2100
+    graphics_app_default: 2100
+    sm_current: 345
+    sm_max: 2100
+    memory_current: 2500            # HBM3e
+    memory_max: 2500
+    memory_app: 2500
+    memory_app_default: 2500
+    video_current: 1200
+    video_max: 2100
+
+  # ---------------------------------------------------------------------------
+  # Clocks throttle reasons
+  # ---------------------------------------------------------------------------
+  clocks_throttle_reasons:
+    gpu_idle: true
+    applications_clocks_setting: false
+    sw_power_cap: false
+    hw_slowdown: false
+    hw_thermal_slowdown: false
+    hw_power_brake_slowdown: false
+    sync_boost: false
+    sw_thermal_slowdown: false
+    display_clocks_setting: false
+
+  # ---------------------------------------------------------------------------
+  # Supported clocks
+  # ---------------------------------------------------------------------------
+  supported_clocks:
+    memory_clocks:
+      - freq_mhz: 2500
+        graphics_clocks: [345, 690, 1035, 1380, 1725, 1890, 2100]
+
+  # ---------------------------------------------------------------------------
+  # Performance state
+  # ---------------------------------------------------------------------------
+  performance_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Utilization (percentage, 0-100)
+  # ---------------------------------------------------------------------------
+  utilization:
+    gpu: 0
+    memory: 0
+    encoder: 0
+    decoder: 0
+    jpeg: 0
+    ofa: 0
+
+  # ---------------------------------------------------------------------------
+  # Encoder/Decoder statistics
+  # ---------------------------------------------------------------------------
+  encoder_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  fbc_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  # ---------------------------------------------------------------------------
+  # ECC configuration
+  # ---------------------------------------------------------------------------
+  ecc:
+    mode_current: "enabled"
+    mode_pending: "enabled"
+    default_mode: "enabled"
+    errors:
+      volatile:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+      aggregate:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+
+  # ---------------------------------------------------------------------------
+  # Retired pages
+  # ---------------------------------------------------------------------------
+  retired_pages:
+    single_bit_retirement:
+      count: 0
+      addresses: []
+    double_bit_retirement:
+      count: 0
+      addresses: []
+    pending_blacklist: false
+    pending_retirement: false
+
+  # ---------------------------------------------------------------------------
+  # Remapped rows
+  # ---------------------------------------------------------------------------
+  remapped_rows:
+    correctable: 0
+    uncorrectable: 0
+    pending: false
+    failure_occurred: false
+
+  # ---------------------------------------------------------------------------
+  # Display configuration
+  # ---------------------------------------------------------------------------
+  display:
+    mode: "disabled"
+    active: "disabled"
+
+  # ---------------------------------------------------------------------------
+  # Persistence mode
+  # ---------------------------------------------------------------------------
+  persistence_mode: "enabled"
+
+  # ---------------------------------------------------------------------------
+  # Compute mode
+  # ---------------------------------------------------------------------------
+  compute_mode: "default"
+
+  # ---------------------------------------------------------------------------
+  # MIG configuration - GB200 supports MIG
+  # ---------------------------------------------------------------------------
+  mig:
+    mode_current: "disabled"
+    mode_pending: "disabled"
+    max_gpu_instances: 7
+
+  # ---------------------------------------------------------------------------
+  # GPU operation mode (GOM)
+  # ---------------------------------------------------------------------------
+  gpu_operation_mode:
+    current: "all_on"
+    pending: "all_on"
+
+  # ---------------------------------------------------------------------------
+  # Driver model (Windows only)
+  # ---------------------------------------------------------------------------
+  driver_model:
+    current: "N/A"
+    pending: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Accounting mode
+  # ---------------------------------------------------------------------------
+  accounting:
+    mode: "disabled"
+    buffer_size: 4000
+
+  # ---------------------------------------------------------------------------
+  # Virtualization
+  # ---------------------------------------------------------------------------
+  virtualization:
+    mode: "none"
+    host_vgpu_mode: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # GSP Firmware
+  # ---------------------------------------------------------------------------
+  gsp_firmware:
+    mode: "enabled"
+    version: "560.35.03"
+
+  # ---------------------------------------------------------------------------
+  # Blackwell-specific features
+  # ---------------------------------------------------------------------------
+  features:
+    transformer_engine: true        # 2nd gen Transformer Engine
+    fp4_support: true               # FP4 precision support
+    fp8_support: true               # FP8 precision support
+    confidential_compute: true      # CC/TEE support
+    nvlink_c2c: true                # NVLink Chip-to-Chip (Grace connection)
+    decompression_engine: true      # Hardware decompression
+    fifth_gen_tensor_cores: true    # 5th generation tensor cores
+
+  # ---------------------------------------------------------------------------
+  # Grace CPU pairing (GB200 specific)
+  # ---------------------------------------------------------------------------
+  grace_superchip:
+    enabled: true
+    cpu_cores: 72                   # Grace CPU cores
+    cpu_memory_gb: 480              # LPDDR5X per Grace CPU
+    coherent_memory: true           # NVLink-C2C coherent memory
+
+  # ---------------------------------------------------------------------------
+  # Processes (empty at idle)
+  # ---------------------------------------------------------------------------
+  processes: []
+
+# =============================================================================
+# Device-specific overrides
+# GB200 NVL72 has 72 GPUs, but we'll define 8 for testing
+# In a real GB200 system, GPUs are paired in superchips with Grace CPUs
+# =============================================================================
+devices:
+  - index: 0
+    uuid: "GPU-GB200-0000-0000-0000-000000000000"
+    serial: "1562849103700"
+    pci:
+      bus_id: "00000000:0A:00.0"
+    minor_number: 0
+    grace_cpu_pair: 0               # Paired with Grace CPU 0
+
+  - index: 1
+    uuid: "GPU-GB200-0000-0000-0000-000000000001"
+    serial: "1562849103701"
+    pci:
+      bus_id: "00000000:0B:00.0"
+    minor_number: 1
+    grace_cpu_pair: 0               # Same superchip as GPU 0
+
+  - index: 2
+    uuid: "GPU-GB200-0000-0000-0000-000000000002"
+    serial: "1562849103702"
+    pci:
+      bus_id: "00000000:4A:00.0"
+    minor_number: 2
+    grace_cpu_pair: 1
+
+  - index: 3
+    uuid: "GPU-GB200-0000-0000-0000-000000000003"
+    serial: "1562849103703"
+    pci:
+      bus_id: "00000000:4B:00.0"
+    minor_number: 3
+    grace_cpu_pair: 1
+
+  - index: 4
+    uuid: "GPU-GB200-0000-0000-0000-000000000004"
+    serial: "1562849103704"
+    pci:
+      bus_id: "00000000:8A:00.0"
+    minor_number: 4
+    grace_cpu_pair: 2
+
+  - index: 5
+    uuid: "GPU-GB200-0000-0000-0000-000000000005"
+    serial: "1562849103705"
+    pci:
+      bus_id: "00000000:8B:00.0"
+    minor_number: 5
+    grace_cpu_pair: 2
+
+  - index: 6
+    uuid: "GPU-GB200-0000-0000-0000-000000000006"
+    serial: "1562849103706"
+    pci:
+      bus_id: "00000000:CA:00.0"
+    minor_number: 6
+    grace_cpu_pair: 3
+
+  - index: 7
+    uuid: "GPU-GB200-0000-0000-0000-000000000007"
+    serial: "1562849103707"
+    pci:
+      bus_id: "00000000:CB:00.0"
+    minor_number: 7
+    grace_cpu_pair: 3
+
+# =============================================================================
+# NVLink topology - GB200 uses NVLink 5.0
+# =============================================================================
+nvlink:
+  version: 5
+  links_per_gpu: 18
+  bandwidth_per_link_gbps: 100      # 100 GB/s per link = 1.8 TB/s total per GPU
+  switch_support: true              # NVLink Switch for scale-out
+  switch_count: 0                   # Set for NVL72 configurations (up to 9 switches)
+  c2c_enabled: true                 # NVLink-C2C to Grace CPU
+  # NVLink state per link (18 links)
+  links:
+    - link: 0
+      state: "active"
+      remote_device_type: "gpu"
+      remote_pci_bus_id: "00000000:0B:00.0"
+    - link: 1
+      state: "active"
+      remote_device_type: "cpu"     # NVLink-C2C to Grace
+      remote_pci_bus_id: "N/A"
+    # ... define all 18 links for full topology

--- a/deployments/gpu-mock/helm/gpu-mock/templates/NOTES.txt
+++ b/deployments/gpu-mock/helm/gpu-mock/templates/NOTES.txt
@@ -1,0 +1,41 @@
+Mock GPU environment deployed on all nodes!
+
+  Profile: {{ .Values.gpu.profile }}
+  GPUs per node: {{ .Values.gpu.count }}
+  Driver version: {{ .Values.driverVersion }}
+  Mock driver root: /var/lib/nvidia-mock/driver
+  Mock config: /var/lib/nvidia-mock/config/config.yaml
+
+To use with NVIDIA Device Plugin:
+
+  helm install nvidia-device-plugin nvidia/k8s-device-plugin \
+    --set runtimeClassName="" \
+    --set args[0]="--nvidia-driver-root=/var/lib/nvidia-mock/driver" \
+    --set args[1]="--driver-root-ctr-path=/var/lib/nvidia-mock/driver" \
+    --set args[2]="--device-discovery-strategy=nvml" \
+    --set env[0].name=MOCK_NVML_CONFIG \
+    --set env[0].value=/var/lib/nvidia-mock/config/config.yaml \
+    --set env[1].name=MOCK_NVML_NUM_DEVICES \
+    --set "env[1].value={{ .Values.gpu.count }}"
+
+To use with NVIDIA DRA Driver:
+
+  helm install nvidia-dra-driver nvidia/nvidia-dra-driver-gpu \
+    --set nvidiaDriverRoot=/var/lib/nvidia-mock/driver \
+    --set env[0].name=MOCK_NVML_CONFIG \
+    --set env[0].value=/driver-root/config/config.yaml \
+    --set env[1].name=MOCK_NVML_NUM_DEVICES \
+    --set "env[1].value={{ .Values.gpu.count }}"
+
+To use with GPU Operator:
+
+  helm install gpu-operator nvidia/gpu-operator \
+    --set driver.enabled=false \
+    --set toolkit.enabled=true \
+    --set devicePlugin.enabled=true
+
+To verify mock GPUs are available:
+
+  kubectl get nodes -o custom-columns=\
+    NAME:.metadata.name,\
+    GPU_PRESENT:.metadata.labels.nvidia\.com/gpu\.present

--- a/deployments/gpu-mock/helm/gpu-mock/templates/_helpers.tpl
+++ b/deployments/gpu-mock/helm/gpu-mock/templates/_helpers.tpl
@@ -1,0 +1,71 @@
+{{/* Copyright 2026 NVIDIA CORPORATION */}}
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gpu-mock.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gpu-mock.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gpu-mock.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gpu-mock.labels" -}}
+helm.sh/chart: {{ include "gpu-mock.chart" . }}
+{{ include "gpu-mock.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gpu-mock.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gpu-mock.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+GPU configuration helper.
+Returns the GPU profile configuration YAML content.
+Priority: customConfig > profile file lookup > fail with error.
+*/}}
+{{- define "gpu-mock.gpuConfig" -}}
+{{- if .Values.gpu.customConfig }}
+{{- .Values.gpu.customConfig }}
+{{- else if eq .Values.gpu.profile "a100" }}
+{{- .Files.Get "profiles/a100.yaml" }}
+{{- else if eq .Values.gpu.profile "gb200" }}
+{{- .Files.Get "profiles/gb200.yaml" }}
+{{- else }}
+{{- fail (printf "Unknown GPU profile %q. Supported profiles: a100, gb200. Or set gpu.customConfig with inline YAML." .Values.gpu.profile) }}
+{{- end }}
+{{- end }}

--- a/deployments/gpu-mock/helm/gpu-mock/templates/configmap.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/templates/configmap.yaml
@@ -1,0 +1,11 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gpu-mock.fullname" . }}-config
+  labels:
+    {{- include "gpu-mock.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- include "gpu-mock.gpuConfig" . | nindent 4 }}

--- a/deployments/gpu-mock/helm/gpu-mock/templates/daemonset.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/templates/daemonset.yaml
@@ -1,0 +1,59 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "gpu-mock.fullname" . }}
+  labels:
+    {{- include "gpu-mock.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "gpu-mock.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gpu-mock.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "gpu-mock.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: gpu-mock
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            privileged: true
+          command: ["/scripts/entrypoint.sh"]
+          env:
+            - name: GPU_COUNT
+              value: "{{ .Values.gpu.count }}"
+            - name: DRIVER_VERSION
+              value: "{{ .Values.driverVersion }}"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/scripts/cleanup.sh"]
+          volumeMounts:
+            - name: host-nvidia-mock
+              mountPath: /host/var/lib/nvidia-mock
+            - name: gpu-config
+              mountPath: /config
+      volumes:
+        - name: host-nvidia-mock
+          hostPath:
+            path: /var/lib/nvidia-mock
+            type: DirectoryOrCreate
+        - name: gpu-config
+          configMap:
+            name: {{ include "gpu-mock.fullname" . }}-config

--- a/deployments/gpu-mock/helm/gpu-mock/templates/rbac.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/templates/rbac.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gpu-mock.fullname" . }}
+  labels:
+    {{- include "gpu-mock.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "gpu-mock.fullname" . }}
+  labels:
+    {{- include "gpu-mock.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "gpu-mock.fullname" . }}
+  labels:
+    {{- include "gpu-mock.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "gpu-mock.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "gpu-mock.fullname" . }}
+    namespace: {{ .Release.Namespace }}

--- a/deployments/gpu-mock/helm/gpu-mock/values.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/values.yaml
@@ -1,0 +1,18 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+gpu:
+  profile: a100           # a100 | gb200
+  count: 8
+  customConfig: ""
+
+image:
+  repository: ghcr.io/nvidia/gpu-mock
+  tag: latest
+  pullPolicy: IfNotPresent
+
+driverVersion: "550.163.01"
+
+nodeSelector: {}
+tolerations:
+  - operator: Exists

--- a/deployments/gpu-mock/scripts/cleanup.sh
+++ b/deployments/gpu-mock/scripts/cleanup.sh
@@ -3,7 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Cleans up mock GPU environment from host. Runs as preStop hook.
-rm -rf /host/var/lib/nvidia-mock/*
+MOCK_GPU_DIR="/host/var/lib/nvidia-mock"
+
+if [ -d "$MOCK_GPU_DIR" ] && [ "$MOCK_GPU_DIR" = "/host/var/lib/nvidia-mock" ]; then
+  rm -rf "$MOCK_GPU_DIR"/*
+fi
 if command -v kubectl >/dev/null 2>&1; then
   kubectl label node "$NODE_NAME" nvidia.com/gpu.present- || true
   kubectl label node "$NODE_NAME" feature.node.kubernetes.io/pci-10de.present- || true

--- a/deployments/gpu-mock/scripts/cleanup.sh
+++ b/deployments/gpu-mock/scripts/cleanup.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Cleans up mock GPU environment from host. Runs as preStop hook.
+rm -rf /host/var/lib/nvidia-mock/*
+if command -v kubectl >/dev/null 2>&1; then
+  kubectl label node "$NODE_NAME" nvidia.com/gpu.present- || true
+  kubectl label node "$NODE_NAME" feature.node.kubernetes.io/pci-10de.present- || true
+fi
+echo "Mock GPU environment cleaned up on $NODE_NAME"

--- a/deployments/gpu-mock/scripts/entrypoint.sh
+++ b/deployments/gpu-mock/scripts/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+set -e
+/scripts/setup.sh
+echo "Mock GPU environment ready. Sleeping..."
+exec sleep infinity

--- a/deployments/gpu-mock/scripts/setup.sh
+++ b/deployments/gpu-mock/scripts/setup.sh
@@ -14,7 +14,7 @@ DEV_ROOT=$HOST/dev
 CONFIG_DIR=$HOST/config
 
 # Validate GPU_COUNT does not exceed profile device count
-PROFILE_COUNT=$(grep -c "^  - index:" /config/config.yaml || echo 0)
+PROFILE_COUNT=$(grep -c "^[[:space:]]*- index:" /config/config.yaml || echo 0)
 if [ "$PROFILE_COUNT" -gt 0 ] && [ "$GPU_COUNT" -gt "$PROFILE_COUNT" ]; then
   echo "WARNING: gpu.count ($GPU_COUNT) exceeds profile devices ($PROFILE_COUNT). Capping to $PROFILE_COUNT."
   GPU_COUNT=$PROFILE_COUNT
@@ -41,11 +41,11 @@ mknod -m 666 "$DEV_ROOT/nvidia-uvm" c 510 0 2>/dev/null || true
 mknod -m 666 "$DEV_ROOT/nvidia-uvm-tools" c 510 1 2>/dev/null || true
 
 # 4. Create mock nvidia-smi (required by DRA driver)
-cat > "$DRIVER_ROOT/usr/bin/nvidia-smi" << 'NVIDIA_SMI_EOF'
+#    Uses unquoted heredoc so $DRIVER_VERSION is expanded at setup time.
+cat > "$DRIVER_ROOT/usr/bin/nvidia-smi" << NVIDIA_SMI_EOF
 #!/bin/sh
 # Mock nvidia-smi — returns driver version and basic GPU info.
 # Used by consumers (e.g., DRA driver) that probe nvidia-smi at startup.
-DRIVER_VERSION="${DRIVER_VERSION:-550.163.01}"
 echo "NVIDIA-SMI $DRIVER_VERSION"
 echo "Driver Version: $DRIVER_VERSION"
 echo "CUDA Version: 12.4"

--- a/deployments/gpu-mock/scripts/setup.sh
+++ b/deployments/gpu-mock/scripts/setup.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Sets up mock GPU environment on the host filesystem.
+# Runs as an entrypoint in the gpu-mock DaemonSet container.
+#
+# Required env vars: GPU_COUNT, DRIVER_VERSION, NODE_NAME
+set -e
+
+HOST=/host/var/lib/nvidia-mock
+DRIVER_ROOT=$HOST/driver
+DEV_ROOT=$HOST/dev
+CONFIG_DIR=$HOST/config
+
+# Validate GPU_COUNT does not exceed profile device count
+PROFILE_COUNT=$(grep -c "^  - index:" /config/config.yaml || echo 0)
+if [ "$PROFILE_COUNT" -gt 0 ] && [ "$GPU_COUNT" -gt "$PROFILE_COUNT" ]; then
+  echo "WARNING: gpu.count ($GPU_COUNT) exceeds profile devices ($PROFILE_COUNT). Capping to $PROFILE_COUNT."
+  GPU_COUNT=$PROFILE_COUNT
+fi
+
+echo "Setting up mock GPU environment: $GPU_COUNT GPUs, driver $DRIVER_VERSION"
+
+# 1. Create directory structure
+mkdir -p "$DRIVER_ROOT/usr/lib64" "$DRIVER_ROOT/usr/bin" "$DRIVER_ROOT/config"
+mkdir -p "$DEV_ROOT" "$CONFIG_DIR"
+
+# 2. Copy mock NVML library + create symlinks
+cp "/usr/local/lib/libnvidia-ml.so.$DRIVER_VERSION" "$DRIVER_ROOT/usr/lib64/"
+ln -sf "libnvidia-ml.so.$DRIVER_VERSION" "$DRIVER_ROOT/usr/lib64/libnvidia-ml.so.1"
+ln -sf "libnvidia-ml.so.1" "$DRIVER_ROOT/usr/lib64/libnvidia-ml.so"
+
+# 3. Create char device nodes
+#    Major 195 = nvidia, Major 510 = nvidia-uvm (standard NVIDIA major numbers)
+for i in $(seq 0 $((GPU_COUNT - 1))); do
+  mknod -m 666 "$DEV_ROOT/nvidia$i" c 195 "$i" 2>/dev/null || true
+done
+mknod -m 666 "$DEV_ROOT/nvidiactl" c 195 255 2>/dev/null || true
+mknod -m 666 "$DEV_ROOT/nvidia-uvm" c 510 0 2>/dev/null || true
+mknod -m 666 "$DEV_ROOT/nvidia-uvm-tools" c 510 1 2>/dev/null || true
+
+# 4. Create mock nvidia-smi (required by DRA driver)
+cat > "$DRIVER_ROOT/usr/bin/nvidia-smi" << 'NVIDIA_SMI_EOF'
+#!/bin/sh
+# Mock nvidia-smi — returns driver version and basic GPU info.
+# Used by consumers (e.g., DRA driver) that probe nvidia-smi at startup.
+DRIVER_VERSION="${DRIVER_VERSION:-550.163.01}"
+echo "NVIDIA-SMI $DRIVER_VERSION"
+echo "Driver Version: $DRIVER_VERSION"
+echo "CUDA Version: 12.4"
+exit 0
+NVIDIA_SMI_EOF
+chmod +x "$DRIVER_ROOT/usr/bin/nvidia-smi"
+
+# 5. Copy GPU profile config to both locations:
+#    - config/config.yaml (canonical, used by device plugin)
+#    - driver/config/config.yaml (used by DRA driver when only driver/ is mounted)
+cp /config/config.yaml "$CONFIG_DIR/config.yaml"
+cp /config/config.yaml "$DRIVER_ROOT/config/config.yaml"
+
+# 6. Label node (requires RBAC: get+patch on nodes)
+if command -v kubectl >/dev/null 2>&1; then
+  kubectl label node "$NODE_NAME" nvidia.com/gpu.present=true --overwrite || true
+  kubectl label node "$NODE_NAME" feature.node.kubernetes.io/pci-10de.present=true --overwrite || true
+fi
+
+echo "Mock GPU environment ready: $GPU_COUNT GPUs at $HOST"

--- a/docs/mocknvml/configuration.md
+++ b/docs/mocknvml/configuration.md
@@ -355,7 +355,7 @@ A100 configuration with all 8 devices configured.
 ## Complete Example: GB200 Profile
 
 See `pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml` for a Blackwell
-GB200 configuration with 192GB HBM3e memory.
+GB200 configuration with 192 GiB HBM3e memory.
 
 ## Validation
 

--- a/pkg/gpu/mocknvml/.gitignore
+++ b/pkg/gpu/mocknvml/.gitignore
@@ -1,0 +1,2 @@
+# Build artifacts from `make docker-build`
+libnvidia-ml.so*

--- a/pkg/gpu/mocknvml/README.md
+++ b/pkg/gpu/mocknvml/README.md
@@ -77,7 +77,7 @@ config for consistency.
 YAML configs allow full control over GPU properties. See `configs/` for examples:
 
 - `mock-nvml-config-a100.yaml` - DGX A100 (8x A100-SXM4-40GB)
-- `mock-nvml-config-gb200.yaml` - GB200 NVL (8x GB200 with 192GB HBM3e)
+- `mock-nvml-config-gb200.yaml` - GB200 NVL (8x GB200 with 192 GiB HBM3e)
 
 #### Configuration Structure
 

--- a/pkg/gpu/mocknvml/bridge/nvml_types.h
+++ b/pkg/gpu/mocknvml/bridge/nvml_types.h
@@ -138,6 +138,23 @@ typedef struct nvmlUtilization_st
     unsigned int memory;             //!< Percent of time GPU memory controller was active
 } nvmlUtilization_t;
 
+/*
+ * Memory information (v2) — adds version field and reserved memory
+ */
+typedef struct nvmlMemory_v2_st
+{
+    unsigned int version;            //!< Structure format version (must be 2)
+    unsigned long long total;        //!< Total physical device memory (in bytes)
+    unsigned long long reserved;     //!< Device memory (in bytes) reserved for system use
+    unsigned long long free;         //!< Unallocated device memory (in bytes)
+    unsigned long long used;         //!< Allocated device memory (in bytes)
+} nvmlMemory_v2_t;
+
+/*
+ * Device architecture type
+ */
+typedef unsigned int nvmlDeviceArchitecture_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/pkg/gpu/mocknvml/bridge/stubs_generated.go
+++ b/pkg/gpu/mocknvml/bridge/stubs_generated.go
@@ -124,11 +124,6 @@ func nvmlDeviceGetApplicationsClock() C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetApplicationsClock")
 }
 
-//export nvmlDeviceGetArchitecture
-func nvmlDeviceGetArchitecture() C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetArchitecture")
-}
-
 //export nvmlDeviceGetAttributes_v1
 func nvmlDeviceGetAttributes_v1() C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetAttributes_v1")
@@ -262,11 +257,6 @@ func nvmlDeviceGetCpuAffinityWithinScope() C.nvmlReturn_t {
 //export nvmlDeviceGetCreatableVgpus
 func nvmlDeviceGetCreatableVgpus() C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetCreatableVgpus")
-}
-
-//export nvmlDeviceGetCudaComputeCapability
-func nvmlDeviceGetCudaComputeCapability() C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetCudaComputeCapability")
 }
 
 //export nvmlDeviceGetCurrPcieLinkGeneration
@@ -649,24 +639,9 @@ func nvmlDeviceGetMemoryErrorCounter() C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetMemoryErrorCounter")
 }
 
-//export nvmlDeviceGetMemoryInfo
-func nvmlDeviceGetMemoryInfo() C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetMemoryInfo")
-}
-
-//export nvmlDeviceGetMemoryInfo_v2
-func nvmlDeviceGetMemoryInfo_v2() C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetMemoryInfo_v2")
-}
-
 //export nvmlDeviceGetMigDeviceHandleByIndex
 func nvmlDeviceGetMigDeviceHandleByIndex() C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetMigDeviceHandleByIndex")
-}
-
-//export nvmlDeviceGetMigMode
-func nvmlDeviceGetMigMode() C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetMigMode")
 }
 
 //export nvmlDeviceGetMinMaxClockOfPState
@@ -677,11 +652,6 @@ func nvmlDeviceGetMinMaxClockOfPState() C.nvmlReturn_t {
 //export nvmlDeviceGetMinMaxFanSpeed
 func nvmlDeviceGetMinMaxFanSpeed() C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetMinMaxFanSpeed")
-}
-
-//export nvmlDeviceGetMinorNumber
-func nvmlDeviceGetMinorNumber() C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetMinorNumber")
 }
 
 //export nvmlDeviceGetModuleId
@@ -782,21 +752,6 @@ func nvmlDeviceGetP2PStatus() C.nvmlReturn_t {
 //export nvmlDeviceGetPciInfoExt
 func nvmlDeviceGetPciInfoExt() C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetPciInfoExt")
-}
-
-//export nvmlDeviceGetPciInfo_v1
-func nvmlDeviceGetPciInfo_v1() C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetPciInfo_v1")
-}
-
-//export nvmlDeviceGetPciInfo_v2
-func nvmlDeviceGetPciInfo_v2() C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetPciInfo_v2")
-}
-
-//export nvmlDeviceGetPciInfo_v3
-func nvmlDeviceGetPciInfo_v3() C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetPciInfo_v3")
 }
 
 //export nvmlDeviceGetPcieLinkMaxSpeed

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml
@@ -46,7 +46,7 @@ device_defaults:
     pwr_object: "1.0"
 
   # ---------------------------------------------------------------------------
-  # Memory configuration - 192GB HBM3e per GPU
+  # Memory configuration - 192 GiB HBM3e per GPU
   # ---------------------------------------------------------------------------
   memory:
     total_bytes: 206158430208       # 192 GiB HBM3e

--- a/pkg/gpu/mocknvml/engine/config.go
+++ b/pkg/gpu/mocknvml/engine/config.go
@@ -83,6 +83,14 @@ func LoadConfig() *Config {
 			if config.NumDevices == 0 {
 				config.NumDevices = 8 // Default if no devices specified
 			}
+
+			// Allow MOCK_NVML_NUM_DEVICES to override even with YAML config.
+			// This lets the Helm chart's gpu.count control NVML device count.
+			if num := os.Getenv("MOCK_NVML_NUM_DEVICES"); num != "" {
+				if val, err := strconv.Atoi(num); err == nil && val >= 0 {
+					config.NumDevices = val
+				}
+			}
 			debugLog("[CONFIG] Loaded YAML config: %d devices, driver %s\n", config.NumDevices, config.DriverVersion)
 
 			// Cache the config

--- a/tests/e2e/device-plugin-mock.yaml
+++ b/tests/e2e/device-plugin-mock.yaml
@@ -1,0 +1,48 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Device plugin DaemonSet for E2E testing with gpu-mock chart.
+# Expects gpu-mock chart to be installed first.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin-mock
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: nvidia-device-plugin-mock
+  template:
+    metadata:
+      labels:
+        name: nvidia-device-plugin-mock
+    spec:
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: nvidia-device-plugin
+          image: nvcr.io/nvidia/k8s-device-plugin:v0.18.2
+          env:
+            - name: MOCK_NVML_CONFIG
+              value: "/var/lib/nvidia-mock/config/config.yaml"
+            - name: MOCK_NVML_NUM_DEVICES
+              value: "2"
+          args:
+            - "--nvidia-driver-root=/var/lib/nvidia-mock/driver"
+            - "--driver-root-ctr-path=/var/lib/nvidia-mock/driver"
+            - "--device-discovery-strategy=nvml"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: mock-root
+              mountPath: /var/lib/nvidia-mock
+              readOnly: true
+            - name: device-plugins
+              mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: mock-root
+          hostPath:
+            path: /var/lib/nvidia-mock
+        - name: device-plugins
+          hostPath:
+            path: /var/lib/kubelet/device-plugins


### PR DESCRIPTION
## Summary

Add a Helm chart that turns any Kubernetes cluster into a mock GPU cluster using the CGo-based mock NVML library from PR #204.

- **Helm chart** with GPU profiles (A100 8×40GB, GB200 8×96GB), RBAC, and configurable `gpu.count`
- **Multi-arch Dockerfile** builds mock `.so` from source, debian-slim runtime with kubectl
- **DaemonSet** stages mock driver files, device nodes, config YAML, and labels each node
- **Mock nvidia-smi** script for DRA driver compatibility
- **Bridge functions** for consumer-critical NVML APIs: `GetMinorNumber`, `GetMemoryInfo_v2`, `GetArchitecture`, `GetCudaComputeCapability`, `GetMigMode`
- **`MOCK_NVML_NUM_DEVICES`** env var override so `gpu.count` controls both device nodes and NVML device count
- **E2E CI workflow** — Kind cluster, helm install, device plugin deployment, allocatable GPU assertion

## Quick Start

```bash
# Install gpu-mock — every node gets 8 mock A100 GPUs
helm install gpu-mock ./deployments/gpu-mock/helm/gpu-mock

# Or customize GPU count and profile
helm install gpu-mock ./deployments/gpu-mock/helm/gpu-mock \
  --set gpu.count=4 \
  --set gpu.profile=gb200
```

After install, each node has:
- `/var/lib/nvidia-mock/driver/` — mock driver tree (library, nvidia-smi, config)
- `/var/lib/nvidia-mock/dev/` — device nodes (nvidia0..N, nvidiactl, nvidia-uvm)
- `/var/lib/nvidia-mock/config/config.yaml` — GPU profile config
- Node label `nvidia.com/gpu.present=true`

## Examples

### With NVIDIA Device Plugin

```bash
helm install nvidia-device-plugin nvidia/k8s-device-plugin \
  --set runtimeClassName="" \
  --set args[0]="--nvidia-driver-root=/var/lib/nvidia-mock/driver" \
  --set args[1]="--driver-root-ctr-path=/var/lib/nvidia-mock/driver" \
  --set args[2]="--device-discovery-strategy=nvml" \
  --set env[0].name=MOCK_NVML_CONFIG \
  --set env[0].value=/var/lib/nvidia-mock/config/config.yaml \
  --set env[1].name=MOCK_NVML_NUM_DEVICES \
  --set env[1].value=8

# Verify
kubectl get nodes -o custom-columns=NAME:.metadata.name,GPUs:.status.allocatable.nvidia\.com/gpu
```

### With NVIDIA DRA Driver

```bash
helm install nvidia-dra-driver nvidia/nvidia-dra-driver-gpu \
  --set nvidiaDriverRoot=/var/lib/nvidia-mock/driver \
  --set env[0].name=MOCK_NVML_CONFIG \
  --set env[0].value=/driver-root/config/config.yaml \
  --set env[1].name=MOCK_NVML_NUM_DEVICES \
  --set env[1].value=8
```

### Custom GPU Count

```bash
# Simulate 2 GPUs per node instead of 8
helm install gpu-mock ./deployments/gpu-mock/helm/gpu-mock \
  --set gpu.count=2

# Consumers must also set MOCK_NVML_NUM_DEVICES=2
# to match the gpu.count value
```

## Configuration

| Parameter | Default | Description |
|-----------|---------|-------------|
| `gpu.profile` | `a100` | GPU profile (`a100`, `gb200`) |
| `gpu.count` | `8` | Number of mock GPUs per node |
| `gpu.customConfig` | `""` | Inline YAML to override profile |
| `driverVersion` | `550.163.01` | Mock NVIDIA driver version |
| `image.repository` | `ghcr.io/nvidia/gpu-mock` | Container image |
| `image.tag` | `latest` | Image tag |
| `nodeSelector` | `{}` | Node selector for DaemonSet |
| `tolerations` | `[{operator: Exists}]` | Tolerations (all nodes by default) |

## Validated with

| Consumer | Version | Result |
|----------|---------|--------|
| NVIDIA device plugin | v0.18.2 | allocatable GPUs registered |
| NVIDIA DRA driver | v25.12.0 | GPUs in ResourceSlice |

## Test plan

- [x] E2E: Kind cluster → helm install → device plugin → 2 allocatable GPUs (`gpu.count=2`)
- [x] E2E: Node labels (`nvidia.com/gpu.present=true`)
- [x] E2E: Mock files on host (library, symlinks, device nodes, config)
- [x] `go vet` / `go test` on engine changes
- [x] Multi-arch kubectl download (TARGETARCH)

## Related

- PR #204 — CGo-based mock NVML library (merged)