### PR TITLE
feat(bridge): implement 7 nvidia-smi -q gap closure functions

### DIFF
--- a/deployments/gpu-mock/helm/gpu-mock/profiles/a100.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/profiles/a100.yaml
@@ -53,6 +53,7 @@ device_defaults:
     reserved_bytes: 611319808       # ~583 MiB reserved
     free_bytes: 42338353152         # total - reserved at idle
     used_bytes: 0
+    memory_bus_width: 5120
 
   bar1_memory:
     total_bytes: 68719476736        # 64 GiB
@@ -88,6 +89,7 @@ device_defaults:
     max_limit_mw: 400000            # 400W
     current_draw_mw: 72000          # 72W idle
     power_state: "P0"               # P0-P12
+    total_energy_consumption_mj: 500000  # millijoules since boot
 
   # ---------------------------------------------------------------------------
   # Thermal configuration

--- a/deployments/gpu-mock/helm/gpu-mock/profiles/b200.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/profiles/b200.yaml
@@ -53,6 +53,7 @@ device_defaults:
     reserved_bytes: 1073741824      # ~1 GiB reserved
     free_bytes: 205084688384        # total - reserved at idle
     used_bytes: 0
+    memory_bus_width: 8192
 
   bar1_memory:
     total_bytes: 274877906944       # 256 GiB (standalone B200, not 512 GiB like GB200)
@@ -87,6 +88,7 @@ device_defaults:
     max_limit_mw: 1200000           # 1200W max
     current_draw_mw: 130000         # 130W idle
     power_state: "P0"
+    total_energy_consumption_mj: 900000  # millijoules since boot
 
   # ---------------------------------------------------------------------------
   # Thermal configuration

--- a/deployments/gpu-mock/helm/gpu-mock/profiles/gb200.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/profiles/gb200.yaml
@@ -53,6 +53,7 @@ device_defaults:
     reserved_bytes: 1073741824      # ~1 GiB reserved
     free_bytes: 205084688384        # total - reserved at idle
     used_bytes: 0
+    memory_bus_width: 8192
 
   bar1_memory:
     total_bytes: 549755813888       # 512 GiB (unified memory with Grace)
@@ -87,6 +88,7 @@ device_defaults:
     max_limit_mw: 1200000           # 1200W boost
     current_draw_mw: 145000         # 145W idle
     power_state: "P0"
+    total_energy_consumption_mj: 1000000  # millijoules since boot
 
   # ---------------------------------------------------------------------------
   # Thermal configuration

--- a/deployments/gpu-mock/helm/gpu-mock/profiles/h100.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/profiles/h100.yaml
@@ -53,6 +53,7 @@ device_defaults:
     reserved_bytes: 1073741824      # ~1 GiB reserved
     free_bytes: 84825604096         # total - reserved at idle
     used_bytes: 0
+    memory_bus_width: 5120
 
   bar1_memory:
     total_bytes: 274877906944       # 256 GiB
@@ -87,6 +88,7 @@ device_defaults:
     max_limit_mw: 700000            # 700W max
     current_draw_mw: 95000          # 95W idle
     power_state: "P0"
+    total_energy_consumption_mj: 600000  # millijoules since boot
 
   # ---------------------------------------------------------------------------
   # Thermal configuration

--- a/deployments/gpu-mock/helm/gpu-mock/profiles/l40s.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/profiles/l40s.yaml
@@ -53,6 +53,7 @@ device_defaults:
     reserved_bytes: 536870912        # ~512 MiB reserved
     free_bytes: 51002736640          # total - reserved at idle
     used_bytes: 0
+    memory_bus_width: 256
 
   bar1_memory:
     total_bytes: 274877906944        # 256 GiB
@@ -87,6 +88,7 @@ device_defaults:
     max_limit_mw: 350000             # 350W max
     current_draw_mw: 45000           # 45W idle
     power_state: "P0"
+    total_energy_consumption_mj: 300000  # millijoules since boot
 
   # ---------------------------------------------------------------------------
   # Thermal configuration

