### PR TITLE
feat(mocknvml): NVML Batch 3 - MIG + GPM support

### DIFF
--- a/pkg/gpu/mocknvml/bridge/device.go
+++ b/pkg/gpu/mocknvml/bridge/device.go
@@ -38,6 +38,9 @@
 // - nvmlDeviceGetRemappedRows
 // - nvmlDeviceGetGspFirmwareMode
 // - nvmlDeviceGetDisplayActive
+// - nvmlDeviceGetMaxMigDeviceCount
+// - nvmlDeviceGetMigDeviceHandleByIndex
+// - nvmlGpmQueryDeviceSupport
 
 package main
 
@@ -515,6 +518,73 @@ func nvmlDeviceGetPowerManagementMode(device C.nvmlDevice_t, mode *C.nvmlEnableS
 		return toReturn(ret)
 	}
 	*mode = C.nvmlEnableState_t(m)
+	return C.NVML_SUCCESS
+}
+
+// =============================================================================
+// MIG Functions
+// =============================================================================
+
+//export nvmlDeviceGetMaxMigDeviceCount
+func nvmlDeviceGetMaxMigDeviceCount(device C.nvmlDevice_t, count *C.uint) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetMaxMigDeviceCount"); !ok {
+		return ret
+	}
+	if count == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(device.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	c, ret := dev.GetMaxMigDeviceCount()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	*count = C.uint(c)
+	return C.NVML_SUCCESS
+}
+
+//export nvmlDeviceGetMigDeviceHandleByIndex
+func nvmlDeviceGetMigDeviceHandleByIndex(device C.nvmlDevice_t, index C.uint, migDevice *C.nvmlDevice_t) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetMigDeviceHandleByIndex"); !ok {
+		return ret
+	}
+	if migDevice == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(device.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	_, ret := dev.GetMigDeviceHandleByIndex(int(index))
+	return toReturn(ret)
+}
+
+// =============================================================================
+// GPM Functions
+// =============================================================================
+
+//export nvmlGpmQueryDeviceSupport
+func nvmlGpmQueryDeviceSupport(device C.nvmlDevice_t, gpmSupport *C.nvmlGpmSupport_t) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlGpmQueryDeviceSupport"); !ok {
+		return ret
+	}
+	if gpmSupport == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(device.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	supported, ret := dev.GetGpmSupport()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	gpmSupport.isSupportedDevice = C.uint(supported)
 	return C.NVML_SUCCESS
 }
 

--- a/pkg/gpu/mocknvml/bridge/nvml_types.h
+++ b/pkg/gpu/mocknvml/bridge/nvml_types.h
@@ -254,7 +254,11 @@ typedef struct nvmlFBCStats_st                              nvmlFBCStats_t;
 typedef struct nvmlFanSpeedInfo_st                          nvmlFanSpeedInfo_t;
 typedef struct nvmlFieldValue_st                            nvmlFieldValue_t;
 typedef struct nvmlGpmMetricsGet_st                         nvmlGpmMetricsGet_t;
-typedef struct nvmlGpmSupport_st                            nvmlGpmSupport_t;
+/* GPM support - full definition needed by bridge */
+typedef struct nvmlGpmSupport_st {
+    unsigned int version;
+    unsigned int isSupportedDevice;
+} nvmlGpmSupport_t;
 typedef struct nvmlGpuDynamicPstatesInfo_st                 nvmlGpuDynamicPstatesInfo_t;
 typedef struct nvmlGpuFabricInfoV_st                        nvmlGpuFabricInfoV_t;
 typedef struct nvmlGpuFabricInfo_st                         nvmlGpuFabricInfo_t;

--- a/pkg/gpu/mocknvml/bridge/stubs_generated.go
+++ b/pkg/gpu/mocknvml/bridge/stubs_generated.go
@@ -574,11 +574,6 @@ func nvmlDeviceGetMaxCustomerBoostClock(device C.nvmlDevice_t, clockType C.nvmlC
 	return stubReturn("nvmlDeviceGetMaxCustomerBoostClock")
 }
 
