### PR TITLE
feat(gpu-mock): NVML Batch 2 - process, performance, persistence, advanced

### DIFF
--- a/pkg/gpu/mocknvml/bridge/device.go
+++ b/pkg/gpu/mocknvml/bridge/device.go
@@ -29,6 +29,15 @@
 // - nvmlDeviceGetArchitecture
 // - nvmlDeviceGetCudaComputeCapability
 // - nvmlDeviceGetMigMode
+// - nvmlDeviceGetComputeRunningProcesses_v3
+// - nvmlDeviceGetProcessUtilization
+// - nvmlDeviceGetPerformanceState
+// - nvmlDeviceGetCurrentClocksEventReasons
+// - nvmlDeviceGetPersistenceMode
+// - nvmlDeviceSetPersistenceMode
+// - nvmlDeviceGetRemappedRows
+// - nvmlDeviceGetGspFirmwareMode
+// - nvmlDeviceGetDisplayActive
 
 package main
 
@@ -582,5 +591,225 @@ func nvmlDeviceGetMigMode(nvmlDevice C.nvmlDevice_t, currentMode *C.uint, pendin
 	}
 	*currentMode = C.uint(current)
 	*pendingMode = C.uint(pending)
+	return C.NVML_SUCCESS
+}
+
+// =============================================================================
+// Process Functions
+// =============================================================================
+
+//export nvmlDeviceGetComputeRunningProcesses_v3
+func nvmlDeviceGetComputeRunningProcesses_v3(nvmlDevice C.nvmlDevice_t, infoCount *C.uint, infos *C.nvmlProcessInfo_t) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetComputeRunningProcesses_v3"); !ok {
+		return ret
+	}
+	if infoCount == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	procs, ret := dev.GetComputeRunningProcesses()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	if infos == nil {
+		// Caller is querying the count
+		*infoCount = C.uint(len(procs))
+		return C.NVML_SUCCESS
+	}
+	bufSize := int(*infoCount)
+	if len(procs) > bufSize {
+		*infoCount = C.uint(len(procs))
+		return C.NVML_ERROR_INSUFFICIENT_SIZE
+	}
+	*infoCount = C.uint(len(procs))
+	if len(procs) > 0 {
+		// Write process info to the caller's buffer
+		outSlice := unsafe.Slice(infos, len(procs))
+		for i, p := range procs {
+			outSlice[i].pid = C.uint(p.Pid)
+			outSlice[i].usedGpuMemory = C.ulonglong(p.UsedGpuMemory)
+			outSlice[i].gpuInstanceId = C.uint(p.GpuInstanceId)
+			outSlice[i].computeInstanceId = C.uint(p.ComputeInstanceId)
+		}
+	}
+	return C.NVML_SUCCESS
+}
+
+//export nvmlDeviceGetProcessUtilization
+func nvmlDeviceGetProcessUtilization(nvmlDevice C.nvmlDevice_t, utilization *C.nvmlProcessUtilizationSample_t, processSamplesCount *C.uint, lastSeenTimeStamp C.ulonglong) C.nvmlReturn_t {
+	if processSamplesCount == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	samples, ret := dev.GetProcessUtilization(uint64(lastSeenTimeStamp))
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	*processSamplesCount = C.uint(len(samples))
+	return C.NVML_SUCCESS
+}
+
+// =============================================================================
+// Performance Functions
+// =============================================================================
+
+//export nvmlDeviceGetPerformanceState
+func nvmlDeviceGetPerformanceState(nvmlDevice C.nvmlDevice_t, pState *C.nvmlPstates_t) C.nvmlReturn_t {
+	if pState == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	state, ret := dev.GetPerformanceState()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	*pState = C.nvmlPstates_t(state)
+	return C.NVML_SUCCESS
+}
+
+//export nvmlDeviceGetCurrentClocksEventReasons
+func nvmlDeviceGetCurrentClocksEventReasons(nvmlDevice C.nvmlDevice_t, clocksEventReasons *C.ulonglong) C.nvmlReturn_t {
+	if clocksEventReasons == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	reasons, ret := dev.GetCurrentClocksEventReasons()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	*clocksEventReasons = C.ulonglong(reasons)
+	return C.NVML_SUCCESS
+}
+
+// =============================================================================
+// Persistence Functions
+// =============================================================================
+
+//export nvmlDeviceGetPersistenceMode
+func nvmlDeviceGetPersistenceMode(nvmlDevice C.nvmlDevice_t, mode *C.nvmlEnableState_t) C.nvmlReturn_t {
+	if mode == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	state, ret := dev.GetPersistenceMode()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	*mode = C.nvmlEnableState_t(state)
+	return C.NVML_SUCCESS
+}
+
+//export nvmlDeviceSetPersistenceMode
+func nvmlDeviceSetPersistenceMode(nvmlDevice C.nvmlDevice_t, mode C.nvmlEnableState_t) C.nvmlReturn_t {
+	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	ret := dev.SetPersistenceMode(nvml.EnableState(mode))
+	return toReturn(ret)
+}
+
+// =============================================================================
+// Advanced Functions
+// =============================================================================
+
+//export nvmlDeviceGetRemappedRows
+func nvmlDeviceGetRemappedRows(nvmlDevice C.nvmlDevice_t, corrRows *C.uint, uncRows *C.uint, isPending *C.uint, failureOccurred *C.uint) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetRemappedRows"); !ok {
+		return ret
+	}
+	if corrRows == nil || uncRows == nil || isPending == nil || failureOccurred == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	corr, unc, pending, failure, ret := dev.GetRemappedRows()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	*corrRows = C.uint(corr)
+	*uncRows = C.uint(unc)
+	if pending {
+		*isPending = 1
+	} else {
+		*isPending = 0
+	}
+	if failure {
+		*failureOccurred = 1
+	} else {
+		*failureOccurred = 0
+	}
+	return C.NVML_SUCCESS
+}
+
+//export nvmlDeviceGetGspFirmwareMode
+func nvmlDeviceGetGspFirmwareMode(nvmlDevice C.nvmlDevice_t, isEnabled *C.uint, defaultMode *C.uint) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetGspFirmwareMode"); !ok {
+		return ret
+	}
+	if isEnabled == nil || defaultMode == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	enabled, defMode, ret := dev.GetGspFirmwareMode()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	if enabled {
+		*isEnabled = 1
+	} else {
+		*isEnabled = 0
+	}
+	if defMode {
+		*defaultMode = 1
+	} else {
+		*defaultMode = 0
+	}
+	return C.NVML_SUCCESS
+}
+
+//export nvmlDeviceGetDisplayActive
+func nvmlDeviceGetDisplayActive(nvmlDevice C.nvmlDevice_t, isActive *C.nvmlEnableState_t) C.nvmlReturn_t {
+	if isActive == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	active, ret := dev.GetDisplayActive()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	*isActive = C.nvmlEnableState_t(active)
 	return C.NVML_SUCCESS
 }

