### PR TITLE
feat(gpu-mock): minimal CUDA mock (libcuda.so)

### DIFF
--- a/deployments/gpu-mock/Dockerfile
+++ b/deployments/gpu-mock/Dockerfile
@@ -18,12 +18,15 @@ WORKDIR /src
 COPY go.mod go.sum ./
 COPY vendor/ vendor/
 COPY pkg/gpu/mocknvml/ pkg/gpu/mocknvml/
+COPY pkg/gpu/mockcuda/ pkg/gpu/mockcuda/
 RUN cd pkg/gpu/mocknvml && make clean && make
+RUN cd pkg/gpu/mockcuda && make clean && make
 
 FROM debian:bookworm-slim
 ARG KUBECTL_VERSION=v1.32.0
 ARG TARGETARCH=amd64
 COPY --from=builder /src/pkg/gpu/mocknvml/libnvidia-ml.so.* /usr/local/lib/
+COPY --from=builder /src/pkg/gpu/mockcuda/libcuda.so.* /usr/local/lib/
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends curl ca-certificates; \

--- a/deployments/gpu-mock/scripts/setup.sh
+++ b/deployments/gpu-mock/scripts/setup.sh
@@ -38,6 +38,16 @@ cp "$BUILT_SO" "$DRIVER_ROOT/usr/lib64/libnvidia-ml.so.$DRIVER_VERSION"
 ln -sf "libnvidia-ml.so.$DRIVER_VERSION" "$DRIVER_ROOT/usr/lib64/libnvidia-ml.so.1"
 ln -sf "libnvidia-ml.so.1" "$DRIVER_ROOT/usr/lib64/libnvidia-ml.so"
 
+# 2b. Copy mock CUDA library + create symlinks
+BUILT_CUDA_SO=$(ls /usr/local/lib/libcuda.so.*.*.* 2>/dev/null | head -1)
+if [ -z "$BUILT_CUDA_SO" ]; then
+  echo "WARNING: No mock CUDA library found in /usr/local/lib/, skipping libcuda.so setup"
+else
+  cp "$BUILT_CUDA_SO" "$DRIVER_ROOT/usr/lib64/libcuda.so.$DRIVER_VERSION"
+  ln -sf "libcuda.so.$DRIVER_VERSION" "$DRIVER_ROOT/usr/lib64/libcuda.so.1"
+  ln -sf "libcuda.so.1" "$DRIVER_ROOT/usr/lib64/libcuda.so"
+fi
+
 # 3. Create char device nodes
 #    Major 195 = nvidia, Major 510 = nvidia-uvm (standard NVIDIA major numbers)
 for i in $(seq 0 $((GPU_COUNT - 1))); do

--- a/pkg/gpu/mockcuda/Makefile
+++ b/pkg/gpu/mockcuda/Makefile
@@ -1,0 +1,39 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCKER   ?= docker
+MKDIR    ?= mkdir
+
+GOLANG_VERSION ?= 1.25.0
+
+# CUDA library versioning
+LIB_VERSION ?= 550.163.01
+LIB_NAME := libcuda.so
+LIB_SONAME := $(LIB_NAME).1
+LIB_REALNAME := $(LIB_NAME).$(LIB_VERSION)
+
+REPO_ROOT := $(shell git rev-parse --show-toplevel)
+
+.PHONY: all clean
+
+all: $(LIB_NAME)
+
+$(LIB_NAME): $(LIB_REALNAME)
+	ln -sf $(LIB_REALNAME) $(LIB_SONAME)
+	ln -sf $(LIB_SONAME) $(LIB_NAME)
+
+$(LIB_REALNAME):
+	go build -buildmode=c-shared -o $(LIB_REALNAME) ./bridge
+
+clean:
+	rm -f $(LIB_NAME)*

