### PR TITLE
fix: normalize repo keys to lowercase for issues/PRs data lookup

### DIFF
--- a/src/components/IssuesPRsDashboard.tsx
+++ b/src/components/IssuesPRsDashboard.tsx
@@ -301,9 +301,9 @@ export default function IssuesPRsDashboard({ data }: Props) {
 
   const rows = useMemo<RowData[]>(() => {
     return projects
-      .filter((p) => data.repos[p.repo])
+      .filter((p) => data.repos[p.repo.toLowerCase()])
       .map((p) => {
-        const repoData = data.repos[p.repo];
+        const repoData = data.repos[p.repo.toLowerCase()];
         return {
           slug: p.slug,
           name: p.name,
@@ -319,7 +319,7 @@ export default function IssuesPRsDashboard({ data }: Props) {
   const ranges: TimeRange[] = [4, 8, 12];
 
   return (
-    <section id="issues-prs" className="mb-6">
+    <section className="mb-6">
       {/* Header with time range selector */}
       <div className="flex items-center justify-between mb-3">
         <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-200">

--- a/src/hooks/useData.ts
+++ b/src/hooks/useData.ts
@@ -113,7 +113,14 @@ export function useIssuesPRs() {
 
   useEffect(() => {
     fetchJSON<IssuesPRsData>('issues_prs.json')
-      .then((d) => setData(d))
+      .then((d) => {
+        // Normalize repo keys to lowercase for consistent lookups
+        const normalized: IssuesPRsData['repos'] = {};
+        for (const [key, value] of Object.entries(d.repos)) {
+          normalized[key.toLowerCase()] = value;
+        }
+        setData({ repos: normalized });
+      })
       .catch((e: Error) => setError(e.message))
       .finally(() => setLoading(false));
   }, []);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -311,7 +311,15 @@ export default function Dashboard() {
       </section>
 
       {/* Issues & PR Health */}
-      {issuesPRs && <IssuesPRsDashboard data={issuesPRs} />}
+      <section id="issues-prs" className="mb-8">
+        {issuesPRs ? (
+          <IssuesPRsDashboard data={issuesPRs} />
+        ) : (
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+            <p className="text-gray-500 dark:text-gray-400">Loading issues and pull requests...</p>
+          </div>
+        )}
+      </section>
 
       {/* Latest Image Builds */}
       <section id="image-builds" className="mb-8">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -47,7 +47,7 @@ export default function Home() {
     if (!issuesPRs) return [];
     return projects
       .map((p) => {
-        const repoData = issuesPRs.repos[p.repo];
+        const repoData = issuesPRs.repos[p.repo.toLowerCase()];
         if (!repoData) return null;
 
         const buckets = repoData.issues.ageBuckets;

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -35,7 +35,7 @@ export default function ProjectDetail() {
   const repoInfo = repos.find((r) => r.fullName.toLowerCase() === repoKey);
   const projectWorkflows = workflows.filter((w) => w.repo.toLowerCase() === repoKey);
   const projectImages = images.filter((i) => i.repo.toLowerCase() === repoKey);
-  const projectIssuesPRs = issuesPRs?.repos[project.repo] ?? null;
+  const projectIssuesPRs = issuesPRs?.repos[project.repo.toLowerCase()] ?? null;
 
   const workflowTrend = useMemo(() => {
     if (!history) return [];


### PR DESCRIPTION
## Summary

- **Bug:** The Go `artifact_fetcher` generates `issues_prs.json` with lowercase repo keys (`nvidia/gpu-operator`) but `projects.ts` uses uppercase (`NVIDIA/gpu-operator`), causing all Issues & PRs data lookups to silently fail
- **Fix 1:** Normalize repo keys to lowercase in the `useIssuesPRs` hook on fetch, and use `.toLowerCase()` at all lookup sites (Home, ProjectDetail, IssuesPRsDashboard)
- **Fix 2:** Always render a `<section id="issues-prs">` wrapper in Dashboard.tsx so hash navigation works even during loading
- **Fix 3:** Remove duplicate `id="issues-prs"` from IssuesPRsDashboard component (now owned by Dashboard wrapper)
- **Fix 4:** Use `IssuesPRsData['repos']` type instead of `typeof d.repos[string]` for correct TypeScript typing

## Test plan

- [ ] Verify Dashboard "Issues & PRs Overview" table shows all repos with data
- [ ] Verify per-project pages show Issues & PRs section with charts
- [ ] Verify Home page summary table shows issue/PR counts
- [ ] Verify navigating to `/dashboard#issues-prs` scrolls to section even during loading