--- a/deployments/gpu-mock/helm/gpu-mock/profiles/t4.yaml
+++ b/deployments/gpu-mock/helm/gpu-mock/profiles/t4.yaml
@@ -53,6 +53,7 @@ device_defaults:
     reserved_bytes: 314572800        # ~300 MiB reserved
     free_bytes: 16865296384          # total - reserved at idle
     used_bytes: 0
+    memory_bus_width: 256
 
   bar1_memory:
     total_bytes: 274877906944        # 256 GiB
@@ -87,6 +88,7 @@ device_defaults:
     max_limit_mw: 70000              # 70W max
     current_draw_mw: 12000           # 12W idle
     power_state: "P0"
+    total_energy_consumption_mj: 100000  # millijoules since boot
 
   # ---------------------------------------------------------------------------
   # Thermal configuration

--- a/pkg/gpu/mocknvml/bridge/device.go
+++ b/pkg/gpu/mocknvml/bridge/device.go
@@ -83,6 +83,13 @@
 // - nvmlDeviceGetNvLinkVersion
 // - nvmlDeviceGetNvLinkCapability
 // - nvmlDeviceGetMemoryErrorCounter
+// - nvmlDeviceGetMemoryBusWidth
+// - nvmlDeviceGetDefaultEccMode
+// - nvmlDeviceGetSupportedClocksThrottleReasons
+// - nvmlDeviceGetAutoBoostedClocksEnabled
+// - nvmlDeviceGetGspFirmwareVersion
+// - nvmlDeviceGetTotalEnergyConsumption
+// - nvmlDeviceGetDetailedEccErrors
 
 package main
 
@@ -1856,5 +1863,159 @@ func nvmlDeviceGetMemoryErrorCounter(device C.nvmlDevice_t, errorType C.nvmlMemo
 		return toReturn(ret)
 	}
 	*count = C.ulonglong(val)
