### PR TITLE
feat(e2e): multi-profile GPU matrix for E2E tests

### DIFF
--- a/.github/workflows/gpu-mock-e2e.yaml
+++ b/.github/workflows/gpu-mock-e2e.yaml
@@ -220,7 +220,7 @@ jobs:
       - name: Create Kind cluster with DRA
         uses: helm/kind-action@v1
         with:
-          cluster_name: gpu-mock-dra-e2e
+          cluster_name: gpu-mock-dra-${{ matrix.gpu-profile }}
           config: tests/e2e/kind-dra-config.yaml
 
       - name: Build gpu-mock image
@@ -230,13 +230,14 @@ jobs:
 
       - name: Load image into Kind
         run: |
-          kind load docker-image gpu-mock:e2e --name gpu-mock-dra-e2e
+          kind load docker-image gpu-mock:e2e --name gpu-mock-dra-${{ matrix.gpu-profile }}
 
       - name: Install gpu-mock Helm chart
         run: |
           helm install gpu-mock deployments/gpu-mock/helm/gpu-mock \
             --set image.repository=gpu-mock \
             --set image.tag=e2e \
+            --set gpu.profile=${{ matrix.gpu-profile }} \
             --set gpu.count=2 \
             --wait --timeout 120s
 
@@ -246,7 +247,7 @@ jobs:
 
       - name: Verify mock files on node
         run: |
-          NODE_CONTAINER=gpu-mock-dra-e2e-control-plane
+          NODE_CONTAINER=gpu-mock-dra-${{ matrix.gpu-profile }}-control-plane
           docker exec "$NODE_CONTAINER" test -f /var/lib/nvidia-mock/driver/config/config.yaml
           docker exec "$NODE_CONTAINER" grep -q "num_devices: 2" /var/lib/nvidia-mock/driver/config/config.yaml
           docker exec "$NODE_CONTAINER" test -L /var/lib/nvidia-mock/driver/usr/lib64/libnvidia-ml.so.1
@@ -256,8 +257,8 @@ jobs:
         run: |
           chmod +x tests/e2e/validate-nvidia-smi.sh
           ./tests/e2e/validate-nvidia-smi.sh \
-            gpu-mock-dra-e2e-control-plane \
-            "NVIDIA A100" \
+            gpu-mock-dra-${{ matrix.gpu-profile }}-control-plane \
+            "${{ matrix.gpu-name }}" \
             2
 
       - name: Add NVIDIA Helm repo
@@ -321,6 +322,17 @@ jobs:
 
   e2e-gpu-operator:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gpu-profile: [a100, h100, t4]
+        include:
+          - gpu-profile: a100
+            gpu-name: "NVIDIA A100"
+          - gpu-profile: h100
+            gpu-name: "NVIDIA H100"
+          - gpu-profile: t4
+            gpu-name: "NVIDIA T4"
     steps:
       - uses: actions/checkout@v6
 
@@ -335,12 +347,12 @@ jobs:
       - name: Create Kind cluster for GPU Operator
         uses: helm/kind-action@v1
         with:
-          cluster_name: gpu-mock-operator-e2e
+          cluster_name: gpu-mock-operator-e2e-${{ matrix.gpu-profile }}
           config: tests/e2e/kind-gpu-operator-config.yaml
 
       - name: Install nvidia-container-toolkit in Kind worker
         run: |
-          NODE_CONTAINER=gpu-mock-operator-e2e-control-plane
+          NODE_CONTAINER=gpu-mock-operator-e2e-${{ matrix.gpu-profile }}-control-plane
           docker exec "$NODE_CONTAINER" bash -c '
             apt-get update -qq
             apt-get install -y -qq curl gpg
@@ -355,7 +367,7 @@ jobs:
 
       - name: Configure toolkit for CDI mode
         run: |
-          NODE_CONTAINER=gpu-mock-operator-e2e-control-plane
+          NODE_CONTAINER=gpu-mock-operator-e2e-${{ matrix.gpu-profile }}-control-plane
           docker exec "$NODE_CONTAINER" nvidia-ctk runtime configure \
             --runtime=containerd --cdi.enabled --set-as-default
           docker exec "$NODE_CONTAINER" bash -c '