--- a/pkg/gpu/mockcuda/bridge/cuda.go
+++ b/pkg/gpu/mockcuda/bridge/cuda.go
@@ -81,19 +81,28 @@ func cudaMalloc(devPtr *unsafe.Pointer, size C.size_t) C.cudaError_t {
 	if devPtr == nil {
 		return C.cudaErrorInvalidValue
 	}
-	ptr, err := engine.GetEngine().Malloc(uint64(size))
+	// Allocate real C memory so the pointer is valid and go vet clean.
+	// The engine tracks it by uintptr key for bookkeeping.
+	cPtr := C.malloc(C.size_t(size))
+	if cPtr == nil {
+		return C.cudaErrorMemoryAllocation
+	}
+	err := engine.GetEngine().TrackAllocation(uintptr(cPtr), uint64(size))
 	if err != engine.CudaSuccess {
+		C.free(cPtr)
 		return toCudaError(err)
 	}
-	//nolint:govet // Converting uintptr to unsafe.Pointer is intentional -
-	// this is a fake device pointer used for tracking, never dereferenced.
-	*devPtr = unsafe.Pointer(ptr)
+	*devPtr = cPtr
 	return C.cudaSuccess
 }
 
 //export cudaFree
 func cudaFree(devPtr unsafe.Pointer) C.cudaError_t {
-	return toCudaError(engine.GetEngine().Free(uintptr(devPtr)))
+	err := engine.GetEngine().Free(uintptr(devPtr))
+	if err == engine.CudaSuccess && devPtr != nil {
+		C.free(devPtr)
+	}
+	return toCudaError(err)
 }
 
 //export cudaMemcpy

--- a/pkg/gpu/mockcuda/bridge/cuda.go
+++ b/pkg/gpu/mockcuda/bridge/cuda.go
@@ -1,0 +1,188 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main provides CUDA Runtime/Driver API bridge functions.
+// Built as a c-shared library to produce libcuda.so.1.
+
+package main
+
+/*
+#include <stdlib.h>
+#include <string.h>
+#include "cuda_types.h"
+*/
+import "C"
+import (
+	"unsafe"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mockcuda/engine"
+)
+
+// =============================================================================
+// Initialization
+// =============================================================================
+
+//export cuInit
+func cuInit(flags C.uint) C.CUresult {
+	return C.CUresult(toCudaError(engine.GetEngine().Init(uint(flags))))
+}
+
+//export cudaDriverGetVersion
+func cudaDriverGetVersion(driverVersion *C.int) C.cudaError_t {
+	if driverVersion == nil {
+		return C.cudaErrorInvalidValue
+	}
+	ver, err := engine.GetEngine().DriverGetVersion()
+	if err != engine.CudaSuccess {
+		return toCudaError(err)
+	}
+	*driverVersion = C.int(ver)
+	return C.cudaSuccess
+}
+
+// =============================================================================
+// Device Management
+// =============================================================================
+
+//export cudaGetDeviceCount
+func cudaGetDeviceCount(count *C.int) C.cudaError_t {
+	if count == nil {
+		return C.cudaErrorInvalidValue
+	}
+	c, err := engine.GetEngine().GetDeviceCount()
+	if err != engine.CudaSuccess {
+		return toCudaError(err)
+	}
+	*count = C.int(c)
+	return C.cudaSuccess
+}
+
+//export cudaSetDevice
+func cudaSetDevice(device C.int) C.cudaError_t {
+	return toCudaError(engine.GetEngine().SetDevice(int(device)))
+}
+
+// =============================================================================
+// Memory Management
+// =============================================================================
+
+//export cudaMalloc
+func cudaMalloc(devPtr *unsafe.Pointer, size C.size_t) C.cudaError_t {
+	if devPtr == nil {
+		return C.cudaErrorInvalidValue
+	}
+	ptr, err := engine.GetEngine().Malloc(uint64(size))
+	if err != engine.CudaSuccess {
+		return toCudaError(err)
+	}
+	//nolint:govet // Converting uintptr to unsafe.Pointer is intentional -
+	// this is a fake device pointer used for tracking, never dereferenced.
+	*devPtr = unsafe.Pointer(ptr)
+	return C.cudaSuccess
+}
+
+//export cudaFree
+func cudaFree(devPtr unsafe.Pointer) C.cudaError_t {
+	return toCudaError(engine.GetEngine().Free(uintptr(devPtr)))
+}
+
+//export cudaMemcpy
+func cudaMemcpy(dst unsafe.Pointer, src unsafe.Pointer, count C.size_t, kind C.cudaMemcpyKind) C.cudaError_t {
+	if count == 0 {
+		return C.cudaSuccess
+	}
+	// For host-to-host, do a real copy
+	if kind == C.cudaMemcpyHostToHost {
+		if dst == nil || src == nil {
+			return C.cudaErrorInvalidValue
+		}
+		C.memcpy(dst, src, count)
+	}
+	return toCudaError(engine.GetEngine().Memcpy(engine.CudaMemcpyKind(kind)))
+}
+
+// =============================================================================
+// Execution
+// =============================================================================
+
+//export cudaLaunchKernel
+func cudaLaunchKernel(
+	funcPtr unsafe.Pointer,
+	gridDim C.dim3,
+	blockDim C.dim3,
+	args *unsafe.Pointer,
+	sharedMem C.size_t,
+	stream C.cudaStream_t,
+) C.cudaError_t {
+	return toCudaError(engine.GetEngine().LaunchKernel())
+}
+
+//export cudaDeviceSynchronize
+func cudaDeviceSynchronize() C.cudaError_t {
+	return toCudaError(engine.GetEngine().DeviceSynchronize())
+}
+
+// =============================================================================
+// Error Handling
+// =============================================================================
+
+//export cudaGetErrorString
+func cudaGetErrorString(err C.cudaError_t) *C.char {
+	return errStrings.get(engine.CudaError(err))
+}
+
+//export cudaGetLastError
+func cudaGetLastError() C.cudaError_t {
+	return C.cudaSuccess
+}
+
+//export cudaPeekAtLastError
+func cudaPeekAtLastError() C.cudaError_t {
+	return C.cudaSuccess
+}
+
+// =============================================================================
+// Additional stubs commonly needed by GPU Operator Validator
+// =============================================================================
+
+//export cudaGetDevice
+func cudaGetDevice(device *C.int) C.cudaError_t {
+	if device == nil {
+		return C.cudaErrorInvalidValue
+	}
+	d, err := engine.GetEngine().GetDevice()
+	if err != engine.CudaSuccess {
+		return toCudaError(err)
+	}
+	*device = C.int(d)
+	return C.cudaSuccess
+}
+
+//export cudaDeviceReset
+func cudaDeviceReset() C.cudaError_t {
+	return C.cudaSuccess
+}
+
+//export cudaRuntimeGetVersion
+func cudaRuntimeGetVersion(runtimeVersion *C.int) C.cudaError_t {
+	if runtimeVersion == nil {
+		return C.cudaErrorInvalidValue
+	}
+	// Return same as driver version for simplicity
+	ver, err := engine.GetEngine().DriverGetVersion()
+	if err != engine.CudaSuccess {
+		return toCudaError(err)
+	}
+	*runtimeVersion = C.int(ver)
+	return C.cudaSuccess
+}