--- a/pkg/gpu/mocknvml/bridge/stubs_generated.go
+++ b/pkg/gpu/mocknvml/bridge/stubs_generated.go
@@ -21,7 +21,7 @@ package main
 */
 import "C"
 
-// 366 stub functions for unimplemented NVML functions.
+// 357 stub functions for unimplemented NVML functions.
 // These return NVML_ERROR_NOT_SUPPORTED (3).
 
 //export nvmlComputeInstanceDestroy
@@ -214,11 +214,6 @@ func nvmlDeviceGetComputeRunningProcesses_v2(device C.nvmlDevice_t, infoCount *C
 	return stubReturn("nvmlDeviceGetComputeRunningProcesses_v2")
 }
 
-//export nvmlDeviceGetComputeRunningProcesses_v3
-func nvmlDeviceGetComputeRunningProcesses_v3(device C.nvmlDevice_t, infoCount *C.uint, infos *C.nvmlProcessInfo_t) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetComputeRunningProcesses_v3")
-}
-
 //export nvmlDeviceGetConfComputeGpuAttestationReport
 func nvmlDeviceGetConfComputeGpuAttestationReport(device C.nvmlDevice_t, gpuAtstReport *C.nvmlConfComputeGpuAttestationReport_t) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetConfComputeGpuAttestationReport")
@@ -274,11 +269,6 @@ func nvmlDeviceGetCurrentClockFreqs(device C.nvmlDevice_t, currentClockFreqs *C.
 	return stubReturn("nvmlDeviceGetCurrentClockFreqs")
 }
 