@@ -371,7 +383,7 @@ jobs:
 
       - name: Restart containerd to pick up nvidia runtime
         run: |
-          NODE_CONTAINER=gpu-mock-operator-e2e-control-plane
+          NODE_CONTAINER=gpu-mock-operator-e2e-${{ matrix.gpu-profile }}-control-plane
           docker exec "$NODE_CONTAINER" systemctl restart containerd
           sleep 5
           docker exec "$NODE_CONTAINER" crictl info | head -5
@@ -383,13 +395,14 @@ jobs:
 
       - name: Load image into Kind
         run: |
-          kind load docker-image gpu-mock:e2e --name gpu-mock-operator-e2e
+          kind load docker-image gpu-mock:e2e --name gpu-mock-operator-e2e-${{ matrix.gpu-profile }}
 
       - name: Install gpu-mock Helm chart
         run: |
           helm install gpu-mock deployments/gpu-mock/helm/gpu-mock \
             --set image.repository=gpu-mock \
             --set image.tag=e2e \
+            --set gpu.profile=${{ matrix.gpu-profile }} \
             --set gpu.count=2 \
             --wait --timeout 120s
 
@@ -399,14 +412,14 @@ jobs:
 
       - name: Verify CDI spec exists on node
         run: |
-          NODE_CONTAINER=gpu-mock-operator-e2e-control-plane
+          NODE_CONTAINER=gpu-mock-operator-e2e-${{ matrix.gpu-profile }}-control-plane
           docker exec "$NODE_CONTAINER" test -f /var/run/cdi/nvidia.yaml
           docker exec "$NODE_CONTAINER" cat /var/run/cdi/nvidia.yaml
           echo "CDI spec verified"
 
       - name: Verify mock driver setup on node
         run: |
-          NODE_CONTAINER=gpu-mock-operator-e2e-control-plane
+          NODE_CONTAINER=gpu-mock-operator-e2e-${{ matrix.gpu-profile }}-control-plane
           echo "=== symlink check ==="
           docker exec "$NODE_CONTAINER" ls -la /run/nvidia/ 2>&1 || echo "no /run/nvidia"
           docker exec "$NODE_CONTAINER" ls -la /run/nvidia/driver 2>&1 || echo "symlink missing"
@@ -426,7 +439,7 @@ jobs:
 
       - name: Test CDI injection end-to-end
         run: |
-          NODE_CONTAINER=gpu-mock-operator-e2e-control-plane
+          NODE_CONTAINER=gpu-mock-operator-e2e-${{ matrix.gpu-profile }}-control-plane
 
           echo "=== CDI spec (first 30 lines) ==="
           docker exec "$NODE_CONTAINER" head -30 /var/run/cdi/nvidia.yaml
@@ -546,7 +559,7 @@ jobs:
           echo "=== gpu-mock pod logs ==="
           kubectl logs -l app.kubernetes.io/name=gpu-mock --tail=50 || true
           echo "=== CDI spec ==="
-          NODE_CONTAINER=gpu-mock-operator-e2e-control-plane
+          NODE_CONTAINER=gpu-mock-operator-e2e-${{ matrix.gpu-profile }}-control-plane
           docker exec "$NODE_CONTAINER" cat /var/run/cdi/nvidia.yaml 2>/dev/null || true
           echo "=== nvidia-container-runtime config ==="
           docker exec "$NODE_CONTAINER" cat /etc/nvidia-container-runtime/config.toml 2>/dev/null || true

--- a/.github/workflows/gpu-mock-e2e.yaml
+++ b/.github/workflows/gpu-mock-e2e.yaml
@@ -24,6 +24,17 @@ on:
 jobs:
   e2e-device-plugin:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gpu-profile: [a100, h100, t4]
+        include:
+          - gpu-profile: a100
+            gpu-name: "NVIDIA A100"
+          - gpu-profile: h100
+            gpu-name: "NVIDIA H100"
+          - gpu-profile: t4
+            gpu-name: "NVIDIA T4"
     steps:
       - uses: actions/checkout@v6
 