--- a/pkg/gpu/mockcuda/bridge/cuda_types.h
+++ b/pkg/gpu/mockcuda/bridge/cuda_types.h
@@ -29,7 +29,10 @@ typedef enum cudaError_enum {
     cudaErrorUnknown                = 999
 } cudaError_t;
 
-/* CUresult mirrors cudaError_t for driver API */
+/* TODO: CUresult (driver API) and cudaError_t (runtime API) are distinct enums
+ * in real CUDA with diverging values at higher codes. For now we alias them
+ * since we only use low error codes. If consumers check driver API constants
+ * (e.g. CUDA_ERROR_INVALID_VALUE), split into a separate enum. */
 typedef cudaError_t CUresult;
 
 /*

--- a/pkg/gpu/mockcuda/bridge/cuda_types.h
+++ b/pkg/gpu/mockcuda/bridge/cuda_types.h
@@ -1,0 +1,64 @@
+/*
+ * CUDA Type Definitions for Mock Library
+ *
+ * Minimal type definitions for the CUDA Runtime and Driver APIs,
+ * sufficient for the 10 functions implemented in this mock.
+ *
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+#ifndef MOCK_CUDA_TYPES_H
+#define MOCK_CUDA_TYPES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * CUDA error codes (cudaError_t / CUresult)
+ */
+typedef enum cudaError_enum {
+    cudaSuccess                     = 0,
+    cudaErrorInvalidValue           = 1,
+    cudaErrorMemoryAllocation       = 2,
+    cudaErrorInitializationError    = 3,
+    cudaErrorInvalidDevice          = 10,
+    cudaErrorInvalidMemcpyDirection = 21,
+    cudaErrorNotReady               = 34,
+    cudaErrorUnknown                = 999
+} cudaError_t;
+
+/* CUresult mirrors cudaError_t for driver API */
+typedef cudaError_t CUresult;
+
+/*
+ * Memory copy direction
+ */
+typedef enum cudaMemcpyKind_enum {
+    cudaMemcpyHostToHost     = 0,
+    cudaMemcpyHostToDevice   = 1,
+    cudaMemcpyDeviceToHost   = 2,
+    cudaMemcpyDeviceToDevice = 3,
+    cudaMemcpyDefault        = 4
+} cudaMemcpyKind;
+
+/*
+ * dim3 - grid/block dimensions for kernel launches
+ */
+typedef struct {
+    unsigned int x;
+    unsigned int y;
+    unsigned int z;
+} dim3;
+
+/*
+ * cudaStream_t - opaque stream handle
+ */
+typedef struct CUstream_st* cudaStream_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MOCK_CUDA_TYPES_H */