-//export nvmlDeviceGetCurrentClocksEventReasons
-func nvmlDeviceGetCurrentClocksEventReasons(device C.nvmlDevice_t, clocksEventReasons *C.ulonglong) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetCurrentClocksEventReasons")
-}
-
 //export nvmlDeviceGetCurrentClocksThrottleReasons
 func nvmlDeviceGetCurrentClocksThrottleReasons(device C.nvmlDevice_t, clocksThrottleReasons *C.ulonglong) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetCurrentClocksThrottleReasons")
@@ -307,11 +297,6 @@ func nvmlDeviceGetDetailedEccErrors(device C.nvmlDevice_t, errorType C.nvmlMemor
 //export nvmlDeviceGetDeviceHandleFromMigDeviceHandle
 func nvmlDeviceGetDeviceHandleFromMigDeviceHandle(migDevice C.nvmlDevice_t, device *C.nvmlDevice_t) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetDeviceHandleFromMigDeviceHandle")
-}
-
-//export nvmlDeviceGetDisplayActive
-func nvmlDeviceGetDisplayActive(device C.nvmlDevice_t, isActive *C.nvmlEnableState_t) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetDisplayActive")
 }
 
 //export nvmlDeviceGetDisplayMode
@@ -507,11 +492,6 @@ func nvmlDeviceGetGridLicensableFeatures_v3(device C.nvmlDevice_t, pGridLicensab
 //export nvmlDeviceGetGridLicensableFeatures_v4
 func nvmlDeviceGetGridLicensableFeatures_v4(device C.nvmlDevice_t, pGridLicensableFeatures *C.nvmlGridLicensableFeatures_t) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetGridLicensableFeatures_v4")
-}
-
-//export nvmlDeviceGetGspFirmwareMode
-func nvmlDeviceGetGspFirmwareMode(device C.nvmlDevice_t, isEnabled *C.uint, defaultMode *C.uint) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetGspFirmwareMode")
 }
 
 //export nvmlDeviceGetGspFirmwareVersion
@@ -761,16 +741,6 @@ func nvmlDeviceGetPerformanceModes(device C.nvmlDevice_t, perfModes *C.nvmlDevic
 	return stubReturn("nvmlDeviceGetPerformanceModes")
 }
 
-//export nvmlDeviceGetPerformanceState
-func nvmlDeviceGetPerformanceState(device C.nvmlDevice_t, pState *C.nvmlPstates_t) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetPerformanceState")
-}
-
-//export nvmlDeviceGetPersistenceMode
-func nvmlDeviceGetPersistenceMode(device C.nvmlDevice_t, mode *C.nvmlEnableState_t) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetPersistenceMode")
-}
-
 //export nvmlDeviceGetPgpuMetadataString
 func nvmlDeviceGetPgpuMetadataString(device C.nvmlDevice_t, pgpuMetadata *C.char, bufferSize *C.uint) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetPgpuMetadataString")
@@ -817,19 +787,9 @@ func nvmlDeviceGetPowerUsage(device C.nvmlDevice_t, power *C.uint) C.nvmlReturn_
 	return stubReturn("nvmlDeviceGetPowerUsage")
 }
 
-//export nvmlDeviceGetProcessUtilization
-func nvmlDeviceGetProcessUtilization(device C.nvmlDevice_t, utilization *C.nvmlProcessUtilizationSample_t, processSamplesCount *C.uint, lastSeenTimeStamp C.ulonglong) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetProcessUtilization")
-}
-
 //export nvmlDeviceGetProcessesUtilizationInfo
 func nvmlDeviceGetProcessesUtilizationInfo(device C.nvmlDevice_t, procesesUtilInfo *C.nvmlProcessesUtilizationInfo_t) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetProcessesUtilizationInfo")
-}
-
-//export nvmlDeviceGetRemappedRows
-func nvmlDeviceGetRemappedRows(device C.nvmlDevice_t, corrRows *C.uint, uncRows *C.uint, isPending *C.uint, failureOccurred *C.uint) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetRemappedRows")
 }
 
 //export nvmlDeviceGetRepairStatus
