### PR TITLE
feat: transparent mock GPU config — auto-discover path, inject num_devices

### DIFF
--- a/.github/workflows/gpu-mock-e2e.yaml
+++ b/.github/workflows/gpu-mock-e2e.yaml
@@ -179,6 +179,7 @@ jobs:
             --create-namespace \
             --set nvidiaDriverRoot=/var/lib/nvidia-mock/driver \
             --set gpuResourcesEnabledOverride=true \
+            --set resources.computeDomains.enabled=false \
             --wait --timeout 180s
 
       - name: Wait for DRA pods

--- a/.github/workflows/gpu-mock-e2e.yaml
+++ b/.github/workflows/gpu-mock-e2e.yaml
@@ -22,7 +22,7 @@ on:
         type: string
 
 jobs:
-  e2e:
+  e2e-device-plugin:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -81,6 +81,8 @@ jobs:
           # Check config at both locations
           docker exec "$NODE_CONTAINER" test -f /var/lib/nvidia-mock/config/config.yaml
           docker exec "$NODE_CONTAINER" test -f /var/lib/nvidia-mock/driver/config/config.yaml
+          # Verify num_devices was injected
+          docker exec "$NODE_CONTAINER" grep -q "num_devices: 2" /var/lib/nvidia-mock/config/config.yaml
           echo "All mock files verified"
 
       - name: Deploy NVIDIA device plugin
@@ -112,6 +114,102 @@ jobs:
           kubectl logs -l app.kubernetes.io/name=gpu-mock --tail=50 || true
           echo "=== device plugin logs ==="
           kubectl -n kube-system logs -l name=nvidia-device-plugin-mock --tail=50 || true
+          echo "=== pod status ==="
+          kubectl get pods -A || true
+          echo "=== node describe ==="
+          kubectl describe nodes || true
+
+  e2e-dra:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ inputs.golang_version }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Create Kind cluster with DRA
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: gpu-mock-dra-e2e
+          config: tests/e2e/kind-dra-config.yaml
+
+      - name: Build gpu-mock image
+        run: |
+          docker build -t gpu-mock:e2e -f deployments/gpu-mock/Dockerfile \
+            --build-arg GOLANG_VERSION=${{ inputs.golang_version }} .
+
+      - name: Load image into Kind
+        run: |
+          kind load docker-image gpu-mock:e2e --name gpu-mock-dra-e2e
+
+      - name: Install gpu-mock Helm chart
+        run: |
+          helm install gpu-mock deployments/gpu-mock/helm/gpu-mock \
+            --set image.repository=gpu-mock \
+            --set image.tag=e2e \
+            --set gpu.count=2 \
+            --wait --timeout 120s
+
+      - name: Verify DaemonSet is ready
+        run: |
+          kubectl rollout status daemonset -l app.kubernetes.io/name=gpu-mock --timeout=60s
+
+      - name: Verify mock files on node
+        run: |
+          NODE_CONTAINER=gpu-mock-dra-e2e-control-plane
+          docker exec "$NODE_CONTAINER" test -f /var/lib/nvidia-mock/driver/config/config.yaml
+          docker exec "$NODE_CONTAINER" grep -q "num_devices: 2" /var/lib/nvidia-mock/driver/config/config.yaml
+          docker exec "$NODE_CONTAINER" test -L /var/lib/nvidia-mock/driver/usr/lib64/libnvidia-ml.so.1
+          echo "Mock files verified"
+
+      - name: Add NVIDIA Helm repo
+        run: |
+          helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+          helm repo update
+
+      - name: Install DRA driver
+        run: |
+          helm install nvidia-dra-driver nvidia/nvidia-dra-driver-gpu \
+            --namespace nvidia \
+            --create-namespace \
+            --set nvidiaDriverRoot=/var/lib/nvidia-mock/driver \
+            --wait --timeout 180s
+
+      - name: Wait for DRA pods
+        run: |
+          kubectl -n nvidia wait --for=condition=ready pod --all --timeout=120s
+
+      - name: Verify ResourceSlice GPU count
+        run: |
+          for i in $(seq 1 30); do
+            COUNT=$(kubectl get resourceslices -o json | \
+              jq '[.items[].spec.devices // [] | length] | add // 0')
+            if [ "$COUNT" = "2" ]; then
+              echo "PASS: ResourceSlice reports $COUNT GPUs"
+              exit 0
+            fi
+            echo "Attempt $i: ResourceSlice GPUs=$COUNT (expected 2), waiting..."
+            sleep 2
+          done
+          echo "FAIL: Expected 2 GPUs in ResourceSlice, got $COUNT"
+          exit 1
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== gpu-mock pod logs ==="
+          kubectl logs -l app.kubernetes.io/name=gpu-mock --tail=50 || true
+          echo "=== DRA driver pods ==="
+          kubectl -n nvidia get pods || true
+          echo "=== DRA driver logs ==="
+          kubectl -n nvidia logs -l app.kubernetes.io/name=nvidia-dra-driver-gpu --tail=100 || true
+          echo "=== ResourceSlices ==="
+          kubectl get resourceslices -o yaml || true
           echo "=== pod status ==="
           kubectl get pods -A || true
           echo "=== node describe ==="

