### PR TITLE
fix(gpu-mock): auto-derive driver version per profile, fix GB200 device ID

### DIFF
--- a/deployments/gpu-mock/helm/gpu-mock/README.md
+++ b/deployments/gpu-mock/helm/gpu-mock/README.md
@@ -177,7 +177,7 @@ kind delete cluster --name gpu-mock-dra
 | `image.repository` | `ghcr.io/nvidia/gpu-mock` | Container image repository |
 | `image.tag` | `latest` | Container image tag |
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy |
-| `driverVersion` | `"550.163.01"` | NVIDIA driver version string to mock |
+| `driverVersion` | `""` (auto) | NVIDIA driver version to mock. When empty, auto-derived from `gpu.profile` (even if `gpu.customConfig` is set): A100/H100 → `550.163.01`, B200/GB200 → `560.35.03`. For non-standard GPUs configured via `gpu.customConfig`, explicitly set `driverVersion`. |
 | `nodeSelector` | `{}` | Node selector for DaemonSet |
 | `tolerations` | `[{operator: Exists}]` | Pod tolerations (default: tolerate all) |
 

--- a/deployments/gpu-mock/helm/gpu-mock/profiles/gb200.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/profiles/gb200.yaml
@@ -63,7 +63,7 @@ device_defaults:
   # PCI configuration
   # ---------------------------------------------------------------------------
   pci:
-    device_id: 0x233010DE           # GB200 (placeholder - check real ID)
+    device_id: 0x234110DE
     subsystem_id: 0x181710DE
 
   pcie:

--- a/deployments/gpu-mock/helm/gpu-mock/templates/NOTES.txt
+++ b/deployments/gpu-mock/helm/gpu-mock/templates/NOTES.txt
@@ -3,7 +3,7 @@ Mock GPU environment deployed on all nodes!
   Profile: {{ .Values.gpu.profile }}
   GPUs per node: {{ .Values.gpu.count }}
   Available profiles: a100, h100, b200, gb200
-  Driver version: {{ .Values.driverVersion }}
+  Driver version: {{ include "gpu-mock.driverVersion" . }}
   Mock driver root: /var/lib/nvidia-mock/driver
   Mock config: /var/lib/nvidia-mock/config/config.yaml
 

--- a/deployments/gpu-mock/helm/gpu-mock/templates/_helpers.tpl
+++ b/deployments/gpu-mock/helm/gpu-mock/templates/_helpers.tpl
@@ -76,8 +76,10 @@ Priority: customConfig > profile file lookup > fail with error.
 
 {{/*
 Driver version helper.
-Returns the user-provided driverVersion, or derives it from the GPU profile.
+Returns the user-provided driverVersion, or derives it from gpu.profile.
 Blackwell profiles (b200, gb200) use 560.35.03; all others use 550.163.01.
+Note: when gpu.customConfig is set, derivation still uses gpu.profile —
+users with custom configs should set driverVersion explicitly.
 */}}
 {{- define "gpu-mock.driverVersion" -}}
 {{- if .Values.driverVersion -}}

--- a/deployments/gpu-mock/helm/gpu-mock/templates/_helpers.tpl
+++ b/deployments/gpu-mock/helm/gpu-mock/templates/_helpers.tpl
@@ -73,3 +73,18 @@ Priority: customConfig > profile file lookup > fail with error.
 {{- fail (printf "Unknown GPU profile %q. Supported profiles: a100, h100, b200, gb200. Or set gpu.customConfig with inline YAML." .Values.gpu.profile) }}
 {{- end }}
 {{- end }}
+
+{{/*
+Driver version helper.
+Returns the user-provided driverVersion, or derives it from the GPU profile.
+Blackwell profiles (b200, gb200) use 560.35.03; all others use 550.163.01.
+*/}}
+{{- define "gpu-mock.driverVersion" -}}
+{{- if .Values.driverVersion -}}
+{{- .Values.driverVersion -}}
+{{- else if or (eq .Values.gpu.profile "b200") (eq .Values.gpu.profile "gb200") -}}
+560.35.03
+{{- else -}}
+550.163.01
+{{- end -}}
+{{- end }}