@@ -1217,11 +1177,6 @@ func nvmlDeviceSetNvLinkUtilizationControl(device C.nvmlDevice_t, link C.uint, c
 //export nvmlDeviceSetNvlinkBwMode
 func nvmlDeviceSetNvlinkBwMode(device C.nvmlDevice_t, setBwMode *C.nvmlNvlinkSetBwMode_t) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceSetNvlinkBwMode")
-}
-
-//export nvmlDeviceSetPersistenceMode
-func nvmlDeviceSetPersistenceMode(device C.nvmlDevice_t, mode C.nvmlEnableState_t) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceSetPersistenceMode")
 }
 
 //export nvmlDeviceSetPowerManagementLimit

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -37,6 +37,9 @@ type ConfigurableDevice struct {
 	// Cached computed values
 	bar1Memory nvml.BAR1Memory
 	pciInfo    nvml.PciInfo
+
+	// Mutable in-memory state (not persisted across restarts)
+	persistenceModeOverride *nvml.EnableState
 }
 
 // NewConfigurableDevice creates a device with YAML configuration
@@ -266,6 +269,29 @@ func (d *ConfigurableDevice) GetGraphicsRunningProcesses() ([]nvml.ProcessInfo, 
 		}
 	}
 	return procs, nvml.SUCCESS
+}
+
+// GetProcessUtilization returns process utilization samples since lastSeenTimestamp
+func (d *ConfigurableDevice) GetProcessUtilization(lastSeenTimestamp uint64) ([]nvml.ProcessUtilizationSample, nvml.Return) {
+	debugLog("[NVML] nvmlDeviceGetProcessUtilization(lastSeen=%d)\n", lastSeenTimestamp)
+	return []nvml.ProcessUtilizationSample{}, nvml.SUCCESS
+}
+
+// GetCurrentClocksEventReasons returns clock event reasons bitmask (newer API name for throttle reasons)
+func (d *ConfigurableDevice) GetCurrentClocksEventReasons() (uint64, nvml.Return) {
+	return d.GetCurrentClocksThrottleReasons()
+}
+
+// GetGspFirmwareMode returns GSP firmware mode (isEnabled, defaultMode)
+func (d *ConfigurableDevice) GetGspFirmwareMode() (bool, bool, nvml.Return) {
+	isEnabled := false
+	defaultMode := false
+	if d.config != nil && d.config.GSPFirmware != nil {
+		isEnabled = d.config.GSPFirmware.Mode == "enabled"
+		defaultMode = isEnabled // default mode follows mode unless overridden
+	}
+	debugLog("[NVML] nvmlDeviceGetGspFirmwareMode -> enabled=%v default=%v\n", isEnabled, defaultMode)
+	return isEnabled, defaultMode, nvml.SUCCESS
 }
 
 // GetSerial returns the device serial number