+	return C.NVML_SUCCESS
+}
+
+// =============================================================================
+// Group G — nvidia-smi query gap closures
+// =============================================================================
+
+//export nvmlDeviceGetMemoryBusWidth
+func nvmlDeviceGetMemoryBusWidth(device C.nvmlDevice_t, busWidth *C.uint) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetMemoryBusWidth"); !ok {
+		return ret
+	}
+	if busWidth == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(device.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	val, ret := dev.GetMemoryBusWidth()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	*busWidth = C.uint(val)
+	return C.NVML_SUCCESS
+}
+
+//export nvmlDeviceGetDefaultEccMode
+func nvmlDeviceGetDefaultEccMode(device C.nvmlDevice_t, defaultMode *C.nvmlEnableState_t) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetDefaultEccMode"); !ok {
+		return ret
+	}
+	if defaultMode == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(device.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	val, ret := dev.GetDefaultEccMode()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	*defaultMode = C.nvmlEnableState_t(val)
+	return C.NVML_SUCCESS
+}
+
+//export nvmlDeviceGetSupportedClocksThrottleReasons
+func nvmlDeviceGetSupportedClocksThrottleReasons(device C.nvmlDevice_t, supportedClocksThrottleReasons *C.ulonglong) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetSupportedClocksThrottleReasons"); !ok {
+		return ret
+	}
+	if supportedClocksThrottleReasons == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(device.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	val, ret := dev.GetSupportedClocksThrottleReasons()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	*supportedClocksThrottleReasons = C.ulonglong(val)
+	return C.NVML_SUCCESS
+}
+
+//export nvmlDeviceGetAutoBoostedClocksEnabled
+func nvmlDeviceGetAutoBoostedClocksEnabled(device C.nvmlDevice_t, isEnabled *C.nvmlEnableState_t, defaultIsEnabled *C.nvmlEnableState_t) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetAutoBoostedClocksEnabled"); !ok {
+		return ret
+	}
+	if isEnabled == nil || defaultIsEnabled == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(device.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	enabled, defaultEnabled, ret := dev.GetAutoBoostedClocksEnabled()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	*isEnabled = C.nvmlEnableState_t(enabled)
+	*defaultIsEnabled = C.nvmlEnableState_t(defaultEnabled)
+	return C.NVML_SUCCESS
+}
+
+//export nvmlDeviceGetGspFirmwareVersion
+func nvmlDeviceGetGspFirmwareVersion(device C.nvmlDevice_t, version *C.char) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetGspFirmwareVersion"); !ok {
+		return ret
+	}
+	if version == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(device.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	val, ret := dev.GetGspFirmwareVersion()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	return goStringToC(val, version, 80)
+}
+
+//export nvmlDeviceGetTotalEnergyConsumption
+func nvmlDeviceGetTotalEnergyConsumption(device C.nvmlDevice_t, energy *C.ulonglong) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetTotalEnergyConsumption"); !ok {
+		return ret
+	}
+	if energy == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(device.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	val, ret := dev.GetTotalEnergyConsumption()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	*energy = C.ulonglong(val)
+	return C.NVML_SUCCESS
+}
+
+//export nvmlDeviceGetDetailedEccErrors
+func nvmlDeviceGetDetailedEccErrors(device C.nvmlDevice_t, errorType C.nvmlMemoryErrorType_t, counterType C.nvmlEccCounterType_t, eccCounts *C.nvmlEccErrorCounts_t) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetDetailedEccErrors"); !ok {
+		return ret
+	}
+	if eccCounts == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(device.handle))
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	counts, ret := dev.GetDetailedEccErrors(nvml.MemoryErrorType(errorType), nvml.EccCounterType(counterType))
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	eccCounts.l1Cache = C.ulonglong(counts.L1Cache)
+	eccCounts.l2Cache = C.ulonglong(counts.L2Cache)
+	eccCounts.deviceMemory = C.ulonglong(counts.DeviceMemory)
+	eccCounts.registerFile = C.ulonglong(counts.RegisterFile)
 	return C.NVML_SUCCESS
 }

--- a/pkg/gpu/mocknvml/bridge/device.go
+++ b/pkg/gpu/mocknvml/bridge/device.go
@@ -1972,7 +1972,7 @@ func nvmlDeviceGetGspFirmwareVersion(device C.nvmlDevice_t, version *C.char) C.n
 	if ret != nvml.SUCCESS {
 		return toReturn(ret)
 	}
-	return goStringToC(val, version, 80)
+	return goStringToC(val, version, nvml.GSP_FIRMWARE_VERSION_BUF_SIZE)
 }
 
 //export nvmlDeviceGetTotalEnergyConsumption

--- a/pkg/gpu/mocknvml/bridge/nvml_types.h
+++ b/pkg/gpu/mocknvml/bridge/nvml_types.h
@@ -249,7 +249,13 @@ typedef struct nvmlDeviceCurrentClockFreqs_st               nvmlDeviceCurrentClo
 typedef struct nvmlDevicePerfModes_st                       nvmlDevicePerfModes_t;
 typedef struct nvmlDevicePowerMizerModes_v1_st              nvmlDevicePowerMizerModes_v1_t;
 typedef struct nvmlDramEncryptionInfo_st                    nvmlDramEncryptionInfo_t;
-typedef struct nvmlEccErrorCounts_st                        nvmlEccErrorCounts_t;
+/* ECC error counts - full definition needed by bridge */
+typedef struct nvmlEccErrorCounts_st {
+    unsigned long long l1Cache;
+    unsigned long long l2Cache;
+    unsigned long long deviceMemory;
+    unsigned long long registerFile;
+} nvmlEccErrorCounts_t;
 typedef struct nvmlEccSramErrorStatus_st                    nvmlEccSramErrorStatus_t;
 typedef struct nvmlEccSramUniqueUncorrectedErrorCounts_st   nvmlEccSramUniqueUncorrectedErrorCounts_t;
 typedef struct nvmlEncoderSessionInfo_st                    nvmlEncoderSessionInfo_t;