@@ -38,7 +49,7 @@ jobs:
       - name: Create Kind cluster
         uses: helm/kind-action@v1
         with:
-          cluster_name: gpu-mock-e2e
+          cluster_name: gpu-mock-e2e-${{ matrix.gpu-profile }}
 
       - name: Build gpu-mock image
         run: |
@@ -47,13 +58,14 @@ jobs:
 
       - name: Load image into Kind
         run: |
-          kind load docker-image gpu-mock:e2e --name gpu-mock-e2e
+          kind load docker-image gpu-mock:e2e --name gpu-mock-e2e-${{ matrix.gpu-profile }}
 
       - name: Install gpu-mock Helm chart
         run: |
           helm install gpu-mock deployments/gpu-mock/helm/gpu-mock \
             --set image.repository=gpu-mock \
             --set image.tag=e2e \
+            --set gpu.profile=${{ matrix.gpu-profile }} \
             --set gpu.count=2 \
             --wait --timeout 120s
 
@@ -70,7 +82,7 @@ jobs:
 
       - name: Verify mock files on node
         run: |
-          NODE_CONTAINER=gpu-mock-e2e-control-plane
+          NODE_CONTAINER=gpu-mock-e2e-${{ matrix.gpu-profile }}-control-plane
           # Check library
           docker exec "$NODE_CONTAINER" sh -c "ls /var/lib/nvidia-mock/driver/usr/lib64/libnvidia-ml.so.* | head -1"
           docker exec "$NODE_CONTAINER" test -L /var/lib/nvidia-mock/driver/usr/lib64/libnvidia-ml.so.1
@@ -89,8 +101,8 @@ jobs:
         run: |
           chmod +x tests/e2e/validate-nvidia-smi.sh
           ./tests/e2e/validate-nvidia-smi.sh \
-            gpu-mock-e2e-control-plane \
-            "NVIDIA A100" \
+            gpu-mock-e2e-${{ matrix.gpu-profile }}-control-plane \
+            "${{ matrix.gpu-name }}" \
             2
 
       - name: Deploy NVIDIA device plugin
@@ -122,7 +134,7 @@ jobs:
         if: false
         run: |
           docker pull nvcr.io/nvidia/gpu-feature-discovery:v0.17.0
-          kind load docker-image nvcr.io/nvidia/gpu-feature-discovery:v0.17.0 --name gpu-mock-e2e
+          kind load docker-image nvcr.io/nvidia/gpu-feature-discovery:v0.17.0 --name gpu-mock-e2e-${{ matrix.gpu-profile }}
           kubectl apply -f tests/e2e/gfd-mock.yaml
           kubectl -n kube-system wait --for=condition=ready \
             pod -l name=nvidia-gfd-mock --timeout=120s
@@ -153,7 +165,7 @@ jobs:
         if: false
         run: |
           docker pull nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0