--- a/.github/workflows/gpu-mock-e2e.yaml
+++ b/.github/workflows/gpu-mock-e2e.yaml
@@ -207,6 +207,12 @@ jobs:
           kubectl logs -l app.kubernetes.io/name=gpu-mock --tail=50 || true
           echo "=== DRA driver pods ==="
           kubectl -n nvidia get pods || true
+          echo "=== DRA kubelet-plugin describe ==="
+          kubectl -n nvidia describe pod -l app.kubernetes.io/component=kubelet-plugin || true
+          echo "=== DRA kubelet-plugin init container logs ==="
+          for pod in $(kubectl -n nvidia get pods -l app.kubernetes.io/component=kubelet-plugin -o name 2>/dev/null); do
+            kubectl -n nvidia logs "$pod" -c init-container --tail=100 || true
+          done
           echo "=== DRA driver logs ==="
           kubectl -n nvidia logs -l app.kubernetes.io/name=nvidia-dra-driver-gpu --tail=100 || true
           echo "=== ResourceSlices ==="

--- a/.github/workflows/gpu-mock-e2e.yaml
+++ b/.github/workflows/gpu-mock-e2e.yaml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Verify DaemonSet is ready
         run: |
-          kubectl rollout status daemonset -l app.kubernetes.io/name=gpu-mock --timeout=60s
+          kubectl rollout status daemonset/gpu-mock --timeout=60s
 
       - name: Verify mock files on node
         run: |

--- a/.github/workflows/gpu-mock-e2e.yaml
+++ b/.github/workflows/gpu-mock-e2e.yaml
@@ -207,12 +207,15 @@ jobs:
           kubectl logs -l app.kubernetes.io/name=gpu-mock --tail=50 || true
           echo "=== DRA driver pods ==="
           kubectl -n nvidia get pods || true
-          echo "=== DRA kubelet-plugin describe ==="
-          kubectl -n nvidia describe pod -l app.kubernetes.io/component=kubelet-plugin || true
-          echo "=== DRA kubelet-plugin init container logs ==="
-          for pod in $(kubectl -n nvidia get pods -l app.kubernetes.io/component=kubelet-plugin -o name 2>/dev/null); do
-            kubectl -n nvidia logs "$pod" -c init-container --tail=100 || true
-          done
+          echo "=== DRA kubelet-plugin pod describe ==="
+          kubectl -n nvidia describe pod -l name=nvidia-dra-driver-gpu-kubelet-plugin || true
+          PLUGIN_POD=$(kubectl -n nvidia get pods --no-headers -o custom-columns=':metadata.name' | grep kubelet-plugin | head -1)
+          if [ -n "$PLUGIN_POD" ]; then
+            echo "=== DRA kubelet-plugin init container logs ($PLUGIN_POD) ==="
+            kubectl -n nvidia logs "$PLUGIN_POD" -c init-container --tail=100 || true
+            echo "=== DRA kubelet-plugin events ==="
+            kubectl -n nvidia get events --field-selector involvedObject.name="$PLUGIN_POD" || true
+          fi
           echo "=== DRA driver logs ==="
           kubectl -n nvidia logs -l app.kubernetes.io/name=nvidia-dra-driver-gpu --tail=100 || true
           echo "=== ResourceSlices ==="