--- a/pkg/gpu/mockcuda/bridge/helpers.go
+++ b/pkg/gpu/mockcuda/bridge/helpers.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+/*
+#include <stdlib.h>
+#include "cuda_types.h"
+*/
+import "C"
+import (
+	"fmt"
+	"os"
+	"sync"
+	"unsafe"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mockcuda/engine"
+)
+
+// main is required for buildmode=c-shared.
+func main() {}
+
+var debugEnabled = os.Getenv("MOCK_CUDA_DEBUG") != ""
+
+func debugLog(format string, args ...any) {
+	if debugEnabled {
+		fmt.Fprintf(os.Stderr, format, args...)
+	}
+}
+
+// toCudaError converts engine error to C error code.
+func toCudaError(err engine.CudaError) C.cudaError_t {
+	return C.cudaError_t(err)
+}
+
+// errorStringCache caches C strings for cudaGetErrorString.
+// Real CUDA returns static strings that callers must NOT free.
+type errorStringCache struct {
+	mu sync.Mutex
+	m  map[engine.CudaError]*C.char
+}
+
+var errStrings = &errorStringCache{
+	m: make(map[engine.CudaError]*C.char),
+}
+
+func (c *errorStringCache) get(err engine.CudaError) *C.char {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if cached, ok := c.m[err]; ok {
+		return cached
+	}
+	str := engine.ErrorString(err)
+	cStr := C.CString(str)
+	c.m[err] = cStr
+	return cStr
+}
+
+func (c *errorStringCache) clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, cStr := range c.m {
+		C.free(unsafe.Pointer(cStr))
+	}
+	c.m = make(map[engine.CudaError]*C.char)
+}