--- a/pkg/gpu/mocknvml/bridge/stubs_generated.go
+++ b/pkg/gpu/mocknvml/bridge/stubs_generated.go
@@ -124,10 +124,7 @@ func nvmlDeviceGetAttributes_v2(device C.nvmlDevice_t, attributes *C.nvmlDeviceA
 	return stubReturn("nvmlDeviceGetAttributes_v2")
 }
 
-//export nvmlDeviceGetAutoBoostedClocksEnabled
-func nvmlDeviceGetAutoBoostedClocksEnabled(device C.nvmlDevice_t, isEnabled *C.nvmlEnableState_t, defaultIsEnabled *C.nvmlEnableState_t) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetAutoBoostedClocksEnabled")
-}
+// nvmlDeviceGetAutoBoostedClocksEnabled — hand-written in device.go
 
 //export nvmlDeviceGetBridgeChipInfo
 func nvmlDeviceGetBridgeChipInfo(device C.nvmlDevice_t, bridgeHierarchy *C.nvmlBridgeChipHierarchy_t) C.nvmlReturn_t {
@@ -224,15 +221,9 @@ func nvmlDeviceGetCurrentClockFreqs(device C.nvmlDevice_t, currentClockFreqs *C.
 	return stubReturn("nvmlDeviceGetCurrentClockFreqs")
 }
 
-//export nvmlDeviceGetDefaultEccMode
-func nvmlDeviceGetDefaultEccMode(device C.nvmlDevice_t, defaultMode *C.nvmlEnableState_t) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetDefaultEccMode")
-}
+// nvmlDeviceGetDefaultEccMode — hand-written in device.go
 
-//export nvmlDeviceGetDetailedEccErrors
-func nvmlDeviceGetDetailedEccErrors(device C.nvmlDevice_t, errorType C.nvmlMemoryErrorType_t, counterType C.nvmlEccCounterType_t, eccCounts *C.nvmlEccErrorCounts_t) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetDetailedEccErrors")
-}
+// nvmlDeviceGetDetailedEccErrors — hand-written in device.go
 
 //export nvmlDeviceGetDeviceHandleFromMigDeviceHandle
 func nvmlDeviceGetDeviceHandleFromMigDeviceHandle(migDevice C.nvmlDevice_t, device *C.nvmlDevice_t) C.nvmlReturn_t {
@@ -399,10 +390,7 @@ func nvmlDeviceGetGridLicensableFeatures_v4(device C.nvmlDevice_t, pGridLicensab
 	return stubReturn("nvmlDeviceGetGridLicensableFeatures_v4")
 }
 
-//export nvmlDeviceGetGspFirmwareVersion
-func nvmlDeviceGetGspFirmwareVersion(device C.nvmlDevice_t, version *C.char) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetGspFirmwareVersion")
-}
+// nvmlDeviceGetGspFirmwareVersion — hand-written in device.go
 
 //export nvmlDeviceGetHandleBySerial
 func nvmlDeviceGetHandleBySerial(serial *C.char, device *C.nvmlDevice_t) C.nvmlReturn_t {
@@ -479,10 +467,7 @@ func nvmlDeviceGetMemoryAffinity(device C.nvmlDevice_t, nodeSetSize C.uint, node
 	return stubReturn("nvmlDeviceGetMemoryAffinity")
 }
 
-//export nvmlDeviceGetMemoryBusWidth
-func nvmlDeviceGetMemoryBusWidth(device C.nvmlDevice_t, busWidth *C.uint) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetMemoryBusWidth")
-}
+// nvmlDeviceGetMemoryBusWidth — hand-written in device.go
 
 //export nvmlDeviceGetMinMaxClockOfPState
 func nvmlDeviceGetMinMaxClockOfPState(device C.nvmlDevice_t, _type C.nvmlClockType_t, pstate C.nvmlPstates_t, minClockMHz *C.uint, maxClockMHz *C.uint) C.nvmlReturn_t {
@@ -639,10 +624,7 @@ func nvmlDeviceGetSupportedClocksEventReasons(device C.nvmlDevice_t, supportedCl
 	return stubReturn("nvmlDeviceGetSupportedClocksEventReasons")
 }
 
-//export nvmlDeviceGetSupportedClocksThrottleReasons
-func nvmlDeviceGetSupportedClocksThrottleReasons(device C.nvmlDevice_t, supportedClocksThrottleReasons *C.ulonglong) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetSupportedClocksThrottleReasons")
-}
+// nvmlDeviceGetSupportedClocksThrottleReasons — hand-written in device.go
 
 // nvmlDeviceGetSupportedEventTypes — hand-written in events.go
 