--- a/.github/workflows/gpu-mock-e2e.yaml
+++ b/.github/workflows/gpu-mock-e2e.yaml
@@ -178,6 +178,7 @@ jobs:
             --namespace nvidia \
             --create-namespace \
             --set nvidiaDriverRoot=/var/lib/nvidia-mock/driver \
+            --set gpuResourcesEnabledOverride=true \
             --wait --timeout 180s
 
       - name: Wait for DRA pods

--- a/deployments/gpu-mock/helm/gpu-mock/templates/NOTES.txt
+++ b/deployments/gpu-mock/helm/gpu-mock/templates/NOTES.txt
@@ -12,20 +12,14 @@ To use with NVIDIA Device Plugin:
     --set runtimeClassName="" \
     --set args[0]="--nvidia-driver-root=/var/lib/nvidia-mock/driver" \
     --set args[1]="--driver-root-ctr-path=/var/lib/nvidia-mock/driver" \
-    --set args[2]="--device-discovery-strategy=nvml" \
-    --set env[0].name=MOCK_NVML_CONFIG \
-    --set env[0].value=/var/lib/nvidia-mock/config/config.yaml \
-    --set env[1].name=MOCK_NVML_NUM_DEVICES \
-    --set "env[1].value={{ .Values.gpu.count }}"
+    --set args[2]="--device-discovery-strategy=nvml"
+
+  No mock-specific env vars needed — the .so auto-discovers its config.
 
 To use with NVIDIA DRA Driver:
 
   helm install nvidia-dra-driver nvidia/nvidia-dra-driver-gpu \
-    --set nvidiaDriverRoot=/var/lib/nvidia-mock/driver \
-    --set env[0].name=MOCK_NVML_CONFIG \
-    --set env[0].value=/driver-root/config/config.yaml \
-    --set env[1].name=MOCK_NVML_NUM_DEVICES \
-    --set "env[1].value={{ .Values.gpu.count }}"
+    --set nvidiaDriverRoot=/var/lib/nvidia-mock/driver
 
 To use with GPU Operator:
 

--- a/deployments/gpu-mock/scripts/setup.sh
+++ b/deployments/gpu-mock/scripts/setup.sh
@@ -55,11 +55,16 @@ chmod +x "$DRIVER_ROOT/usr/bin/nvidia-smi"
 
 # 5. Copy GPU profile config to both locations:
 #    - config/config.yaml (canonical, used by device plugin)
-#    - driver/config/config.yaml (used by DRA driver when only driver/ is mounted)
+#    - driver/config/config.yaml (auto-discovered by .so via /proc/self/maps)
 cp /config/config.yaml "$CONFIG_DIR/config.yaml"
 cp /config/config.yaml "$DRIVER_ROOT/config/config.yaml"
 
-# 6. Label node (requires RBAC: get+patch on nodes)
+# 6. Inject num_devices into config so the .so knows GPU count without env vars.
+#    This makes the on-host config self-contained — consumers just point at driver root.
+sed -i "/^system:/a\\  num_devices: $GPU_COUNT" "$CONFIG_DIR/config.yaml"
+sed -i "/^system:/a\\  num_devices: $GPU_COUNT" "$DRIVER_ROOT/config/config.yaml"
+
+# 7. Label node (requires RBAC: get+patch on nodes)
 if command -v kubectl >/dev/null 2>&1; then
   kubectl label node "$NODE_NAME" nvidia.com/gpu.present=true --overwrite || true
   kubectl label node "$NODE_NAME" feature.node.kubernetes.io/pci-10de.present=true --overwrite || true

