### PR TITLE
feat(e2e): multi-node heterogeneous GPU fleet simulation

### DIFF
--- a/.github/workflows/gpu-mock-e2e.yaml
+++ b/.github/workflows/gpu-mock-e2e.yaml
@@ -546,3 +546,171 @@ jobs:
           kubectl -n gpu-operator logs -l app=nvidia-gpu-feature-discovery --tail=50 || true
           echo "=== node describe ==="
           kubectl describe nodes || true
+
+  e2e-multi-node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ inputs.golang_version }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Create multi-node Kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: gpu-fleet
+          config: tests/e2e/kind-multi-node-config.yaml
+
+      - name: Build gpu-mock image
+        run: |
+          docker build -t gpu-mock:e2e -f deployments/gpu-mock/Dockerfile \
+            --build-arg GOLANG_VERSION=${{ inputs.golang_version }} .
+
+      - name: Load image into Kind
+        run: |
+          kind load docker-image gpu-mock:e2e --name gpu-fleet
+
+      - name: Discover worker node names
+        id: nodes
+        run: |
+          WORKERS=$(kind get nodes --name gpu-fleet | grep worker | sort)
+          echo "Worker nodes: $WORKERS"
+          WORKER1=$(echo "$WORKERS" | head -1)
+          WORKER2=$(echo "$WORKERS" | tail -1)
+          echo "worker1=$WORKER1" >> "$GITHUB_OUTPUT"
+          echo "worker2=$WORKER2" >> "$GITHUB_OUTPUT"
+
+      - name: Verify node labels
+        run: |
+          kubectl get nodes --show-labels | grep gpu-mock/profile || {
+            echo "FAIL: gpu-mock/profile labels not found on worker nodes"
+            kubectl get nodes --show-labels
+            exit 1
+          }
+
+      - name: Install nvidia-container-toolkit on workers
+        run: |
+          for NODE in ${{ steps.nodes.outputs.worker1 }} ${{ steps.nodes.outputs.worker2 }}; do
+            echo "Installing nvidia-container-toolkit on $NODE..."
+            docker exec "$NODE" bash -c '
+              apt-get update -qq &&
+              apt-get install -y -qq curl gpg > /dev/null &&
+              curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey |
+                gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg &&
+              curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list |
+                sed "s#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g" |
+                tee /etc/apt/sources.list.d/nvidia-container-toolkit.list &&
+              apt-get update -qq &&
+              apt-get install -y -qq nvidia-container-toolkit > /dev/null
+            '
+            docker exec "$NODE" systemctl restart containerd
+            echo "Done: $NODE"
+          done
+          sleep 5
+
+      - name: Install gpu-mock on worker-1 (A100 profile)
+        run: |
+          helm install gpu-mock-a100 deployments/gpu-mock/helm/gpu-mock \
+            --set image.repository=gpu-mock \
+            --set image.tag=e2e \
+            --set gpu.profile=a100 \
+            --set gpu.count=2 \
+            --set "nodeSelector.gpu-mock/profile=a100" \
+            --wait --timeout 120s
+
+      - name: Install gpu-mock on worker-2 (T4 profile)
+        run: |
+          helm install gpu-mock-t4 deployments/gpu-mock/helm/gpu-mock \
+            --set image.repository=gpu-mock \
+            --set image.tag=e2e \
+            --set gpu.profile=t4 \
+            --set gpu.count=2 \
+            --set "nodeSelector.gpu-mock/profile=t4" \
+            --wait --timeout 120s
+
+      - name: Verify mock files on both workers
+        run: |
+          echo "=== Worker-1 (A100) ==="
+          docker exec "${{ steps.nodes.outputs.worker1 }}" ls -la /var/lib/nvidia-mock/driver/usr/lib64/libnvidia-ml.so.* | head -2
+          docker exec "${{ steps.nodes.outputs.worker1 }}" grep "NVIDIA A100" /var/lib/nvidia-mock/config/config.yaml | head -1
+
+          echo "=== Worker-2 (T4) ==="
+          docker exec "${{ steps.nodes.outputs.worker2 }}" ls -la /var/lib/nvidia-mock/driver/usr/lib64/libnvidia-ml.so.* | head -2
+          docker exec "${{ steps.nodes.outputs.worker2 }}" grep "NVIDIA T4" /var/lib/nvidia-mock/config/config.yaml | head -1
+
+      - name: Deploy NVIDIA device plugin
+        run: |
+          kubectl apply -f tests/e2e/device-plugin-mock.yaml
+          kubectl -n kube-system wait --for=condition=ready \
+            pod -l name=nvidia-device-plugin-mock --timeout=120s
+
+      - name: Verify GPUs on both nodes
+        run: |
+          WORKER1="${{ steps.nodes.outputs.worker1 }}"
+          WORKER2="${{ steps.nodes.outputs.worker2 }}"
+          echo "Waiting for device-plugin to register GPUs on both nodes..."
+          for i in $(seq 1 30); do
+            A100_GPUS=$(kubectl get node "$WORKER1" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}' 2>/dev/null || echo "0")
+            T4_GPUS=$(kubectl get node "$WORKER2" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}' 2>/dev/null || echo "0")
+            if [ "$A100_GPUS" = "2" ] && [ "$T4_GPUS" = "2" ]; then
+              echo "PASS: Heterogeneous GPU fleet detected"
+              echo "  $WORKER1 (A100): $A100_GPUS GPUs"
+              echo "  $WORKER2 (T4):   $T4_GPUS GPUs"
+              exit 0
+            fi
+            echo "Attempt $i: $WORKER1=$A100_GPUS $WORKER2=$T4_GPUS (expected 2+2), waiting..."
+            sleep 5
+          done
+          echo "FAIL: Expected 2 GPUs on each worker node"
+          kubectl describe nodes | grep -A5 "Allocatable"
+          exit 1
+
+      - name: Test cross-node GPU scheduling
+        run: |
+          cat <<'PODEOF' | kubectl apply -f -
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: gpu-scheduling-test
+          spec:
+            restartPolicy: Never
+            containers:
+              - name: test
+                image: busybox:1.36
+                command: ["sh", "-c", "echo scheduled-on=$(hostname); sleep 5"]
+                resources:
+                  limits:
+                    nvidia.com/gpu: 1
+          PODEOF
+
+          echo "Waiting for pod to be scheduled..."
+          kubectl wait --for=condition=Ready pod/gpu-scheduling-test --timeout=60s || {
+            echo "Pod did not reach Ready state"
+            kubectl describe pod/gpu-scheduling-test
+          }
+          NODE=$(kubectl get pod gpu-scheduling-test -o jsonpath='{.spec.nodeName}')
+          echo "PASS: GPU pod scheduled on node: $NODE"
+          kubectl delete pod gpu-scheduling-test --ignore-not-found
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== gpu-mock pods ==="
+          kubectl get pods -A -l app.kubernetes.io/name=gpu-mock -o wide || true
+          echo "=== gpu-mock-a100 logs ==="
+          kubectl logs -l app.kubernetes.io/instance=gpu-mock-a100 --tail=30 || true
+          echo "=== gpu-mock-t4 logs ==="
+          kubectl logs -l app.kubernetes.io/instance=gpu-mock-t4 --tail=30 || true
+          echo "=== device plugin logs ==="
+          kubectl -n kube-system logs -l name=nvidia-device-plugin-mock --tail=50 || true
+          echo "=== node labels ==="
+          kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, labels: (.metadata.labels | to_entries | map(select(.key | startswith("nvidia.com") or startswith("gpu-mock"))) | from_entries)}' || true
+          echo "=== events ==="
+          kubectl get events --sort-by=.lastTimestamp | tail -30 || true
+          echo "=== node describe ==="
+          kubectl describe nodes || true