@@ -676,10 +658,7 @@ func nvmlDeviceGetTemperatureV(device C.nvmlDevice_t, temperature *C.nvmlTempera
 	return stubReturn("nvmlDeviceGetTemperatureV")
 }
 
-//export nvmlDeviceGetTotalEnergyConsumption
-func nvmlDeviceGetTotalEnergyConsumption(device C.nvmlDevice_t, energy *C.ulonglong) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetTotalEnergyConsumption")
-}
+// nvmlDeviceGetTotalEnergyConsumption — hand-written in device.go
 
 //export nvmlDeviceGetVgpuCapabilities
 func nvmlDeviceGetVgpuCapabilities(device C.nvmlDevice_t, capability C.nvmlDeviceVgpuCapability_t, capResult *C.uint) C.nvmlReturn_t {

--- a/pkg/gpu/mocknvml/engine/config_types.go
+++ b/pkg/gpu/mocknvml/engine/config_types.go
@@ -159,6 +159,7 @@ type MemoryConfig struct {
 	ReservedBytes uint64 `json:"reserved_bytes,omitempty"`
 	FreeBytes     uint64 `json:"free_bytes,omitempty"`
 	UsedBytes     uint64 `json:"used_bytes,omitempty"`
+	MemoryBusWidth uint32 `json:"memory_bus_width,omitempty"` // bits (e.g., 5120 for A100)
 }
 
 // BAR1MemoryConfig defines BAR1 aperture settings
@@ -194,8 +195,9 @@ type PowerConfig struct {
 	EnforcedLimitMW     uint32 `json:"enforced_limit_mw,omitempty"`
 	MinLimitMW          uint32 `json:"min_limit_mw,omitempty"`
 	MaxLimitMW          uint32 `json:"max_limit_mw,omitempty"`
-	CurrentDrawMW       uint32 `json:"current_draw_mw,omitempty"`
-	PowerState          string `json:"power_state,omitempty"`
+	CurrentDrawMW            uint32 `json:"current_draw_mw,omitempty"`
+	PowerState               string `json:"power_state,omitempty"`
+	TotalEnergyConsumptionMJ uint64 `json:"total_energy_consumption_mj,omitempty"` // millijoules since boot
 }
 
 // ThermalConfig defines thermal settings

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -844,8 +844,7 @@ func (d *ConfigurableDevice) GetDefaultEccMode() (nvml.EnableState, nvml.Return)
 
 // GetSupportedClocksThrottleReasons returns bitmask of all supported throttle reasons.
 func (d *ConfigurableDevice) GetSupportedClocksThrottleReasons() (uint64, nvml.Return) {
-	// Standard bitmask for datacenter GPUs: all common reasons supported.
-	reasons := uint64(0x1FF)
+	reasons := uint64(nvml.ClocksThrottleReasonAll)
 	debugLog("[NVML] nvmlDeviceGetSupportedClocksThrottleReasons -> 0x%x\n", reasons)
 	return reasons, nvml.SUCCESS
 }
@@ -871,9 +870,6 @@ func (d *ConfigurableDevice) GetTotalEnergyConsumption() (uint64, nvml.Return) {
 		return 0, nvml.ERROR_NOT_SUPPORTED
 	}
 	energy := d.config.Power.TotalEnergyConsumptionMJ
-	if energy == 0 {
-		return 0, nvml.ERROR_NOT_SUPPORTED
-	}
 	debugLog("[NVML] nvmlDeviceGetTotalEnergyConsumption -> %d mJ\n", energy)
 	return energy, nvml.SUCCESS
 }

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -816,6 +816,78 @@ func (d *ConfigurableDevice) GetBoardId() (uint32, nvml.Return) {
 	return 0, nvml.SUCCESS
 }
 