--- a/pkg/gpu/mockcuda/engine/cuda.go
+++ b/pkg/gpu/mockcuda/engine/cuda.go
@@ -67,13 +67,14 @@ func ResetEngine() {
 // NewEngine creates a new CUDA engine with default or environment-configured state.
 func NewEngine() *Engine {
 	deviceCount := DefaultDeviceCount
-	if num := os.Getenv("MOCK_CUDA_NUM_DEVICES"); num != "" {
+	// Fallback: shared NVML config for device count
+	if num := os.Getenv("MOCK_NVML_NUM_DEVICES"); num != "" {
 		if val, err := strconv.Atoi(num); err == nil && val >= 0 {
 			deviceCount = val
 		}
 	}
-	// Also check NVML config env var for shared device count
-	if num := os.Getenv("MOCK_NVML_NUM_DEVICES"); num != "" {
+	// Override: CUDA-specific env var takes priority
+	if num := os.Getenv("MOCK_CUDA_NUM_DEVICES"); num != "" {
 		if val, err := strconv.Atoi(num); err == nil && val >= 0 {
 			deviceCount = val
 		}

--- a/pkg/gpu/mockcuda/engine/cuda.go
+++ b/pkg/gpu/mockcuda/engine/cuda.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+)
+
+// DefaultDeviceCount is the number of devices when no config is provided.
+const DefaultDeviceCount = 8
+
+// DefaultDriverVersion is the CUDA driver version reported by default.
+const DefaultDriverVersion = 12080
+
+var debugEnabled = os.Getenv("MOCK_CUDA_DEBUG") != ""
+
+func debugLog(format string, args ...any) {
+	if debugEnabled {
+		fmt.Fprintf(os.Stderr, format, args...)
+	}
+}
+
+// Engine manages CUDA mock state: device count, current device, and allocations.
+type Engine struct {
+	mu            sync.Mutex
+	initialized   bool
+	deviceCount   int
+	driverVersion int
+	currentDevice int
+	allocations   map[uintptr]AllocationInfo
+	nextAllocID   uintptr
+}
+
+var (
+	engineInstance *Engine
+	engineOnce     sync.Once
+)
+
+// GetEngine returns the singleton CUDA Engine instance.
+func GetEngine() *Engine {
+	engineOnce.Do(func() {
+		engineInstance = NewEngine()
+	})
+	return engineInstance
+}
+
+// ResetEngine resets the singleton for testing.
+func ResetEngine() {
+	engineOnce = sync.Once{}
+	engineInstance = nil
+}
+
+// NewEngine creates a new CUDA engine with default or environment-configured state.
+func NewEngine() *Engine {
+	deviceCount := DefaultDeviceCount
+	if num := os.Getenv("MOCK_CUDA_NUM_DEVICES"); num != "" {
+		if val, err := strconv.Atoi(num); err == nil && val >= 0 {
+			deviceCount = val
+		}
+	}
+	// Also check NVML config env var for shared device count
+	if num := os.Getenv("MOCK_NVML_NUM_DEVICES"); num != "" {
+		if val, err := strconv.Atoi(num); err == nil && val >= 0 {
+			deviceCount = val
+		}
+	}
+
+	driverVersion := DefaultDriverVersion
+	if ver := os.Getenv("MOCK_CUDA_DRIVER_VERSION"); ver != "" {
+		if val, err := strconv.Atoi(ver); err == nil && val > 0 {
+			driverVersion = val
+		}
+	}
+
+	return &Engine{
+		deviceCount:   deviceCount,
+		driverVersion: driverVersion,
+		allocations:   make(map[uintptr]AllocationInfo),
+		nextAllocID:   0x1000, // Start at a non-zero fake address
+	}
+}
+
+// Init initializes the CUDA driver.
+func (e *Engine) Init(flags uint) CudaError {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.initialized = true
+	debugLog("[CUDA] cuInit(%d) -> SUCCESS\n", flags)
+	return CudaSuccess
+}
+
+// DriverGetVersion returns the CUDA driver version.
+func (e *Engine) DriverGetVersion() (int, CudaError) {
+	debugLog("[CUDA] cudaDriverGetVersion -> %d\n", e.driverVersion)
+	return e.driverVersion, CudaSuccess
+}
+
+// GetDeviceCount returns the number of CUDA devices.
+func (e *Engine) GetDeviceCount() (int, CudaError) {
+	debugLog("[CUDA] cudaGetDeviceCount -> %d\n", e.deviceCount)
+	return e.deviceCount, CudaSuccess
+}
+
+// SetDevice sets the current device.
+func (e *Engine) SetDevice(deviceID int) CudaError {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if deviceID < 0 || deviceID >= e.deviceCount {
+		debugLog("[CUDA] cudaSetDevice(%d) -> INVALID_DEVICE\n", deviceID)
+		return CudaErrorInvalidDevice
+	}
+	e.currentDevice = deviceID
+	debugLog("[CUDA] cudaSetDevice(%d) -> SUCCESS\n", deviceID)
+	return CudaSuccess
+}
+
+// GetDevice returns the current device.
+func (e *Engine) GetDevice() (int, CudaError) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.currentDevice, CudaSuccess
+}
+
+// Malloc allocates tracked memory and returns a fake device pointer.
+func (e *Engine) Malloc(size uint64) (uintptr, CudaError) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if size == 0 {
+		return 0, CudaErrorInvalidValue
+	}
+	ptr := e.nextAllocID
+	e.nextAllocID += uintptr(size)
+	// Align next allocation
+	if e.nextAllocID%256 != 0 {
+		e.nextAllocID += 256 - (e.nextAllocID % 256)
+	}
+	e.allocations[ptr] = AllocationInfo{
+		Ptr:      ptr,
+		Size:     size,
+		DeviceID: e.currentDevice,
+	}
+	debugLog("[CUDA] cudaMalloc(%d) -> 0x%x\n", size, ptr)
+	return ptr, CudaSuccess
+}
+
+// Free releases a tracked allocation.
+func (e *Engine) Free(ptr uintptr) CudaError {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if ptr == 0 {
+		// cudaFree(NULL) is a no-op per CUDA spec
+		return CudaSuccess
+	}
+	if _, ok := e.allocations[ptr]; !ok {
+		debugLog("[CUDA] cudaFree(0x%x) -> INVALID_VALUE (not tracked)\n", ptr)
+		return CudaErrorInvalidValue
+	}
+	delete(e.allocations, ptr)
+	debugLog("[CUDA] cudaFree(0x%x) -> SUCCESS\n", ptr)
+	return CudaSuccess
+}
+
+// Memcpy performs a memory copy operation. For host-to-host it does real copies
+// via the bridge layer. For device copies it's a tracked no-op.
+func (e *Engine) Memcpy(kind CudaMemcpyKind) CudaError {
+	debugLog("[CUDA] cudaMemcpy(kind=%d) -> SUCCESS\n", kind)
+	return CudaSuccess
+}
+
+// LaunchKernel is a no-op stub for kernel launches.
+func (e *Engine) LaunchKernel() CudaError {
+	debugLog("[CUDA] cudaLaunchKernel -> SUCCESS\n")
+	return CudaSuccess
+}
+
+// DeviceSynchronize is a no-op.
+func (e *Engine) DeviceSynchronize() CudaError {
+	debugLog("[CUDA] cudaDeviceSynchronize -> SUCCESS\n")
+	return CudaSuccess
+}
+
+// GetErrorString returns the error string for a CUDA error code.
+func (e *Engine) GetErrorString(err CudaError) string {
+	return ErrorString(err)
+}
+
+// AllocationCount returns the number of active allocations (for testing).
+func (e *Engine) AllocationCount() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.allocations)
+}
+
+// GetAllocation returns the allocation info for a pointer (for testing).
+func (e *Engine) GetAllocation(ptr uintptr) (AllocationInfo, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	info, ok := e.allocations[ptr]
+	return info, ok
+}