-          kind load docker-image nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0 --name gpu-mock-e2e
+          kind load docker-image nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0 --name gpu-mock-e2e-${{ matrix.gpu-profile }}
           kubectl apply -f tests/e2e/validator-mock.yaml
           kubectl wait --for=condition=complete job/gpu-validator-mock --timeout=120s || {
             echo "Validator job did not complete. Checking status..."
@@ -183,6 +195,17 @@ jobs:
 
   e2e-dra:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gpu-profile: [a100, h100, t4]
+        include:
+          - gpu-profile: a100
+            gpu-name: "NVIDIA A100"
+          - gpu-profile: h100
+            gpu-name: "NVIDIA H100"
+          - gpu-profile: t4
+            gpu-name: "NVIDIA T4"
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/gpu-mock-e2e.yaml
+++ b/.github/workflows/gpu-mock-e2e.yaml
@@ -20,6 +20,22 @@ on:
       golang_version:
         required: true
         type: string
+      gpu_profiles:
+        required: false
+        type: string
+        default: '["a100", "h100", "t4"]'
+  workflow_dispatch:
+    inputs:
+      golang_version:
+        description: 'Go version'
+        required: true
+        default: '1.23'
+        type: string
+      gpu_profiles:
+        description: 'GPU profiles to test (JSON array)'
+        required: false
+        default: '["a100", "h100", "b200", "gb200", "l40s", "t4"]'
+        type: string
 
 jobs:
   e2e-device-plugin:
@@ -27,16 +43,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gpu-profile: [a100, h100, t4]
-        include:
-          - gpu-profile: a100
-            gpu-name: "NVIDIA A100"
-          - gpu-profile: h100
-            gpu-name: "NVIDIA H100"
-          - gpu-profile: t4
-            gpu-name: "NVIDIA T4"
+        gpu-profile: ${{ fromJson(inputs.gpu_profiles) }}
     steps:
       - uses: actions/checkout@v6
+
+      - name: Set GPU display name
+        id: gpu-info
+        run: |
+          case "${{ matrix.gpu-profile }}" in
+            a100) echo "gpu-name=NVIDIA A100" >> "$GITHUB_OUTPUT" ;;
+            h100) echo "gpu-name=NVIDIA H100" >> "$GITHUB_OUTPUT" ;;
+            b200) echo "gpu-name=NVIDIA B200" >> "$GITHUB_OUTPUT" ;;
+            gb200) echo "gpu-name=NVIDIA GB200" >> "$GITHUB_OUTPUT" ;;
+            l40s) echo "gpu-name=NVIDIA L40S" >> "$GITHUB_OUTPUT" ;;
+            t4)   echo "gpu-name=NVIDIA T4" >> "$GITHUB_OUTPUT" ;;
+            *)    echo "gpu-name=Unknown" >> "$GITHUB_OUTPUT" ;;
+          esac
 
       - name: Install Go
         uses: actions/setup-go@v6
@@ -102,7 +124,7 @@ jobs:
           chmod +x tests/e2e/validate-nvidia-smi.sh
           ./tests/e2e/validate-nvidia-smi.sh \
             gpu-mock-e2e-${{ matrix.gpu-profile }}-control-plane \
-            "${{ matrix.gpu-name }}" \
+            "${{ steps.gpu-info.outputs.gpu-name }}" \
             2
 
       - name: Deploy NVIDIA device plugin
@@ -198,16 +220,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gpu-profile: [a100, h100, t4]
-        include:
-          - gpu-profile: a100
-            gpu-name: "NVIDIA A100"
-          - gpu-profile: h100
-            gpu-name: "NVIDIA H100"
-          - gpu-profile: t4
-            gpu-name: "NVIDIA T4"
+        gpu-profile: ${{ fromJson(inputs.gpu_profiles) }}
     steps:
       - uses: actions/checkout@v6
+
+      - name: Set GPU display name
+        id: gpu-info
+        run: |
+          case "${{ matrix.gpu-profile }}" in
+            a100) echo "gpu-name=NVIDIA A100" >> "$GITHUB_OUTPUT" ;;
+            h100) echo "gpu-name=NVIDIA H100" >> "$GITHUB_OUTPUT" ;;
+            b200) echo "gpu-name=NVIDIA B200" >> "$GITHUB_OUTPUT" ;;
+            gb200) echo "gpu-name=NVIDIA GB200" >> "$GITHUB_OUTPUT" ;;
+            l40s) echo "gpu-name=NVIDIA L40S" >> "$GITHUB_OUTPUT" ;;
+            t4)   echo "gpu-name=NVIDIA T4" >> "$GITHUB_OUTPUT" ;;
+            *)    echo "gpu-name=Unknown" >> "$GITHUB_OUTPUT" ;;
+          esac
 
       - name: Install Go
         uses: actions/setup-go@v6
@@ -258,7 +286,7 @@ jobs:
           chmod +x tests/e2e/validate-nvidia-smi.sh
           ./tests/e2e/validate-nvidia-smi.sh \
             gpu-mock-dra-${{ matrix.gpu-profile }}-control-plane \
-            "${{ matrix.gpu-name }}" \
+            "${{ steps.gpu-info.outputs.gpu-name }}" \
             2
 
       - name: Add NVIDIA Helm repo
