### PR TITLE
feat(gpu-mock): version-aware NVML function dispatch

### DIFF
--- a/pkg/gpu/mocknvml/bridge/device.go
+++ b/pkg/gpu/mocknvml/bridge/device.go
@@ -291,6 +291,9 @@ func nvmlDeviceGetMemoryInfo(nvmlDevice C.nvmlDevice_t, memory *C.nvmlMemory_t) 
 
 //export nvmlDeviceGetMemoryInfo_v2
 func nvmlDeviceGetMemoryInfo_v2(nvmlDevice C.nvmlDevice_t, memory *C.nvmlMemory_v2_t) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetMemoryInfo_v2"); !ok {
+		return ret
+	}
 	if memory == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
@@ -310,6 +313,9 @@ func nvmlDeviceGetMemoryInfo_v2(nvmlDevice C.nvmlDevice_t, memory *C.nvmlMemory_
 
 //export nvmlDeviceGetArchitecture
 func nvmlDeviceGetArchitecture(nvmlDevice C.nvmlDevice_t, arch *C.nvmlDeviceArchitecture_t) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetArchitecture"); !ok {
+		return ret
+	}
 	if arch == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}

--- a/pkg/gpu/mocknvml/bridge/helpers.go
+++ b/pkg/gpu/mocknvml/bridge/helpers.go
@@ -39,6 +39,7 @@ import (
 	"unsafe"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
 )
 
 // main is required for buildmode=c-shared.
@@ -131,14 +132,33 @@ func goStringToC(s string, buf *C.char, length C.uint) C.nvmlReturn_t {
 }
 
 // stubReturn handles unimplemented function calls.
+// First checks the version registry: if the function doesn't exist in the
+// configured driver version, returns FUNCTION_NOT_FOUND.
 // In strict mode, panics to help identify missing implementations.
 // Otherwise returns NOT_SUPPORTED (gracefully handled by most consumers).
 func stubReturn(funcName string) C.nvmlReturn_t {
+	driverVersion := engine.GetEngine().GetConfig().DriverVersion
+	if !engine.FunctionAvailable(funcName, driverVersion) {
+		debugLog("[NVML-STUB] %s called (FUNCTION_NOT_FOUND for driver %s)\n", funcName, driverVersion)
+		return C.NVML_ERROR_FUNCTION_NOT_FOUND
+	}
 	if strictMode {
 		panic(fmt.Sprintf("MOCK_NVML_STRICT: unimplemented function called: %s", funcName))
 	}
 	debugLog("[NVML-STUB] %s called (NOT IMPLEMENTED)\n", funcName)
 	return C.NVML_ERROR_NOT_SUPPORTED
+}
+
+// bridgeVersionCheck checks if a hand-written bridge function is available
+// in the configured driver version. Returns true if available, false otherwise.
+// When false, the caller should return the provided nvmlReturn_t value.
+func bridgeVersionCheck(funcName string) (C.nvmlReturn_t, bool) {
+	driverVersion := engine.GetEngine().GetConfig().DriverVersion
+	if !engine.FunctionAvailable(funcName, driverVersion) {
+		debugLog("[NVML] %s called (FUNCTION_NOT_FOUND for driver %s)\n", funcName, driverVersion)
+		return C.NVML_ERROR_FUNCTION_NOT_FOUND, false
+	}
+	return C.NVML_SUCCESS, true
 }
 
 //export nvmlErrorString