--- a/.github/workflows/gpu-mock-e2e.yaml
+++ b/.github/workflows/gpu-mock-e2e.yaml
@@ -692,6 +692,7 @@ jobs:
           kubectl wait --for=condition=Ready pod/gpu-scheduling-test --timeout=60s || {
             echo "Pod did not reach Ready state"
             kubectl describe pod/gpu-scheduling-test
+            exit 1
           }
           NODE=$(kubectl get pod gpu-scheduling-test -o jsonpath='{.spec.nodeName}')
           echo "PASS: GPU pod scheduled on node: $NODE"

--- a/deployments/gpu-mock/helm/gpu-mock/README.md
+++ b/deployments/gpu-mock/helm/gpu-mock/README.md
@@ -165,13 +165,45 @@ Expected: `8` (default gpu.count).
 kind delete cluster --name gpu-mock-dra
 ```
 
+## Multi-Node Heterogeneous GPU Fleet
+
+Simulate a cluster with different GPU types on different nodes by installing
+multiple Helm releases with `nodeSelector`:
+
+```bash
+# Label your nodes (Kind does this via cluster config)
+kubectl label node worker-1 gpu-mock/profile=a100
+kubectl label node worker-2 gpu-mock/profile=t4
+
+# Install a different GPU profile per node
+helm install gpu-mock-a100 deployments/gpu-mock/helm/gpu-mock \
+  --set image.repository=gpu-mock \
+  --set image.tag=local \
+  --set gpu.profile=a100 \
+  --set gpu.count=4 \
+  --set "nodeSelector.gpu-mock/profile=a100"
+
+helm install gpu-mock-t4 deployments/gpu-mock/helm/gpu-mock \
+  --set image.repository=gpu-mock \
+  --set image.tag=local \
+  --set gpu.profile=t4 \
+  --set gpu.count=2 \
+  --set "nodeSelector.gpu-mock/profile=t4"
+```
+
+Each release creates its own DaemonSet, ConfigMap, and RBAC resources. The
+device plugin (or DRA driver) discovers different GPU types on each node,
+enabling heterogeneous scheduling and topology-aware placement testing.
+
+For a Kind cluster with labeled workers, see `tests/e2e/kind-multi-node-config.yaml`.
+
 ## Configuration
 
 ### Values
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `gpu.profile` | `a100` | GPU profile: `a100`, `h100`, `b200`, or `gb200` |
+| `gpu.profile` | `a100` | GPU profile: `a100`, `h100`, `b200`, `gb200`, `l40s`, or `t4` |
 | `gpu.count` | `8` | Number of mock GPUs per node |
 | `gpu.customConfig` | `""` | Inline YAML to override profile config entirely |
 | `image.repository` | `ghcr.io/nvidia/gpu-mock` | Container image repository |
@@ -203,23 +235,23 @@ helm install gpu-mock deployments/gpu-mock/helm/gpu-mock \
 
 #### Profile Comparison
 
-| | A100 | H100 | B200 | GB200 |
-|---|---|---|---|---|
-| **Profile name** | `a100` | `h100` | `b200` | `gb200` |
-| **Full name** | A100-SXM4-40GB | H100 80GB HBM3 | B200 | GB200 NVL |
-| **Architecture** | Ampere | Hopper | Blackwell | Blackwell |
-| **Compute capability** | 8.0 | 9.0 | 10.0 | 10.0 |
-| **CUDA cores** | 6,912 | 16,896 | 18,432 | 18,432 |
-| **Memory** | 40 GiB HBM2e | 80 GiB HBM3 | 192 GiB HBM3e | 192 GiB HBM3e |
-| **NVLink** | v3, 12 links | v4, 18 links | v5, 18 links | v5, 18 links |
-| **NVLink BW** | 600 GB/s | 900 GB/s | 1.8 TB/s | 1.8 TB/s |
-| **TDP** | 400W | 700W | 1,000W | 1,000W |
-| **PCIe** | Gen4 | Gen5 | Gen6 | Gen6 |
-| **MIG instances** | 7 | 7 | 7 | 7 |
-| **Grace CPU** | — | — | — | Yes (NVLink-C2C) |
-| **FP8** | — | Yes | Yes | Yes |
-| **FP4** | — | — | Yes | Yes |
-| **Driver version** | 550.163.01 | 550.163.01 | 560.35.03 | 560.35.03 |
+| | A100 | H100 | B200 | GB200 | L40S | T4 |
+|---|---|---|---|---|---|---|
+| **Profile name** | `a100` | `h100` | `b200` | `gb200` | `l40s` | `t4` |
+| **Full name** | A100-SXM4-40GB | H100 80GB HBM3 | B200 | GB200 NVL | L40S | Tesla T4 |
+| **Architecture** | Ampere | Hopper | Blackwell | Blackwell | Ada Lovelace | Turing |
+| **Compute capability** | 8.0 | 9.0 | 10.0 | 10.0 | 8.9 | 7.5 |
+| **CUDA cores** | 6,912 | 16,896 | 18,432 | 18,432 | 18,176 | 2,560 |
+| **Memory** | 40 GiB HBM2e | 80 GiB HBM3 | 192 GiB HBM3e | 192 GiB HBM3e | 48 GiB GDDR6 | 16 GiB GDDR6 |
+| **NVLink** | v3, 12 links | v4, 18 links | v5, 18 links | v5, 18 links | — | — |
+| **NVLink BW** | 600 GB/s | 900 GB/s | 1.8 TB/s | 1.8 TB/s | — | — |
+| **TDP** | 400W | 700W | 1,000W | 1,000W | 350W | 70W |
+| **PCIe** | Gen4 | Gen5 | Gen6 | Gen6 | Gen4 | Gen3 |
+| **MIG instances** | 7 | 7 | 7 | 7 | 0 | 0 |
+| **Grace CPU** | — | — | — | Yes (NVLink-C2C) | — | — |
+| **FP8** | — | Yes | Yes | Yes | Yes | — |
+| **FP4** | — | — | Yes | Yes | — | — |
+| **Driver version** | 550.163.01 | 550.163.01 | 560.35.03 | 560.35.03 | 550.163.01 | 550.163.01 |
 
 #### When to Use Each Profile
 
@@ -227,6 +259,8 @@ helm install gpu-mock deployments/gpu-mock/helm/gpu-mock \
 - **`h100`** — testing Hopper-specific features: FP8, Transformer Engine, PCIe Gen5, or NVLink v4 topology.
 - **`b200`** — testing next-gen Blackwell features: FP4, NVLink v5, PCIe Gen6. Standalone GPU (no Grace CPU).
 - **`gb200`** — testing Grace-Blackwell Superchip: NVLink-C2C to Grace CPU, unified memory, and Blackwell features.
+- **`l40s`** — testing Ada Lovelace inference workloads: FP8, PCIe Gen4, no NVLink (PCIe-only topology).
+- **`t4`** — testing Turing inference GPUs: low power (70W), small memory (16 GiB), 4 GPUs per node.
 
 ### Custom Configuration
 

--- a/tests/e2e/kind-multi-node-config.yaml
+++ b/tests/e2e/kind-multi-node-config.yaml
@@ -1,0 +1,30 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Kind cluster config for multi-node GPU fleet simulation.
+# Creates 1 control-plane + 2 workers with CDI enabled on all nodes.
+# Each worker gets a different GPU profile via separate Helm releases
+# using nodeSelector to target the gpu-mock/profile label.
+#
+# Usage:
+#   kind create cluster --name gpu-fleet --config tests/e2e/kind-multi-node-config.yaml
+#   helm install gpu-mock-a100 gpu-mock/ --set gpu.profile=a100 --set nodeSelector.gpu-mock/profile=a100
+#   helm install gpu-mock-t4 gpu-mock/ --set gpu.profile=t4 --set nodeSelector.gpu-mock/profile=t4
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri"]
+      enable_cdi = true
+    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
+      runtime_type = "io.containerd.runc.v2"
+    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
+      BinaryName = "/usr/bin/nvidia-container-runtime"
+nodes:
+  - role: control-plane
+  - role: worker
+    labels:
+      gpu-mock/profile: a100
+  - role: worker
+    labels:
+      gpu-mock/profile: t4


### PR DESCRIPTION
## Summary

Enable per-node GPU profile selection so a single Kind cluster simulates a heterogeneous GPU fleet.

- **Multi-node Kind config**: 1 control-plane + 2 workers, each labeled with `gpu-mock/profile`
- **Separate Helm releases**: `gpu-mock-a100` targets worker-1, `gpu-mock-t4` targets worker-2 via `nodeSelector`
- **E2E validation**: device-plugin discovers GPUs on both nodes, cross-node scheduling works

This is a capability no other GPU mock project has — simulating heterogeneous GPU fleets for scheduling and placement testing.

Related: #250

## Changes

| Commit | Scope |
|--------|-------|
| Kind config | `tests/e2e/kind-multi-node-config.yaml` — 1 CP + 2 workers |
| E2E job | `.github/workflows/gpu-mock-e2e.yaml` — `e2e-multi-node` job |

## Test plan

- [ ] `e2e-multi-node` job passes in CI
- [ ] Both workers report 2 allocatable GPUs
- [ ] GPU pod gets scheduled to a worker node