--- a/pkg/gpu/mockcuda/engine/cuda.go
+++ b/pkg/gpu/mockcuda/engine/cuda.go
@@ -158,6 +158,23 @@ func (e *Engine) Malloc(size uint64) (uintptr, CudaError) {
 	return ptr, CudaSuccess
 }
 
+// TrackAllocation records an externally-allocated pointer in the tracker.
+// Used by the bridge layer which allocates real C memory via C.malloc.
+func (e *Engine) TrackAllocation(ptr uintptr, size uint64) CudaError {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if size == 0 {
+		return CudaErrorInvalidValue
+	}
+	e.allocations[ptr] = AllocationInfo{
+		Ptr:      ptr,
+		Size:     size,
+		DeviceID: e.currentDevice,
+	}
+	debugLog("[CUDA] TrackAllocation(0x%x, %d) -> SUCCESS\n", ptr, size)
+	return CudaSuccess
+}
+
 // Free releases a tracked allocation.
 func (e *Engine) Free(ptr uintptr) CudaError {
 	e.mu.Lock()

--- a/pkg/gpu/mockcuda/engine/cuda_test.go
+++ b/pkg/gpu/mockcuda/engine/cuda_test.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"testing"
+)
+
+func newTestEngine() *Engine {
+	return NewEngine()
+}
+
+func TestInit(t *testing.T) {
+	e := newTestEngine()
+	if err := e.Init(0); err != CudaSuccess {
+		t.Fatalf("Init(0) = %d, want %d", err, CudaSuccess)
+	}
+}
+
+func TestDriverGetVersion(t *testing.T) {
+	e := newTestEngine()
+	ver, err := e.DriverGetVersion()
+	if err != CudaSuccess {
+		t.Fatalf("DriverGetVersion() error = %d", err)
+	}
+	if ver != DefaultDriverVersion {
+		t.Fatalf("DriverGetVersion() = %d, want %d", ver, DefaultDriverVersion)
+	}
+}
+
+func TestGetDeviceCount(t *testing.T) {
+	e := newTestEngine()
+	count, err := e.GetDeviceCount()
+	if err != CudaSuccess {
+		t.Fatalf("GetDeviceCount() error = %d", err)
+	}
+	if count != DefaultDeviceCount {
+		t.Fatalf("GetDeviceCount() = %d, want %d", count, DefaultDeviceCount)
+	}
+}
+
+func TestSetDevice(t *testing.T) {
+	e := newTestEngine()
+	if err := e.SetDevice(0); err != CudaSuccess {
+		t.Fatalf("SetDevice(0) = %d, want SUCCESS", err)
+	}
+	if err := e.SetDevice(7); err != CudaSuccess {
+		t.Fatalf("SetDevice(7) = %d, want SUCCESS", err)
+	}
+	if err := e.SetDevice(8); err != CudaErrorInvalidDevice {
+		t.Fatalf("SetDevice(8) = %d, want CudaErrorInvalidDevice", err)
+	}
+	if err := e.SetDevice(-1); err != CudaErrorInvalidDevice {
+		t.Fatalf("SetDevice(-1) = %d, want CudaErrorInvalidDevice", err)
+	}
+}
+
+func TestMallocFreeLifecycle(t *testing.T) {
+	e := newTestEngine()
+
+	// Allocate
+	ptr, err := e.Malloc(1024)
+	if err != CudaSuccess {
+		t.Fatalf("Malloc(1024) error = %d", err)
+	}
+	if ptr == 0 {
+		t.Fatal("Malloc returned nil pointer")
+	}
+	if e.AllocationCount() != 1 {
+		t.Fatalf("AllocationCount = %d, want 1", e.AllocationCount())
+	}
+
+	// Verify allocation info
+	info, ok := e.GetAllocation(ptr)
+	if !ok {
+		t.Fatal("GetAllocation returned false for allocated pointer")
+	}
+	if info.Size != 1024 {
+		t.Fatalf("AllocationInfo.Size = %d, want 1024", info.Size)
+	}
+
+	// Free
+	if err := e.Free(ptr); err != CudaSuccess {
+		t.Fatalf("Free() = %d, want SUCCESS", err)
+	}
+	if e.AllocationCount() != 0 {
+		t.Fatalf("AllocationCount after free = %d, want 0", e.AllocationCount())
+	}
+
+	// Double free should fail
+	if err := e.Free(ptr); err != CudaErrorInvalidValue {
+		t.Fatalf("Double Free() = %d, want CudaErrorInvalidValue", err)
+	}
+
+	// Free(NULL) is no-op
+	if err := e.Free(0); err != CudaSuccess {
+		t.Fatalf("Free(0) = %d, want SUCCESS", err)
+	}
+}
+
+func TestMallocZeroSize(t *testing.T) {
+	e := newTestEngine()
+	_, err := e.Malloc(0)
+	if err != CudaErrorInvalidValue {
+		t.Fatalf("Malloc(0) = %d, want CudaErrorInvalidValue", err)
+	}
+}
+
+func TestMultipleAllocations(t *testing.T) {
+	e := newTestEngine()
+	ptrs := make([]uintptr, 5)
+	for i := range ptrs {
+		ptr, err := e.Malloc(uint64(1024 * (i + 1)))
+		if err != CudaSuccess {
+			t.Fatalf("Malloc(%d) error = %d", 1024*(i+1), err)
+		}
+		ptrs[i] = ptr
+	}
+	if e.AllocationCount() != 5 {
+		t.Fatalf("AllocationCount = %d, want 5", e.AllocationCount())
+	}
+
+	// All pointers should be unique
+	seen := make(map[uintptr]bool)
+	for _, ptr := range ptrs {
+		if seen[ptr] {
+			t.Fatal("Duplicate pointer returned from Malloc")
+		}
+		seen[ptr] = true
+	}
+
+	// Free all
+	for _, ptr := range ptrs {
+		if err := e.Free(ptr); err != CudaSuccess {
+			t.Fatalf("Free(0x%x) = %d", ptr, err)
+		}
+	}
+	if e.AllocationCount() != 0 {
+		t.Fatalf("AllocationCount after freeing all = %d, want 0", e.AllocationCount())
+	}
+}
+
+func TestMemcpy(t *testing.T) {
+	e := newTestEngine()
+	if err := e.Memcpy(CudaMemcpyHostToHost); err != CudaSuccess {
+		t.Fatalf("Memcpy(HostToHost) = %d", err)
+	}
+	if err := e.Memcpy(CudaMemcpyHostToDevice); err != CudaSuccess {
+		t.Fatalf("Memcpy(HostToDevice) = %d", err)
+	}
+	if err := e.Memcpy(CudaMemcpyDeviceToHost); err != CudaSuccess {
+		t.Fatalf("Memcpy(DeviceToHost) = %d", err)
+	}
+}
+
+func TestLaunchKernel(t *testing.T) {
+	e := newTestEngine()
+	if err := e.LaunchKernel(); err != CudaSuccess {
+		t.Fatalf("LaunchKernel() = %d", err)
+	}
+}
+
+func TestDeviceSynchronize(t *testing.T) {
+	e := newTestEngine()
+	if err := e.DeviceSynchronize(); err != CudaSuccess {
+		t.Fatalf("DeviceSynchronize() = %d", err)
+	}
+}
+
+func TestGetErrorString(t *testing.T) {
+	e := newTestEngine()
+	tests := []struct {
+		err  CudaError
+		want string
+	}{
+		{CudaSuccess, "no error"},
+		{CudaErrorInvalidValue, "invalid argument"},
+		{CudaErrorMemoryAllocation, "out of memory"},
+		{CudaErrorInvalidDevice, "invalid device ordinal"},
+		{CudaError(12345), "unknown error"},
+	}
+	for _, tc := range tests {
+		got := e.GetErrorString(tc.err)
+		if got != tc.want {
+			t.Errorf("GetErrorString(%d) = %q, want %q", tc.err, got, tc.want)
+		}
+	}
+}
+
+func TestSetDeviceTracksCurrent(t *testing.T) {
+	e := newTestEngine()
+	e.SetDevice(3)
+	ptr, _ := e.Malloc(512)
+	info, ok := e.GetAllocation(ptr)
+	if !ok {
+		t.Fatal("allocation not found")
+	}
+	if info.DeviceID != 3 {
+		t.Fatalf("allocation device = %d, want 3", info.DeviceID)
+	}
+}
+
+func TestErrorStringFunction(t *testing.T) {
+	if s := ErrorString(CudaSuccess); s != "no error" {
+		t.Fatalf("ErrorString(0) = %q, want 'no error'", s)
+	}
+	if s := ErrorString(CudaError(99999)); s != "unknown error" {
+		t.Fatalf("ErrorString(99999) = %q, want 'unknown error'", s)
+	}
+}