@@ -325,16 +353,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gpu-profile: [a100, h100, t4]
-        include:
-          - gpu-profile: a100
-            gpu-name: "NVIDIA A100"
-          - gpu-profile: h100
-            gpu-name: "NVIDIA H100"
-          - gpu-profile: t4
-            gpu-name: "NVIDIA T4"
+        gpu-profile: ${{ fromJson(inputs.gpu_profiles) }}
     steps:
       - uses: actions/checkout@v6
+
+      - name: Set GPU display name
+        id: gpu-info
+        run: |
+          case "${{ matrix.gpu-profile }}" in
+            a100) echo "gpu-name=NVIDIA A100" >> "$GITHUB_OUTPUT" ;;
+            h100) echo "gpu-name=NVIDIA H100" >> "$GITHUB_OUTPUT" ;;
+            b200) echo "gpu-name=NVIDIA B200" >> "$GITHUB_OUTPUT" ;;
+            gb200) echo "gpu-name=NVIDIA GB200" >> "$GITHUB_OUTPUT" ;;
+            l40s) echo "gpu-name=NVIDIA L40S" >> "$GITHUB_OUTPUT" ;;
+            t4)   echo "gpu-name=NVIDIA T4" >> "$GITHUB_OUTPUT" ;;
+            *)    echo "gpu-name=Unknown" >> "$GITHUB_OUTPUT" ;;
+          esac
 
       - name: Install Go
         uses: actions/setup-go@v6

--- a/.github/workflows/gpu-mock-e2e.yaml
+++ b/.github/workflows/gpu-mock-e2e.yaml
@@ -347,12 +347,12 @@ jobs:
       - name: Create Kind cluster for GPU Operator
         uses: helm/kind-action@v1
         with:
-          cluster_name: gpu-mock-operator-e2e-${{ matrix.gpu-profile }}
+          cluster_name: gpu-mock-op-${{ matrix.gpu-profile }}
           config: tests/e2e/kind-gpu-operator-config.yaml
 
       - name: Install nvidia-container-toolkit in Kind worker
         run: |
-          NODE_CONTAINER=gpu-mock-operator-e2e-${{ matrix.gpu-profile }}-control-plane
+          NODE_CONTAINER=gpu-mock-op-${{ matrix.gpu-profile }}-control-plane
           docker exec "$NODE_CONTAINER" bash -c '
             apt-get update -qq
             apt-get install -y -qq curl gpg
@@ -367,7 +367,7 @@ jobs:
 
       - name: Configure toolkit for CDI mode
         run: |
-          NODE_CONTAINER=gpu-mock-operator-e2e-${{ matrix.gpu-profile }}-control-plane
+          NODE_CONTAINER=gpu-mock-op-${{ matrix.gpu-profile }}-control-plane
           docker exec "$NODE_CONTAINER" nvidia-ctk runtime configure \
             --runtime=containerd --cdi.enabled --set-as-default
           docker exec "$NODE_CONTAINER" bash -c '
@@ -383,7 +383,7 @@ jobs:
 
       - name: Restart containerd to pick up nvidia runtime
         run: |
-          NODE_CONTAINER=gpu-mock-operator-e2e-${{ matrix.gpu-profile }}-control-plane
+          NODE_CONTAINER=gpu-mock-op-${{ matrix.gpu-profile }}-control-plane
           docker exec "$NODE_CONTAINER" systemctl restart containerd
           sleep 5
           docker exec "$NODE_CONTAINER" crictl info | head -5
@@ -395,7 +395,7 @@ jobs:
 
       - name: Load image into Kind
         run: |
-          kind load docker-image gpu-mock:e2e --name gpu-mock-operator-e2e-${{ matrix.gpu-profile }}
+          kind load docker-image gpu-mock:e2e --name gpu-mock-op-${{ matrix.gpu-profile }}
 
       - name: Install gpu-mock Helm chart
         run: |
@@ -412,14 +412,14 @@ jobs:
 
       - name: Verify CDI spec exists on node
         run: |
