### PR TITLE
feat(gpu-mock): add L40S and T4 GPU profiles

### DIFF
--- a/deployments/gpu-mock/helm/gpu-mock/profiles/l40s.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/profiles/l40s.yaml
@@ -1,0 +1,362 @@
+# Mock NVML Configuration: L40S
+# Full configuration for nvidia-smi -x -q compatibility
+# Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
+
+version: "1.0"
+
+# =============================================================================
+# System-level configuration
+# =============================================================================
+system:
+  driver_version: "550.163.01"
+  nvml_version: "12.550.163.01"
+  cuda_version: "12.4"
+  cuda_version_major: 12
+  cuda_version_minor: 4
+
+# =============================================================================
+# Default device configuration (applied to all devices unless overridden)
+# =============================================================================
+device_defaults:
+  # ---------------------------------------------------------------------------
+  # Basic identification
+  # ---------------------------------------------------------------------------
+  name: "NVIDIA L40S"
+  brand: "nvidia"
+  serial: "1562830094500"
+  board_part_number: "900-2G133-0020-000"
+  vbios_version: "95.02.5C.00.03"
+
+  # ---------------------------------------------------------------------------
+  # Architecture
+  # ---------------------------------------------------------------------------
+  architecture: "ada_lovelace"
+  compute_capability:
+    major: 8
+    minor: 9
+  num_gpu_cores: 18176              # CUDA cores (Ada Lovelace)
+
+  # ---------------------------------------------------------------------------
+  # InfoROM versions
+  # ---------------------------------------------------------------------------
+  inforom:
+    image_version: "G133.0020.00.02"
+    oem_object: "2.1"
+    ecc_object: "7.16"
+    pwr_object: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Memory configuration - 48 GiB GDDR6
+  # ---------------------------------------------------------------------------
+  memory:
+    total_bytes: 51539607552         # 48 GiB GDDR6
+    reserved_bytes: 536870912        # ~512 MiB reserved
+    free_bytes: 51002736640          # total - reserved at idle
+    used_bytes: 0
+
+  bar1_memory:
+    total_bytes: 274877906944        # 256 GiB
+    free_bytes: 274877906944
+    used_bytes: 0
+
+  # ---------------------------------------------------------------------------
+  # PCI configuration
+  # ---------------------------------------------------------------------------
+  pci:
+    device_id: 0x26B510DE            # L40S
+    subsystem_id: 0x169710DE
+
+  pcie:
+    max_link_gen: 4                  # PCIe Gen4
+    current_link_gen: 4
+    max_link_width: 16               # x16
+    current_link_width: 16
+    replay_counter: 0
+    tx_throughput_kbps: 0
+    rx_throughput_kbps: 0
+
+  # ---------------------------------------------------------------------------
+  # Power configuration - 350W TDP
+  # ---------------------------------------------------------------------------
+  power:
+    management_supported: true
+    management_mode: "enabled"
+    default_limit_mw: 350000         # 350W
+    enforced_limit_mw: 350000
+    min_limit_mw: 100000             # 100W minimum
+    max_limit_mw: 350000             # 350W max
+    current_draw_mw: 45000           # 45W idle
+    power_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Thermal configuration
+  # ---------------------------------------------------------------------------
+  thermal:
+    temperature_gpu_c: 32            # Idle temperature
+    temperature_memory_c: 30
+    shutdown_threshold_c: 96
+    slowdown_threshold_c: 93
+    max_operating_c: 89
+    target_temperature_c: 83
+
+  # ---------------------------------------------------------------------------
+  # Fan configuration (passive cooling, PCIe form factor)
+  # ---------------------------------------------------------------------------
+  fan:
+    count: 0                         # Passively cooled PCIe card
+    speed_percent: "N/A"
+    target_speed_percent: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Clock speeds (MHz)
+  # ---------------------------------------------------------------------------
+  clocks:
+    graphics_current: 210            # Idle
+    graphics_max: 2520
+    graphics_app: 2520
+    graphics_app_default: 2520
+    sm_current: 210
+    sm_max: 2520
+    memory_current: 10001            # GDDR6
+    memory_max: 10001
+    memory_app: 10001
+    memory_app_default: 10001
+    video_current: 1110
+    video_max: 2520
+
+  # ---------------------------------------------------------------------------
+  # Clocks throttle reasons
+  # ---------------------------------------------------------------------------
+  clocks_throttle_reasons:
+    gpu_idle: true
+    applications_clocks_setting: false
+    sw_power_cap: false
+    hw_slowdown: false
+    hw_thermal_slowdown: false
+    hw_power_brake_slowdown: false
+    sync_boost: false
+    sw_thermal_slowdown: false
+    display_clocks_setting: false
+
+  # ---------------------------------------------------------------------------
+  # Supported clocks
+  # ---------------------------------------------------------------------------
+  supported_clocks:
+    memory_clocks:
+      - freq_mhz: 10001
+        graphics_clocks: [210, 420, 840, 1260, 1680, 2100, 2310, 2520]
+
+  # ---------------------------------------------------------------------------
+  # Performance state
+  # ---------------------------------------------------------------------------
+  performance_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Utilization (percentage, 0-100)
+  # ---------------------------------------------------------------------------
+  utilization:
+    gpu: 0
+    memory: 0
+    encoder: 0
+    decoder: 0
+    jpeg: 0
+    ofa: 0
+
+  # ---------------------------------------------------------------------------
+  # Encoder/Decoder statistics
+  # ---------------------------------------------------------------------------
+  encoder_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  fbc_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  # ---------------------------------------------------------------------------
+  # ECC configuration
+  # ---------------------------------------------------------------------------
+  ecc:
+    mode_current: "enabled"
+    mode_pending: "enabled"
+    default_mode: "enabled"
+    errors:
+      volatile:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+      aggregate:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+
+  # ---------------------------------------------------------------------------
+  # Retired pages
+  # ---------------------------------------------------------------------------
+  retired_pages:
+    single_bit_retirement:
+      count: 0
+      addresses: []
+    double_bit_retirement:
+      count: 0
+      addresses: []
+    pending_blacklist: false
+    pending_retirement: false
+
+  # ---------------------------------------------------------------------------
+  # Remapped rows
+  # ---------------------------------------------------------------------------
+  remapped_rows:
+    correctable: 0
+    uncorrectable: 0
+    pending: false
+    failure_occurred: false
+
+  # ---------------------------------------------------------------------------
+  # Display configuration
+  # ---------------------------------------------------------------------------
+  display:
+    mode: "disabled"
+    active: "disabled"
+
+  # ---------------------------------------------------------------------------
+  # Persistence mode
+  # ---------------------------------------------------------------------------
+  persistence_mode: "enabled"
+
+  # ---------------------------------------------------------------------------
+  # Compute mode
+  # ---------------------------------------------------------------------------
+  compute_mode: "default"
+
+  # ---------------------------------------------------------------------------
+  # MIG configuration (L40S does not support MIG)
+  # ---------------------------------------------------------------------------
+  mig:
+    mode_current: "disabled"
+    mode_pending: "disabled"
+    max_gpu_instances: 0
+
+  # ---------------------------------------------------------------------------
+  # GPU operation mode (GOM)
+  # ---------------------------------------------------------------------------
+  gpu_operation_mode:
+    current: "all_on"
+    pending: "all_on"
+
+  # ---------------------------------------------------------------------------
+  # Driver model (Windows only)
+  # ---------------------------------------------------------------------------
+  driver_model:
+    current: "N/A"
+    pending: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Accounting mode
+  # ---------------------------------------------------------------------------
+  accounting:
+    mode: "disabled"
+    buffer_size: 4000
+
+  # ---------------------------------------------------------------------------
+  # Virtualization
+  # ---------------------------------------------------------------------------
+  virtualization:
+    mode: "none"
+    host_vgpu_mode: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # GSP Firmware
+  # ---------------------------------------------------------------------------
+  gsp_firmware:
+    mode: "enabled"
+    version: "550.163.01"
+
+  # ---------------------------------------------------------------------------
+  # Processes (empty at idle)
+  # ---------------------------------------------------------------------------
+  processes: []
+
+# =============================================================================
+# Device-specific overrides (indexed 0-7 for L40S server)
+# =============================================================================
+devices:
+  - index: 0
+    uuid: "GPU-L40S-0000-0000-0000-000000000000"
+    serial: "1562830094500"
+    pci:
+      bus_id: "00000000:17:00.0"
+    minor_number: 0
+
+  - index: 1
+    uuid: "GPU-L40S-0000-0000-0000-000000000001"
+    serial: "1562830094501"
+    pci:
+      bus_id: "00000000:31:00.0"
+    minor_number: 1
+
+  - index: 2
+    uuid: "GPU-L40S-0000-0000-0000-000000000002"
+    serial: "1562830094502"
+    pci:
+      bus_id: "00000000:B1:00.0"
+    minor_number: 2
+
+  - index: 3
+    uuid: "GPU-L40S-0000-0000-0000-000000000003"
+    serial: "1562830094503"
+    pci:
+      bus_id: "00000000:CA:00.0"
+    minor_number: 3
+
+  - index: 4
+    uuid: "GPU-L40S-0000-0000-0000-000000000004"
+    serial: "1562830094504"
+    pci:
+      bus_id: "00000000:18:00.0"
+    minor_number: 4
+
+  - index: 5
+    uuid: "GPU-L40S-0000-0000-0000-000000000005"
+    serial: "1562830094505"
+    pci:
+      bus_id: "00000000:32:00.0"
+    minor_number: 5
+
+  - index: 6
+    uuid: "GPU-L40S-0000-0000-0000-000000000006"
+    serial: "1562830094506"
+    pci:
+      bus_id: "00000000:B2:00.0"
+    minor_number: 6
+
+  - index: 7
+    uuid: "GPU-L40S-0000-0000-0000-000000000007"
+    serial: "1562830094507"
+    pci:
+      bus_id: "00000000:CB:00.0"
+    minor_number: 7

