### PR TITLE
Dashboard: enriched image builds, layout fixes, and dark mode improvements

### DIFF
--- a/artifact_fetcher.go
+++ b/artifact_fetcher.go
@@ -1330,7 +1330,6 @@ func writeJSON(path string, v any) error {
 	return enc.Encode(v)
 }
 
-
 var (
 	semverRe = regexp.MustCompile(`^v?\d+\.\d+\.\d+`)
 	commitRe = regexp.MustCompile(`^([0-9a-f]{7,40})`)

--- a/public/data/images.json
+++ b/public/data/images.json
@@ -4,13 +4,17 @@
       "repo": "nvidia/gpu-operator",
       "tag": "9ee21750",
       "pushedAt": "2025-05-21T00:35:17Z",
-      "htmlUrl": "https://github.com/nvidia/gpu-operator/pkgs/container/gpu-operator/420112772?tag=9ee21750"
+      "htmlUrl": "https://github.com/nvidia/gpu-operator/pkgs/container/gpu-operator/420112772?tag=9ee21750",
+      "imageType": "ci",
+      "commitUrl": "https://github.com/nvidia/gpu-operator/commit/9ee21750"
     },
     {
       "repo": "nvidia/k8s-device-plugin",
       "tag": "6f41f70c-ubi9",
       "pushedAt": "2025-05-15T14:57:43Z",
-      "htmlUrl": "https://github.com/nvidia/k8s-device-plugin/pkgs/container/k8s-device-plugin/416491509?tag=6f41f70c-ubi9"
+      "htmlUrl": "https://github.com/nvidia/k8s-device-plugin/pkgs/container/k8s-device-plugin/416491509?tag=6f41f70c-ubi9",
+      "imageType": "ci",
+      "commitUrl": "https://github.com/nvidia/k8s-device-plugin/commit/6f41f70c"
     }
   ]
 }

