### PR TITLE
docs(gpu-mock): fix broken NOTES.txt, add chart README and root README

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,3 +16,12 @@ version: "2"
 
 run:
   timeout: 5m
+
+linters:
+  settings:
+    staticcheck:
+      checks:
+        - "all"
+        - "-ST1000"
+        - "-ST1003"
+        - "-QF*"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
 # k8s-test-infra
+
+Kubernetes test infrastructure for NVIDIA GPU software — mock GPU environments,
+CI tooling, and testing utilities.
+
+## GPU Mock
+
+Turn any Kubernetes cluster into a multi-GPU environment for testing.
+No physical NVIDIA hardware required.
+
+```bash
+# 1. Build the image (no published image yet)
+docker build -t gpu-mock:local -f deployments/gpu-mock/Dockerfile .
+
+# 2. Load into KIND
+kind create cluster --name gpu-test
+kind load docker-image gpu-mock:local --name gpu-test
+
+# 3. Install
+helm install gpu-mock deployments/gpu-mock/helm/gpu-mock \
+  --set image.repository=gpu-mock \
+  --set image.tag=local
+```
+
+After install, deploy a consumer to test:
+
+| Consumer | Guide |
+|----------|-------|
+| **NVIDIA Device Plugin** | [Quick Start](deployments/gpu-mock/helm/gpu-mock/README.md#quick-start-device-plugin-on-kind) |
+| **NVIDIA DRA Driver** | [Quick Start](deployments/gpu-mock/helm/gpu-mock/README.md#quick-start-dra-driver-on-kind) |
+
+**Full documentation:** [gpu-mock Helm chart README](deployments/gpu-mock/helm/gpu-mock/README.md)
+
+## Mock NVML Library
+
+The underlying CGo-based mock `libnvidia-ml.so` that powers gpu-mock.
+Use standalone for local development and CI pipelines.
+
+| Document | Description |
+|----------|-------------|
+| [Overview](docs/mocknvml/README.md) | What Mock NVML is and how to use it |
+| [Quick Start](docs/mocknvml/quickstart.md) | Build and run in 5 minutes |
+| [Configuration](docs/mocknvml/configuration.md) | YAML configuration reference |
+| [Architecture](docs/mocknvml/architecture.md) | System design and components |
+
+## License
+
+Apache License 2.0 — see [LICENSE](LICENSE).

--- a/deployments/gpu-mock/helm/gpu-mock/README.md
+++ b/deployments/gpu-mock/helm/gpu-mock/README.md
@@ -1,0 +1,245 @@
+# gpu-mock Helm Chart
+
+Mock GPU infrastructure for Kubernetes testing. Turns any cluster into a
+multi-GPU environment using a CGo-based mock NVML library — no physical
+NVIDIA hardware required.
+
+## What It Does
+
+Deploys a DaemonSet that creates on every node:
+- Mock `libnvidia-ml.so` shared library at `/var/lib/nvidia-mock/driver/usr/lib64/`
+- Device nodes (`/dev/nvidia0`, `/dev/nvidia1`, ..., `/dev/nvidiactl`)
+- GPU configuration at `/var/lib/nvidia-mock/driver/config/config.yaml`
+- Node label `nvidia.com/gpu.present=true`
+
+Consumers (DRA driver, device plugin) point at `/var/lib/nvidia-mock/driver`
+as the NVIDIA driver root and discover GPUs through standard NVML APIs.
+
+## Prerequisites
+
+| Tool | Version | Required For |
+|------|---------|-------------|
+| [Docker](https://docs.docker.com/get-docker/) | 20.10+ | Building the image |
+| [Kind](https://kind.sigs.k8s.io/) | 0.20+ | Local cluster (or use your own) |
+| [kubectl](https://kubernetes.io/docs/tasks/tools/) | 1.31+ | Cluster access |
+| [Helm](https://helm.sh/docs/intro/install/) | 3.x | Chart installation |
+| [Go](https://go.dev/dl/) | 1.23+ | Building from source |
+| [jq](https://jqlang.github.io/jq/) | any | DRA verification only |
+
+**Cluster requirements:**
+- Privileged pods must be allowed (gpu-mock DaemonSet uses `privileged: true` for `mknod`)
+- For DRA: Kubernetes 1.31+ with `DynamicResourceAllocation` feature gate enabled
+
+## Quick Start: Device Plugin on KIND
+
+This path uses the NVIDIA device plugin to expose mock GPUs as
+`nvidia.com/gpu` allocatable resources. Tested in CI via
+`.github/workflows/gpu-mock-e2e.yaml` → `e2e-device-plugin` job.
+
+### 1. Create a KIND cluster
+
+```bash
+kind create cluster --name gpu-mock-test
+```
+
+### 2. Build and load the gpu-mock image
+
+There is no published image yet. Build from source:
+
+```bash
+# From the repository root
+docker build -t gpu-mock:local -f deployments/gpu-mock/Dockerfile .
+kind load docker-image gpu-mock:local --name gpu-mock-test
+```
+
+### 3. Install gpu-mock
+
+```bash
+helm install gpu-mock deployments/gpu-mock/helm/gpu-mock \
+  --set image.repository=gpu-mock \
+  --set image.tag=local \
+  --wait --timeout 120s
+```
+
+### 4. Verify gpu-mock is running
+
+```bash
+kubectl rollout status daemonset/gpu-mock --timeout=60s
+kubectl get nodes -o custom-columns=\
+  NAME:.metadata.name,\
+  GPU_PRESENT:.metadata.labels.nvidia\.com/gpu\.present
+```
+
+Expected: `GPU_PRESENT` shows `true`.
+
+### 5. Deploy the device plugin
+
+```bash
+kubectl apply -f tests/e2e/device-plugin-mock.yaml
+kubectl -n kube-system wait --for=condition=ready \
+  pod -l name=nvidia-device-plugin-mock --timeout=120s
+```
+
+### 6. Verify allocatable GPUs
+
+```bash
+NODE=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+kubectl get node "$NODE" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}'
+```
+
+Expected: `8` (default gpu.count).
+
+### 7. Clean up
+
+```bash
+kind delete cluster --name gpu-mock-test
+```
+
+## Quick Start: DRA Driver on KIND
+
+This path uses the NVIDIA DRA (Dynamic Resource Allocation) driver to expose
+mock GPUs as ResourceSlices. DRA requires a cluster with specific feature
+gates. Tested in CI via `.github/workflows/gpu-mock-e2e.yaml` → `e2e-dra` job.
+
+### 1. Create a KIND cluster with DRA enabled
+
+```bash
+kind create cluster --name gpu-mock-dra --config tests/e2e/kind-dra-config.yaml
+```
+
+This config enables:
+- `DynamicResourceAllocation` feature gate
+- CDI (Container Device Interface) in containerd
+- `resource.k8s.io/v1beta1` API
+
+### 2. Build and load the gpu-mock image
+
+```bash
+docker build -t gpu-mock:local -f deployments/gpu-mock/Dockerfile .
+kind load docker-image gpu-mock:local --name gpu-mock-dra
+```
+
+### 3. Install gpu-mock
+
+```bash
+helm install gpu-mock deployments/gpu-mock/helm/gpu-mock \
+  --set image.repository=gpu-mock \
+  --set image.tag=local \
+  --wait --timeout 120s
+```
+
+### 4. Verify gpu-mock is running
+
+```bash
+kubectl rollout status daemonset/gpu-mock --timeout=60s
+```
+
+### 5. Install the DRA driver
+
+```bash
+helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+helm repo update
+
+helm install nvidia-dra-driver nvidia/nvidia-dra-driver-gpu \
+  --namespace nvidia \
+  --create-namespace \
+  --set nvidiaDriverRoot=/var/lib/nvidia-mock/driver \
+  --set gpuResourcesEnabledOverride=true \
+  --set resources.computeDomains.enabled=false \
+  --wait --timeout 180s
+```
+
+### 6. Verify ResourceSlices
+
+```bash
+kubectl -n nvidia wait --for=condition=ready pod --all --timeout=120s
+kubectl get resourceslices -o json | \
+  jq '[.items[].spec.devices // [] | length] | add // 0'
+```
+
+Expected: `8` (default gpu.count).
+
+### 7. Clean up
+
+```bash
+kind delete cluster --name gpu-mock-dra
+```
+
+## Configuration
+
+### Values
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `gpu.profile` | `a100` | GPU profile: `a100` or `gb200` |
+| `gpu.count` | `8` | Number of mock GPUs per node |
+| `gpu.customConfig` | `""` | Inline YAML to override profile config |
+| `image.repository` | `ghcr.io/nvidia/gpu-mock` | Container image repository |
+| `image.tag` | `latest` | Container image tag |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy |
+| `driverVersion` | `"550.163.01"` | NVIDIA driver version to mock |
+| `nodeSelector` | `{}` | Node selector for DaemonSet |
+| `tolerations` | `[{operator: Exists}]` | Pod tolerations (default: tolerate all) |
+
+### GPU Profiles
+
+**A100** (`gpu.profile: a100`): NVIDIA A100-SXM4-40GB, Ampere, 40 GiB HBM2e, 12 NVLink v3 links
+
+**GB200** (`gpu.profile: gb200`): NVIDIA GB200 NVL, Blackwell, 192 GiB HBM3e, 18 NVLink v5 links
+
+### Custom Configuration
+
+Override the profile entirely with inline YAML:
+
+```bash
+helm install gpu-mock deployments/gpu-mock/helm/gpu-mock \
+  --set-file gpu.customConfig=my-custom-gpus.yaml
+```
+
+See `deployments/gpu-mock/helm/gpu-mock/profiles/` for profile format.
+
+## How It Works
+
+The chart deploys:
+
+1. **DaemonSet** — runs a privileged container on each node that:
+   - Copies `libnvidia-ml.so.{version}` to the host at `/var/lib/nvidia-mock/driver/usr/lib64/`
+   - Creates symlinks (`libnvidia-ml.so.1` → `libnvidia-ml.so.{version}`)
+   - Creates device nodes (`/dev/nvidia0` ... `/dev/nvidiaX`, `/dev/nvidiactl`)
+   - Writes GPU config YAML at `/var/lib/nvidia-mock/driver/config/config.yaml`
+   - Labels the node `nvidia.com/gpu.present=true`
+2. **ConfigMap** — GPU configuration from the selected profile
+3. **RBAC** — ServiceAccount with permission to patch node labels
+
+Consumer components (DRA driver, device plugin) mount `/var/lib/nvidia-mock`
+and use `--nvidia-driver-root=/var/lib/nvidia-mock/driver` to discover GPUs
+through standard NVML `tryResolveLibrary` paths.
+
+## Troubleshooting
+
+**ImagePullBackOff**: No published image exists yet. Build from source (see Quick Start).
+
+**DaemonSet not ready**: Check pod logs: `kubectl logs -l app.kubernetes.io/name=gpu-mock`
+
+**Device plugin shows 0 GPUs**: Verify mock files exist on the node:
+```bash
+NODE_CONTAINER=$(docker ps --filter name=control-plane -q)
+docker exec "$NODE_CONTAINER" ls /var/lib/nvidia-mock/driver/usr/lib64/libnvidia-ml.so.*
+docker exec "$NODE_CONTAINER" cat /var/lib/nvidia-mock/driver/config/config.yaml
+```
+
+**DRA driver pods not ready**: Check DRA logs:
+```bash
+kubectl -n nvidia logs -l app.kubernetes.io/name=nvidia-dra-driver-gpu --tail=100
+```
+
+**Privileged pods blocked**: Your cluster may have PodSecurity or OPA/Gatekeeper
+policies blocking `privileged: true`. KIND allows this by default. For managed
+clusters, you may need to create a PodSecurity exception for the gpu-mock namespace.
+
+## Related Documentation
+
+- [Mock NVML Library Documentation](../../../../docs/mocknvml/README.md)
+- [E2E Test Workflow](../../../../.github/workflows/gpu-mock-e2e.yaml)
+- [KIND DRA Config](../../../../tests/e2e/kind-dra-config.yaml)
+- [Device Plugin Mock Manifest](../../../../tests/e2e/device-plugin-mock.yaml)

--- a/deployments/gpu-mock/helm/gpu-mock/README.md
+++ b/deployments/gpu-mock/helm/gpu-mock/README.md
@@ -65,9 +65,7 @@ helm install gpu-mock deployments/gpu-mock/helm/gpu-mock \
 
 ```bash
 kubectl rollout status daemonset/gpu-mock --timeout=60s
-kubectl get nodes -o custom-columns=\
-  NAME:.metadata.name,\
-  GPU_PRESENT:.metadata.labels.nvidia\.com/gpu\.present
+kubectl get nodes -o 'custom-columns=NAME:.metadata.name,GPU_PRESENT:.metadata.labels.nvidia\.com/gpu\.present'
 ```
 
 Expected: `GPU_PRESENT` shows `true`.
@@ -152,6 +150,8 @@ helm install nvidia-dra-driver nvidia/nvidia-dra-driver-gpu \
 ### 6. Verify ResourceSlices
 
 ```bash
+# DRA pods may take a few seconds to appear after helm install completes
+sleep 5
 kubectl -n nvidia wait --for=condition=ready pod --all --timeout=120s
 kubectl get resourceslices -o json | \
   jq '[.items[].spec.devices // [] | length] | add // 0'

--- a/deployments/gpu-mock/helm/gpu-mock/README.md
+++ b/deployments/gpu-mock/helm/gpu-mock/README.md
@@ -171,32 +171,141 @@ kind delete cluster --name gpu-mock-dra
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `gpu.profile` | `a100` | GPU profile: `a100` or `gb200` |
+| `gpu.profile` | `a100` | GPU profile: `a100`, `h100`, `b200`, or `gb200` |
 | `gpu.count` | `8` | Number of mock GPUs per node |
-| `gpu.customConfig` | `""` | Inline YAML to override profile config |
+| `gpu.customConfig` | `""` | Inline YAML to override profile config entirely |
 | `image.repository` | `ghcr.io/nvidia/gpu-mock` | Container image repository |
 | `image.tag` | `latest` | Container image tag |
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy |
-| `driverVersion` | `"550.163.01"` | NVIDIA driver version to mock |
+| `driverVersion` | `"550.163.01"` | NVIDIA driver version string to mock |
 | `nodeSelector` | `{}` | Node selector for DaemonSet |
 | `tolerations` | `[{operator: Exists}]` | Pod tolerations (default: tolerate all) |
 
 ### GPU Profiles
 
-**A100** (`gpu.profile: a100`): NVIDIA A100-SXM4-40GB, Ampere, 40 GiB HBM2e, 12 NVLink v3 links
+Built-in profiles provide realistic hardware specs for common data center GPUs.
+Select a profile with `--set gpu.profile=<name>`:
 
-**GB200** (`gpu.profile: gb200`): NVIDIA GB200 NVL, Blackwell, 192 GiB HBM3e, 18 NVLink v5 links
+```bash
+# Deploy as an 8-GPU H100 node
+helm install gpu-mock deployments/gpu-mock/helm/gpu-mock \
+  --set image.repository=gpu-mock \
+  --set image.tag=local \
+  --set gpu.profile=h100
+
+# Deploy as a 4-GPU B200 node
+helm install gpu-mock deployments/gpu-mock/helm/gpu-mock \
+  --set image.repository=gpu-mock \
+  --set image.tag=local \
+  --set gpu.profile=b200 \
+  --set gpu.count=4
+```
+
+#### Profile Comparison
+
+| | A100 | H100 | B200 | GB200 |
+|---|---|---|---|---|
+| **Profile name** | `a100` | `h100` | `b200` | `gb200` |
+| **Full name** | A100-SXM4-40GB | H100 80GB HBM3 | B200 | GB200 NVL |
+| **Architecture** | Ampere | Hopper | Blackwell | Blackwell |
+| **Compute capability** | 8.0 | 9.0 | 10.0 | 10.0 |
+| **CUDA cores** | 6,912 | 16,896 | 18,432 | 18,432 |
+| **Memory** | 40 GiB HBM2e | 80 GiB HBM3 | 192 GiB HBM3e | 192 GiB HBM3e |
+| **NVLink** | v3, 12 links | v4, 18 links | v5, 18 links | v5, 18 links |
+| **NVLink BW** | 600 GB/s | 900 GB/s | 1.8 TB/s | 1.8 TB/s |
+| **TDP** | 400W | 700W | 1,000W | 1,000W |
+| **PCIe** | Gen4 | Gen5 | Gen6 | Gen6 |
+| **MIG instances** | 7 | 7 | 7 | 7 |
+| **Grace CPU** | — | — | — | Yes (NVLink-C2C) |
+| **FP8** | — | Yes | Yes | Yes |
+| **FP4** | — | — | Yes | Yes |
+| **Driver version** | 550.163.01 | 550.163.01 | 560.35.03 | 560.35.03 |
+
+#### When to Use Each Profile
+
+- **`a100`** (default) — broadest compatibility. Most NVIDIA software assumes A100 in docs and examples. Use this unless you need a specific architecture.
+- **`h100`** — testing Hopper-specific features: FP8, Transformer Engine, PCIe Gen5, or NVLink v4 topology.
+- **`b200`** — testing next-gen Blackwell features: FP4, NVLink v5, PCIe Gen6. Standalone GPU (no Grace CPU).
+- **`gb200`** — testing Grace-Blackwell Superchip: NVLink-C2C to Grace CPU, unified memory, and Blackwell features.
 
 ### Custom Configuration
 
-Override the profile entirely with inline YAML:
+For GPU types not covered by built-in profiles, provide your own config YAML.
+
+#### Option A: File-based (recommended)
+
+Create a YAML file following the profile format, then pass it at install time:
 
 ```bash
 helm install gpu-mock deployments/gpu-mock/helm/gpu-mock \
+  --set image.repository=gpu-mock \
+  --set image.tag=local \
   --set-file gpu.customConfig=my-custom-gpus.yaml
 ```
 
-See `deployments/gpu-mock/helm/gpu-mock/profiles/` for profile format.
+#### Option B: Inline values
+
+For small overrides, embed the config directly in a values file:
+
+```yaml
+# custom-values.yaml
+gpu:
+  count: 4
+  customConfig: |
+    version: "1.0"
+    system:
+      driver_version: "550.163.01"
+      nvml_version: "12.550.163.01"
+      cuda_version: "12.4"
+      cuda_version_major: 12
+      cuda_version_minor: 4
+    device_defaults:
+      name: "NVIDIA L40S"
+      architecture: "ada_lovelace"
+      compute_capability:
+        major: 8
+        minor: 9
+      num_gpu_cores: 18176
+      memory:
+        total_bytes: 48318382080
+        reserved_bytes: 536870912
+        free_bytes: 47781511168
+        used_bytes: 0
+    devices:
+      - index: 0
+        uuid: "GPU-L40S-0000-0000-0000-000000000000"
+        minor_number: 0
+```
+
+```bash
+helm install gpu-mock deployments/gpu-mock/helm/gpu-mock \
+  --set image.repository=gpu-mock \
+  --set image.tag=local \
+  -f custom-values.yaml
+```
+
+#### Writing a Custom Profile
+
+Use an existing profile as your starting point:
+
+```bash
+cp deployments/gpu-mock/helm/gpu-mock/profiles/a100.yaml my-custom-gpus.yaml
+```
+
+Key fields to change:
+
+| Field | What to set |
+|-------|-------------|
+| `device_defaults.name` | GPU name shown in `nvidia-smi` |
+| `device_defaults.architecture` | Architecture string (`ampere`, `hopper`, `blackwell`, etc.) |
+| `device_defaults.compute_capability` | `major` / `minor` version |
+| `device_defaults.num_gpu_cores` | CUDA core count |
+| `device_defaults.memory.total_bytes` | Total GPU memory in bytes |
+| `devices` | One entry per GPU (match `gpu.count`) with unique UUIDs |
+| `nvlink` | NVLink version and links (or omit for PCIe-only GPUs) |
+
+The full YAML schema matches the fields exposed by `nvidia-smi -x -q`. See the built-in
+profiles in `deployments/gpu-mock/helm/gpu-mock/profiles/` for complete examples.
 
 ## How It Works
 

--- a/deployments/gpu-mock/helm/gpu-mock/profiles/b200.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/profiles/b200.yaml
@@ -1,0 +1,386 @@
+# Mock NVML Configuration: B200
+# Full configuration for nvidia-smi -x -q compatibility
+# Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
+
+version: "1.0"
+
+# =============================================================================
+# System-level configuration
+# =============================================================================
+system:
+  driver_version: "560.35.03"
+  nvml_version: "12.560.35.03"
+  cuda_version: "12.6"
+  cuda_version_major: 12
+  cuda_version_minor: 6
+
+# =============================================================================
+# Default device configuration (applied to all devices unless overridden)
+# =============================================================================
+device_defaults:
+  # ---------------------------------------------------------------------------
+  # Basic identification
+  # ---------------------------------------------------------------------------
+  name: "NVIDIA B200"
+  brand: "nvidia"
+  serial: "1562849203750"
+  board_part_number: "699-2G540-0200-000"
+  vbios_version: "96.00.A0.00.01"
+
+  # ---------------------------------------------------------------------------
+  # Architecture
+  # ---------------------------------------------------------------------------
+  architecture: "blackwell"
+  compute_capability:
+    major: 10
+    minor: 0
+  num_gpu_cores: 18432              # CUDA cores
+
+  # ---------------------------------------------------------------------------
+  # InfoROM versions
+  # ---------------------------------------------------------------------------
+  inforom:
+    image_version: "B200.0200.00.01"
+    oem_object: "2.1"
+    ecc_object: "7.16"
+    pwr_object: "1.0"
+
+  # ---------------------------------------------------------------------------
+  # Memory configuration - 192 GiB HBM3e
+  # ---------------------------------------------------------------------------
+  memory:
+    total_bytes: 206158430208       # 192 GiB HBM3e
+    reserved_bytes: 1073741824      # ~1 GiB reserved
+    free_bytes: 205084688384        # total - reserved at idle
+    used_bytes: 0
+
+  bar1_memory:
+    total_bytes: 274877906944       # 256 GiB (standalone B200, not 512 GiB like GB200)
+    free_bytes: 274877906944
+    used_bytes: 0
+
+  # ---------------------------------------------------------------------------
+  # PCI configuration
+  # ---------------------------------------------------------------------------
+  pci:
+    device_id: 0x234010DE           # B200 standalone
+    subsystem_id: 0x181810DE
+
+  pcie:
+    max_link_gen: 6                 # PCIe Gen6
+    current_link_gen: 6
+    max_link_width: 16              # x16
+    current_link_width: 16
+    replay_counter: 0
+    tx_throughput_kbps: 0
+    rx_throughput_kbps: 0
+
+  # ---------------------------------------------------------------------------
+  # Power configuration - 1000W TDP
+  # ---------------------------------------------------------------------------
+  power:
+    management_supported: true
+    management_mode: "enabled"
+    default_limit_mw: 1000000       # 1000W
+    enforced_limit_mw: 1000000
+    min_limit_mw: 400000            # 400W minimum
+    max_limit_mw: 1200000           # 1200W max
+    current_draw_mw: 130000         # 130W idle
+    power_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Thermal configuration
+  # ---------------------------------------------------------------------------
+  thermal:
+    temperature_gpu_c: 35           # Idle temperature
+    temperature_memory_c: 33
+    shutdown_threshold_c: 95
+    slowdown_threshold_c: 90
+    max_operating_c: 85
+    target_temperature_c: 85
+
+  # ---------------------------------------------------------------------------
+  # Fan configuration (N/A - liquid cooled)
+  # ---------------------------------------------------------------------------
+  fan:
+    count: 0                        # Liquid cooled, no fans
+    speed_percent: "N/A"
+    target_speed_percent: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Clock speeds (MHz) - Blackwell
+  # ---------------------------------------------------------------------------
+  clocks:
+    graphics_current: 345           # Idle
+    graphics_max: 2100
+    graphics_app: 2100
+    graphics_app_default: 2100
+    sm_current: 345
+    sm_max: 2100
+    memory_current: 2500            # HBM3e
+    memory_max: 2500
+    memory_app: 2500
+    memory_app_default: 2500
+    video_current: 1200
+    video_max: 2100
+
+  # ---------------------------------------------------------------------------
+  # Clocks throttle reasons
+  # ---------------------------------------------------------------------------
+  clocks_throttle_reasons:
+    gpu_idle: true
+    applications_clocks_setting: false
+    sw_power_cap: false
+    hw_slowdown: false
+    hw_thermal_slowdown: false
+    hw_power_brake_slowdown: false
+    sync_boost: false
+    sw_thermal_slowdown: false
+    display_clocks_setting: false
+
+  # ---------------------------------------------------------------------------
+  # Supported clocks
+  # ---------------------------------------------------------------------------
+  supported_clocks:
+    memory_clocks:
+      - freq_mhz: 2500
+        graphics_clocks: [345, 690, 1035, 1380, 1725, 1890, 2100]
+
+  # ---------------------------------------------------------------------------
+  # Performance state
+  # ---------------------------------------------------------------------------
+  performance_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Utilization (percentage, 0-100)
+  # ---------------------------------------------------------------------------
+  utilization:
+    gpu: 0
+    memory: 0
+    encoder: 0
+    decoder: 0
+    jpeg: 0
+    ofa: 0
+
+  # ---------------------------------------------------------------------------
+  # Encoder/Decoder statistics
+  # ---------------------------------------------------------------------------
+  encoder_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  fbc_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  # ---------------------------------------------------------------------------
+  # ECC configuration
+  # ---------------------------------------------------------------------------
+  ecc:
+    mode_current: "enabled"
+    mode_pending: "enabled"
+    default_mode: "enabled"
+    errors:
+      volatile:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+      aggregate:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+
+  # ---------------------------------------------------------------------------
+  # Retired pages
+  # ---------------------------------------------------------------------------
+  retired_pages:
+    single_bit_retirement:
+      count: 0
+      addresses: []
+    double_bit_retirement:
+      count: 0
+      addresses: []
+    pending_blacklist: false
+    pending_retirement: false
+
+  # ---------------------------------------------------------------------------
+  # Remapped rows
+  # ---------------------------------------------------------------------------
+  remapped_rows:
+    correctable: 0
+    uncorrectable: 0
+    pending: false
+    failure_occurred: false
+
+  # ---------------------------------------------------------------------------
+  # Display configuration
+  # ---------------------------------------------------------------------------
+  display:
+    mode: "disabled"
+    active: "disabled"
+
+  # ---------------------------------------------------------------------------
+  # Persistence mode
+  # ---------------------------------------------------------------------------
+  persistence_mode: "enabled"
+
+  # ---------------------------------------------------------------------------
+  # Compute mode
+  # ---------------------------------------------------------------------------
+  compute_mode: "default"
+
+  # ---------------------------------------------------------------------------
+  # MIG configuration
+  # ---------------------------------------------------------------------------
+  mig:
+    mode_current: "disabled"
+    mode_pending: "disabled"
+    max_gpu_instances: 7
+
+  # ---------------------------------------------------------------------------
+  # GPU operation mode (GOM)
+  # ---------------------------------------------------------------------------
+  gpu_operation_mode:
+    current: "all_on"
+    pending: "all_on"
+
+  # ---------------------------------------------------------------------------
+  # Driver model (Windows only)
+  # ---------------------------------------------------------------------------
+  driver_model:
+    current: "N/A"
+    pending: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Accounting mode
+  # ---------------------------------------------------------------------------
+  accounting:
+    mode: "disabled"
+    buffer_size: 4000
+
+  # ---------------------------------------------------------------------------
+  # Virtualization
+  # ---------------------------------------------------------------------------
+  virtualization:
+    mode: "none"
+    host_vgpu_mode: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # GSP Firmware
+  # ---------------------------------------------------------------------------
+  gsp_firmware:
+    mode: "enabled"
+    version: "560.35.03"
+
+  # ---------------------------------------------------------------------------
+  # Blackwell-specific features (standalone B200 - no NVLink-C2C)
+  # ---------------------------------------------------------------------------
+  features:
+    transformer_engine: true
+    fp4_support: true
+    fp8_support: true
+    confidential_compute: true
+    decompression_engine: true
+    fifth_gen_tensor_cores: true
+
+  # ---------------------------------------------------------------------------
+  # Processes (empty at idle)
+  # ---------------------------------------------------------------------------
+  processes: []
+
+# =============================================================================
+# Device-specific overrides (indexed 0-7 for B200)
+# =============================================================================
+devices:
+  - index: 0
+    uuid: "GPU-B200-0000-0000-0000-000000000000"
+    serial: "1562849203700"
+    pci:
+      bus_id: "00000000:1A:00.0"
+    minor_number: 0
+
+  - index: 1
+    uuid: "GPU-B200-0000-0000-0000-000000000001"
+    serial: "1562849203701"
+    pci:
+      bus_id: "00000000:1B:00.0"
+    minor_number: 1
+
+  - index: 2
+    uuid: "GPU-B200-0000-0000-0000-000000000002"
+    serial: "1562849203702"
+    pci:
+      bus_id: "00000000:4A:00.0"
+    minor_number: 2
+
+  - index: 3
+    uuid: "GPU-B200-0000-0000-0000-000000000003"
+    serial: "1562849203703"
+    pci:
+      bus_id: "00000000:4B:00.0"
+    minor_number: 3
+
+  - index: 4
+    uuid: "GPU-B200-0000-0000-0000-000000000004"
+    serial: "1562849203704"
+    pci:
+      bus_id: "00000000:8A:00.0"
+    minor_number: 4
+
+  - index: 5
+    uuid: "GPU-B200-0000-0000-0000-000000000005"
+    serial: "1562849203705"
+    pci:
+      bus_id: "00000000:8B:00.0"
+    minor_number: 5
+
+  - index: 6
+    uuid: "GPU-B200-0000-0000-0000-000000000006"
+    serial: "1562849203706"
+    pci:
+      bus_id: "00000000:CA:00.0"
+    minor_number: 6
+
+  - index: 7
+    uuid: "GPU-B200-0000-0000-0000-000000000007"
+    serial: "1562849203707"
+    pci:
+      bus_id: "00000000:CB:00.0"
+    minor_number: 7
+
+# =============================================================================
+# NVLink topology - B200 NVLink 5 (GPU-to-GPU only, no C2C)
+# =============================================================================
+nvlink:
+  version: 5
+  links_per_gpu: 18
+  bandwidth_per_link_gbps: 100      # 100 GB/s per link = 1.8 TB/s total per GPU
+  links:
+    - link: 0
+      state: "active"
+      remote_device_type: "gpu"
+      remote_pci_bus_id: "00000000:1B:00.0"

--- a/deployments/gpu-mock/helm/gpu-mock/profiles/h100.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/profiles/h100.yaml
@@ -1,0 +1,383 @@
+# Mock NVML Configuration: HGX H100
+# Full configuration for nvidia-smi -x -q compatibility
+# Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
+
+version: "1.0"
+
+# =============================================================================
+# System-level configuration
+# =============================================================================
+system:
+  driver_version: "550.163.01"
+  nvml_version: "12.550.163.01"
+  cuda_version: "12.4"
+  cuda_version_major: 12
+  cuda_version_minor: 4
+
+# =============================================================================
+# Default device configuration (applied to all devices unless overridden)
+# =============================================================================
+device_defaults:
+  # ---------------------------------------------------------------------------
+  # Basic identification
+  # ---------------------------------------------------------------------------
+  name: "NVIDIA H100 80GB HBM3"
+  brand: "nvidia"
+  serial: "1562821083900"
+  board_part_number: "699-21010-0200-000"
+  vbios_version: "96.00.74.00.09"
+
+  # ---------------------------------------------------------------------------
+  # Architecture
+  # ---------------------------------------------------------------------------
+  architecture: "hopper"
+  compute_capability:
+    major: 9
+    minor: 0
+  num_gpu_cores: 16896              # CUDA cores
+
+  # ---------------------------------------------------------------------------
+  # InfoROM versions
+  # ---------------------------------------------------------------------------
+  inforom:
+    image_version: "H100.0200.00.04"
+    oem_object: "2.1"
+    ecc_object: "7.16"
+    pwr_object: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Memory configuration - 80 GiB HBM3
+  # ---------------------------------------------------------------------------
+  memory:
+    total_bytes: 85899345920        # 80 GiB HBM3
+    reserved_bytes: 1073741824      # ~1 GiB reserved
+    free_bytes: 84825604096         # total - reserved at idle
+    used_bytes: 0
+
+  bar1_memory:
+    total_bytes: 274877906944       # 256 GiB
+    free_bytes: 274877906944
+    used_bytes: 0
+
+  # ---------------------------------------------------------------------------
+  # PCI configuration
+  # ---------------------------------------------------------------------------
+  pci:
+    device_id: 0x233010DE           # H100 SXM 80GB
+    subsystem_id: 0x165810DE
+
+  pcie:
+    max_link_gen: 5                 # PCIe Gen5
+    current_link_gen: 5
+    max_link_width: 16              # x16
+    current_link_width: 16
+    replay_counter: 0
+    tx_throughput_kbps: 0
+    rx_throughput_kbps: 0
+
+  # ---------------------------------------------------------------------------
+  # Power configuration - 700W TDP
+  # ---------------------------------------------------------------------------
+  power:
+    management_supported: true
+    management_mode: "enabled"
+    default_limit_mw: 700000         # 700W
+    enforced_limit_mw: 700000
+    min_limit_mw: 200000            # 200W minimum
+    max_limit_mw: 700000            # 700W max
+    current_draw_mw: 95000          # 95W idle
+    power_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Thermal configuration
+  # ---------------------------------------------------------------------------
+  thermal:
+    temperature_gpu_c: 34           # Idle temperature
+    temperature_memory_c: 32
+    shutdown_threshold_c: 92
+    slowdown_threshold_c: 87
+    max_operating_c: 83
+    target_temperature_c: 83
+
+  # ---------------------------------------------------------------------------
+  # Fan configuration (N/A for SXM form factor)
+  # ---------------------------------------------------------------------------
+  fan:
+    count: 0                        # SXM has no fans (liquid cooled)
+    speed_percent: "N/A"
+    target_speed_percent: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Clock speeds (MHz)
+  # ---------------------------------------------------------------------------
+  clocks:
+    graphics_current: 345           # Idle
+    graphics_max: 1980
+    graphics_app: 1980
+    graphics_app_default: 1980
+    sm_current: 345
+    sm_max: 1980
+    memory_current: 1593            # HBM3
+    memory_max: 1593
+    memory_app: 1593
+    memory_app_default: 1593
+    video_current: 345
+    video_max: 1980
+
+  # ---------------------------------------------------------------------------
+  # Clocks throttle reasons
+  # ---------------------------------------------------------------------------
+  clocks_throttle_reasons:
+    gpu_idle: true
+    applications_clocks_setting: false
+    sw_power_cap: false
+    hw_slowdown: false
+    hw_thermal_slowdown: false
+    hw_power_brake_slowdown: false
+    sync_boost: false
+    sw_thermal_slowdown: false
+    display_clocks_setting: false
+
+  # ---------------------------------------------------------------------------
+  # Supported clocks (for nvidia-smi -q -d SUPPORTED_CLOCKS)
+  # ---------------------------------------------------------------------------
+  supported_clocks:
+    memory_clocks:
+      - freq_mhz: 1593
+        graphics_clocks: [345, 690, 1035, 1380, 1620, 1800, 1980]
+
+  # ---------------------------------------------------------------------------
+  # Performance state
+  # ---------------------------------------------------------------------------
+  performance_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Utilization (percentage, 0-100)
+  # ---------------------------------------------------------------------------
+  utilization:
+    gpu: 0
+    memory: 0
+    encoder: 0
+    decoder: 0
+    jpeg: 0
+    ofa: 0
+
+  # ---------------------------------------------------------------------------
+  # Encoder/Decoder statistics
+  # ---------------------------------------------------------------------------
+  encoder_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  fbc_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  # ---------------------------------------------------------------------------
+  # ECC configuration
+  # ---------------------------------------------------------------------------
+  ecc:
+    mode_current: "enabled"
+    mode_pending: "enabled"
+    default_mode: "enabled"
+    errors:
+      volatile:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+      aggregate:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+
+  # ---------------------------------------------------------------------------
+  # Retired pages
+  # ---------------------------------------------------------------------------
+  retired_pages:
+    single_bit_retirement:
+      count: 0
+      addresses: []
+    double_bit_retirement:
+      count: 0
+      addresses: []
+    pending_blacklist: false
+    pending_retirement: false
+
+  # ---------------------------------------------------------------------------
+  # Remapped rows
+  # ---------------------------------------------------------------------------
+  remapped_rows:
+    correctable: 0
+    uncorrectable: 0
+    pending: false
+    failure_occurred: false
+
+  # ---------------------------------------------------------------------------
+  # Display configuration
+  # ---------------------------------------------------------------------------
+  display:
+    mode: "disabled"
+    active: "disabled"
+
+  # ---------------------------------------------------------------------------
+  # Persistence mode
+  # ---------------------------------------------------------------------------
+  persistence_mode: "enabled"
+
+  # ---------------------------------------------------------------------------
+  # Compute mode
+  # ---------------------------------------------------------------------------
+  compute_mode: "default"
+
+  # ---------------------------------------------------------------------------
+  # MIG configuration
+  # ---------------------------------------------------------------------------
+  mig:
+    mode_current: "disabled"
+    mode_pending: "disabled"
+    max_gpu_instances: 7
+
+  # ---------------------------------------------------------------------------
+  # GPU operation mode (GOM)
+  # ---------------------------------------------------------------------------
+  gpu_operation_mode:
+    current: "all_on"
+    pending: "all_on"
+
+  # ---------------------------------------------------------------------------
+  # Driver model (Windows only)
+  # ---------------------------------------------------------------------------
+  driver_model:
+    current: "N/A"
+    pending: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Accounting mode
+  # ---------------------------------------------------------------------------
+  accounting:
+    mode: "disabled"
+    buffer_size: 4000
+
+  # ---------------------------------------------------------------------------
+  # Virtualization
+  # ---------------------------------------------------------------------------
+  virtualization:
+    mode: "none"
+    host_vgpu_mode: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # GSP Firmware
+  # ---------------------------------------------------------------------------
+  gsp_firmware:
+    mode: "enabled"
+    version: "550.163.01"
+
+  # ---------------------------------------------------------------------------
+  # Hopper-specific features
+  # ---------------------------------------------------------------------------
+  features:
+    transformer_engine: true
+    fp8_support: true
+    confidential_compute: true
+
+  # ---------------------------------------------------------------------------
+  # Processes (empty at idle)
+  # ---------------------------------------------------------------------------
+  processes: []
+
+# =============================================================================
+# Device-specific overrides (indexed 0-7 for HGX H100)
+# =============================================================================
+devices:
+  - index: 0
+    uuid: "GPU-H100-0000-0000-0000-000000000000"
+    serial: "1562821083900"
+    pci:
+      bus_id: "00000000:1A:00.0"
+    minor_number: 0
+
+  - index: 1
+    uuid: "GPU-H100-0000-0000-0000-000000000001"
+    serial: "1562821083901"
+    pci:
+      bus_id: "00000000:1B:00.0"
+    minor_number: 1
+
+  - index: 2
+    uuid: "GPU-H100-0000-0000-0000-000000000002"
+    serial: "1562821083902"
+    pci:
+      bus_id: "00000000:4A:00.0"
+    minor_number: 2
+
+  - index: 3
+    uuid: "GPU-H100-0000-0000-0000-000000000003"
+    serial: "1562821083903"
+    pci:
+      bus_id: "00000000:4B:00.0"
+    minor_number: 3
+
+  - index: 4
+    uuid: "GPU-H100-0000-0000-0000-000000000004"
+    serial: "1562821083904"
+    pci:
+      bus_id: "00000000:8A:00.0"
+    minor_number: 4
+
+  - index: 5
+    uuid: "GPU-H100-0000-0000-0000-000000000005"
+    serial: "1562821083905"
+    pci:
+      bus_id: "00000000:8B:00.0"
+    minor_number: 5
+
+  - index: 6
+    uuid: "GPU-H100-0000-0000-0000-000000000006"
+    serial: "1562821083906"
+    pci:
+      bus_id: "00000000:CA:00.0"
+    minor_number: 6
+
+  - index: 7
+    uuid: "GPU-H100-0000-0000-0000-000000000007"
+    serial: "1562821083907"
+    pci:
+      bus_id: "00000000:CB:00.0"
+    minor_number: 7
+
+# =============================================================================
+# NVLink topology - H100 NVLink 4
+# =============================================================================
+nvlink:
+  version: 4
+  links_per_gpu: 18
+  bandwidth_per_link_gbps: 50       # 50 GB/s per link = 900 GB/s total per GPU
+  links:
+    - link: 0
+      state: "active"
+      remote_device_type: "gpu"
+      remote_pci_bus_id: "00000000:1B:00.0"

--- a/deployments/gpu-mock/helm/gpu-mock/templates/NOTES.txt
+++ b/deployments/gpu-mock/helm/gpu-mock/templates/NOTES.txt
@@ -6,29 +6,62 @@ Mock GPU environment deployed on all nodes!
   Mock driver root: /var/lib/nvidia-mock/driver
   Mock config: /var/lib/nvidia-mock/config/config.yaml
 
-To use with NVIDIA Device Plugin:
+NOTE: If you installed from source (no published image yet), you built the
+image locally and loaded it into your cluster. See the chart README for
+build-from-source instructions.
 
-  helm install nvidia-device-plugin nvidia/k8s-device-plugin \
-    --set runtimeClassName="" \
-    --set args[0]="--nvidia-driver-root=/var/lib/nvidia-mock/driver" \
-    --set args[1]="--driver-root-ctr-path=/var/lib/nvidia-mock/driver" \
-    --set args[2]="--device-discovery-strategy=nvml"
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  No mock-specific env vars needed — the .so auto-discovers its config.
+OPTION A: NVIDIA Device Plugin
 
-To use with NVIDIA DRA Driver:
+  kubectl apply -f https://raw.githubusercontent.com/NVIDIA/k8s-test-infra/main/tests/e2e/device-plugin-mock.yaml
+  kubectl -n kube-system wait --for=condition=ready \
+    pod -l name=nvidia-device-plugin-mock --timeout=120s
 
-  helm install nvidia-dra-driver nvidia/nvidia-dra-driver-gpu \
-    --set nvidiaDriverRoot=/var/lib/nvidia-mock/driver
+  Verify allocatable GPUs:
 
-To use with GPU Operator:
+    NODE=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+    kubectl get node "$NODE" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}'
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+OPTION B: NVIDIA DRA Driver (requires DRA-enabled cluster)
+
+  Cluster prerequisites (KIND):
+    kind create cluster --config tests/e2e/kind-dra-config.yaml
+
+  Install:
+    helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+    helm repo update
+
+    helm install nvidia-dra-driver nvidia/nvidia-dra-driver-gpu \
+      --namespace nvidia \
+      --create-namespace \
+      --set nvidiaDriverRoot=/var/lib/nvidia-mock/driver \
+      --set gpuResourcesEnabledOverride=true \
+      --set resources.computeDomains.enabled=false \
+      --wait --timeout 180s
+
+  Verify ResourceSlices:
+
+    kubectl get resourceslices -o json | \
+      jq '[.items[].spec.devices // [] | length] | add // 0'
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+OPTION C: GPU Operator (UNTESTED — contributions welcome)
 
   helm install gpu-operator nvidia/gpu-operator \
     --set driver.enabled=false \
     --set toolkit.enabled=true \
     --set devicePlugin.enabled=true
 
-To verify mock GPUs are available:
+  ⚠ This integration has no E2E test coverage. If you get it working,
+  please contribute the test back.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Quick check — node labels:
 
   kubectl get nodes -o custom-columns=\
     NAME:.metadata.name,\

--- a/deployments/gpu-mock/helm/gpu-mock/templates/NOTES.txt
+++ b/deployments/gpu-mock/helm/gpu-mock/templates/NOTES.txt
@@ -63,6 +63,4 @@ OPTION C: GPU Operator (UNTESTED — contributions welcome)
 
 Quick check — node labels:
 
-  kubectl get nodes -o custom-columns=\
-    NAME:.metadata.name,\
-    GPU_PRESENT:.metadata.labels.nvidia\.com/gpu\.present
+  kubectl get nodes -o 'custom-columns=NAME:.metadata.name,GPU_PRESENT:.metadata.labels.nvidia\.com/gpu\.present'

--- a/deployments/gpu-mock/helm/gpu-mock/templates/NOTES.txt
+++ b/deployments/gpu-mock/helm/gpu-mock/templates/NOTES.txt
@@ -2,6 +2,7 @@ Mock GPU environment deployed on all nodes!
 
   Profile: {{ .Values.gpu.profile }}
   GPUs per node: {{ .Values.gpu.count }}
+  Available profiles: a100, h100, b200, gb200
   Driver version: {{ .Values.driverVersion }}
   Mock driver root: /var/lib/nvidia-mock/driver
   Mock config: /var/lib/nvidia-mock/config/config.yaml

--- a/deployments/gpu-mock/helm/gpu-mock/templates/_helpers.tpl
+++ b/deployments/gpu-mock/helm/gpu-mock/templates/_helpers.tpl
@@ -63,9 +63,13 @@ Priority: customConfig > profile file lookup > fail with error.
 {{- .Values.gpu.customConfig }}
 {{- else if eq .Values.gpu.profile "a100" }}
 {{- .Files.Get "profiles/a100.yaml" }}
+{{- else if eq .Values.gpu.profile "h100" }}
+{{- .Files.Get "profiles/h100.yaml" }}
+{{- else if eq .Values.gpu.profile "b200" }}
+{{- .Files.Get "profiles/b200.yaml" }}
 {{- else if eq .Values.gpu.profile "gb200" }}
 {{- .Files.Get "profiles/gb200.yaml" }}
 {{- else }}
-{{- fail (printf "Unknown GPU profile %q. Supported profiles: a100, gb200. Or set gpu.customConfig with inline YAML." .Values.gpu.profile) }}
+{{- fail (printf "Unknown GPU profile %q. Supported profiles: a100, h100, b200, gb200. Or set gpu.customConfig with inline YAML." .Values.gpu.profile) }}
 {{- end }}
 {{- end }}

--- a/deployments/gpu-mock/helm/gpu-mock/values.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/values.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 gpu:
-  profile: a100           # a100 | gb200
+  profile: a100           # a100 | h100 | b200 | gb200
   count: 8
   customConfig: ""
 


### PR DESCRIPTION
## Summary

A 360 review of gpu-mock documentation found that a user following the docs
**cannot** successfully deploy gpu-mock with either DRA Driver or Device Plugin.

- **NOTES.txt DRA section was wrong**: missing `--namespace nvidia`,
  `gpuResourcesEnabledOverride=true`, `resources.computeDomains.enabled=false`,
  and `helm repo add` prerequisite
- **Device plugin section used untested Helm command**: replaced with the
  CI-tested manifest (`tests/e2e/device-plugin-mock.yaml`)
- **GPU Operator section is untested**: marked as such
- **No chart README existed**: added with two tested quick-start paths
- **Root README was empty**: added project overview and navigation

All commands derived from the CI-tested `gpu-mock-e2e.yaml` workflow.

## Changes

- `deployments/gpu-mock/helm/gpu-mock/templates/NOTES.txt` — corrected all
  consumer commands, added image build note, added consumer-specific verification
- `deployments/gpu-mock/helm/gpu-mock/README.md` — **NEW**: chart README with
  Device Plugin and DRA quick-starts, prerequisites, values reference, troubleshooting
- `README.md` — project overview, gpu-mock quick-start snippet, doc navigation

## Test plan

- [x] `helm lint deployments/gpu-mock/helm/gpu-mock` passes
- [x] `helm template` renders NOTES.txt cleanly
- [x] Device Plugin quick-start commands match `e2e-device-plugin` CI job
- [x] DRA quick-start commands match `e2e-dra` CI job
- [x] All doc links resolve to existing files
- [ ] CI passes (e2e-device-plugin + e2e-dra jobs)