-//export nvmlDeviceGetMaxMigDeviceCount
-func nvmlDeviceGetMaxMigDeviceCount(device C.nvmlDevice_t, count *C.uint) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetMaxMigDeviceCount")
-}
-
 //export nvmlDeviceGetMaxPcieLinkGeneration
 func nvmlDeviceGetMaxPcieLinkGeneration(device C.nvmlDevice_t, maxLinkGen *C.uint) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetMaxPcieLinkGeneration")
@@ -612,11 +607,6 @@ func nvmlDeviceGetMemoryBusWidth(device C.nvmlDevice_t, busWidth *C.uint) C.nvml
 //export nvmlDeviceGetMemoryErrorCounter
 func nvmlDeviceGetMemoryErrorCounter(device C.nvmlDevice_t, errorType C.nvmlMemoryErrorType_t, counterType C.nvmlEccCounterType_t, locationType C.nvmlMemoryLocation_t, count *C.ulonglong) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetMemoryErrorCounter")
-}
-
-//export nvmlDeviceGetMigDeviceHandleByIndex
-func nvmlDeviceGetMigDeviceHandleByIndex(device C.nvmlDevice_t, index C.uint, migDevice *C.nvmlDevice_t) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetMigDeviceHandleByIndex")
 }
 
 //export nvmlDeviceGetMinMaxClockOfPState
@@ -1297,11 +1287,6 @@ func nvmlGpmMetricsGet(metricsGet *C.nvmlGpmMetricsGet_t) C.nvmlReturn_t {
 //export nvmlGpmMigSampleGet
 func nvmlGpmMigSampleGet(device C.nvmlDevice_t, gpuInstanceId C.uint, gpmSample C.nvmlGpmSample_t) C.nvmlReturn_t {
 	return stubReturn("nvmlGpmMigSampleGet")
-}
-
-//export nvmlGpmQueryDeviceSupport
-func nvmlGpmQueryDeviceSupport(device C.nvmlDevice_t, gpmSupport *C.nvmlGpmSupport_t) C.nvmlReturn_t {
-	return stubReturn("nvmlGpmQueryDeviceSupport")
 }
 
 //export nvmlGpmQueryIfStreamingEnabled

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -939,10 +939,47 @@ func (d *ConfigurableDevice) GetPowerState() (nvml.Pstates, nvml.Return) {
 	return d.GetPerformanceState()
 }
 
-// GetMigMode returns MIG mode
+// GetMigMode returns MIG mode (current, pending)
 func (d *ConfigurableDevice) GetMigMode() (int, int, nvml.Return) {
-	debugLog("[NVML] nvmlDeviceGetMigMode -> disabled\n")
-	return 0, 0, nvml.SUCCESS // Disabled, Disabled
+	current, pending := 0, 0
+	if d.config != nil && d.config.MIG != nil {
+		if d.config.MIG.ModeCurrent == "enabled" {
+			current = 1
+		}
+		if d.config.MIG.ModePending == "enabled" {
+			pending = 1
+		}
+	}
+	debugLog("[NVML] nvmlDeviceGetMigMode -> current=%d pending=%d\n", current, pending)
+	return current, pending, nvml.SUCCESS
+}
+
+// GetMaxMigDeviceCount returns the maximum number of MIG devices
+func (d *ConfigurableDevice) GetMaxMigDeviceCount() (int, nvml.Return) {
+	count := 0
+	if d.config != nil && d.config.MIG != nil {
+		count = d.config.MIG.MaxGPUInstances
+	}
+	debugLog("[NVML] nvmlDeviceGetMaxMigDeviceCount -> %d\n", count)
+	return count, nvml.SUCCESS
+}
+
+// GetMigDeviceHandleByIndex returns a MIG device handle by index.
+// Returns NOT_SUPPORTED when MIG is disabled (default).
+func (d *ConfigurableDevice) GetMigDeviceHandleByIndex(index int) (nvml.Device, nvml.Return) {
+	if d.config == nil || d.config.MIG == nil || d.config.MIG.ModeCurrent != "enabled" {
+		debugLog("[NVML] nvmlDeviceGetMigDeviceHandleByIndex(%d) -> NOT_SUPPORTED (MIG disabled)\n", index)
+		return nil, nvml.ERROR_NOT_SUPPORTED
+	}
+	debugLog("[NVML] nvmlDeviceGetMigDeviceHandleByIndex(%d) -> NOT_SUPPORTED (no MIG devices configured)\n", index)
+	return nil, nvml.ERROR_NOT_SUPPORTED
+}
+
+// GetGpmSupport returns whether GPM (GPU Performance Monitoring) is supported.
+// Returns 0 (not supported) by default.
+func (d *ConfigurableDevice) GetGpmSupport() (uint32, nvml.Return) {
+	debugLog("[NVML] nvmlGpmQueryDeviceSupport -> 0 (not supported)\n")
+	return 0, nvml.SUCCESS
 }
 
 // GetArchitecture returns GPU architecture

--- a/pkg/gpu/mocknvml/engine/device_test.go
+++ b/pkg/gpu/mocknvml/engine/device_test.go
@@ -819,3 +819,91 @@ func TestConfigurableDevice_GetDisplayActive_Enabled(t *testing.T) {
 		t.Errorf("Expected ENABLED, got %d", active)
 	}
 }