@@ -516,12 +542,24 @@ func (d *ConfigurableDevice) GetPerformanceState() (nvml.Pstates, nvml.Return) {
 
 // GetPersistenceMode returns persistence mode status
 func (d *ConfigurableDevice) GetPersistenceMode() (nvml.EnableState, nvml.Return) {
+	// Check in-memory override first (set by SetPersistenceMode)
+	if d.persistenceModeOverride != nil {
+		debugLog("[NVML] nvmlDeviceGetPersistenceMode -> %d (override)\n", *d.persistenceModeOverride)
+		return *d.persistenceModeOverride, nvml.SUCCESS
+	}
 	enabled := nvml.FEATURE_DISABLED
 	if d.config != nil && d.config.PersistenceMode == "enabled" {
 		enabled = nvml.FEATURE_ENABLED
 	}
 	debugLog("[NVML] nvmlDeviceGetPersistenceMode -> %d\n", enabled)
 	return enabled, nvml.SUCCESS
+}
+
+// SetPersistenceMode sets persistence mode in-memory (not persisted across restarts)
+func (d *ConfigurableDevice) SetPersistenceMode(mode nvml.EnableState) nvml.Return {
+	debugLog("[NVML] nvmlDeviceSetPersistenceMode(%d)\n", mode)
+	d.persistenceModeOverride = &mode
+	return nvml.SUCCESS
 }
 
 // GetComputeMode returns compute mode
@@ -983,8 +1021,16 @@ func (d *ConfigurableDevice) GetRetiredPagesPendingStatus() (nvml.EnableState, n
 
 // GetRemappedRows returns remapped row information
 func (d *ConfigurableDevice) GetRemappedRows() (int, int, bool, bool, nvml.Return) {
-	debugLog("[NVML] nvmlDeviceGetRemappedRows -> 0, 0, false, false\n")
-	return 0, 0, false, false, nvml.SUCCESS
+	corrRows, uncRows := 0, 0
+	isPending, failureOccurred := false, false
+	if d.config != nil && d.config.RemappedRows != nil {
+		corrRows = d.config.RemappedRows.Correctable
+		uncRows = d.config.RemappedRows.Uncorrectable
+		isPending = d.config.RemappedRows.Pending
+		failureOccurred = d.config.RemappedRows.FailureOccurred
+	}
+	debugLog("[NVML] nvmlDeviceGetRemappedRows -> corr=%d unc=%d pending=%v failure=%v\n", corrRows, uncRows, isPending, failureOccurred)
+	return corrRows, uncRows, isPending, failureOccurred, nvml.SUCCESS
 }
 
 // GetFanSpeed_v2 returns fan speed for a specific fan

--- a/pkg/gpu/mocknvml/engine/device_test.go
+++ b/pkg/gpu/mocknvml/engine/device_test.go
@@ -120,7 +120,7 @@ func TestConfigurableDevice_GetPciInfo(t *testing.T) {
 }
 
 // =============================================================================
-// Topology Tests
+// Topology Tests (from T4/Batch 1)
 // =============================================================================
 
 func TestConfigurableDevice_GetTopologyCommonAncestor(t *testing.T) {
@@ -193,7 +193,7 @@ func TestConfigurableDevice_GetTopologyCommonAncestor_WithConfig(t *testing.T) {
 }
 
 // =============================================================================
-// NVLink Tests
+// NVLink Tests (from T4/Batch 1)
 // =============================================================================
 
 func TestConfigurableDevice_GetNvLinkState_WithConfig(t *testing.T) {
@@ -309,7 +309,7 @@ func TestConfigurableDevice_GetNvLinkRemotePciInfo(t *testing.T) {
 }
 
 // =============================================================================
-// Thermal Tests
+// Thermal Tests (from T4/Batch 1)
 // =============================================================================
 
 func TestConfigurableDevice_GetTemperatureThreshold_WithConfig(t *testing.T) {
@@ -400,7 +400,7 @@ func TestConfigurableDevice_GetThermalSettings(t *testing.T) {
 }
 
 // =============================================================================
-// Power Tests
+// Power Tests (from T4/Batch 1)
 // =============================================================================
 
 func TestConfigurableDevice_GetEnforcedPowerLimit_WithConfig(t *testing.T) {
@@ -498,5 +498,324 @@ func TestConfigurableDevice_GetPowerManagementMode_Default(t *testing.T) {
 	}
 	if mode != nvml.FEATURE_DISABLED {
 		t.Errorf("Expected FEATURE_DISABLED, got %d", mode)
+	}
+}
+
+// =============================================================================
+// Batch 2 Test Helper
+// =============================================================================
+
+// newTestDeviceWithConfig creates a test engine with YAML config and returns the first device.
+func newTestDeviceWithConfig(t *testing.T, deviceCfg *DeviceConfig) *ConfigurableDevice {
+	t.Helper()
+	cfg := &Config{
+		NumDevices:    1,
+		DriverVersion: "550.163",
+		YAMLConfig: &YAMLConfig{
+			Version: "1.0",
+			System: SystemConfig{
+				DriverVersion: "550.163",
+				NVMLVersion:   "12.550.163",
+				NumDevices:    1,
+			},
+			DeviceDefaults: *deviceCfg,
+		},
+	}
+	e := NewEngine(cfg)
+	_ = e.Init()
+	t.Cleanup(func() { _ = e.Shutdown() })
+
+	handle, _ := e.DeviceGetHandleByIndex(0)
+	dev := e.LookupDevice(handle)
+	cd, ok := dev.(*ConfigurableDevice)
+	if !ok {
+		t.Fatal("Expected ConfigurableDevice type")
+	}
+	return cd
+}
+
+// =============================================================================
+// Process functions (Batch 2)
+// =============================================================================
+
+func TestConfigurableDevice_GetComputeRunningProcesses_WithConfig(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+		Processes: []ProcessConfig{
+			{PID: 1234, Type: "C", Name: "python", UsedMemoryMiB: 1024},
+			{PID: 5678, Type: "C", Name: "torch", UsedMemoryMiB: 2048},
+			{PID: 9999, Type: "G", Name: "Xorg", UsedMemoryMiB: 128},
+		},
+	})
+
+	procs, ret := dev.GetComputeRunningProcesses()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetComputeRunningProcesses failed: %v", ret)
+	}
+	if len(procs) != 2 {
+		t.Fatalf("Expected 2 compute processes, got %d", len(procs))
+	}
+	if procs[0].Pid != 1234 {
+		t.Errorf("Expected PID 1234, got %d", procs[0].Pid)
+	}
+	if procs[0].UsedGpuMemory != 1024*1024*1024 {
+		t.Errorf("Expected 1 GiB memory, got %d", procs[0].UsedGpuMemory)
+	}
+	if procs[1].Pid != 5678 {
+		t.Errorf("Expected PID 5678, got %d", procs[1].Pid)
+	}
+}
+
+func TestConfigurableDevice_GetProcessUtilization_Default(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	utils, ret := dev.GetProcessUtilization(0)
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetProcessUtilization failed: %v", ret)
+	}
+	if len(utils) != 0 {
+		t.Errorf("Expected empty utilization list, got %d", len(utils))
+	}
+}
+
+// =============================================================================
+// Performance functions (Batch 2)
+// =============================================================================
+
+func TestConfigurableDevice_GetPerformanceState_Default(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	pstate, ret := dev.GetPerformanceState()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetPerformanceState failed: %v", ret)
+	}
+	if pstate != nvml.PSTATE_0 {
+		t.Errorf("Expected P0 default, got %d", pstate)
+	}
+}
+
+func TestConfigurableDevice_GetPerformanceState_Configured(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name:             "NVIDIA A100-SXM4-80GB",
+		PerformanceState: "P8",
+	})
+
+	pstate, ret := dev.GetPerformanceState()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetPerformanceState failed: %v", ret)
+	}
+	if pstate != nvml.PSTATE_8 {
+		t.Errorf("Expected P8, got %d", pstate)
+	}
+}
+
+func TestConfigurableDevice_GetCurrentClocksEventReasons_Default(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	reasons, ret := dev.GetCurrentClocksEventReasons()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetCurrentClocksEventReasons failed: %v", ret)
+	}
+	if reasons != 0 {
+		t.Errorf("Expected 0 (no throttling), got 0x%x", reasons)
+	}
+}
+
+// =============================================================================
+// Persistence functions (Batch 2)
+// =============================================================================
+
+func TestConfigurableDevice_GetPersistenceMode_Default(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	mode, ret := dev.GetPersistenceMode()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetPersistenceMode failed: %v", ret)
+	}
+	if mode != nvml.FEATURE_DISABLED {
+		t.Errorf("Expected DISABLED default, got %d", mode)
+	}
+}
+
+func TestConfigurableDevice_GetPersistenceMode_Configured(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name:            "NVIDIA A100-SXM4-80GB",
+		PersistenceMode: "enabled",
+	})
+
+	mode, ret := dev.GetPersistenceMode()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetPersistenceMode failed: %v", ret)
+	}
+	if mode != nvml.FEATURE_ENABLED {
+		t.Errorf("Expected ENABLED, got %d", mode)
+	}
+}
+
+func TestConfigurableDevice_SetPersistenceMode(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	// Initially disabled
+	mode, ret := dev.GetPersistenceMode()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetPersistenceMode failed: %v", ret)
+	}
+	if mode != nvml.FEATURE_DISABLED {
+		t.Errorf("Expected DISABLED initially, got %d", mode)
+	}
+
+	// Set to enabled
+	ret = dev.SetPersistenceMode(nvml.FEATURE_ENABLED)
+	if ret != nvml.SUCCESS {
+		t.Fatalf("SetPersistenceMode failed: %v", ret)
+	}
+
+	// Now should be enabled
+	mode, ret = dev.GetPersistenceMode()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetPersistenceMode failed: %v", ret)
+	}
+	if mode != nvml.FEATURE_ENABLED {
+		t.Errorf("Expected ENABLED after set, got %d", mode)
+	}
+
+	// Set back to disabled
+	ret = dev.SetPersistenceMode(nvml.FEATURE_DISABLED)
+	if ret != nvml.SUCCESS {
+		t.Fatalf("SetPersistenceMode failed: %v", ret)
+	}
+
+	mode, ret = dev.GetPersistenceMode()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetPersistenceMode failed: %v", ret)
+	}
+	if mode != nvml.FEATURE_DISABLED {
+		t.Errorf("Expected DISABLED after unset, got %d", mode)
+	}
+}
+
+// =============================================================================
+// Advanced functions (Batch 2)
+// =============================================================================
+
+func TestConfigurableDevice_GetRemappedRows_Default(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	corrRows, uncRows, isPending, failureOccurred, ret := dev.GetRemappedRows()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetRemappedRows failed: %v", ret)
+	}
+	if corrRows != 0 || uncRows != 0 {
+		t.Errorf("Expected 0 rows, got corr=%d unc=%d", corrRows, uncRows)
+	}
+	if isPending || failureOccurred {
+		t.Errorf("Expected no pending/failure, got pending=%v failure=%v", isPending, failureOccurred)
+	}
+}
+
+func TestConfigurableDevice_GetRemappedRows_Configured(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+		RemappedRows: &RemappedRowsConfig{
+			Correctable:     2,
+			Uncorrectable:   1,
+			Pending:         true,
+			FailureOccurred: false,
+		},
+	})
+
+	corrRows, uncRows, isPending, failureOccurred, ret := dev.GetRemappedRows()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetRemappedRows failed: %v", ret)
+	}
+	if corrRows != 2 {
+		t.Errorf("Expected 2 correctable rows, got %d", corrRows)
+	}
+	if uncRows != 1 {
+		t.Errorf("Expected 1 uncorrectable row, got %d", uncRows)
+	}
+	if !isPending {
+		t.Errorf("Expected pending=true")
+	}
+	if failureOccurred {
+		t.Errorf("Expected failure=false")
+	}
+}
+
+func TestConfigurableDevice_GetGspFirmwareMode_Default(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	isEnabled, defaultMode, ret := dev.GetGspFirmwareMode()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetGspFirmwareMode failed: %v", ret)
+	}
+	// Default: disabled
+	if isEnabled {
+		t.Errorf("Expected GSP disabled by default")
+	}
+	if defaultMode {
+		t.Errorf("Expected GSP default mode disabled by default")
+	}
+}
+
+func TestConfigurableDevice_GetGspFirmwareMode_Enabled(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+		GSPFirmware: &GSPFirmwareConfig{
+			Mode: "enabled",
+		},
+	})
+
+	isEnabled, _, ret := dev.GetGspFirmwareMode()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetGspFirmwareMode failed: %v", ret)
+	}
+	if !isEnabled {
+		t.Errorf("Expected GSP enabled")
+	}
+}
+
+func TestConfigurableDevice_GetDisplayActive_Default(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	active, ret := dev.GetDisplayActive()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetDisplayActive failed: %v", ret)
+	}
+	if active != nvml.FEATURE_DISABLED {
+		t.Errorf("Expected DISABLED default, got %d", active)
+	}
+}
+
+func TestConfigurableDevice_GetDisplayActive_Enabled(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+		Display: &DisplayConfig{
+			Active: "enabled",
+		},
+	})
+
+	active, ret := dev.GetDisplayActive()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetDisplayActive failed: %v", ret)
+	}
+	if active != nvml.FEATURE_ENABLED {
+		t.Errorf("Expected ENABLED, got %d", active)
 	}
 }


### PR DESCRIPTION
## Summary

- Implement 9 NVML bridge functions with YAML-driven configuration and engine tests
- Process: GetComputeRunningProcesses_v3, GetProcessUtilization
- Performance: GetPerformanceState, GetCurrentClocksEventReasons
- Persistence: GetPersistenceMode, SetPersistenceMode (in-memory state)
- Advanced: GetRemappedRows, GetGspFirmwareMode, GetDisplayActive

## Test Plan

- [x] 13 new engine unit tests covering defaults and configured values
- [x] All existing engine tests still pass
- [x] Bridge package compiles cleanly