### PR TITLE
ci: add scheduled trigger for gh-pages deploy

### DIFF
--- a/.github/workflows/trigger-pages-deploy.yaml
+++ b/.github/workflows/trigger-pages-deploy.yaml
@@ -1,0 +1,32 @@
+# Copyright 2026 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Trigger gh-pages deploy
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger gh-pages deploy
+        run: gh workflow run deploy.yaml --ref gh-pages --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- GitHub Actions cron only runs on the default branch
- The gh-pages deploy workflow schedule was silently ignored
- Add a workflow on main that triggers gh-pages deploy every 6 hours via workflow_dispatch

## Test plan
- [ ] Manually trigger via workflow_dispatch to verify it works
- [ ] Wait for next cron cycle and confirm gh-pages deploy runs