--- a/deployments/gpu-mock/scripts/setup.sh
+++ b/deployments/gpu-mock/scripts/setup.sh
@@ -43,7 +43,7 @@ mknod -m 666 "$DEV_ROOT/nvidia-uvm-tools" c 510 1 2>/dev/null || true
 # 4. Create mock nvidia-smi (required by DRA driver)
 #    Uses unquoted heredoc so $DRIVER_VERSION is expanded at setup time.
 cat > "$DRIVER_ROOT/usr/bin/nvidia-smi" << NVIDIA_SMI_EOF
-#!/bin/sh
+#!/bin/bash
 # Mock nvidia-smi — returns driver version and basic GPU info.
 # Used by consumers (e.g., DRA driver) that probe nvidia-smi at startup.
 echo "NVIDIA-SMI $DRIVER_VERSION"

--- a/pkg/gpu/mocknvml/engine/config.go
+++ b/pkg/gpu/mocknvml/engine/config.go
@@ -161,7 +161,13 @@ func discoverConfigPath() string {
 		if len(fields) < 6 {
 			continue
 		}
+		// The last field is normally the pathname, but after file replacement
+		// (e.g. library upgrade) it can be "pathname (deleted)". In that case
+		// the absolute path is the second-to-last field.
 		soPath := fields[len(fields)-1]
+		if soPath == "(deleted)" && len(fields) >= 7 {
+			soPath = fields[len(fields)-2]
+		}
 		if !strings.HasPrefix(soPath, "/") {
 			continue
 		}

--- a/pkg/gpu/mocknvml/engine/config.go
+++ b/pkg/gpu/mocknvml/engine/config.go
@@ -174,6 +174,9 @@ func discoverConfigPath() string {
 			return configPath
 		}
 	}
+	if err := scanner.Err(); err != nil {
+		debugLog("[CONFIG] Error scanning /proc/self/maps: %v\n", err)
+	}
 	return ""
 }
 

--- a/pkg/gpu/mocknvml/engine/config.go
+++ b/pkg/gpu/mocknvml/engine/config.go
@@ -14,9 +14,13 @@
 package engine
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 
 	"sigs.k8s.io/yaml"
@@ -55,9 +59,17 @@ func DefaultConfig() *Config {
 }
 
 // LoadConfig loads configuration from YAML file (if specified) or environment variables.