-          NODE_CONTAINER=gpu-mock-operator-e2e-${{ matrix.gpu-profile }}-control-plane
+          NODE_CONTAINER=gpu-mock-op-${{ matrix.gpu-profile }}-control-plane
           docker exec "$NODE_CONTAINER" test -f /var/run/cdi/nvidia.yaml
           docker exec "$NODE_CONTAINER" cat /var/run/cdi/nvidia.yaml
           echo "CDI spec verified"
 
       - name: Verify mock driver setup on node
         run: |
-          NODE_CONTAINER=gpu-mock-operator-e2e-${{ matrix.gpu-profile }}-control-plane
+          NODE_CONTAINER=gpu-mock-op-${{ matrix.gpu-profile }}-control-plane
           echo "=== symlink check ==="
           docker exec "$NODE_CONTAINER" ls -la /run/nvidia/ 2>&1 || echo "no /run/nvidia"
           docker exec "$NODE_CONTAINER" ls -la /run/nvidia/driver 2>&1 || echo "symlink missing"
@@ -439,7 +439,7 @@ jobs:
 
       - name: Test CDI injection end-to-end
         run: |
-          NODE_CONTAINER=gpu-mock-operator-e2e-${{ matrix.gpu-profile }}-control-plane
+          NODE_CONTAINER=gpu-mock-op-${{ matrix.gpu-profile }}-control-plane
 
           echo "=== CDI spec (first 30 lines) ==="
           docker exec "$NODE_CONTAINER" head -30 /var/run/cdi/nvidia.yaml
@@ -559,7 +559,7 @@ jobs:
           echo "=== gpu-mock pod logs ==="
           kubectl logs -l app.kubernetes.io/name=gpu-mock --tail=50 || true
           echo "=== CDI spec ==="
-          NODE_CONTAINER=gpu-mock-operator-e2e-${{ matrix.gpu-profile }}-control-plane
+          NODE_CONTAINER=gpu-mock-op-${{ matrix.gpu-profile }}-control-plane
           docker exec "$NODE_CONTAINER" cat /var/run/cdi/nvidia.yaml 2>/dev/null || true
           echo "=== nvidia-container-runtime config ==="
           docker exec "$NODE_CONTAINER" cat /etc/nvidia-container-runtime/config.toml 2>/dev/null || true

--- a/.github/workflows/gpu-mock-e2e.yaml
+++ b/.github/workflows/gpu-mock-e2e.yaml
@@ -357,19 +357,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set GPU display name
-        id: gpu-info
-        run: |
-          case "${{ matrix.gpu-profile }}" in
-            a100) echo "gpu-name=NVIDIA A100" >> "$GITHUB_OUTPUT" ;;
-            h100) echo "gpu-name=NVIDIA H100" >> "$GITHUB_OUTPUT" ;;
-            b200) echo "gpu-name=NVIDIA B200" >> "$GITHUB_OUTPUT" ;;
-            gb200) echo "gpu-name=NVIDIA GB200" >> "$GITHUB_OUTPUT" ;;
-            l40s) echo "gpu-name=NVIDIA L40S" >> "$GITHUB_OUTPUT" ;;
-            t4)   echo "gpu-name=NVIDIA T4" >> "$GITHUB_OUTPUT" ;;
-            *)    echo "gpu-name=Unknown" >> "$GITHUB_OUTPUT" ;;
-          esac
-
       - name: Install Go
         uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
## Summary
- Add `strategy.matrix.gpu-profile` to all 3 single-node E2E jobs (device-plugin, DRA, GPU Operator)
- Default CI tests A100, H100, T4 (3 architectures: Ampere, Hopper, Turing)
- `fail-fast: false` ensures full coverage data even if one profile fails
- Manual `workflow_dispatch` trigger supports all 6 profiles (a100, h100, b200, gb200, l40s, t4)
- Each profile gets its own Kind cluster running in parallel — no wall time increase

## CI Impact
| Metric | Before | After |
|--------|--------|-------|
| E2E jobs | 3 | 9 |
| Wall time | ~3 min | ~3 min (parallel) |
| Profiles tested | 1 (a100) | 3 (a100, h100, t4) |

Closes #248

## Test Plan
- [ ] All 9 matrix jobs pass in CI
- [ ] Manual workflow_dispatch with full 6-profile array works