--- a/deployments/gpu-mock/helm/gpu-mock/profiles/t4.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/profiles/t4.yaml
@@ -1,0 +1,334 @@
+# Mock NVML Configuration: T4
+# Full configuration for nvidia-smi -x -q compatibility
+# Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
+
+version: "1.0"
+
+# =============================================================================
+# System-level configuration
+# =============================================================================
+system:
+  driver_version: "550.163.01"
+  nvml_version: "12.550.163.01"
+  cuda_version: "12.4"
+  cuda_version_major: 12
+  cuda_version_minor: 4
+
+# =============================================================================
+# Default device configuration (applied to all devices unless overridden)
+# =============================================================================
+device_defaults:
+  # ---------------------------------------------------------------------------
+  # Basic identification
+  # ---------------------------------------------------------------------------
+  name: "NVIDIA T4"
+  brand: "nvidia"
+  serial: "0421819085498"
+  board_part_number: "900-2G183-0000-000"
+  vbios_version: "90.04.84.00.06"
+
+  # ---------------------------------------------------------------------------
+  # Architecture
+  # ---------------------------------------------------------------------------
+  architecture: "turing"
+  compute_capability:
+    major: 7
+    minor: 5
+  num_gpu_cores: 2560                # CUDA cores (Turing)
+
+  # ---------------------------------------------------------------------------
+  # InfoROM versions
+  # ---------------------------------------------------------------------------
+  inforom:
+    image_version: "G183.0200.00.02"
+    oem_object: "1.1"
+    ecc_object: "5.0"
+    pwr_object: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Memory configuration - 16 GiB GDDR6
+  # ---------------------------------------------------------------------------
+  memory:
+    total_bytes: 17179869184         # 16 GiB GDDR6
+    reserved_bytes: 314572800        # ~300 MiB reserved
+    free_bytes: 16865296384          # total - reserved at idle
+    used_bytes: 0
+
+  bar1_memory:
+    total_bytes: 274877906944        # 256 GiB
+    free_bytes: 274877906944
+    used_bytes: 0
+
+  # ---------------------------------------------------------------------------
+  # PCI configuration
+  # ---------------------------------------------------------------------------
+  pci:
+    device_id: 0x1EB810DE            # T4
+    subsystem_id: 0x12A210DE
+
+  pcie:
+    max_link_gen: 3                  # PCIe Gen3
+    current_link_gen: 3
+    max_link_width: 16               # x16
+    current_link_width: 16
+    replay_counter: 0
+    tx_throughput_kbps: 0
+    rx_throughput_kbps: 0
+
+  # ---------------------------------------------------------------------------
+  # Power configuration - 70W TDP
+  # ---------------------------------------------------------------------------
+  power:
+    management_supported: true
+    management_mode: "enabled"
+    default_limit_mw: 70000          # 70W
+    enforced_limit_mw: 70000
+    min_limit_mw: 60000              # 60W minimum
+    max_limit_mw: 70000              # 70W max
+    current_draw_mw: 12000           # 12W idle
+    power_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Thermal configuration
+  # ---------------------------------------------------------------------------
+  thermal:
+    temperature_gpu_c: 30            # Idle temperature
+    temperature_memory_c: 28
+    shutdown_threshold_c: 96
+    slowdown_threshold_c: 93
+    max_operating_c: 89
+    target_temperature_c: 83
+
+  # ---------------------------------------------------------------------------
+  # Fan configuration (passively cooled, single-slot PCIe)
+  # ---------------------------------------------------------------------------
+  fan:
+    count: 0                         # Passively cooled
+    speed_percent: "N/A"
+    target_speed_percent: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Clock speeds (MHz)
+  # ---------------------------------------------------------------------------
+  clocks:
+    graphics_current: 300            # Idle
+    graphics_max: 1590
+    graphics_app: 1590
+    graphics_app_default: 1590
+    sm_current: 300
+    sm_max: 1590
+    memory_current: 5001             # GDDR6
+    memory_max: 5001
+    memory_app: 5001
+    memory_app_default: 5001
+    video_current: 540
+    video_max: 1470
+
+  # ---------------------------------------------------------------------------
+  # Clocks throttle reasons
+  # ---------------------------------------------------------------------------
+  clocks_throttle_reasons:
+    gpu_idle: true
+    applications_clocks_setting: false
+    sw_power_cap: false
+    hw_slowdown: false
+    hw_thermal_slowdown: false
+    hw_power_brake_slowdown: false
+    sync_boost: false
+    sw_thermal_slowdown: false
+    display_clocks_setting: false
+
+  # ---------------------------------------------------------------------------
+  # Supported clocks
+  # ---------------------------------------------------------------------------
+  supported_clocks:
+    memory_clocks:
+      - freq_mhz: 5001
+        graphics_clocks: [300, 585, 810, 1005, 1200, 1380, 1590]
+
+  # ---------------------------------------------------------------------------
+  # Performance state
+  # ---------------------------------------------------------------------------
+  performance_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Utilization (percentage, 0-100)
+  # ---------------------------------------------------------------------------
+  utilization:
+    gpu: 0
+    memory: 0
+    encoder: 0
+    decoder: 0
+    jpeg: 0
+    ofa: 0
+
+  # ---------------------------------------------------------------------------
+  # Encoder/Decoder statistics
+  # ---------------------------------------------------------------------------
+  encoder_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  fbc_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  # ---------------------------------------------------------------------------
+  # ECC configuration
+  # ---------------------------------------------------------------------------
+  ecc:
+    mode_current: "enabled"
+    mode_pending: "enabled"
+    default_mode: "enabled"
+    errors:
+      volatile:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+      aggregate:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+
+  # ---------------------------------------------------------------------------
+  # Retired pages
+  # ---------------------------------------------------------------------------
+  retired_pages:
+    single_bit_retirement:
+      count: 0
+      addresses: []
+    double_bit_retirement:
+      count: 0
+      addresses: []
+    pending_blacklist: false
+    pending_retirement: false
+
+  # ---------------------------------------------------------------------------
+  # Remapped rows
+  # ---------------------------------------------------------------------------
+  remapped_rows:
+    correctable: 0
+    uncorrectable: 0
+    pending: false
+    failure_occurred: false
+
+  # ---------------------------------------------------------------------------
+  # Display configuration
+  # ---------------------------------------------------------------------------
+  display:
+    mode: "disabled"
+    active: "disabled"
+
+  # ---------------------------------------------------------------------------
+  # Persistence mode
+  # ---------------------------------------------------------------------------
+  persistence_mode: "enabled"
+
+  # ---------------------------------------------------------------------------
+  # Compute mode
+  # ---------------------------------------------------------------------------
+  compute_mode: "default"
+
+  # ---------------------------------------------------------------------------
+  # MIG configuration (T4 does not support MIG)
+  # ---------------------------------------------------------------------------
+  mig:
+    mode_current: "disabled"
+    mode_pending: "disabled"
+    max_gpu_instances: 0
+
+  # ---------------------------------------------------------------------------
+  # GPU operation mode (GOM)
+  # ---------------------------------------------------------------------------
+  gpu_operation_mode:
+    current: "all_on"
+    pending: "all_on"
+
+  # ---------------------------------------------------------------------------
+  # Driver model (Windows only)
+  # ---------------------------------------------------------------------------
+  driver_model:
+    current: "N/A"
+    pending: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Accounting mode
+  # ---------------------------------------------------------------------------
+  accounting:
+    mode: "disabled"
+    buffer_size: 4000
+
+  # ---------------------------------------------------------------------------
+  # Virtualization
+  # ---------------------------------------------------------------------------
+  virtualization:
+    mode: "none"
+    host_vgpu_mode: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # GSP Firmware
+  # ---------------------------------------------------------------------------
+  gsp_firmware:
+    mode: "enabled"
+    version: "550.163.01"
+
+  # ---------------------------------------------------------------------------
+  # Processes (empty at idle)
+  # ---------------------------------------------------------------------------
+  processes: []
+
+# =============================================================================
+# Device-specific overrides (indexed 0-3 for T4 server)
+# =============================================================================
+devices:
+  - index: 0
+    uuid: "GPU-T4-0000-0000-0000-000000000000"
+    serial: "0421819085400"
+    pci:
+      bus_id: "00000000:3B:00.0"
+    minor_number: 0
+
+  - index: 1
+    uuid: "GPU-T4-0000-0000-0000-000000000001"
+    serial: "0421819085401"
+    pci:
+      bus_id: "00000000:86:00.0"
+    minor_number: 1
+
+  - index: 2
+    uuid: "GPU-T4-0000-0000-0000-000000000002"
+    serial: "0421819085402"
+    pci:
+      bus_id: "00000000:AF:00.0"
+    minor_number: 2
+
+  - index: 3
+    uuid: "GPU-T4-0000-0000-0000-000000000003"
+    serial: "0421819085403"
+    pci:
+      bus_id: "00000000:D8:00.0"
+    minor_number: 3