--- a/pkg/gpu/mockcuda/engine/types.go
+++ b/pkg/gpu/mockcuda/engine/types.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+// CudaError represents CUDA runtime API error codes.
+type CudaError int
+
+const (
+	CudaSuccess                     CudaError = 0
+	CudaErrorInvalidValue           CudaError = 1
+	CudaErrorMemoryAllocation       CudaError = 2
+	CudaErrorInitializationError    CudaError = 3
+	CudaErrorInvalidDevice          CudaError = 10
+	CudaErrorInvalidMemcpyDirection CudaError = 21
+	CudaErrorNotReady               CudaError = 34
+	CudaErrorUnknown                CudaError = 999
+)
+
+// CudaMemcpyKind specifies the direction of a memory copy.
+type CudaMemcpyKind int
+
+const (
+	CudaMemcpyHostToHost     CudaMemcpyKind = 0
+	CudaMemcpyHostToDevice   CudaMemcpyKind = 1
+	CudaMemcpyDeviceToHost   CudaMemcpyKind = 2
+	CudaMemcpyDeviceToDevice CudaMemcpyKind = 3
+	CudaMemcpyDefault        CudaMemcpyKind = 4
+)
+
+// AllocationInfo tracks a single GPU memory allocation.
+type AllocationInfo struct {
+	Ptr      uintptr
+	Size     uint64
+	DeviceID int
+}
+
+// errorStrings maps CUDA error codes to human-readable strings.
+var errorStrings = map[CudaError]string{
+	CudaSuccess:                     "no error",
+	CudaErrorInvalidValue:           "invalid argument",
+	CudaErrorMemoryAllocation:       "out of memory",
+	CudaErrorInitializationError:    "initialization error",
+	CudaErrorInvalidDevice:          "invalid device ordinal",
+	CudaErrorInvalidMemcpyDirection: "invalid memcpy direction",
+	CudaErrorNotReady:               "device not ready",
+	CudaErrorUnknown:                "unknown error",
+}
+
+// ErrorString returns the human-readable string for a CUDA error code.
+func ErrorString(err CudaError) string {
+	if s, ok := errorStrings[err]; ok {
+		return s
+	}
+	return "unknown error"
+}