--- a/deployments/gpu-mock/helm/gpu-mock/templates/daemonset.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/templates/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
             - name: GPU_COUNT
               value: "{{ .Values.gpu.count }}"
             - name: DRIVER_VERSION
-              value: "{{ .Values.driverVersion }}"
+              value: "{{ include "gpu-mock.driverVersion" . }}"
             - name: NODE_NAME
               valueFrom:
                 fieldRef:

--- a/deployments/gpu-mock/helm/gpu-mock/values.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/values.yaml
@@ -11,7 +11,7 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
-driverVersion: "550.163.01"
+driverVersion: ""                  # Auto-derived from profile. Override: "550.163.01"
 
 nodeSelector: {}
 tolerations:

--- a/deployments/gpu-mock/scripts/setup.sh
+++ b/deployments/gpu-mock/scripts/setup.sh
@@ -27,7 +27,14 @@ mkdir -p "$DRIVER_ROOT/usr/lib64" "$DRIVER_ROOT/usr/bin" "$DRIVER_ROOT/config"
 mkdir -p "$DEV_ROOT" "$CONFIG_DIR"
 
 # 2. Copy mock NVML library + create symlinks
-cp "/usr/local/lib/libnvidia-ml.so.$DRIVER_VERSION" "$DRIVER_ROOT/usr/lib64/"
+#    The .so is built with a fixed version (Makefile LIB_VERSION); rename to match
+#    the target DRIVER_VERSION so consumers see a consistent version string.
+BUILT_SO=$(ls /usr/local/lib/libnvidia-ml.so.*.*.* 2>/dev/null | head -1)
+if [ -z "$BUILT_SO" ]; then
+  echo "ERROR: No mock NVML library found in /usr/local/lib/" >&2
+  exit 1
+fi
+cp "$BUILT_SO" "$DRIVER_ROOT/usr/lib64/libnvidia-ml.so.$DRIVER_VERSION"
 ln -sf "libnvidia-ml.so.$DRIVER_VERSION" "$DRIVER_ROOT/usr/lib64/libnvidia-ml.so.1"
 ln -sf "libnvidia-ml.so.1" "$DRIVER_ROOT/usr/lib64/libnvidia-ml.so"
 


### PR DESCRIPTION
## Summary

- Auto-derive `driverVersion` from the selected GPU profile (Blackwell profiles use `560.35.03`, others use `550.163.01`)
- Fix `setup.sh` to discover the `.so` by glob instead of hardcoding the version in the filename — enables version renaming for Blackwell profiles
- Replace GB200's placeholder PCI device ID with a distinct mock ID (`0x234110DE`)
- Document the auto-derived behavior in the chart README values table

Fixes two minor items identified in the PR #223 final review.

## Changes

| Commit | Description |
|--------|-------------|
| `5838e056` | `setup.sh`: glob-discover `.so` instead of hardcoded version |
| `ed7c6141` | Template helper `gpu-mock.driverVersion` + update daemonset/NOTES/values |
| `c00fcbab` | GB200 PCI device_id `0x233010DE` → `0x234110DE` |
| `c4fdf12b` | README values table updated for auto-derived `driverVersion` |

## Validation

| Profile | DRIVER_VERSION | Device Name |
|---------|---------------|-------------|
| a100 | 550.163.01 | NVIDIA A100-SXM4-40GB |
| h100 | 550.163.01 | NVIDIA H100 80GB HBM3 |
| b200 | 560.35.03 | NVIDIA B200 |
| gb200 | 560.35.03 | NVIDIA GB200 NVL |

Explicit `--set driverVersion=X` still overrides the auto-derived value.

## Test plan

- [x] `helm template` with each profile shows correct `DRIVER_VERSION` env var
- [x] `helm lint` clean
- [x] Explicit `--set driverVersion=555.42.06` overrides auto-derived value
- [ ] E2E CI passes (device-plugin + DRA)