--- a/pkg/gpu/mocknvml/engine/version.go
+++ b/pkg/gpu/mocknvml/engine/version.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"strconv"
+	"strings"
+)
+
+// FunctionVersion describes the driver version range where an NVML function exists.
+type FunctionVersion struct {
+	Added   string // Driver version where function was introduced (e.g., "470.0")
+	Removed string // Driver version where function was removed (empty = still present)
+}
+
+// functionRegistry maps NVML function names to their version boundaries.
+// Unknown functions default to "available" for backwards compatibility.
+var functionRegistry = map[string]FunctionVersion{
+	// Core functions (331.x)
+	"nvmlInit_v2":                    {Added: "331.0"},
+	"nvmlDeviceGetCount_v2":          {Added: "331.0"},
+	"nvmlDeviceGetHandleByIndex_v2":  {Added: "331.0"},
+
+	// 450.x additions
+	"nvmlDeviceGetRemappedRows": {Added: "450.0"},
+
+	// 470.x additions
+	"nvmlDeviceGetArchitecture":          {Added: "470.0"},
+	"nvmlDeviceGetGpuMaxPcieLinkGeneration": {Added: "470.0"},
+
+	// 510.x additions
+	"nvmlDeviceGetMemoryInfo_v2":              {Added: "510.0"},
+	"nvmlDeviceGetComputeRunningProcesses_v3": {Added: "510.0"},
+	"nvmlDeviceGetGraphicsRunningProcesses_v3": {Added: "510.0"},
+	"nvmlDeviceGetGspFirmwareMode":            {Added: "510.0"},
+
+	// 535.x additions
+	"nvmlGpmQueryDeviceSupport": {Added: "535.0"},
+
+	// 560.x additions
+	"nvmlDeviceGetPlatformInfo": {Added: "560.0"},
+}
+
+// GetFunctionRegistry returns a copy of the function version registry.
+func GetFunctionRegistry() map[string]FunctionVersion {
+	result := make(map[string]FunctionVersion, len(functionRegistry))
+	for k, v := range functionRegistry {
+		result[k] = v
+	}
+	return result
+}
+
+// FunctionAvailable returns true if the named function exists in the given driver version.
+// Unknown functions default to available (backwards compatibility).
+func FunctionAvailable(funcName, driverVersion string) bool {
+	entry, exists := functionRegistry[funcName]
+	if !exists {
+		return true
+	}
+	if CompareDriverVersions(driverVersion, entry.Added) < 0 {
+		return false
+	}
+	if entry.Removed != "" && CompareDriverVersions(driverVersion, entry.Removed) >= 0 {
+		return false
+	}
+	return true
+}
+
+// CompareDriverVersions compares two NVIDIA driver version strings.
+// Returns -1 if a < b, 0 if a == b, 1 if a > b.
+// Supports formats: "550", "550.163", "550.163.01"
+func CompareDriverVersions(a, b string) int {
+	aParts := parseVersion(a)
+	bParts := parseVersion(b)
+
+	for i := 0; i < 3; i++ {
+		if aParts[i] < bParts[i] {
+			return -1
+		}
+		if aParts[i] > bParts[i] {
+			return 1
+		}
+	}
+	return 0
+}
+
+// parseVersion splits a version string into [major, minor, patch].
+// Missing components default to 0.
+func parseVersion(v string) [3]int {
+	var result [3]int
+	parts := strings.SplitN(v, ".", 3)
+	for i, p := range parts {
+		if i >= 3 {
+			break
+		}
+		n, _ := strconv.Atoi(p)
+		result[i] = n
+	}
+	return result
+}