-// Results are cached - subsequent calls with the same MOCK_NVML_CONFIG return cached config.
+// Results are cached - subsequent calls with the same config path return cached config.
+//
+// Config resolution order:
+//  1. MOCK_NVML_CONFIG env var (explicit path)
+//  2. Auto-discover from /proc/self/maps (Linux only)
+//  3. Fall back to env vars / defaults
 func LoadConfig() *Config {
 	configPath := os.Getenv("MOCK_NVML_CONFIG")
+	if configPath == "" {
+		configPath = discoverConfigPath()
+	}
 
 	configCacheMu.Lock()
 	defer configCacheMu.Unlock()
@@ -84,12 +96,11 @@ func LoadConfig() *Config {
 				config.NumDevices = 8 // Default if no devices specified
 			}
 
-			// Allow MOCK_NVML_NUM_DEVICES to override even with YAML config.
-			// This lets the Helm chart's gpu.count control NVML device count.
-			if num := os.Getenv("MOCK_NVML_NUM_DEVICES"); num != "" {
-				if val, err := strconv.Atoi(num); err == nil && val >= 0 {
-					config.NumDevices = val
-				}
+			// system.num_devices overrides the device list count.
+			// setup.sh injects this so the .so knows the desired GPU count
+			// without consumers needing to set env vars.
+			if yamlConfig.System.NumDevices > 0 {
+				config.NumDevices = yamlConfig.System.NumDevices
 			}
 			debugLog("[CONFIG] Loaded YAML config: %d devices, driver %s\n", config.NumDevices, config.DriverVersion)
 
@@ -117,6 +128,53 @@ func LoadConfig() *Config {
 	configCache = config
 	configCachePath = configPath
 	return config
+}
+
+// discoverConfigPath attempts to locate the config file by reading /proc/self/maps
+// to find the path of the loaded mock NVML .so, then navigating to the config directory.
+//
+// Expected layout:
+//
+//	.so at:     <driver_root>/usr/lib64/libnvidia-ml.so.<version>
+//	config at:  <driver_root>/config/config.yaml
+//
+// Returns empty string if auto-discovery is not possible (non-Linux, file not found).
+func discoverConfigPath() string {
+	if runtime.GOOS != "linux" {
+		return ""
+	}
+
+	f, err := os.Open("/proc/self/maps")
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.Contains(line, "libnvidia-ml.so") {
+			continue
+		}
+		// /proc/self/maps format: addr-addr perms offset dev inode   pathname
+		fields := strings.Fields(line)
+		if len(fields) < 6 {
+			continue
+		}
+		soPath := fields[len(fields)-1]
+		if !strings.HasPrefix(soPath, "/") {
+			continue
+		}
+		// Navigate from <driver_root>/usr/lib64/libnvidia-ml.so.* to <driver_root>/config/config.yaml
+		libDir := filepath.Dir(soPath)                   // .../usr/lib64
+		driverRoot := filepath.Dir(filepath.Dir(libDir)) // .../driver_root
+		configPath := filepath.Join(driverRoot, "config", "config.yaml")
+		if _, err := os.Stat(configPath); err == nil {
+			debugLog("[CONFIG] Auto-discovered config at %s\n", configPath)
+			return configPath
+		}
+	}
+	return ""
 }
 
 // LoadYAMLConfig loads and parses a YAML configuration file
@@ -282,4 +340,4 @@ func mergeDeviceOverride(base *DeviceConfig, override *DeviceOverride) {
 	// Add more fields as needed
 }
 
-// Note: debugLog is defined in device.go to avoid duplication
+// Note: debugLog is defined in utils.go to avoid duplication

--- a/pkg/gpu/mocknvml/engine/config.go
+++ b/pkg/gpu/mocknvml/engine/config.go
@@ -148,7 +148,7 @@ func discoverConfigPath() string {
 	if err != nil {
 		return ""
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {

--- a/pkg/gpu/mocknvml/engine/config_types.go
+++ b/pkg/gpu/mocknvml/engine/config_types.go
@@ -30,6 +30,7 @@ type SystemConfig struct {
 	CUDAVersion      string `json:"cuda_version"`
 	CUDAVersionMajor int    `json:"cuda_version_major"`
 	CUDAVersionMinor int    `json:"cuda_version_minor"`
+	NumDevices       int    `json:"num_devices,omitempty"`
 }
 
 // DeviceConfig represents the full device configuration.

--- a/tests/e2e/device-plugin-mock.yaml
+++ b/tests/e2e/device-plugin-mock.yaml
@@ -3,6 +3,9 @@
 #
 # Device plugin DaemonSet for E2E testing with gpu-mock chart.
 # Expects gpu-mock chart to be installed first.
+#
+# No mock-specific env vars needed — the .so auto-discovers its config
+# from /proc/self/maps and reads num_devices from the YAML.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -22,11 +25,6 @@ spec:
       containers:
         - name: nvidia-device-plugin
           image: nvcr.io/nvidia/k8s-device-plugin:v0.18.2
-          env:
-            - name: MOCK_NVML_CONFIG
-              value: "/var/lib/nvidia-mock/config/config.yaml"
-            - name: MOCK_NVML_NUM_DEVICES
-              value: "2"
           args:
             - "--nvidia-driver-root=/var/lib/nvidia-mock/driver"
             - "--driver-root-ctr-path=/var/lib/nvidia-mock/driver"

--- a/tests/e2e/kind-dra-config.yaml
+++ b/tests/e2e/kind-dra-config.yaml
@@ -7,5 +7,17 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 featureGates:
   DynamicResourceAllocation: true
+containerdConfigPatches:
+  # Enable CDI (Container Device Interface) for DRA driver device management.
+  # See: https://tags.cncf.io/container-device-interface#containerd-configuration
+  - |-
+    [plugins."io.containerd.grpc.v1.cri"]
+      enable_cdi = true
 nodes:
   - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+          extraArgs:
+            runtime-config: "resource.k8s.io/v1beta1=true"

--- a/tests/e2e/kind-dra-config.yaml
+++ b/tests/e2e/kind-dra-config.yaml
@@ -1,0 +1,11 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Kind cluster config with DRA (Dynamic Resource Allocation) feature gates enabled.
+# Used by the DRA E2E test job.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  DynamicResourceAllocation: true
+nodes:
+  - role: control-plane


### PR DESCRIPTION
## Summary

> **Stacked on #212** — after #212 merges, this PR's diff will auto-update to show only the new commit.

Eliminates mock-specific env vars from consumer manifests so DRA/device-plugin developers can just `helm install` against a gpu-mock cluster.

- **Auto-discover config path**: the `.so` reads `/proc/self/maps` to find its own path, navigates to `<driver_root>/config/config.yaml`
- **`system.num_devices` in YAML**: `setup.sh` injects `num_devices: $GPU_COUNT` into the on-host config after copying
- **Simplified device-plugin manifest**: no `MOCK_NVML_CONFIG` or `MOCK_NVML_NUM_DEVICES` env vars needed
- **Parallel E2E jobs**: split workflow into `e2e-device-plugin` + `e2e-dra` running concurrently
- **DRA E2E**: new Kind config with `DynamicResourceAllocation` feature gate, installs `nvidia-dra-driver-gpu`, asserts ResourceSlice GPU count

**Target developer experience:**
```bash
helm install gpu-mock ./gpu-mock --set gpu.count=4
helm install nvidia-dra-driver nvidia/nvidia-dra-driver-gpu \
  --set nvidiaDriverRoot=/var/lib/nvidia-mock/driver
# Done. No MOCK_NVML_CONFIG. No MOCK_NVML_NUM_DEVICES. Just works.
```

## Files changed

| File | Change |
|------|--------|
| `pkg/gpu/mocknvml/engine/config.go` | Add `discoverConfigPath()`, use `num_devices` from YAML |
| `pkg/gpu/mocknvml/engine/config_types.go` | Add `NumDevices int` to `SystemConfig` |
| `pkg/gpu/mocknvml/engine/config_test.go` | Tests for auto-discovery and num_devices |
| `deployments/gpu-mock/scripts/setup.sh` | Inject `num_devices: $GPU_COUNT` into config |
| `deployments/gpu-mock/helm/gpu-mock/templates/NOTES.txt` | Update consumer examples (no env vars) |
| `tests/e2e/device-plugin-mock.yaml` | Remove mock env vars |
| `tests/e2e/kind-dra-config.yaml` | New: Kind config with DRA feature gates |
| `.github/workflows/gpu-mock-e2e.yaml` | Split into parallel device-plugin + DRA jobs |

## Test plan

- [x] `go test ./pkg/gpu/mocknvml/engine/ -v` — 43 tests pass (4 new)
- [x] `go build ./pkg/gpu/mocknvml/engine/...` — compiles clean
- [x] No `MOCK_NVML_CONFIG`/`MOCK_NVML_NUM_DEVICES` in E2E manifests or Helm templates
- [ ] CI: device-plugin E2E — 2 allocatable GPUs
- [ ] CI: DRA E2E — 2 GPUs in ResourceSlice