--- a/deployments/gpu-mock/helm/gpu-mock/templates/_helpers.tpl
+++ b/deployments/gpu-mock/helm/gpu-mock/templates/_helpers.tpl
@@ -69,8 +69,12 @@ Priority: customConfig > profile file lookup > fail with error.
 {{- .Files.Get "profiles/b200.yaml" }}
 {{- else if eq .Values.gpu.profile "gb200" }}
 {{- .Files.Get "profiles/gb200.yaml" }}
+{{- else if eq .Values.gpu.profile "l40s" }}
+{{- .Files.Get "profiles/l40s.yaml" }}
+{{- else if eq .Values.gpu.profile "t4" }}
+{{- .Files.Get "profiles/t4.yaml" }}
 {{- else }}
-{{- fail (printf "Unknown GPU profile %q. Supported profiles: a100, h100, b200, gb200. Or set gpu.customConfig with inline YAML." .Values.gpu.profile) }}
+{{- fail (printf "Unknown GPU profile %q. Supported profiles: a100, h100, b200, gb200, l40s, t4. Or set gpu.customConfig with inline YAML." .Values.gpu.profile) }}
 {{- end }}
 {{- end }}
 

--- a/deployments/gpu-mock/helm/gpu-mock/values.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/values.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 gpu:
-  profile: a100           # a100 | h100 | b200 | gb200
+  profile: a100           # a100 | h100 | b200 | gb200 | l40s | t4
   count: 8
   customConfig: ""
 

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-l40s.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-l40s.yaml
@@ -1,0 +1,362 @@
+# Mock NVML Configuration: L40S
+# Full configuration for nvidia-smi -x -q compatibility
+# Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
+
+version: "1.0"
+
+# =============================================================================
+# System-level configuration
+# =============================================================================
+system:
+  driver_version: "550.163.01"
+  nvml_version: "12.550.163.01"
+  cuda_version: "12.4"
+  cuda_version_major: 12
+  cuda_version_minor: 4
+
+# =============================================================================
+# Default device configuration (applied to all devices unless overridden)
+# =============================================================================
+device_defaults:
+  # ---------------------------------------------------------------------------
+  # Basic identification
+  # ---------------------------------------------------------------------------
+  name: "NVIDIA L40S"
+  brand: "nvidia"
+  serial: "1562830094500"
+  board_part_number: "900-2G133-0020-000"
+  vbios_version: "95.02.5C.00.03"
+
+  # ---------------------------------------------------------------------------
+  # Architecture
+  # ---------------------------------------------------------------------------
+  architecture: "ada_lovelace"
+  compute_capability:
+    major: 8
+    minor: 9
+  num_gpu_cores: 18176              # CUDA cores (Ada Lovelace)
+
+  # ---------------------------------------------------------------------------
+  # InfoROM versions
+  # ---------------------------------------------------------------------------
+  inforom:
+    image_version: "G133.0020.00.02"
+    oem_object: "2.1"
+    ecc_object: "7.16"
+    pwr_object: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Memory configuration - 48 GiB GDDR6
+  # ---------------------------------------------------------------------------
+  memory:
+    total_bytes: 51539607552         # 48 GiB GDDR6
+    reserved_bytes: 536870912        # ~512 MiB reserved
+    free_bytes: 51002736640          # total - reserved at idle
+    used_bytes: 0
+
+  bar1_memory:
+    total_bytes: 274877906944        # 256 GiB
+    free_bytes: 274877906944
+    used_bytes: 0
+
+  # ---------------------------------------------------------------------------
+  # PCI configuration
+  # ---------------------------------------------------------------------------
+  pci:
+    device_id: 0x26B510DE            # L40S
+    subsystem_id: 0x169710DE
+
+  pcie:
+    max_link_gen: 4                  # PCIe Gen4
+    current_link_gen: 4
+    max_link_width: 16               # x16
+    current_link_width: 16
+    replay_counter: 0
+    tx_throughput_kbps: 0
+    rx_throughput_kbps: 0
+
+  # ---------------------------------------------------------------------------
+  # Power configuration - 350W TDP
+  # ---------------------------------------------------------------------------
+  power:
+    management_supported: true
+    management_mode: "enabled"
+    default_limit_mw: 350000         # 350W
+    enforced_limit_mw: 350000
+    min_limit_mw: 100000             # 100W minimum
+    max_limit_mw: 350000             # 350W max
+    current_draw_mw: 45000           # 45W idle
+    power_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Thermal configuration
+  # ---------------------------------------------------------------------------
+  thermal:
+    temperature_gpu_c: 32            # Idle temperature
+    temperature_memory_c: 30
+    shutdown_threshold_c: 96
+    slowdown_threshold_c: 93
+    max_operating_c: 89
+    target_temperature_c: 83
+
+  # ---------------------------------------------------------------------------
+  # Fan configuration (passive cooling, PCIe form factor)
+  # ---------------------------------------------------------------------------
+  fan:
+    count: 0                         # Passively cooled PCIe card
+    speed_percent: "N/A"
+    target_speed_percent: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Clock speeds (MHz)
+  # ---------------------------------------------------------------------------
+  clocks:
+    graphics_current: 210            # Idle
+    graphics_max: 2520
+    graphics_app: 2520
+    graphics_app_default: 2520
+    sm_current: 210
+    sm_max: 2520
+    memory_current: 10001            # GDDR6
+    memory_max: 10001
+    memory_app: 10001
+    memory_app_default: 10001
+    video_current: 1110
+    video_max: 2520
+
+  # ---------------------------------------------------------------------------
+  # Clocks throttle reasons
+  # ---------------------------------------------------------------------------
+  clocks_throttle_reasons:
+    gpu_idle: true
+    applications_clocks_setting: false
+    sw_power_cap: false
+    hw_slowdown: false
+    hw_thermal_slowdown: false
+    hw_power_brake_slowdown: false
+    sync_boost: false
+    sw_thermal_slowdown: false
+    display_clocks_setting: false
+
+  # ---------------------------------------------------------------------------
+  # Supported clocks
+  # ---------------------------------------------------------------------------
+  supported_clocks:
+    memory_clocks:
+      - freq_mhz: 10001
+        graphics_clocks: [210, 420, 840, 1260, 1680, 2100, 2310, 2520]
+
+  # ---------------------------------------------------------------------------
+  # Performance state
+  # ---------------------------------------------------------------------------
+  performance_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Utilization (percentage, 0-100)
+  # ---------------------------------------------------------------------------
+  utilization:
+    gpu: 0
+    memory: 0
+    encoder: 0
+    decoder: 0
+    jpeg: 0
+    ofa: 0
+
+  # ---------------------------------------------------------------------------
+  # Encoder/Decoder statistics
+  # ---------------------------------------------------------------------------
+  encoder_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  fbc_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  # ---------------------------------------------------------------------------
+  # ECC configuration
+  # ---------------------------------------------------------------------------
+  ecc:
+    mode_current: "enabled"
+    mode_pending: "enabled"
+    default_mode: "enabled"
+    errors:
+      volatile:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+      aggregate:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+
+  # ---------------------------------------------------------------------------
+  # Retired pages
+  # ---------------------------------------------------------------------------
+  retired_pages:
+    single_bit_retirement:
+      count: 0
+      addresses: []
+    double_bit_retirement:
+      count: 0
+      addresses: []
+    pending_blacklist: false
+    pending_retirement: false
+
+  # ---------------------------------------------------------------------------
+  # Remapped rows
+  # ---------------------------------------------------------------------------
+  remapped_rows:
+    correctable: 0
+    uncorrectable: 0
+    pending: false
+    failure_occurred: false
+
+  # ---------------------------------------------------------------------------
+  # Display configuration
+  # ---------------------------------------------------------------------------
+  display:
+    mode: "disabled"
+    active: "disabled"
+
+  # ---------------------------------------------------------------------------
+  # Persistence mode
+  # ---------------------------------------------------------------------------
+  persistence_mode: "enabled"
+
+  # ---------------------------------------------------------------------------
+  # Compute mode
+  # ---------------------------------------------------------------------------
+  compute_mode: "default"
+
+  # ---------------------------------------------------------------------------
+  # MIG configuration (L40S does not support MIG)
+  # ---------------------------------------------------------------------------
+  mig:
+    mode_current: "disabled"
+    mode_pending: "disabled"
+    max_gpu_instances: 0
+
+  # ---------------------------------------------------------------------------
+  # GPU operation mode (GOM)
+  # ---------------------------------------------------------------------------
+  gpu_operation_mode:
+    current: "all_on"
+    pending: "all_on"
+
+  # ---------------------------------------------------------------------------
+  # Driver model (Windows only)
+  # ---------------------------------------------------------------------------
+  driver_model:
+    current: "N/A"
+    pending: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Accounting mode
+  # ---------------------------------------------------------------------------
+  accounting:
+    mode: "disabled"
+    buffer_size: 4000
+
+  # ---------------------------------------------------------------------------
+  # Virtualization
+  # ---------------------------------------------------------------------------
+  virtualization:
+    mode: "none"
+    host_vgpu_mode: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # GSP Firmware
+  # ---------------------------------------------------------------------------
+  gsp_firmware:
+    mode: "enabled"
+    version: "550.163.01"
+
+  # ---------------------------------------------------------------------------
+  # Processes (empty at idle)
+  # ---------------------------------------------------------------------------
+  processes: []
+
+# =============================================================================
+# Device-specific overrides (indexed 0-7 for L40S server)
+# =============================================================================
+devices:
+  - index: 0
+    uuid: "GPU-L40S-0000-0000-0000-000000000000"
+    serial: "1562830094500"
+    pci:
+      bus_id: "00000000:17:00.0"
+    minor_number: 0
+
+  - index: 1
+    uuid: "GPU-L40S-0000-0000-0000-000000000001"
+    serial: "1562830094501"
+    pci:
+      bus_id: "00000000:31:00.0"
+    minor_number: 1
+
+  - index: 2
+    uuid: "GPU-L40S-0000-0000-0000-000000000002"
+    serial: "1562830094502"
+    pci:
+      bus_id: "00000000:B1:00.0"
+    minor_number: 2
+
+  - index: 3
+    uuid: "GPU-L40S-0000-0000-0000-000000000003"
+    serial: "1562830094503"
+    pci:
+      bus_id: "00000000:CA:00.0"
+    minor_number: 3
+
+  - index: 4
+    uuid: "GPU-L40S-0000-0000-0000-000000000004"
+    serial: "1562830094504"
+    pci:
+      bus_id: "00000000:18:00.0"
+    minor_number: 4
+
+  - index: 5
+    uuid: "GPU-L40S-0000-0000-0000-000000000005"
+    serial: "1562830094505"
+    pci:
+      bus_id: "00000000:32:00.0"
+    minor_number: 5
+
+  - index: 6
+    uuid: "GPU-L40S-0000-0000-0000-000000000006"
+    serial: "1562830094506"
+    pci:
+      bus_id: "00000000:B2:00.0"
+    minor_number: 6
+
+  - index: 7
+    uuid: "GPU-L40S-0000-0000-0000-000000000007"
+    serial: "1562830094507"
+    pci:
+      bus_id: "00000000:CB:00.0"
+    minor_number: 7

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-t4.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-t4.yaml
@@ -1,0 +1,334 @@
+# Mock NVML Configuration: T4
+# Full configuration for nvidia-smi -x -q compatibility
+# Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
+
+version: "1.0"
+
+# =============================================================================
+# System-level configuration
+# =============================================================================
+system:
+  driver_version: "550.163.01"
+  nvml_version: "12.550.163.01"
+  cuda_version: "12.4"
+  cuda_version_major: 12
+  cuda_version_minor: 4
+
+# =============================================================================
+# Default device configuration (applied to all devices unless overridden)
+# =============================================================================
+device_defaults:
+  # ---------------------------------------------------------------------------
+  # Basic identification
+  # ---------------------------------------------------------------------------
+  name: "NVIDIA T4"
+  brand: "nvidia"
+  serial: "0421819085498"
+  board_part_number: "900-2G183-0000-000"
+  vbios_version: "90.04.84.00.06"
+
+  # ---------------------------------------------------------------------------
+  # Architecture
+  # ---------------------------------------------------------------------------
+  architecture: "turing"
+  compute_capability:
+    major: 7
+    minor: 5
+  num_gpu_cores: 2560                # CUDA cores (Turing)
+
+  # ---------------------------------------------------------------------------
+  # InfoROM versions
+  # ---------------------------------------------------------------------------
+  inforom:
+    image_version: "G183.0200.00.02"
+    oem_object: "1.1"
+    ecc_object: "5.0"
+    pwr_object: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Memory configuration - 16 GiB GDDR6
+  # ---------------------------------------------------------------------------
+  memory:
+    total_bytes: 17179869184         # 16 GiB GDDR6
+    reserved_bytes: 314572800        # ~300 MiB reserved
+    free_bytes: 16865296384          # total - reserved at idle
+    used_bytes: 0
+
+  bar1_memory:
+    total_bytes: 274877906944        # 256 GiB
+    free_bytes: 274877906944
+    used_bytes: 0
+
+  # ---------------------------------------------------------------------------
+  # PCI configuration
+  # ---------------------------------------------------------------------------
+  pci:
+    device_id: 0x1EB810DE            # T4
+    subsystem_id: 0x12A210DE
+
+  pcie:
+    max_link_gen: 3                  # PCIe Gen3
+    current_link_gen: 3
+    max_link_width: 16               # x16
+    current_link_width: 16
+    replay_counter: 0
+    tx_throughput_kbps: 0
+    rx_throughput_kbps: 0
+
+  # ---------------------------------------------------------------------------
+  # Power configuration - 70W TDP
+  # ---------------------------------------------------------------------------
+  power:
+    management_supported: true
+    management_mode: "enabled"
+    default_limit_mw: 70000          # 70W
+    enforced_limit_mw: 70000
+    min_limit_mw: 60000              # 60W minimum
+    max_limit_mw: 70000              # 70W max
+    current_draw_mw: 12000           # 12W idle
+    power_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Thermal configuration
+  # ---------------------------------------------------------------------------
+  thermal:
+    temperature_gpu_c: 30            # Idle temperature
+    temperature_memory_c: 28
+    shutdown_threshold_c: 96
+    slowdown_threshold_c: 93
+    max_operating_c: 89
+    target_temperature_c: 83
+
+  # ---------------------------------------------------------------------------
+  # Fan configuration (passively cooled, single-slot PCIe)
+  # ---------------------------------------------------------------------------
+  fan:
+    count: 0                         # Passively cooled
+    speed_percent: "N/A"
+    target_speed_percent: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Clock speeds (MHz)
+  # ---------------------------------------------------------------------------
+  clocks:
+    graphics_current: 300            # Idle
+    graphics_max: 1590
+    graphics_app: 1590
+    graphics_app_default: 1590
+    sm_current: 300
+    sm_max: 1590
+    memory_current: 5001             # GDDR6
+    memory_max: 5001
+    memory_app: 5001
+    memory_app_default: 5001
+    video_current: 540
+    video_max: 1470
+
+  # ---------------------------------------------------------------------------
+  # Clocks throttle reasons
+  # ---------------------------------------------------------------------------
+  clocks_throttle_reasons:
+    gpu_idle: true
+    applications_clocks_setting: false
+    sw_power_cap: false
+    hw_slowdown: false
+    hw_thermal_slowdown: false
+    hw_power_brake_slowdown: false
+    sync_boost: false
+    sw_thermal_slowdown: false
+    display_clocks_setting: false
+
+  # ---------------------------------------------------------------------------
+  # Supported clocks
+  # ---------------------------------------------------------------------------
+  supported_clocks:
+    memory_clocks:
+      - freq_mhz: 5001
+        graphics_clocks: [300, 585, 810, 1005, 1200, 1380, 1590]
+
+  # ---------------------------------------------------------------------------
+  # Performance state
+  # ---------------------------------------------------------------------------
+  performance_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Utilization (percentage, 0-100)
+  # ---------------------------------------------------------------------------
+  utilization:
+    gpu: 0
+    memory: 0
+    encoder: 0
+    decoder: 0
+    jpeg: 0
+    ofa: 0
+
+  # ---------------------------------------------------------------------------
+  # Encoder/Decoder statistics
+  # ---------------------------------------------------------------------------
+  encoder_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  fbc_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  # ---------------------------------------------------------------------------
+  # ECC configuration
+  # ---------------------------------------------------------------------------
+  ecc:
+    mode_current: "enabled"
+    mode_pending: "enabled"
+    default_mode: "enabled"
+    errors:
+      volatile:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+      aggregate:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+
+  # ---------------------------------------------------------------------------
+  # Retired pages
+  # ---------------------------------------------------------------------------
+  retired_pages:
+    single_bit_retirement:
+      count: 0
+      addresses: []
+    double_bit_retirement:
+      count: 0
+      addresses: []
+    pending_blacklist: false
+    pending_retirement: false
+
+  # ---------------------------------------------------------------------------
+  # Remapped rows
+  # ---------------------------------------------------------------------------
+  remapped_rows:
+    correctable: 0
+    uncorrectable: 0
+    pending: false
+    failure_occurred: false
+
+  # ---------------------------------------------------------------------------
+  # Display configuration
+  # ---------------------------------------------------------------------------
+  display:
+    mode: "disabled"
+    active: "disabled"
+
+  # ---------------------------------------------------------------------------
+  # Persistence mode
+  # ---------------------------------------------------------------------------
+  persistence_mode: "enabled"
+
+  # ---------------------------------------------------------------------------
+  # Compute mode
+  # ---------------------------------------------------------------------------
+  compute_mode: "default"
+
+  # ---------------------------------------------------------------------------
+  # MIG configuration (T4 does not support MIG)
+  # ---------------------------------------------------------------------------
+  mig:
+    mode_current: "disabled"
+    mode_pending: "disabled"
+    max_gpu_instances: 0
+
+  # ---------------------------------------------------------------------------
+  # GPU operation mode (GOM)
+  # ---------------------------------------------------------------------------
+  gpu_operation_mode:
+    current: "all_on"
+    pending: "all_on"
+
+  # ---------------------------------------------------------------------------
+  # Driver model (Windows only)
+  # ---------------------------------------------------------------------------
+  driver_model:
+    current: "N/A"
+    pending: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Accounting mode
+  # ---------------------------------------------------------------------------
+  accounting:
+    mode: "disabled"
+    buffer_size: 4000
+
+  # ---------------------------------------------------------------------------
+  # Virtualization
+  # ---------------------------------------------------------------------------
+  virtualization:
+    mode: "none"
+    host_vgpu_mode: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # GSP Firmware
+  # ---------------------------------------------------------------------------
+  gsp_firmware:
+    mode: "enabled"
+    version: "550.163.01"
+
+  # ---------------------------------------------------------------------------
+  # Processes (empty at idle)
+  # ---------------------------------------------------------------------------
+  processes: []
+
+# =============================================================================
+# Device-specific overrides (indexed 0-3 for T4 server)
+# =============================================================================
+devices:
+  - index: 0
+    uuid: "GPU-T4-0000-0000-0000-000000000000"
+    serial: "0421819085400"
+    pci:
+      bus_id: "00000000:3B:00.0"
+    minor_number: 0
+
+  - index: 1
+    uuid: "GPU-T4-0000-0000-0000-000000000001"
+    serial: "0421819085401"
+    pci:
+      bus_id: "00000000:86:00.0"
+    minor_number: 1
+
+  - index: 2
+    uuid: "GPU-T4-0000-0000-0000-000000000002"
+    serial: "0421819085402"
+    pci:
+      bus_id: "00000000:AF:00.0"
+    minor_number: 2
+
+  - index: 3
+    uuid: "GPU-T4-0000-0000-0000-000000000003"
+    serial: "0421819085403"
+    pci:
+      bus_id: "00000000:D8:00.0"
+    minor_number: 3