--- a/pkg/gpu/mocknvml/engine/version.go
+++ b/pkg/gpu/mocknvml/engine/version.go
@@ -28,22 +28,22 @@ type FunctionVersion struct {
 // Unknown functions default to "available" for backwards compatibility.
 var functionRegistry = map[string]FunctionVersion{
 	// Core functions (331.x)
-	"nvmlInit_v2":                    {Added: "331.0"},
-	"nvmlDeviceGetCount_v2":          {Added: "331.0"},
-	"nvmlDeviceGetHandleByIndex_v2":  {Added: "331.0"},
+	"nvmlInit_v2":                   {Added: "331.0"},
+	"nvmlDeviceGetCount_v2":         {Added: "331.0"},
+	"nvmlDeviceGetHandleByIndex_v2": {Added: "331.0"},
 
 	// 450.x additions
 	"nvmlDeviceGetRemappedRows": {Added: "450.0"},
 
 	// 470.x additions
-	"nvmlDeviceGetArchitecture":          {Added: "470.0"},
+	"nvmlDeviceGetArchitecture":             {Added: "470.0"},
 	"nvmlDeviceGetGpuMaxPcieLinkGeneration": {Added: "470.0"},
 
 	// 510.x additions
-	"nvmlDeviceGetMemoryInfo_v2":              {Added: "510.0"},
-	"nvmlDeviceGetComputeRunningProcesses_v3": {Added: "510.0"},
+	"nvmlDeviceGetMemoryInfo_v2":               {Added: "510.0"},
+	"nvmlDeviceGetComputeRunningProcesses_v3":  {Added: "510.0"},
 	"nvmlDeviceGetGraphicsRunningProcesses_v3": {Added: "510.0"},
-	"nvmlDeviceGetGspFirmwareMode":            {Added: "510.0"},
+	"nvmlDeviceGetGspFirmwareMode":             {Added: "510.0"},
 
 	// 535.x additions
 	"nvmlGpmQueryDeviceSupport": {Added: "535.0"},

--- a/pkg/gpu/mocknvml/engine/version_test.go
+++ b/pkg/gpu/mocknvml/engine/version_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import "testing"
+
+func TestCompareDriverVersions(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want int // -1, 0, 1
+	}{
+		// Equal versions
+		{"equal full", "550.163.01", "550.163.01", 0},
+		{"equal major only", "550", "550", 0},
+		{"equal major.minor", "550.163", "550.163", 0},
+
+		// Major version differences
+		{"major less", "550.163.01", "560.28.03", -1},
+		{"major greater", "560.28.03", "550.163.01", 1},
+
+		// Minor version differences
+		{"minor less", "550.100.01", "550.163.01", -1},
+		{"minor greater", "550.163.01", "550.100.01", 1},
+
+		// Patch version differences
+		{"patch less", "550.163.01", "550.163.02", -1},
+		{"patch greater", "550.163.02", "550.163.01", 1},
+
+		// Mixed formats (major-only vs full)
+		{"major-only vs full equal major", "550", "550.163.01", -1},
+		{"full vs major-only equal major", "550.163.01", "550", 1},
+		{"major-only vs major.minor", "550", "550.0", 0},
+
+		// Edge cases
+		{"leading zeros in patch", "550.163.01", "550.163.1", 0},
+		{"zero patch", "550.163.0", "550.163", 0},
+
+		// Boundary versions from NVML data
+		{"331 vs 470", "331.0", "470.0", -1},
+		{"510 vs 535", "510.0", "535.0", -1},
+		{"535 vs 560", "535.0", "560.0", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CompareDriverVersions(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("CompareDriverVersions(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFunctionAvailable(t *testing.T) {
+	tests := []struct {
+		name          string
+		driverVersion string
+		funcName      string
+		want          bool
+	}{
+		// Function added in 470.x, configured at 550.x -> available
+		{"available after added", "550.163.01", "nvmlDeviceGetArchitecture", true},
+
+		// Function added in 560.x, configured at 550.x -> NOT available
+		{"not available before added", "550.163.01", "nvmlDeviceGetPlatformInfo", false},
+
+		// Function added in 510.x, configured at 510.x -> available (exact match)
+		{"available at exact version", "510.0", "nvmlDeviceGetMemoryInfo_v2", true},
+
+		// Function added in 510.x, configured at 470.x -> NOT available
+		{"not available before version", "470.0", "nvmlDeviceGetMemoryInfo_v2", false},
+
+		// Unknown function -> defaults to available (backwards compat)
+		{"unknown function available", "550.163.01", "nvmlSomeUnknownFunction", true},
+
+		// Very old driver, basic functions still available
+		{"basic function on old driver", "331.0", "nvmlInit_v2", true},
+
+		// Function added in 535.x
+		{"gpm not available on 510", "510.0", "nvmlGpmQueryDeviceSupport", false},
+		{"gpm available on 535", "535.0", "nvmlGpmQueryDeviceSupport", true},
+		{"gpm available on 560", "560.0", "nvmlGpmQueryDeviceSupport", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FunctionAvailable(tt.funcName, tt.driverVersion)
+			if got != tt.want {
+				t.Errorf("FunctionAvailable(%q, %q) = %v, want %v", tt.funcName, tt.driverVersion, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFunctionRegistry_Coverage(t *testing.T) {
+	// Verify that expected functions exist in the registry
+	expectedFunctions := []string{
+		"nvmlInit_v2",
+		"nvmlDeviceGetCount_v2",
+		"nvmlDeviceGetHandleByIndex_v2",
+		"nvmlDeviceGetMemoryInfo_v2",
+		"nvmlDeviceGetArchitecture",
+		"nvmlDeviceGetComputeRunningProcesses_v3",
+		"nvmlDeviceGetGraphicsRunningProcesses_v3",
+		"nvmlDeviceGetGpuMaxPcieLinkGeneration",
+		"nvmlDeviceGetRemappedRows",
+		"nvmlDeviceGetGspFirmwareMode",
+		"nvmlGpmQueryDeviceSupport",
+		"nvmlDeviceGetPlatformInfo",
+	}
+
+	registry := GetFunctionRegistry()
+	for _, name := range expectedFunctions {
+		if _, ok := registry[name]; !ok {
+			t.Errorf("expected function %q not found in registry", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Implements ADR-003: version-aware dispatch for mock NVML library
- Functions not present in configured driver version now return `FUNCTION_NOT_FOUND` (nvmlReturn_t=13) instead of `NOT_SUPPORTED`
- Enables testing consumer behavior across driver version boundaries (e.g., device-plugin graceful degradation on older drivers)

## Changes

- **`engine/version.go`**: Function version registry (~12 key NVML functions with introduction versions) + semantic version comparison utility
- **`engine/version_test.go`**: Tests for semver comparison, function availability logic, and registry coverage
- **`bridge/helpers.go`**: Updated `stubReturn()` to check version registry; added `bridgeVersionCheck()` for hand-written functions
- **`bridge/device.go`**: Added version guards to `nvmlDeviceGetMemoryInfo_v2` (510.x) and `nvmlDeviceGetArchitecture` (470.x)

## Key design decisions

- Unknown functions default to "available" (backwards compat)
- go-nvml doesn't distinguish `dlsym` failure from `FUNCTION_NOT_FOUND` return, so single-binary runtime dispatch is equivalent to multiple `.so` builds
- Registry is extensible: add new entries without changing dispatch logic

## Test plan

- [x] `TestCompareDriverVersions` - semver edge cases (major-only, major.minor, major.minor.patch, leading zeros)
- [x] `TestFunctionAvailable` - version-aware dispatch for known/unknown functions across driver versions
- [x] `TestFunctionRegistry_Coverage` - all expected functions exist in registry
- [x] All existing engine tests pass
- [ ] Integration testing with device-plugin configured at v535 (manual)