+
+// =============================================================================
+// MIG Tests (Batch 3)
+// =============================================================================
+
+func TestConfigurableDevice_GetMaxMigDeviceCount_Default(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	count, ret := dev.GetMaxMigDeviceCount()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetMaxMigDeviceCount failed: %v", ret)
+	}
+	// Default: MIG disabled, count = 0
+	if count != 0 {
+		t.Errorf("Expected 0 (MIG disabled), got %d", count)
+	}
+}
+
+func TestConfigurableDevice_GetMaxMigDeviceCount_Configured(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+		MIG: &MIGConfig{
+			ModeCurrent:     "enabled",
+			MaxGPUInstances: 7,
+		},
+	})
+
+	count, ret := dev.GetMaxMigDeviceCount()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetMaxMigDeviceCount failed: %v", ret)
+	}
+	if count != 7 {
+		t.Errorf("Expected 7, got %d", count)
+	}
+}
+
+func TestConfigurableDevice_GetMigMode_WithConfig(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+		MIG: &MIGConfig{
+			ModeCurrent: "enabled",
+			ModePending: "disabled",
+		},
+	})
+
+	current, pending, ret := dev.GetMigMode()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetMigMode failed: %v", ret)
+	}
+	if current != 1 {
+		t.Errorf("Expected current=1 (enabled), got %d", current)
+	}
+	if pending != 0 {
+		t.Errorf("Expected pending=0 (disabled), got %d", pending)
+	}
+}
+
+func TestConfigurableDevice_GetMigDeviceHandleByIndex_MIGDisabled(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	_, ret := dev.GetMigDeviceHandleByIndex(0)
+	if ret != nvml.ERROR_NOT_SUPPORTED {
+		t.Errorf("Expected NOT_SUPPORTED when MIG disabled, got %v", ret)
+	}
+}
+
+// =============================================================================
+// GPM Tests (Batch 3)
+// =============================================================================
+
+func TestConfigurableDevice_GetGpmSupport_Default(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	supported, ret := dev.GetGpmSupport()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetGpmSupport failed: %v", ret)
+	}
+	// Default: not supported
+	if supported != 0 {
+		t.Errorf("Expected 0 (not supported), got %d", supported)
+	}
+}


### PR DESCRIPTION
## Summary

- Implement `nvmlDeviceGetMaxMigDeviceCount` - returns max MIG device count from YAML config (0 when MIG disabled)
- Implement `nvmlDeviceGetMigDeviceHandleByIndex` - returns `NOT_SUPPORTED` (MIG devices not yet modeled)
- Enhance `nvmlDeviceGetMigMode` to read current/pending mode from YAML config instead of hardcoded disabled
- Implement `nvmlGpmQueryDeviceSupport` - returns GPM support status (default: not supported)
- Add full `nvmlGpmSupport_st` struct definition to `nvml_types.h` for bridge field access
- Remove 3 stubs from `stubs_generated.go` (replaced by hand-written bridge implementations)
- Add 5 engine-level tests following established patterns

## Test plan

- [x] `go test ./pkg/gpu/mocknvml/engine/...` passes (5 new tests + all existing)
- [x] `go build ./...` compiles cleanly (including CGo bridge)
- [ ] QA review of bridge/engine patterns