--- a/pkg/gpu/mocknvml/engine/config_profiles_test.go
+++ b/pkg/gpu/mocknvml/engine/config_profiles_test.go
@@ -1,0 +1,236 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// testdataDir returns the absolute path to the profiles directory.
+func testdataDir() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "..", "..", "..", "..", "deployments", "gpu-mock", "helm", "gpu-mock", "profiles")
+}
+
+func TestLoadConfig_L40SProfile(t *testing.T) {
+	profilePath := filepath.Join(testdataDir(), "l40s.yaml")
+
+	yamlCfg, err := LoadYAMLConfig(profilePath)
+	if err != nil {
+		t.Fatalf("Failed to load L40S profile: %v", err)
+	}
+
+	// Verify device count: L40S typically 8 GPUs in a server
+	if got := len(yamlCfg.Devices); got != 8 {
+		t.Errorf("L40S device count: got %d, want 8", got)
+	}
+
+	// Verify architecture
+	if got := yamlCfg.DeviceDefaults.Architecture; got != "ada_lovelace" {
+		t.Errorf("L40S architecture: got %q, want %q", got, "ada_lovelace")
+	}
+
+	// Verify compute capability 8.9
+	cc := yamlCfg.DeviceDefaults.ComputeCapability
+	if cc == nil {
+		t.Fatal("L40S compute_capability is nil")
+	}
+	if cc.Major != 8 || cc.Minor != 9 {
+		t.Errorf("L40S compute capability: got %d.%d, want 8.9", cc.Major, cc.Minor)
+	}
+
+	// Verify memory: 48 GiB = 51539607552 bytes
+	mem := yamlCfg.DeviceDefaults.Memory
+	if mem == nil {
+		t.Fatal("L40S memory config is nil")
+	}
+	expectedMemBytes := uint64(51539607552) // 48 GiB
+	if mem.TotalBytes != expectedMemBytes {
+		t.Errorf("L40S memory total_bytes: got %d, want %d", mem.TotalBytes, expectedMemBytes)
+	}
+
+	// Verify PCI device ID: 0x26B510DE
+	pci := yamlCfg.DeviceDefaults.PCI
+	if pci == nil {
+		t.Fatal("L40S PCI config is nil")
+	}
+	expectedDeviceID := uint32(0x26B510DE)
+	if pci.DeviceID != expectedDeviceID {
+		t.Errorf("L40S PCI device_id: got 0x%08X, want 0x%08X", pci.DeviceID, expectedDeviceID)
+	}
+
+	// Verify GPU name
+	if got := yamlCfg.DeviceDefaults.Name; got != "NVIDIA L40S" {
+		t.Errorf("L40S name: got %q, want %q", got, "NVIDIA L40S")
+	}
+
+	// Verify no NVLink (L40S is PCIe only)
+	if yamlCfg.NVLink != nil {
+		t.Error("L40S should not have NVLink configuration")
+	}
+
+	// Verify PCIe Gen4
+	pcie := yamlCfg.DeviceDefaults.PCIe
+	if pcie == nil {
+		t.Fatal("L40S PCIe config is nil")
+	}
+	if pcie.MaxLinkGen != 4 {
+		t.Errorf("L40S PCIe max_link_gen: got %d, want 4", pcie.MaxLinkGen)
+	}
+
+	// Verify power: 350W TDP
+	power := yamlCfg.DeviceDefaults.Power
+	if power == nil {
+		t.Fatal("L40S power config is nil")
+	}
+	if power.DefaultLimitMW != 350000 {
+		t.Errorf("L40S power default_limit_mw: got %d, want 350000", power.DefaultLimitMW)
+	}
+}
+
+func TestLoadConfig_T4Profile(t *testing.T) {
+	profilePath := filepath.Join(testdataDir(), "t4.yaml")
+
+	yamlCfg, err := LoadYAMLConfig(profilePath)
+	if err != nil {
+		t.Fatalf("Failed to load T4 profile: %v", err)
+	}
+
+	// Verify device count: T4 typically 4 GPUs
+	if got := len(yamlCfg.Devices); got != 4 {
+		t.Errorf("T4 device count: got %d, want 4", got)
+	}
+
+	// Verify architecture
+	if got := yamlCfg.DeviceDefaults.Architecture; got != "turing" {
+		t.Errorf("T4 architecture: got %q, want %q", got, "turing")
+	}
+
+	// Verify compute capability 7.5
+	cc := yamlCfg.DeviceDefaults.ComputeCapability
+	if cc == nil {
+		t.Fatal("T4 compute_capability is nil")
+	}
+	if cc.Major != 7 || cc.Minor != 5 {
+		t.Errorf("T4 compute capability: got %d.%d, want 7.5", cc.Major, cc.Minor)
+	}
+
+	// Verify memory: 16 GiB = 17179869184 bytes
+	mem := yamlCfg.DeviceDefaults.Memory
+	if mem == nil {
+		t.Fatal("T4 memory config is nil")
+	}
+	expectedMemBytes := uint64(17179869184) // 16 GiB
+	if mem.TotalBytes != expectedMemBytes {
+		t.Errorf("T4 memory total_bytes: got %d, want %d", mem.TotalBytes, expectedMemBytes)
+	}
+
+	// Verify PCI device ID: 0x1EB810DE
+	pci := yamlCfg.DeviceDefaults.PCI
+	if pci == nil {
+		t.Fatal("T4 PCI config is nil")
+	}
+	expectedDeviceID := uint32(0x1EB810DE)
+	if pci.DeviceID != expectedDeviceID {
+		t.Errorf("T4 PCI device_id: got 0x%08X, want 0x%08X", pci.DeviceID, expectedDeviceID)
+	}
+
+	// Verify GPU name
+	if got := yamlCfg.DeviceDefaults.Name; got != "NVIDIA T4" {
+		t.Errorf("T4 name: got %q, want %q", got, "NVIDIA T4")
+	}
+
+	// Verify no NVLink (T4 is PCIe only)
+	if yamlCfg.NVLink != nil {
+		t.Error("T4 should not have NVLink configuration")
+	}
+
+	// Verify PCIe Gen3
+	pcie := yamlCfg.DeviceDefaults.PCIe
+	if pcie == nil {
+		t.Fatal("T4 PCIe config is nil")
+	}
+	if pcie.MaxLinkGen != 3 {
+		t.Errorf("T4 PCIe max_link_gen: got %d, want 3", pcie.MaxLinkGen)
+	}
+
+	// Verify power: 70W TDP
+	power := yamlCfg.DeviceDefaults.Power
+	if power == nil {
+		t.Fatal("T4 power config is nil")
+	}
+	if power.DefaultLimitMW != 70000 {
+		t.Errorf("T4 power default_limit_mw: got %d, want 70000", power.DefaultLimitMW)
+	}
+}
+
+func TestLoadConfig_AllProfilesConsistent(t *testing.T) {
+	profiles := []struct {
+		name         string
+		file         string
+		architecture string
+		ccMajor      int
+		ccMinor      int
+		memGiB       uint64
+		deviceCount  int
+	}{
+		{"A100", "a100.yaml", "ampere", 8, 0, 40, 8},
+		{"H100", "h100.yaml", "hopper", 9, 0, 80, 8},
+		{"B200", "b200.yaml", "blackwell", 10, 0, 192, 8},
+		{"GB200", "gb200.yaml", "blackwell", 10, 0, 192, 8},
+		{"L40S", "l40s.yaml", "ada_lovelace", 8, 9, 48, 8},
+		{"T4", "t4.yaml", "turing", 7, 5, 16, 4},
+	}
+
+	for _, p := range profiles {
+		t.Run(p.name, func(t *testing.T) {
+			profilePath := filepath.Join(testdataDir(), p.file)
+			yamlCfg, err := LoadYAMLConfig(profilePath)
+			if err != nil {
+				t.Fatalf("Failed to load %s profile: %v", p.name, err)
+			}
+
+			if yamlCfg.DeviceDefaults.Architecture != p.architecture {
+				t.Errorf("%s architecture: got %q, want %q", p.name, yamlCfg.DeviceDefaults.Architecture, p.architecture)
+			}
+
+			cc := yamlCfg.DeviceDefaults.ComputeCapability
+			if cc == nil {
+				t.Fatalf("%s compute_capability is nil", p.name)
+			}
+			if cc.Major != p.ccMajor || cc.Minor != p.ccMinor {
+				t.Errorf("%s compute capability: got %d.%d, want %d.%d", p.name, cc.Major, cc.Minor, p.ccMajor, p.ccMinor)
+			}
+
+			mem := yamlCfg.DeviceDefaults.Memory
+			if mem == nil {
+				t.Fatalf("%s memory config is nil", p.name)
+			}
+			expectedBytes := p.memGiB * 1024 * 1024 * 1024
+			if mem.TotalBytes != expectedBytes {
+				t.Errorf("%s memory: got %d bytes, want %d bytes (%d GiB)", p.name, mem.TotalBytes, expectedBytes, p.memGiB)
+			}
+
+			if len(yamlCfg.Devices) != p.deviceCount {
+				t.Errorf("%s device count: got %d, want %d", p.name, len(yamlCfg.Devices), p.deviceCount)
+			}
+
+			if yamlCfg.System.DriverVersion == "" {
+				t.Errorf("%s driver_version is empty", p.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add NVIDIA L40S (Ada Lovelace sm_89, 48 GiB GDDR6, 8 GPUs, PCIe Gen4, 350W) profile
- Add NVIDIA T4 (Turing sm_75, 16 GiB GDDR6, 4 GPUs, PCIe Gen3, 70W) profile
- Integrate both profiles into Helm chart (values.yaml + _helpers.tpl)
- Add standalone configs in `pkg/gpu/mocknvml/configs/`
- Add engine tests validating all 6 profiles (A100, H100, B200, GB200, L40S, T4)

## Test plan

- [x] `go test ./pkg/gpu/mocknvml/engine/ -v` -- all 42 tests pass
- [x] `helm template --set gpu.profile=l40s` renders correct ConfigMap
- [x] `helm template --set gpu.profile=t4` renders correct ConfigMap
- [ ] CI passes