--- a/src/hooks/useData.ts
+++ b/src/hooks/useData.ts
@@ -116,7 +116,7 @@ export function useIssuesPRs() {
       .then((d) => {
         // Normalize repo keys to lowercase for consistent lookups
         const normalized: IssuesPRsData['repos'] = {};
-        for (const [key, value] of Object.entries(d.repos)) {
+        for (const [key, value] of Object.entries(d.repos ?? {})) {
           normalized[key.toLowerCase()] = value;
         }
         setData({ repos: normalized });

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -368,10 +368,10 @@ export default function Dashboard() {
                     <td className="px-4 py-3 text-sm">
                       <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
                         img.imageType === 'release'
-                          ? 'bg-green-100 text-status-pass dark:bg-green-900/30'
+                          ? 'bg-green-100 text-status-pass dark:bg-green-900/30 dark:text-green-300'
                           : img.imageType === 'ci'
                             ? 'bg-gray-100 text-gray-600 dark:bg-gray-600 dark:text-gray-300'
-                            : 'bg-amber-100 text-status-warn dark:bg-amber-900/30'
+                            : 'bg-amber-100 text-status-warn dark:bg-amber-900/30 dark:text-amber-300'
                       }`}>
                         {img.imageType === 'release' ? 'Release' : img.imageType === 'ci' ? 'CI' : 'Dev'}
                       </span>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -346,6 +346,8 @@ export default function Dashboard() {
                 <tr>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Repo</th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Tag</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Type</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Source</th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Pushed At</th>
                 </tr>
               </thead>
@@ -362,6 +364,31 @@ export default function Dashboard() {
                       >
                         {img.tag}
                       </a>
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                        img.imageType === 'release'
+                          ? 'bg-green-100 text-status-pass dark:bg-green-900/30'
+                          : img.imageType === 'ci'
+                            ? 'bg-gray-100 text-gray-600 dark:bg-gray-600 dark:text-gray-300'
+                            : 'bg-amber-100 text-status-warn dark:bg-amber-900/30'
+                      }`}>
+                        {img.imageType === 'release' ? 'Release' : img.imageType === 'ci' ? 'CI' : 'Dev'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      {img.commitUrl ? (
+                        <a
+                          href={img.commitUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-nvidia-green hover:text-nvidia-green-dark font-mono text-xs"
+                        >
+                          {img.tag.match(/^[0-9a-f]{7,}/)?.[0]?.slice(0, 8) ?? img.tag}
+                        </a>
+                      ) : (
+                        <span className="text-gray-400 dark:text-gray-500">—</span>
+                      )}
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{img.pushedAt}</td>
                   </tr>

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -237,10 +237,10 @@ export default function ProjectDetail() {
                     <td className="px-4 py-3 text-sm">
                       <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
                         img.imageType === 'release'
-                          ? 'bg-green-100 text-status-pass dark:bg-green-900/30'
+                          ? 'bg-green-100 text-status-pass dark:bg-green-900/30 dark:text-green-300'
                           : img.imageType === 'ci'
                             ? 'bg-gray-100 text-gray-600 dark:bg-gray-600 dark:text-gray-300'
-                            : 'bg-amber-100 text-status-warn dark:bg-amber-900/30'
+                            : 'bg-amber-100 text-status-warn dark:bg-amber-900/30 dark:text-amber-300'
                       }`}>
                         {img.imageType === 'release' ? 'Release' : img.imageType === 'ci' ? 'CI' : 'Dev'}
                       </span>

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -216,6 +216,8 @@ export default function ProjectDetail() {
               <thead className="bg-gray-50 dark:bg-gray-700">
                 <tr>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Tag</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Type</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Source</th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Pushed At</th>
                 </tr>
               </thead>
@@ -231,6 +233,31 @@ export default function ProjectDetail() {
                       >
                         {img.tag}
                       </a>
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                        img.imageType === 'release'
+                          ? 'bg-green-100 text-status-pass dark:bg-green-900/30'
+                          : img.imageType === 'ci'
+                            ? 'bg-gray-100 text-gray-600 dark:bg-gray-600 dark:text-gray-300'
+                            : 'bg-amber-100 text-status-warn dark:bg-amber-900/30'
+                      }`}>
+                        {img.imageType === 'release' ? 'Release' : img.imageType === 'ci' ? 'CI' : 'Dev'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      {img.commitUrl ? (
+                        <a
+                          href={img.commitUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-nvidia-green hover:text-nvidia-green-dark font-mono text-xs"
+                        >
+                          {img.tag.match(/^[0-9a-f]{7,}/)?.[0]?.slice(0, 8) ?? img.tag}
+                        </a>
+                      ) : (
+                        <span className="text-gray-400 dark:text-gray-500">—</span>
+                      )}
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{img.pushedAt}</td>
                   </tr>

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -35,7 +35,7 @@ export default function ProjectDetail() {
   const repoInfo = repos.find((r) => r.fullName.toLowerCase() === repoKey);
   const projectWorkflows = workflows.filter((w) => w.repo.toLowerCase() === repoKey);
   const projectImages = images.filter((i) => i.repo.toLowerCase() === repoKey);
-  const projectIssuesPRs = issuesPRs?.repos[project.repo.toLowerCase()] ?? null;
+  const projectIssuesPRs = issuesPRs?.repos[repoKey] ?? null;
 
   const workflowTrend = useMemo(() => {
     if (!history) return [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,8 @@ export interface ImageBuild {
   tag: string;
   pushedAt: string;
   htmlUrl: string;
+  imageType: 'release' | 'ci' | 'dev';
+  commitUrl: string;
 }
 
 export interface RepoInfo {


### PR DESCRIPTION
## Summary

- **Enriched image builds**: Add image type badges (Release/CI/Dev) and source commit links to both the dashboard Latest Image Builds and per-project Container Images tables. Tags are classified by pattern (semver = release, commit SHA = CI, other = dev) and linked back to the GitHub commit or release page. No additional API calls — metadata is parsed from existing tag strings.
- **Layout and UX fixes**: Center page content via Layout, sort workflow status by newest first, normalize repo keys to lowercase for issues/PRs hash navigation, configure Tailwind v4 dark mode class strategy.
- **CI cleanup**: Remove dead schedule trigger from deploy workflow.

## Test plan

- [ ] Verify go build ./artifact_fetcher.go passes
- [ ] Verify npm run build produces clean output
- [ ] Verify dashboard Latest Image Builds shows 5 columns (Repo, Tag, Type, Source, Pushed At) with colored badges
- [ ] Verify per-project Container Images shows 4 columns (Tag, Type, Source, Pushed At) with colored badges
- [ ] Verify dark mode badge text contrast for Release (green) and Dev (amber) badges
- [ ] Verify Source column links to correct GitHub commit/release pages