### PR TITLE
feat(gpu-mock): DRA + device plugin PoC validation scripts

### DIFF
--- a/.agents/reports/2026-03-05-poc-validation.md
+++ b/.agents/reports/2026-03-05-poc-validation.md
@@ -1,0 +1,161 @@
+# PoC Validation Report: DRA + Device Plugin on Kind with gpu-mock
+
+> Date: 2026-03-05
+> Status: **Scripts ready, pending execution**
+> Branch: `feat/gpu-mock-poc-validation`
+
+## Overview
+
+This report documents the PoC validation of NVIDIA GPU consumers (DRA driver and device plugin) running against the gpu-mock infrastructure on Kind clusters.
+
+## Test Environment
+
+| Component | Version |
+|-----------|---------|
+| gpu-mock | Wave 0 complete (PRs #226, #227, #228) |
+| GPU profile | A100 (DGX A100, 8 GPUs, 40 GiB HBM2e each) |
+| NVIDIA device plugin | v0.18.2 |
+| NVIDIA DRA driver | v0.10.x (latest from Helm) |
+| Kind | latest |
+| Kubernetes | v1.32.x (Kind default) |
+
+## Architecture
+
+```
+Kind Cluster (single control-plane node)
+|
++-- gpu-mock DaemonSet
+|   |-- Builds libnvidia-ml.so (mock) from Go source
+|   |-- Copies to host: /var/lib/nvidia-mock/driver/usr/lib64/
+|   |-- Creates device nodes: /var/lib/nvidia-mock/dev/nvidia{0-7}
+|   |-- Deploys config: /var/lib/nvidia-mock/driver/config/config.yaml
+|   `-- Labels node: nvidia.com/gpu.present=true
+|
++-- NVIDIA Device Plugin (Phase 1)
+|   |-- Loads mock libnvidia-ml.so via --nvidia-driver-root
+|   |-- Discovers 8 mock GPUs via NVML API
+|   `-- Registers nvidia.com/gpu: 8 on node
+|
++-- NVIDIA DRA Driver (Phase 2)
+    |-- Loads mock libnvidia-ml.so via nvidiaDriverRoot
+    |-- Discovers 8 mock GPUs via NVML API
+    `-- Publishes ResourceSlices with mock GPU UUIDs
+```
+
+## Scripts
+
+All scripts are in `tests/poc-validation/`:
+
+| Script | Purpose |
+|--------|---------|
+| `setup-kind-cluster.sh` | Creates Kind cluster, builds+loads gpu-mock image, installs Helm chart |
+| `deploy-device-plugin.sh` | Deploys device plugin with MOCK_NVML_DEBUG=1, validates GPU count |
+| `deploy-dra-driver.sh` | Deploys DRA driver, validates ResourceSlice GPU count |
+| `capture-nvml-traces.sh` | Extracts NVML call traces from container logs |
+| `run-all.sh` | Orchestrates full validation (both phases) |
+
+### Usage
+
+```bash
+# Full validation (both device plugin and DRA)
+cd tests/poc-validation
+./run-all.sh --profile a100 --gpu-count 8
+
+# Or run phases individually:
+./setup-kind-cluster.sh --profile a100 --gpu-count 8
+./deploy-device-plugin.sh --expected-gpus 8
+./capture-nvml-traces.sh
+
+# For DRA (requires --dra flag for Kind cluster):
+./setup-kind-cluster.sh --profile a100 --gpu-count 8 --dra
+./deploy-dra-driver.sh --expected-gpus 8
+./capture-nvml-traces.sh
+```
+
+## Expected NVML Functions Called
+
+Based on analysis of NVIDIA device plugin v0.18.2 and DRA driver source code:
+
+### Device Plugin (nvidia-device-plugin v0.18.2)
+
+Core discovery functions (must work):
+- `nvmlInit_v2` / `nvmlShutdown`
+- `nvmlSystemGetDriverVersion`
+- `nvmlSystemGetNVMLVersion`
+- `nvmlDeviceGetCount_v2`
+- `nvmlDeviceGetHandleByIndex_v2`
+- `nvmlDeviceGetUUID`
+- `nvmlDeviceGetName`
+- `nvmlDeviceGetMinorNumber`
+- `nvmlDeviceGetPciInfo_v3`
+- `nvmlDeviceGetMemoryInfo_v2`
+- `nvmlDeviceGetCudaComputeCapability`
+- `nvmlDeviceGetMigMode`
+- `nvmlDeviceGetGpuInstanceId`
+
+Health monitoring (called periodically, can return NOT_SUPPORTED):
+- `nvmlDeviceGetNvLinkState`
+- `nvmlDeviceGetNvLinkRemotePciInfo_v2`
+- `nvmlDeviceGetFieldValues` (XID errors)
+
+### DRA Driver (nvidia-dra-driver-gpu v0.10.x)
+
+Core discovery (must work):
+- `nvmlInit_v2` / `nvmlShutdown`
+- `nvmlSystemGetDriverVersion`
+- `nvmlDeviceGetCount_v2`
+- `nvmlDeviceGetHandleByIndex_v2`
+- `nvmlDeviceGetUUID`
+- `nvmlDeviceGetName`
+- `nvmlDeviceGetArchitecture`
+- `nvmlDeviceGetCudaComputeCapability`
+- `nvmlDeviceGetMemoryInfo_v2`
+- `nvmlDeviceGetPciInfo_v3`
+- `nvmlDeviceGetBrand`
+- `nvmlDeviceGetMigMode`
+- `nvmlDeviceGetMaxMigDeviceCount`
+
+Resource publishing (needed for ResourceSlice attributes):
+- `nvmlDeviceGetNvLinkState`
+- `nvmlDeviceGetNvLinkRemotePciInfo_v2`
+- `nvmlDeviceGetNvLinkVersion`
+
+## Phase Gate Criteria
+
+| Criterion | Status |
+|-----------|--------|
+| Kind cluster creates successfully | Pending |
+| gpu-mock DaemonSet deploys and creates mock files | Pending |
+| Device plugin discovers mock GPUs | Pending |
+| Node reports `nvidia.com/gpu: 8` | Pending |
+| DRA driver publishes ResourceSlices | Pending |
+| ResourceSlices contain 8 GPUs with correct UUIDs | Pending |
+| NVML call traces captured | Pending |
+
+## Known Limitations
+
+1. **MOCK_NVML_DEBUG environment**: The debug logging is compiled into the .so, but the env var must be set in the consumer container's environment, not in the gpu-mock pod. The debug manifests handle this.
+
+2. **DRA driver init container**: The DRA driver Helm chart may run init containers that probe nvidia-smi. The mock nvidia-smi script handles basic version queries.
+
+3. **LD_LIBRARY_PATH**: Device plugin and DRA driver use `--nvidia-driver-root` to find libnvidia-ml.so. The mock .so must be at the exact path they expect: `$DRIVER_ROOT/usr/lib64/libnvidia-ml.so.1`.
+
+4. **CDI for DRA**: DRA requires CDI (Container Device Interface) support in containerd. The `kind-dra-config.yaml` enables this.
+
+## NVML Call Trace Analysis
+
+> To be populated after execution. Run `capture-nvml-traces.sh` to generate.
+
+The trace output will be in `tests/poc-validation/logs/nvml-trace-summary.md` and will categorize each NVML function as:
+- **Implemented**: Bridge function exists, returns profile-driven data
+- **Stub (NOT_SUPPORTED)**: Returns NOT_SUPPORTED, consumer handles gracefully
+- **Stub (FUNCTION_NOT_FOUND)**: Version-gated, not available for configured driver version
+
+Functions that return NOT_SUPPORTED but are called by consumers are candidates for Wave 2+ implementation.
+
+## Next Steps
+
+1. Execute `run-all.sh` on a machine with Docker available (CI runner or dev machine)
+2. Capture NVML traces and update this report with actual results
+3. Use trace data to prioritize T4 (NVML Batch 1) and T5 (NVML Batch 2) function lists
+4. If DRA fails: document exact error and escalate to distinguished-engineer

--- a/tests/poc-validation/README.md
+++ b/tests/poc-validation/README.md
@@ -1,0 +1,54 @@
+# GPU Mock PoC Validation
+
+Reproducible scripts for validating NVIDIA GPU consumers (device plugin, DRA driver) against the gpu-mock infrastructure on Kind clusters.
+
+## Prerequisites
+
+- Docker (with daemon running)
+- kind
+- helm
+- kubectl
+- jq
+
+## Quick Start
+
+```bash
+# Full validation (device plugin + DRA driver)
+./run-all.sh --profile a100 --gpu-count 8
+
+# Results in ./logs/
+```
+
+## Individual Scripts
+
+```bash
+# Phase 1: Device Plugin
+./setup-kind-cluster.sh --profile a100 --gpu-count 8
+./deploy-device-plugin.sh --expected-gpus 8
+./capture-nvml-traces.sh
+
+# Phase 2: DRA Driver (needs DRA-enabled cluster)
+./setup-kind-cluster.sh --profile a100 --gpu-count 8 --dra
+./deploy-dra-driver.sh --expected-gpus 8
+./capture-nvml-traces.sh
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GPU_PROFILE` | `a100` | GPU profile (a100, h100, b200, gb200, l40s, t4) |
+| `GPU_COUNT` | `8` | Number of mock GPUs |
+| `CLUSTER_NAME` | `gpu-mock-poc` | Kind cluster name |
+| `MOCK_NVML_DEBUG` | `1` | Enable NVML debug traces |
+| `GOLANG_VERSION` | `1.25` | Go version for building gpu-mock image |
+
+## Output
+
+Logs and traces are saved to `./logs/`:
+
+- `device-plugin-nvml-calls.log` - Filtered NVML calls from device plugin
+- `dra-driver-nvml-calls.log` - Filtered NVML calls from DRA driver
+- `nvml-trace-summary.md` - Summary of all NVML functions called
+- `resourceslices.yaml` - DRA ResourceSlice output
+- `node-status.json` - Node status with allocatable GPUs

--- a/tests/poc-validation/capture-nvml-traces.sh
+++ b/tests/poc-validation/capture-nvml-traces.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Captures NVML call traces from device plugin and DRA driver containers.
+# MOCK_NVML_DEBUG=1 must be set in the consumer containers (not gpu-mock).
+#
+# The gpu-mock chart deploys libnvidia-ml.so to the host. When device plugin
+# or DRA driver loads this .so, debug traces go to that consumer's stderr.
+#
+# Usage: ./capture-nvml-traces.sh [--output-dir ./logs]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT_DIR="${OUTPUT_DIR:-$SCRIPT_DIR/logs}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+    *) echo "Unknown flag: $1"; exit 1 ;;
+  esac
+done
+
+mkdir -p "$OUTPUT_DIR"
+
+echo "=== Capturing NVML Call Traces ==="
+echo "Output: $OUTPUT_DIR"
+echo ""
+
+# Capture device plugin traces
+echo "--- Device Plugin logs ---"
+if kubectl -n kube-system get pods -l name=nvidia-device-plugin-mock --no-headers 2>/dev/null | grep -q Running; then
+  kubectl -n kube-system logs -l name=nvidia-device-plugin-mock --tail=5000 \
+    > "$OUTPUT_DIR/device-plugin-trace-raw.log" 2>&1
+
+  # Extract NVML stub/bridge calls
+  grep -E '\[NVML' "$OUTPUT_DIR/device-plugin-trace-raw.log" \
+    > "$OUTPUT_DIR/device-plugin-nvml-calls.log" 2>/dev/null || true
+
+  STUB_COUNT=$(grep -c '\[NVML-STUB\]' "$OUTPUT_DIR/device-plugin-nvml-calls.log" 2>/dev/null || echo 0)
+  IMPL_COUNT=$(grep -c '\[NVML\]' "$OUTPUT_DIR/device-plugin-nvml-calls.log" 2>/dev/null || echo 0)
+  echo "  Stub calls: $STUB_COUNT"
+  echo "  Implemented calls: $IMPL_COUNT"
+
+  # Extract unique function names called
+  grep -oP '\[NVML(?:-STUB)?\]\s+\K\S+' "$OUTPUT_DIR/device-plugin-nvml-calls.log" \
+    | sed 's/ called.*//' | sort -u \
+    > "$OUTPUT_DIR/device-plugin-functions-called.txt" 2>/dev/null || true
+  echo "  Unique functions: $(wc -l < "$OUTPUT_DIR/device-plugin-functions-called.txt" | tr -d ' ')"
+else
+  echo "  Device plugin not running, skipping"
+fi
+
+echo ""
+
+# Capture DRA driver traces
+echo "--- DRA Driver logs ---"
+if kubectl -n nvidia get pods -l app.kubernetes.io/name=nvidia-dra-driver-gpu --no-headers 2>/dev/null | grep -q Running; then
+  kubectl -n nvidia logs -l app.kubernetes.io/name=nvidia-dra-driver-gpu --all-containers --tail=5000 \
+    > "$OUTPUT_DIR/dra-driver-trace-raw.log" 2>&1
+
+  # Extract NVML stub/bridge calls
+  grep -E '\[NVML' "$OUTPUT_DIR/dra-driver-trace-raw.log" \
+    > "$OUTPUT_DIR/dra-driver-nvml-calls.log" 2>/dev/null || true
+
+  STUB_COUNT=$(grep -c '\[NVML-STUB\]' "$OUTPUT_DIR/dra-driver-nvml-calls.log" 2>/dev/null || echo 0)
+  IMPL_COUNT=$(grep -c '\[NVML\]' "$OUTPUT_DIR/dra-driver-nvml-calls.log" 2>/dev/null || echo 0)
+  echo "  Stub calls: $STUB_COUNT"
+  echo "  Implemented calls: $IMPL_COUNT"
+
+  grep -oP '\[NVML(?:-STUB)?\]\s+\K\S+' "$OUTPUT_DIR/dra-driver-nvml-calls.log" \
+    | sed 's/ called.*//' | sort -u \
+    > "$OUTPUT_DIR/dra-driver-functions-called.txt" 2>/dev/null || true
+  echo "  Unique functions: $(wc -l < "$OUTPUT_DIR/dra-driver-functions-called.txt" | tr -d ' ')"
+
+  # Also capture kubelet-plugin specifically
+  PLUGIN_POD=$(kubectl -n nvidia get pods --no-headers -o custom-columns=':metadata.name' | grep kubelet-plugin | head -1)
+  if [ -n "$PLUGIN_POD" ]; then
+    kubectl -n nvidia logs "$PLUGIN_POD" --all-containers --tail=5000 \
+      > "$OUTPUT_DIR/dra-kubelet-plugin-trace.log" 2>&1 || true
+  fi
+else
+  echo "  DRA driver not running, skipping"
+fi
+
+echo ""
+
+# Generate summary report
+echo "=== Generating trace summary ==="
+{
+  echo "# NVML Call Trace Summary"
+  echo "# Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo ""
+
+  if [ -f "$OUTPUT_DIR/device-plugin-functions-called.txt" ]; then
+    echo "## Device Plugin (v0.18.2)"
+    echo ""
+    echo "### Functions Called"
+    echo ""
+    while IFS= read -r func; do
+      if grep -q "\[NVML-STUB\] $func" "$OUTPUT_DIR/device-plugin-nvml-calls.log" 2>/dev/null; then
+        echo "- [ ] $func (NOT_SUPPORTED - stub)"
+      else
+        echo "- [x] $func (implemented)"
+      fi
+    done < "$OUTPUT_DIR/device-plugin-functions-called.txt"
+    echo ""
+  fi
+
+  if [ -f "$OUTPUT_DIR/dra-driver-functions-called.txt" ]; then
+    echo "## DRA Driver (v0.10.x)"
+    echo ""
+    echo "### Functions Called"
+    echo ""
+    while IFS= read -r func; do
+      if grep -q "\[NVML-STUB\] $func" "$OUTPUT_DIR/dra-driver-nvml-calls.log" 2>/dev/null; then
+        echo "- [ ] $func (NOT_SUPPORTED - stub)"
+      else
+        echo "- [x] $func (implemented)"
+      fi
+    done < "$OUTPUT_DIR/dra-driver-functions-called.txt"
+    echo ""
+  fi
+
+  # Combined unique functions for prioritization
+  echo "## Combined: All NVML Functions Called by Consumers"
+  echo ""
+  cat "$OUTPUT_DIR/"*-functions-called.txt 2>/dev/null | sort -u | while IFS= read -r func; do
+    echo "- $func"
+  done
+  echo ""
+
+  echo "## Stub Functions (Need Implementation for Full Support)"
+  echo ""
+  echo "These functions returned NOT_SUPPORTED and may need implementation:"
+  echo ""
+  grep '\[NVML-STUB\]' "$OUTPUT_DIR/"*-nvml-calls.log 2>/dev/null \
+    | grep -oP '\[NVML-STUB\]\s+\K\S+' | sed 's/ called.*//' | sort -u | while IFS= read -r func; do
+    echo "- $func"
+  done
+} > "$OUTPUT_DIR/nvml-trace-summary.md"
+
+echo "Summary written to $OUTPUT_DIR/nvml-trace-summary.md"
+echo ""
+echo "=== Trace capture complete ==="

--- a/tests/poc-validation/deploy-device-plugin.sh
+++ b/tests/poc-validation/deploy-device-plugin.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deploys the NVIDIA device plugin against gpu-mock and validates GPU count.
+# Must run after setup-kind-cluster.sh.
+#
+# Usage: ./deploy-device-plugin.sh [--expected-gpus 8]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+EXPECTED_GPUS="${EXPECTED_GPUS:-8}"
+CLUSTER_NAME="${CLUSTER_NAME:-gpu-mock-poc}"
+LOG_DIR="${LOG_DIR:-$SCRIPT_DIR/logs}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expected-gpus) EXPECTED_GPUS="$2"; shift 2 ;;
+    --cluster-name) CLUSTER_NAME="$2"; shift 2 ;;
+    *) echo "Unknown flag: $1"; exit 1 ;;
+  esac
+done
+
+mkdir -p "$LOG_DIR"
+
+echo "=== Deploying NVIDIA Device Plugin ==="
+echo "Expected GPUs: $EXPECTED_GPUS"
+echo ""
+
+# Step 1: Deploy device plugin (debug manifest with MOCK_NVML_DEBUG=1)
+echo "=== Step 1: Applying device plugin manifest (debug-enabled) ==="
+kubectl apply -f "$SCRIPT_DIR/device-plugin-mock-debug.yaml"
+
+echo ""
+echo "=== Step 2: Waiting for device plugin pod ==="
+kubectl -n kube-system wait --for=condition=ready \
+  pod -l name=nvidia-device-plugin-mock --timeout=120s
+
+# Step 3: Capture device plugin logs (with NVML debug traces)
+echo ""
+echo "=== Step 3: Capturing device plugin startup logs ==="
+sleep 5  # Allow time for initial NVML calls
+kubectl -n kube-system logs -l name=nvidia-device-plugin-mock --tail=500 \
+  > "$LOG_DIR/device-plugin-startup.log" 2>&1 || true
+echo "Logs saved to $LOG_DIR/device-plugin-startup.log"
+
+# Step 4: Capture NVML debug traces from gpu-mock pod
+echo ""
+echo "=== Step 4: Capturing NVML debug traces from gpu-mock ==="
+# The MOCK_NVML_DEBUG traces go to stderr of the process that loaded libnvidia-ml.so.
+# For device plugin, traces appear in the device plugin container's stderr.
+# We also check the gpu-mock pod for any traces from setup.
+kubectl logs -l app.kubernetes.io/name=gpu-mock --tail=200 \
+  > "$LOG_DIR/gpu-mock-pod.log" 2>&1 || true
+
+# Step 5: Verify allocatable GPUs
+echo ""
+echo "=== Step 5: Verifying allocatable GPUs ==="
+NODE=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+for i in $(seq 1 30); do
+  GPUS=$(kubectl get node "$NODE" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}')
+  if [ "$GPUS" = "$EXPECTED_GPUS" ]; then
+    echo "PASS: Node reports $GPUS allocatable GPUs"
+
+    # Save final state
+    kubectl get node "$NODE" -o json > "$LOG_DIR/node-status.json"
+    kubectl -n kube-system logs -l name=nvidia-device-plugin-mock --tail=1000 \
+      > "$LOG_DIR/device-plugin-full.log" 2>&1 || true
+
+    echo ""
+    echo "=== Device Plugin Validation PASSED ==="
+    echo "  Allocatable GPUs: $GPUS"
+    echo "  Logs: $LOG_DIR/"
+    exit 0
+  fi
+  echo "Attempt $i/30: allocatable GPUs=$GPUS (expected $EXPECTED_GPUS), waiting..."
+  sleep 2
+done
+
+echo "FAIL: Expected $EXPECTED_GPUS allocatable GPUs, got ${GPUS:-none}"
+
+# Collect debug info on failure
+echo ""
+echo "=== Collecting failure debug info ==="
+kubectl -n kube-system describe pod -l name=nvidia-device-plugin-mock \
+  > "$LOG_DIR/device-plugin-describe.log" 2>&1 || true
+kubectl -n kube-system logs -l name=nvidia-device-plugin-mock --tail=1000 \
+  > "$LOG_DIR/device-plugin-full.log" 2>&1 || true
+kubectl describe nodes > "$LOG_DIR/node-describe.log" 2>&1 || true
+
+echo "Debug logs saved to $LOG_DIR/"
+exit 1

--- a/tests/poc-validation/deploy-dra-driver.sh
+++ b/tests/poc-validation/deploy-dra-driver.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deploys the NVIDIA DRA driver against gpu-mock and validates ResourceSlices.
+# Must run after setup-kind-cluster.sh with --dra flag.
+#
+# Usage: ./deploy-dra-driver.sh [--expected-gpus 8]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG_DIR="${LOG_DIR:-$SCRIPT_DIR/logs}"
+
+EXPECTED_GPUS="${EXPECTED_GPUS:-8}"
+CLUSTER_NAME="${CLUSTER_NAME:-gpu-mock-poc}"
+DRA_CHART_VERSION="${DRA_CHART_VERSION:-}"  # Empty = latest
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expected-gpus) EXPECTED_GPUS="$2"; shift 2 ;;
+    --cluster-name) CLUSTER_NAME="$2"; shift 2 ;;
+    --chart-version) DRA_CHART_VERSION="$2"; shift 2 ;;
+    *) echo "Unknown flag: $1"; exit 1 ;;
+  esac
+done
+
+mkdir -p "$LOG_DIR"
+
+echo "=== Deploying NVIDIA DRA Driver ==="
+echo "Expected GPUs: $EXPECTED_GPUS"
+echo ""
+
+# Step 1: Add NVIDIA Helm repo
+echo "=== Step 1: Adding NVIDIA Helm repo ==="
+helm repo add nvidia https://helm.ngc.nvidia.com/nvidia 2>/dev/null || true
+helm repo update
+
+# Step 2: Install DRA driver
+echo ""
+echo "=== Step 2: Installing DRA driver ==="
+VERSION_FLAG=""
+if [ -n "$DRA_CHART_VERSION" ]; then
+  VERSION_FLAG="--version $DRA_CHART_VERSION"
+fi
+
+# shellcheck disable=SC2086
+helm install nvidia-dra-driver nvidia/nvidia-dra-driver-gpu \
+  --namespace nvidia \
+  --create-namespace \
+  --set nvidiaDriverRoot=/var/lib/nvidia-mock/driver \
+  --set gpuResourcesEnabledOverride=true \
+  --set resources.computeDomains.enabled=false \
+  $VERSION_FLAG \
+  --wait --timeout 180s
+
+# Step 3: Wait for DRA pods
+echo ""
+echo "=== Step 3: Waiting for DRA pods ==="
+kubectl -n nvidia wait --for=condition=ready pod --all --timeout=120s
+
+# Step 4: Capture DRA driver logs
+echo ""
+echo "=== Step 4: Capturing DRA driver logs ==="
+sleep 5  # Allow time for initial NVML discovery
+kubectl -n nvidia logs -l app.kubernetes.io/name=nvidia-dra-driver-gpu --tail=500 \
+  > "$LOG_DIR/dra-driver-startup.log" 2>&1 || true
+
+# Capture kubelet-plugin logs specifically (this is where NVML calls happen)
+PLUGIN_POD=$(kubectl -n nvidia get pods --no-headers -o custom-columns=':metadata.name' | grep kubelet-plugin | head -1)
+if [ -n "$PLUGIN_POD" ]; then
+  kubectl -n nvidia logs "$PLUGIN_POD" --all-containers --tail=500 \
+    > "$LOG_DIR/dra-kubelet-plugin.log" 2>&1 || true
+  echo "DRA kubelet-plugin logs saved"
+fi
+
+# Step 5: Verify ResourceSlices
+echo ""
+echo "=== Step 5: Verifying ResourceSlices ==="
+for i in $(seq 1 30); do
+  COUNT=$(kubectl get resourceslices -o json | \
+    jq '[.items[].spec.devices // [] | length] | add // 0')
+  if [ "$COUNT" = "$EXPECTED_GPUS" ]; then
+    echo "PASS: ResourceSlice reports $COUNT GPUs"
+
+    # Save ResourceSlice details
+    kubectl get resourceslices -o yaml > "$LOG_DIR/resourceslices.yaml"
+    kubectl get resourceslices -o json > "$LOG_DIR/resourceslices.json"
+
+    # Extract GPU UUIDs from ResourceSlices
+    echo ""
+    echo "=== GPU UUIDs in ResourceSlices ==="
+    jq -r '.items[].spec.devices[]?.basic?.attributes?.uuid?.StringValue // empty' \
+      "$LOG_DIR/resourceslices.json" 2>/dev/null || \
+    jq -r '.items[].spec.devices[]? | .name // "unnamed"' \
+      "$LOG_DIR/resourceslices.json"
+
+    # Save final DRA logs
+    kubectl -n nvidia logs -l app.kubernetes.io/name=nvidia-dra-driver-gpu --tail=2000 \
+      > "$LOG_DIR/dra-driver-full.log" 2>&1 || true
+
+    echo ""
+    echo "=== DRA Driver Validation PASSED ==="
+    echo "  ResourceSlice GPUs: $COUNT"
+    echo "  Logs: $LOG_DIR/"
+    exit 0
+  fi
+  echo "Attempt $i/30: ResourceSlice GPUs=$COUNT (expected $EXPECTED_GPUS), waiting..."
+  sleep 2
+done
+
+echo "FAIL: Expected $EXPECTED_GPUS GPUs in ResourceSlice, got ${COUNT:-0}"
+
+# Collect debug info on failure
+echo ""
+echo "=== Collecting failure debug info ==="
+kubectl -n nvidia get pods -o wide > "$LOG_DIR/dra-pods.log" 2>&1 || true
+kubectl -n nvidia describe pods > "$LOG_DIR/dra-pods-describe.log" 2>&1 || true
+kubectl -n nvidia logs -l app.kubernetes.io/name=nvidia-dra-driver-gpu --tail=2000 \
+  > "$LOG_DIR/dra-driver-full.log" 2>&1 || true
+kubectl get resourceslices -o yaml > "$LOG_DIR/resourceslices.yaml" 2>&1 || true
+kubectl describe nodes > "$LOG_DIR/node-describe.log" 2>&1 || true
+
+echo "Debug logs saved to $LOG_DIR/"
+exit 1

--- a/tests/poc-validation/device-plugin-mock-debug.yaml
+++ b/tests/poc-validation/device-plugin-mock-debug.yaml
@@ -1,0 +1,47 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Device plugin DaemonSet for PoC validation with NVML debug tracing enabled.
+# MOCK_NVML_DEBUG=1 causes the mock libnvidia-ml.so to log every NVML call
+# to stderr, allowing us to capture which functions consumers actually invoke.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin-mock
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: nvidia-device-plugin-mock
+  template:
+    metadata:
+      labels:
+        name: nvidia-device-plugin-mock
+    spec:
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: nvidia-device-plugin
+          image: nvcr.io/nvidia/k8s-device-plugin:v0.18.2
+          args:
+            - "--nvidia-driver-root=/var/lib/nvidia-mock/driver"
+            - "--driver-root-ctr-path=/var/lib/nvidia-mock/driver"
+            - "--device-discovery-strategy=nvml"
+          env:
+            - name: MOCK_NVML_DEBUG
+              value: "1"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: mock-root
+              mountPath: /var/lib/nvidia-mock
+              readOnly: true
+            - name: device-plugins
+              mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: mock-root
+          hostPath:
+            path: /var/lib/nvidia-mock
+        - name: device-plugins
+          hostPath:
+            path: /var/lib/kubelet/device-plugins

--- a/tests/poc-validation/logs/.gitignore
+++ b/tests/poc-validation/logs/.gitignore
@@ -1,0 +1,3 @@
+# Log files are generated at runtime, not committed
+*
+!.gitignore

--- a/tests/poc-validation/run-all.sh
+++ b/tests/poc-validation/run-all.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# End-to-end PoC validation: creates Kind cluster, deploys gpu-mock,
+# tests both device plugin and DRA driver, captures NVML traces.
+#
+# Usage: ./run-all.sh [--profile a100] [--gpu-count 8]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+GPU_PROFILE="${GPU_PROFILE:-a100}"
+GPU_COUNT="${GPU_COUNT:-8}"
+export CLUSTER_NAME="gpu-mock-poc"
+export LOG_DIR="$SCRIPT_DIR/logs"
+export EXPECTED_GPUS="$GPU_COUNT"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile) GPU_PROFILE="$2"; shift 2 ;;
+    --gpu-count) GPU_COUNT="$2"; EXPECTED_GPUS="$GPU_COUNT"; shift 2 ;;
+    *) echo "Unknown flag: $1"; exit 1 ;;
+  esac
+done
+
+RESULTS_FILE="$LOG_DIR/results.txt"
+mkdir -p "$LOG_DIR"
+
+pass() { echo "PASS: $1" | tee -a "$RESULTS_FILE"; }
+fail() { echo "FAIL: $1" | tee -a "$RESULTS_FILE"; }
+
+echo "=== Full PoC Validation Run ==="
+echo "Profile: $GPU_PROFILE, GPUs: $GPU_COUNT"
+echo "Logs: $LOG_DIR"
+echo ""
+> "$RESULTS_FILE"
+
+cleanup() {
+  echo ""
+  echo "=== Cleanup ==="
+  kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# -------------------------------------------------------
+# Phase 1: Device Plugin validation (standard Kind cluster)
+# -------------------------------------------------------
+echo "=========================================="
+echo "Phase 1: Device Plugin on standard Kind"
+echo "=========================================="
+
+GPU_PROFILE="$GPU_PROFILE" GPU_COUNT="$GPU_COUNT" \
+  "$SCRIPT_DIR/setup-kind-cluster.sh" --profile "$GPU_PROFILE" --gpu-count "$GPU_COUNT"
+
+if "$SCRIPT_DIR/deploy-device-plugin.sh" --expected-gpus "$GPU_COUNT"; then
+  pass "Device Plugin reports $GPU_COUNT GPUs"
+else
+  fail "Device Plugin GPU count"
+fi
+
+# Capture device plugin traces
+"$SCRIPT_DIR/capture-nvml-traces.sh" --output-dir "$LOG_DIR" || true
+
+# Tear down for Phase 2
+kind delete cluster --name "$CLUSTER_NAME"
+
+# -------------------------------------------------------
+# Phase 2: DRA Driver validation (DRA-enabled Kind cluster)
+# -------------------------------------------------------
+echo ""
+echo "=========================================="
+echo "Phase 2: DRA Driver on DRA-enabled Kind"
+echo "=========================================="
+
+GPU_PROFILE="$GPU_PROFILE" GPU_COUNT="$GPU_COUNT" \
+  "$SCRIPT_DIR/setup-kind-cluster.sh" --profile "$GPU_PROFILE" --gpu-count "$GPU_COUNT" --dra
+
+if "$SCRIPT_DIR/deploy-dra-driver.sh" --expected-gpus "$GPU_COUNT"; then
+  pass "DRA Driver publishes $GPU_COUNT GPUs in ResourceSlices"
+else
+  fail "DRA Driver ResourceSlice GPU count"
+fi
+
+# Capture DRA traces
+"$SCRIPT_DIR/capture-nvml-traces.sh" --output-dir "$LOG_DIR" || true
+
+# -------------------------------------------------------
+# Summary
+# -------------------------------------------------------
+echo ""
+echo "=========================================="
+echo "PoC Validation Results"
+echo "=========================================="
+cat "$RESULTS_FILE"
+echo ""
+echo "NVML trace summary: $LOG_DIR/nvml-trace-summary.md"
+echo "Full logs: $LOG_DIR/"
+
+if grep -q "FAIL" "$RESULTS_FILE"; then
+  echo ""
+  echo "Some validations FAILED. See logs for details."
+  exit 1
+fi
+
+echo ""
+echo "All validations PASSED."

--- a/tests/poc-validation/setup-kind-cluster.sh
+++ b/tests/poc-validation/setup-kind-cluster.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Creates a Kind cluster with gpu-mock installed (A100 profile).
+# Usage: ./setup-kind-cluster.sh [--profile a100] [--gpu-count 8] [--dra]
+#
+# Prerequisites: docker, kind, helm, kubectl
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Defaults
+GPU_PROFILE="${GPU_PROFILE:-a100}"
+GPU_COUNT="${GPU_COUNT:-8}"
+GOLANG_VERSION="${GOLANG_VERSION:-1.25}"
+ENABLE_DRA="${ENABLE_DRA:-false}"
+CLUSTER_NAME="gpu-mock-poc"
+MOCK_NVML_DEBUG="${MOCK_NVML_DEBUG:-1}"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile) GPU_PROFILE="$2"; shift 2 ;;
+    --gpu-count) GPU_COUNT="$2"; shift 2 ;;
+    --dra) ENABLE_DRA="true"; shift ;;
+    --cluster-name) CLUSTER_NAME="$2"; shift 2 ;;
+    --no-debug) MOCK_NVML_DEBUG=""; shift ;;
+    *) echo "Unknown flag: $1"; exit 1 ;;
+  esac
+done
+
+echo "=== GPU Mock PoC Validation ==="
+echo "Profile: $GPU_PROFILE"
+echo "GPU Count: $GPU_COUNT"
+echo "DRA Enabled: $ENABLE_DRA"
+echo "Cluster: $CLUSTER_NAME"
+echo "Debug: ${MOCK_NVML_DEBUG:+enabled}"
+echo ""
+
+# Verify prerequisites
+for tool in docker kind helm kubectl; do
+  if ! command -v "$tool" &>/dev/null; then
+    echo "ERROR: $tool is required but not found" >&2
+    exit 1
+  fi
+done
+
+# Check Docker daemon
+if ! docker info &>/dev/null; then
+  echo "ERROR: Docker daemon is not running" >&2
+  exit 1
+fi
+
+# Clean up any existing cluster
+if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+  echo "Deleting existing cluster: $CLUSTER_NAME"
+  kind delete cluster --name "$CLUSTER_NAME"
+fi
+
+# Step 1: Create Kind cluster
+echo ""
+echo "=== Step 1: Creating Kind cluster ==="
+if [ "$ENABLE_DRA" = "true" ]; then
+  kind create cluster --name "$CLUSTER_NAME" \
+    --config "$REPO_ROOT/tests/e2e/kind-dra-config.yaml"
+else
+  kind create cluster --name "$CLUSTER_NAME"
+fi
+
+# Step 2: Build gpu-mock image
+echo ""
+echo "=== Step 2: Building gpu-mock image ==="
+docker build -t gpu-mock:poc -f "$REPO_ROOT/deployments/gpu-mock/Dockerfile" \
+  --build-arg GOLANG_VERSION="$GOLANG_VERSION" \
+  "$REPO_ROOT"
+
+# Step 3: Load image into Kind
+echo ""
+echo "=== Step 3: Loading image into Kind ==="
+kind load docker-image gpu-mock:poc --name "$CLUSTER_NAME"
+
+# Step 4: Install gpu-mock Helm chart
+echo ""
+echo "=== Step 4: Installing gpu-mock Helm chart (profile=$GPU_PROFILE, count=$GPU_COUNT) ==="
+helm install gpu-mock "$REPO_ROOT/deployments/gpu-mock/helm/gpu-mock" \
+  --set image.repository=gpu-mock \
+  --set image.tag=poc \
+  --set gpu.profile="$GPU_PROFILE" \
+  --set gpu.count="$GPU_COUNT" \
+  --wait --timeout 120s
+
+# Step 5: Wait for DaemonSet
+echo ""
+echo "=== Step 5: Waiting for gpu-mock DaemonSet ==="
+kubectl rollout status daemonset/gpu-mock --timeout=60s
+
+# Step 6: Verify mock files on node
+echo ""
+echo "=== Step 6: Verifying mock files on node ==="
+NODE_CONTAINER="${CLUSTER_NAME}-control-plane"
+docker exec "$NODE_CONTAINER" test -L /var/lib/nvidia-mock/driver/usr/lib64/libnvidia-ml.so.1
+docker exec "$NODE_CONTAINER" test -f /var/lib/nvidia-mock/driver/config/config.yaml
+docker exec "$NODE_CONTAINER" test -e /var/lib/nvidia-mock/dev/nvidia0
+echo "Mock files verified on node"
+
+# Step 7: Verify node labels
+echo ""
+echo "=== Step 7: Verifying node labels ==="
+NODE=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+LABEL=$(kubectl get node "$NODE" -o jsonpath='{.metadata.labels.nvidia\.com/gpu\.present}')
+echo "nvidia.com/gpu.present=$LABEL"
+if [ "$LABEL" != "true" ]; then
+  echo "WARNING: Node label nvidia.com/gpu.present not set"
+fi
+
+echo ""
+echo "=== Kind cluster ready ==="
+echo "Cluster: $CLUSTER_NAME"
+echo "Node container: $NODE_CONTAINER"
+echo ""
+echo "Next steps:"
+echo "  Deploy device plugin: ./deploy-device-plugin.sh"
+echo "  Deploy DRA driver:    ./deploy-dra-driver.sh"


### PR DESCRIPTION
## Summary

- Add reproducible Kind cluster setup and validation scripts for testing NVIDIA GPU consumers (device plugin v0.18.2, DRA driver v0.10.x) against gpu-mock
- Include NVML call trace capture with `MOCK_NVML_DEBUG=1` for profiling which functions consumers actually invoke
- Document expected NVML function usage and Phase 0 gate criteria in validation report

## Scripts

| Script | Purpose |
|--------|---------|
| `tests/poc-validation/setup-kind-cluster.sh` | Creates Kind cluster, builds gpu-mock image, installs Helm chart |
| `tests/poc-validation/deploy-device-plugin.sh` | Deploys device plugin with debug tracing, validates allocatable GPUs |
| `tests/poc-validation/deploy-dra-driver.sh` | Deploys DRA driver, validates ResourceSlice GPU count |
| `tests/poc-validation/capture-nvml-traces.sh` | Extracts and summarizes NVML call traces |
| `tests/poc-validation/run-all.sh` | Full orchestrated validation (both phases) |

## Prerequisites

Requires Docker daemon. Scripts are designed for CI runners or development machines.

## Test plan

- [ ] Run `./tests/poc-validation/run-all.sh` on a machine with Docker
- [ ] Verify device plugin reports correct GPU count
- [ ] Verify DRA driver publishes ResourceSlices
- [ ] Review NVML trace summary for Wave 2+ prioritization