### PR DESCRIPTION
## Summary

- Adds `pkg/gpu/mockcuda/` with engine/bridge separation following the established mocknvml pattern
- Implements 10 core CUDA Runtime/Driver API functions plus 5 convenience stubs (15 total exported symbols)
- Engine tracks device state and memory allocations with mutex-protected maps; bridge is a thin CGo layer
- Builds as `libcuda.so.1` via `go build -buildmode=c-shared`

### Functions Implemented

| Function | Category | Behavior |
|----------|----------|----------|
| `cuInit` | Init | Sets initialized flag |
| `cudaDriverGetVersion` | Init | Returns configurable version (default 12080) |
| `cudaGetDeviceCount` | Device | Returns count from env or default (8) |
| `cudaSetDevice` / `cudaGetDevice` | Device | Validates index, tracks current device |
| `cudaMalloc` / `cudaFree` | Memory | Allocation tracking with fake device pointers |
| `cudaMemcpy` | Memory | Real memcpy for host-to-host, no-op for device |
| `cudaLaunchKernel` | Execution | No-op (returns success) |
| `cudaDeviceSynchronize` | Execution | No-op (returns success) |
| `cudaGetErrorString` | Error | Error code to string table |
| `cudaGetLastError` / `cudaPeekAtLastError` | Error | Always returns success |
| `cudaDeviceReset` | Device | No-op |
| `cudaRuntimeGetVersion` | Init | Returns driver version |

## Test plan

- [x] `go test ./pkg/gpu/mockcuda/engine/...` passes (13 tests)
- [x] `go build -buildmode=c-shared` produces valid shared library
- [x] All 15 symbols verified exported via `nm -g`
- [ ] QA review of API surface and patterns