+// GetMemoryBusWidth returns the memory bus width in bits.
+func (d *ConfigurableDevice) GetMemoryBusWidth() (uint32, nvml.Return) {
+	width := uint32(0)
+	if d.config != nil && d.config.Memory != nil {
+		width = d.config.Memory.MemoryBusWidth
+	}
+	if width == 0 {
+		return 0, nvml.ERROR_NOT_SUPPORTED
+	}
+	debugLog("[NVML] nvmlDeviceGetMemoryBusWidth -> %d bits\n", width)
+	return width, nvml.SUCCESS
+}
+
+// GetDefaultEccMode returns the default ECC mode.
+func (d *ConfigurableDevice) GetDefaultEccMode() (nvml.EnableState, nvml.Return) {
+	if d.config == nil || d.config.ECC == nil {
+		return nvml.FEATURE_DISABLED, nvml.SUCCESS
+	}
+	mode := nvml.FEATURE_DISABLED
+	if d.config.ECC.DefaultMode == "enabled" {
+		mode = nvml.FEATURE_ENABLED
+	}
+	debugLog("[NVML] nvmlDeviceGetDefaultEccMode -> %d\n", mode)
+	return mode, nvml.SUCCESS
+}
+
+// GetSupportedClocksThrottleReasons returns bitmask of all supported throttle reasons.
+func (d *ConfigurableDevice) GetSupportedClocksThrottleReasons() (uint64, nvml.Return) {
+	// Standard bitmask for datacenter GPUs: all common reasons supported.
+	reasons := uint64(0x1FF)
+	debugLog("[NVML] nvmlDeviceGetSupportedClocksThrottleReasons -> 0x%x\n", reasons)
+	return reasons, nvml.SUCCESS
+}
+
+// GetAutoBoostedClocksEnabled returns auto-boost status.
+// Datacenter GPUs (A100, H100, etc.) don't support auto-boost.
+func (d *ConfigurableDevice) GetAutoBoostedClocksEnabled() (nvml.EnableState, nvml.EnableState, nvml.Return) {
+	return nvml.FEATURE_DISABLED, nvml.FEATURE_DISABLED, nvml.ERROR_NOT_SUPPORTED
+}
+
+// GetGspFirmwareVersion returns the GSP firmware version string.
+func (d *ConfigurableDevice) GetGspFirmwareVersion() (string, nvml.Return) {
+	if d.config == nil || d.config.GSPFirmware == nil || d.config.GSPFirmware.Version == "" {
+		return "", nvml.ERROR_NOT_SUPPORTED
+	}
+	debugLog("[NVML] nvmlDeviceGetGspFirmwareVersion -> %s\n", d.config.GSPFirmware.Version)
+	return d.config.GSPFirmware.Version, nvml.SUCCESS
+}
+
+// GetTotalEnergyConsumption returns cumulative energy in millijoules.
+func (d *ConfigurableDevice) GetTotalEnergyConsumption() (uint64, nvml.Return) {
+	if d.config == nil || d.config.Power == nil {
+		return 0, nvml.ERROR_NOT_SUPPORTED
+	}
+	energy := d.config.Power.TotalEnergyConsumptionMJ
+	if energy == 0 {
+		return 0, nvml.ERROR_NOT_SUPPORTED
+	}
+	debugLog("[NVML] nvmlDeviceGetTotalEnergyConsumption -> %d mJ\n", energy)
+	return energy, nvml.SUCCESS
+}
+
+// GetDetailedEccErrors returns per-location ECC error counts.
+func (d *ConfigurableDevice) GetDetailedEccErrors(errorType nvml.MemoryErrorType, counterType nvml.EccCounterType) (nvml.EccErrorCounts, nvml.Return) {
+	counts := nvml.EccErrorCounts{}
+	if d.config == nil || d.config.ECC == nil {
+		return counts, nvml.SUCCESS
+	}
+	debugLog("[NVML] nvmlDeviceGetDetailedEccErrors(errorType=%d, counterType=%d) -> zeros\n", errorType, counterType)
+	return counts, nvml.SUCCESS
+}
+
 // GetEncoderCapacity returns encoder capacity
 func (d *ConfigurableDevice) GetEncoderCapacity(encoderType nvml.EncoderType) (int, nvml.Return) {
 	debugLog("[NVML] nvmlDeviceGetEncoderCapacity(type=%d) -> 100\n", encoderType)

--- a/pkg/gpu/mocknvml/engine/device_test.go
+++ b/pkg/gpu/mocknvml/engine/device_test.go
@@ -893,6 +893,183 @@ func TestConfigurableDevice_GetMigDeviceHandleByIndex_MIGDisabled(t *testing.T) 
 // GPM Tests (Batch 3)
 // =============================================================================
 
+// =============================================================================
+// nvidia-smi -q Gap Closure Tests
+// =============================================================================
+
+func TestConfigurableDevice_GetMemoryBusWidth_Configured(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+		Memory: &MemoryConfig{
+			TotalBytes:     42949672960,
+			MemoryBusWidth: 5120,
+		},
+	})
+
+	width, ret := dev.GetMemoryBusWidth()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetMemoryBusWidth failed: %v", ret)
+	}
+	if width != 5120 {
+		t.Errorf("Expected 5120, got %d", width)
+	}
+}
+
+func TestConfigurableDevice_GetMemoryBusWidth_NotConfigured(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	_, ret := dev.GetMemoryBusWidth()
+	if ret != nvml.ERROR_NOT_SUPPORTED {
+		t.Errorf("Expected NOT_SUPPORTED when no memory config, got %v", ret)
+	}
+}
+
+func TestConfigurableDevice_GetDefaultEccMode_Enabled(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+		ECC: &ECCConfig{
+			DefaultMode: "enabled",
+		},
+	})
+
+	mode, ret := dev.GetDefaultEccMode()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetDefaultEccMode failed: %v", ret)
+	}
+	if mode != nvml.FEATURE_ENABLED {
+		t.Errorf("Expected ENABLED, got %d", mode)
+	}
+}
+
+func TestConfigurableDevice_GetDefaultEccMode_NoConfig(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	mode, ret := dev.GetDefaultEccMode()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetDefaultEccMode failed: %v", ret)
+	}
+	if mode != nvml.FEATURE_DISABLED {
+		t.Errorf("Expected DISABLED when no ECC config, got %d", mode)
+	}
+}
+
+func TestConfigurableDevice_GetSupportedClocksThrottleReasons(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	reasons, ret := dev.GetSupportedClocksThrottleReasons()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetSupportedClocksThrottleReasons failed: %v", ret)
+	}
+	if reasons != uint64(nvml.ClocksThrottleReasonAll) {
+		t.Errorf("Expected 0x%x, got 0x%x", nvml.ClocksThrottleReasonAll, reasons)
+	}
+}
+
+func TestConfigurableDevice_GetAutoBoostedClocksEnabled(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	_, _, ret := dev.GetAutoBoostedClocksEnabled()
+	if ret != nvml.ERROR_NOT_SUPPORTED {
+		t.Errorf("Expected NOT_SUPPORTED for datacenter GPU, got %v", ret)
+	}
+}
+
+func TestConfigurableDevice_GetGspFirmwareVersion_Configured(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+		GSPFirmware: &GSPFirmwareConfig{
+			Version: "550.54.15",
+		},
+	})
+
+	version, ret := dev.GetGspFirmwareVersion()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetGspFirmwareVersion failed: %v", ret)
+	}
+	if version != "550.54.15" {
+		t.Errorf("Expected '550.54.15', got '%s'", version)
+	}
+}
+
+func TestConfigurableDevice_GetGspFirmwareVersion_NoConfig(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	_, ret := dev.GetGspFirmwareVersion()
+	if ret != nvml.ERROR_NOT_SUPPORTED {
+		t.Errorf("Expected NOT_SUPPORTED when no GSP config, got %v", ret)
+	}
+}
+
+func TestConfigurableDevice_GetTotalEnergyConsumption_Configured(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+		Power: &PowerConfig{
+			TotalEnergyConsumptionMJ: 500000,
+		},
+	})
+
+	energy, ret := dev.GetTotalEnergyConsumption()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetTotalEnergyConsumption failed: %v", ret)
+	}
+	if energy != 500000 {
+		t.Errorf("Expected 500000, got %d", energy)
+	}
+}
+
+func TestConfigurableDevice_GetTotalEnergyConsumption_Zero(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+		Power: &PowerConfig{
+			TotalEnergyConsumptionMJ: 0,
+		},
+	})
+
+	energy, ret := dev.GetTotalEnergyConsumption()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetTotalEnergyConsumption failed: %v", ret)
+	}
+	if energy != 0 {
+		t.Errorf("Expected 0 (valid zero), got %d", energy)
+	}
+}
+
+func TestConfigurableDevice_GetTotalEnergyConsumption_NoPowerConfig(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	_, ret := dev.GetTotalEnergyConsumption()
+	if ret != nvml.ERROR_NOT_SUPPORTED {
+		t.Errorf("Expected NOT_SUPPORTED when no power config, got %v", ret)
+	}
+}
+
+func TestConfigurableDevice_GetDetailedEccErrors_Default(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+	})
+
+	counts, ret := dev.GetDetailedEccErrors(nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.VOLATILE_ECC)
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetDetailedEccErrors failed: %v", ret)
+	}
+	if counts.L1Cache != 0 || counts.L2Cache != 0 || counts.DeviceMemory != 0 || counts.RegisterFile != 0 {
+		t.Errorf("Expected all zeros, got l1=%d l2=%d mem=%d reg=%d",
+			counts.L1Cache, counts.L2Cache, counts.DeviceMemory, counts.RegisterFile)
+	}
+}
+
 func TestConfigurableDevice_GetGpmSupport_Default(t *testing.T) {
 	dev := newTestDeviceWithConfig(t, &DeviceConfig{
 		Name: "NVIDIA A100-SXM4-80GB",


### PR DESCRIPTION
## Summary
- Implement 7 stubbed NVML functions so `nvidia-smi -q` produces complete output with no N/A gaps for fields that real GPUs always report
- **Task 1:** `GetMemoryBusWidth`, `GetDefaultEccMode`, `GetSupportedClocksThrottleReasons`
- **Task 2:** `GetAutoBoostedClocksEnabled`, `GetGspFirmwareVersion`, `GetTotalEnergyConsumption`, `GetDetailedEccErrors`

## Changes
- Add `MemoryBusWidth` to `MemoryConfig`, `TotalEnergyConsumptionMJ` to `PowerConfig` (engine config)
- Add 7 engine methods on `ConfigurableDevice` + 7 bridge C ABI exports
- Remove 7 stubs from `stubs_generated.go`
- Add full `nvmlEccErrorCounts_st` struct definition to `nvml_types.h`
- Add `memory_bus_width` and `total_energy_consumption_mj` to all 6 GPU profiles

## Test plan
- [x] Engine unit tests pass (`go test ./pkg/gpu/mocknvml/engine/...`)
- [x] Bridge compiles (`go build -buildmode=c-shared ./bridge`)
- [ ] CI: full build + E2E tests on Linux