### PR TITLE
feat(generator): add tests, stats, and validation to bridge generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,3 +77,7 @@ check-modules: modules
 	@git diff --exit-code -- $$(find . -name go.mod -name go.sum)
 	@echo "- Checking if the go mod vendor dir is in sync..."
 	@git diff --exit-code -- $$(find . -name vendor)
+
+.PHONY: generate
+generate:
+	go generate ./pkg/gpu/mocknvml/bridge/...

--- a/cmd/generate-bridge/main.go
+++ b/cmd/generate-bridge/main.go
@@ -49,6 +49,7 @@ func main() {
 	bridge := flag.String("bridge", "pkg/gpu/mocknvml/bridge", "Bridge directory to scan for existing implementations")
 	output := flag.String("output", "pkg/gpu/mocknvml/bridge/stubs_generated.go", "Output file for generated stubs")
 	stats := flag.Bool("stats", false, "Print coverage statistics and exit")
+	validate := flag.Bool("validate", false, "Validate hand-written export signatures against nvml.h prototypes")
 	flag.Parse()
 
 	if *stats {
@@ -58,6 +59,29 @@ func main() {
 		}
 		printStats(os.Stdout, allFunctions, *bridge)
 		return
+	}
+
+	if *validate {
+		headerFile, err := os.Open(*header)
+		if err != nil {
+			log.Fatalf("Failed to open header: %v", err)
+		}
+		defer func() { _ = headerFile.Close() }()
+
+		prototypes, err := parseNVMLPrototypes(headerFile)
+		if err != nil {
+			log.Fatalf("Failed to parse header: %v", err)
+		}
+
+		mismatches := validateSignatures(*bridge, prototypes)
+		if len(mismatches) == 0 {
+			fmt.Println("All hand-written exports match nvml.h prototypes.")
+			return
+		}
+		for _, m := range mismatches {
+			fmt.Printf("WARNING: %s\n", m)
+		}
+		os.Exit(1)
 	}
 
 	// Step 1: Parse input file to get all NVML function names
@@ -321,4 +345,66 @@ func printStats(w io.Writer, allFunctions []string, bridgeDir string) {
 			fmt.Fprintf(w, "    %-20s %d functions\n", f+":", fileCounts[f])
 		}
 	}
+}
+
+// validateSignatures checks that hand-written //export functions have the
+// correct number of parameters compared to their C prototypes in nvml.h.
+// Returns a list of mismatch descriptions.
+func validateSignatures(bridgeDir string, prototypes map[string]FuncProto) []string {
+	var mismatches []string
+
+	_ = filepath.Walk(bridgeDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "stubs_generated.go") {
+			return err
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		lines := strings.Split(string(content), "\n")
+		for i, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if !strings.HasPrefix(trimmed, "//export ") {
+				continue
+			}
+			funcName := strings.TrimSpace(strings.TrimPrefix(trimmed, "//export "))
+
+			// Find the func line (should be next non-empty line)
+			goParamCount := 0
+			for j := i + 1; j < len(lines) && j <= i+3; j++ {
+				funcLine := strings.TrimSpace(lines[j])
+				if strings.HasPrefix(funcLine, "func ") {
+					parenOpen := strings.Index(funcLine, "(")
+					parenClose := strings.Index(funcLine, ")")
+					if parenOpen >= 0 && parenClose > parenOpen {
+						paramStr := strings.TrimSpace(funcLine[parenOpen+1 : parenClose])
+						if paramStr == "" {
+							goParamCount = 0
+						} else {
+							goParamCount = strings.Count(paramStr, ",") + 1
+						}
+					}
+					break
+				}
+			}
+
+			// Look up C prototype
+			proto, ok := lookupProto(funcName, prototypes)
+			if !ok {
+				continue
+			}
+
+			if goParamCount != len(proto.Params) {
+				mismatches = append(mismatches, fmt.Sprintf(
+					"%s:%d: %s has %d Go params but nvml.h prototype has %d C params",
+					filepath.Base(path), i+1, funcName, goParamCount, len(proto.Params),
+				))
+			}
+		}
+		return nil
+	})
+
+	return mismatches
 }

--- a/cmd/generate-bridge/main.go
+++ b/cmd/generate-bridge/main.go
@@ -35,6 +35,7 @@ import (
 	"go/format"
 	"go/parser"
 	"go/token"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -47,7 +48,17 @@ func main() {
 	header := flag.String("header", "vendor/github.com/NVIDIA/go-nvml/pkg/nvml/nvml.h", "NVML C header file for prototype extraction")
 	bridge := flag.String("bridge", "pkg/gpu/mocknvml/bridge", "Bridge directory to scan for existing implementations")
 	output := flag.String("output", "pkg/gpu/mocknvml/bridge/stubs_generated.go", "Output file for generated stubs")
+	stats := flag.Bool("stats", false, "Print coverage statistics and exit")
 	flag.Parse()
+
+	if *stats {
+		allFunctions, err := parseNVMLFunctions(*input)
+		if err != nil {
+			log.Fatalf("Failed to parse input: %v", err)
+		}
+		printStats(os.Stdout, allFunctions, *bridge)
+		return
+	}
 
 	// Step 1: Parse input file to get all NVML function names
 	allFunctions, err := parseNVMLFunctions(*input)
@@ -248,4 +259,66 @@ import "C"
 	log.Printf("Generated %d stubs with correct signatures, %d without", withProto, withoutProto)
 
 	return buf.String()
+}
+
+// printStats writes NVML function coverage statistics to w.
+func printStats(w io.Writer, allFunctions []string, bridgeDir string) {
+	exports, err := scanBridgeExports(bridgeDir)
+	if err != nil {
+		fmt.Fprintf(w, "Error scanning bridge: %v\n", err)
+		return
+	}
+
+	total := len(allFunctions)
+	implemented := len(exports)
+	stubs := total - implemented
+	pctImpl := 0.0
+	pctStub := 0.0
+	if total > 0 {
+		pctImpl = float64(implemented) / float64(total) * 100
+		pctStub = float64(stubs) / float64(total) * 100
+	}
+
+	fmt.Fprintf(w, "NVML Function Coverage:\n")
+	fmt.Fprintf(w, "  Total functions:               %d\n", total)
+	fmt.Fprintf(w, "  Hand-written implementations:  %d (%.1f%%)\n", implemented, pctImpl)
+	fmt.Fprintf(w, "  Generated stubs:               %d (%.1f%%)\n", stubs, pctStub)
+
+	// Per-file breakdown
+	fileCounts := make(map[string]int)
+	err = filepath.Walk(bridgeDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "stubs_generated.go") {
+			return err
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		count := 0
+		for _, line := range strings.Split(string(content), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "//export ") {
+				count++
+			}
+		}
+		if count > 0 {
+			fileCounts[filepath.Base(path)] = count
+		}
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(w, "  Error scanning files: %v\n", err)
+		return
+	}
+
+	if len(fileCounts) > 0 {
+		fmt.Fprintf(w, "\n  By file:\n")
+		var files []string
+		for f := range fileCounts {
+			files = append(files, f)
+		}
+		sort.Strings(files)
+		for _, f := range files {
+			fmt.Fprintf(w, "    %-20s %d functions\n", f+":", fileCounts[f])
+		}
+	}
 }

--- a/cmd/generate-bridge/main.go
+++ b/cmd/generate-bridge/main.go
@@ -289,7 +289,7 @@ import "C"
 func printStats(w io.Writer, allFunctions []string, bridgeDir string) {
 	exports, err := scanBridgeExports(bridgeDir)
 	if err != nil {
-		fmt.Fprintf(w, "Error scanning bridge: %v\n", err)
+		_, _ = fmt.Fprintf(w, "Error scanning bridge: %v\n", err)
 		return
 	}
 
@@ -303,10 +303,10 @@ func printStats(w io.Writer, allFunctions []string, bridgeDir string) {
 		pctStub = float64(stubs) / float64(total) * 100
 	}
 
-	fmt.Fprintf(w, "NVML Function Coverage:\n")
-	fmt.Fprintf(w, "  Total functions:               %d\n", total)
-	fmt.Fprintf(w, "  Hand-written implementations:  %d (%.1f%%)\n", implemented, pctImpl)
-	fmt.Fprintf(w, "  Generated stubs:               %d (%.1f%%)\n", stubs, pctStub)
+	_, _ = fmt.Fprintf(w, "NVML Function Coverage:\n")
+	_, _ = fmt.Fprintf(w, "  Total functions:               %d\n", total)
+	_, _ = fmt.Fprintf(w, "  Hand-written implementations:  %d (%.1f%%)\n", implemented, pctImpl)
+	_, _ = fmt.Fprintf(w, "  Generated stubs:               %d (%.1f%%)\n", stubs, pctStub)
 
 	// Per-file breakdown
 	fileCounts := make(map[string]int)
@@ -330,19 +330,19 @@ func printStats(w io.Writer, allFunctions []string, bridgeDir string) {
 		return nil
 	})
 	if err != nil {
-		fmt.Fprintf(w, "  Error scanning files: %v\n", err)
+		_, _ = fmt.Fprintf(w, "  Error scanning files: %v\n", err)
 		return
 	}
 
 	if len(fileCounts) > 0 {
-		fmt.Fprintf(w, "\n  By file:\n")
+		_, _ = fmt.Fprintf(w, "\n  By file:\n")
 		var files []string
 		for f := range fileCounts {
 			files = append(files, f)
 		}
 		sort.Strings(files)
 		for _, f := range files {
-			fmt.Fprintf(w, "    %-20s %d functions\n", f+":", fileCounts[f])
+			_, _ = fmt.Fprintf(w, "    %-20s %d functions\n", f+":", fileCounts[f])
 		}
 	}
 }

--- a/cmd/generate-bridge/main.go
+++ b/cmd/generate-bridge/main.go
@@ -49,7 +49,7 @@ func main() {
 	bridge := flag.String("bridge", "pkg/gpu/mocknvml/bridge", "Bridge directory to scan for existing implementations")
 	output := flag.String("output", "pkg/gpu/mocknvml/bridge/stubs_generated.go", "Output file for generated stubs")
 	stats := flag.Bool("stats", false, "Print coverage statistics and exit")
-	validate := flag.Bool("validate", false, "Validate hand-written export signatures against nvml.h prototypes")
+	validate := flag.Bool("validate", false, "Validate hand-written export parameter counts against nvml.h prototypes")
 	flag.Parse()
 
 	if *stats {
@@ -73,9 +73,12 @@ func main() {
 			log.Fatalf("Failed to parse header: %v", err)
 		}
 
-		mismatches := validateSignatures(*bridge, prototypes)
+		mismatches, err := validateSignatures(*bridge, prototypes)
+		if err != nil {
+			log.Fatalf("Failed to scan bridge directory: %v", err)
+		}
 		if len(mismatches) == 0 {
-			fmt.Println("All hand-written exports match nvml.h prototypes.")
+			fmt.Println("All hand-written exports match nvml.h parameter counts.")
 			return
 		}
 		for _, m := range mismatches {
@@ -293,8 +296,20 @@ func printStats(w io.Writer, allFunctions []string, bridgeDir string) {
 		return
 	}
 
+	// Count only exports that correspond to functions in allFunctions
+	// to avoid overcounting bridge-internal exports not in nvml.go.
+	allSet := make(map[string]bool, len(allFunctions))
+	for _, fn := range allFunctions {
+		allSet[fn] = true
+	}
+	implemented := 0
+	for fn := range exports {
+		if allSet[fn] {
+			implemented++
+		}
+	}
+
 	total := len(allFunctions)
-	implemented := len(exports)
 	stubs := total - implemented
 	pctImpl := 0.0
 	pctStub := 0.0
@@ -349,11 +364,11 @@ func printStats(w io.Writer, allFunctions []string, bridgeDir string) {
 
 // validateSignatures checks that hand-written //export functions have the
 // correct number of parameters compared to their C prototypes in nvml.h.
-// Returns a list of mismatch descriptions.
-func validateSignatures(bridgeDir string, prototypes map[string]FuncProto) []string {
+// Returns a list of mismatch descriptions and any walk error.
+func validateSignatures(bridgeDir string, prototypes map[string]FuncProto) ([]string, error) {
 	var mismatches []string
 
-	_ = filepath.Walk(bridgeDir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(bridgeDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "stubs_generated.go") {
 			return err
 		}
@@ -406,5 +421,5 @@ func validateSignatures(bridgeDir string, prototypes map[string]FuncProto) []str
 		return nil
 	})
 
-	return mismatches
+	return mismatches, err
 }

--- a/cmd/generate-bridge/main_test.go
+++ b/cmd/generate-bridge/main_test.go
@@ -432,7 +432,10 @@ func nvmlDeviceGetName() C.nvmlReturn_t {
 		},
 	}
 
-	mismatches := validateSignatures(dir, protos)
+	mismatches, err := validateSignatures(dir, protos)
+	if err != nil {
+		t.Fatalf("validateSignatures: %v", err)
+	}
 
 	if len(mismatches) != 1 {
 		t.Fatalf("expected 1 mismatch, got %d: %v", len(mismatches), mismatches)

--- a/cmd/generate-bridge/main_test.go
+++ b/cmd/generate-bridge/main_test.go
@@ -389,3 +389,55 @@ func nvmlInit_v2() {}
 		t.Errorf("expected 'device.go' in per-file breakdown:\n%s", output)
 	}
 }
+
+func TestValidateSignatures(t *testing.T) {
+	dir := t.TempDir()
+
+	// Correct: 1 param matching prototype
+	correctGo := `package main
+
+//export nvmlDeviceGetCount_v2
+func nvmlDeviceGetCount_v2(deviceCount *C.uint) C.nvmlReturn_t {
+	return 0
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "correct.go"), []byte(correctGo), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrong: 0 params but prototype says 3
+	wrongGo := `package main
+
+//export nvmlDeviceGetName
+func nvmlDeviceGetName() C.nvmlReturn_t {
+	return 0
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "wrong.go"), []byte(wrongGo), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	protos := map[string]FuncProto{
+		"nvmlDeviceGetCount_v2": {
+			Name:   "nvmlDeviceGetCount_v2",
+			Params: []CParam{{CType: "unsigned int *", Name: "deviceCount"}},
+		},
+		"nvmlDeviceGetName": {
+			Name: "nvmlDeviceGetName",
+			Params: []CParam{
+				{CType: "nvmlDevice_t", Name: "device"},
+				{CType: "char *", Name: "name"},
+				{CType: "unsigned int", Name: "length"},
+			},
+		},
+	}
+
+	mismatches := validateSignatures(dir, protos)
+
+	if len(mismatches) != 1 {
+		t.Fatalf("expected 1 mismatch, got %d: %v", len(mismatches), mismatches)
+	}
+	if !strings.Contains(mismatches[0], "nvmlDeviceGetName") {
+		t.Errorf("expected mismatch for nvmlDeviceGetName, got: %s", mismatches[0])
+	}
+}

--- a/cmd/generate-bridge/main_test.go
+++ b/cmd/generate-bridge/main_test.go
@@ -14,6 +14,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -200,5 +202,72 @@ func TestGenerateStubWithSignaturePointerParam(t *testing.T) {
 
 	if !strings.Contains(stub, "func nvmlDeviceGetCount_v2(deviceCount *C.uint)") {
 		t.Errorf("incorrect pointer param signature in:\n%s", stub)
+	}
+}
+
+func TestScanBridgeExports(t *testing.T) {
+	dir := t.TempDir()
+
+	deviceGo := `package main
+
+//export nvmlDeviceGetCount_v2
+func nvmlDeviceGetCount_v2() {}
+
+//export nvmlDeviceGetName
+func nvmlDeviceGetName() {}
+`
+	if err := os.WriteFile(filepath.Join(dir, "device.go"), []byte(deviceGo), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	initGo := `package main
+
+//export nvmlInit_v2
+func nvmlInit_v2() {}
+`
+	if err := os.WriteFile(filepath.Join(dir, "init.go"), []byte(initGo), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// stubs_generated.go should be SKIPPED
+	stubsGo := `package main
+
+//export nvmlStubFunction
+func nvmlStubFunction() {}
+`
+	if err := os.WriteFile(filepath.Join(dir, "stubs_generated.go"), []byte(stubsGo), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	exports, err := scanBridgeExports(dir)
+	if err != nil {
+		t.Fatalf("scanBridgeExports: %v", err)
+	}
+
+	if len(exports) != 3 {
+		t.Fatalf("expected 3 exports, got %d: %v", len(exports), exports)
+	}
+
+	for _, fn := range []string{"nvmlDeviceGetCount_v2", "nvmlDeviceGetName", "nvmlInit_v2"} {
+		if !exports[fn] {
+			t.Errorf("expected export %q not found", fn)
+		}
+	}
+
+	if exports["nvmlStubFunction"] {
+		t.Error("stubs_generated.go should be skipped but nvmlStubFunction was found")
+	}
+}
+
+func TestScanBridgeExportsEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+
+	exports, err := scanBridgeExports(dir)
+	if err != nil {
+		t.Fatalf("scanBridgeExports: %v", err)
+	}
+
+	if len(exports) != 0 {
+		t.Fatalf("expected 0 exports from empty dir, got %d", len(exports))
 	}
 }

--- a/cmd/generate-bridge/main_test.go
+++ b/cmd/generate-bridge/main_test.go
@@ -348,3 +348,44 @@ func TestLookupProtoNoMatch(t *testing.T) {
 		t.Fatal("expected no match for nonexistent function")
 	}
 }
+
+func TestPrintStats(t *testing.T) {
+	dir := t.TempDir()
+
+	deviceGo := `package main
+
+//export nvmlDeviceGetCount_v2
+func nvmlDeviceGetCount_v2() {}
+
+//export nvmlDeviceGetName
+func nvmlDeviceGetName() {}
+`
+	if err := os.WriteFile(filepath.Join(dir, "device.go"), []byte(deviceGo), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	initGo := `package main
+
+//export nvmlInit_v2
+func nvmlInit_v2() {}
+`
+	if err := os.WriteFile(filepath.Join(dir, "init.go"), []byte(initGo), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	allFunctions := []string{"nvmlDeviceGetCount_v2", "nvmlDeviceGetName", "nvmlInit_v2", "nvmlShutdown", "nvmlFoo"}
+
+	var buf strings.Builder
+	printStats(&buf, allFunctions, dir)
+	output := buf.String()
+
+	if !strings.Contains(output, "Total functions") {
+		t.Errorf("expected 'Total functions' in output:\n%s", output)
+	}
+	if !strings.Contains(output, "5") {
+		t.Errorf("expected total count 5 in output:\n%s", output)
+	}
+	if !strings.Contains(output, "device.go") {
+		t.Errorf("expected 'device.go' in per-file breakdown:\n%s", output)
+	}
+}

--- a/cmd/generate-bridge/main_test.go
+++ b/cmd/generate-bridge/main_test.go
@@ -271,3 +271,80 @@ func TestScanBridgeExportsEmptyDir(t *testing.T) {
 		t.Fatalf("expected 0 exports from empty dir, got %d", len(exports))
 	}
 }
+
+func TestFindMissing(t *testing.T) {
+	all := []string{"nvmlInit_v2", "nvmlShutdown", "nvmlDeviceGetCount_v2", "nvmlDeviceGetName"}
+	existing := map[string]bool{
+		"nvmlInit_v2":  true,
+		"nvmlShutdown": true,
+	}
+
+	missing := findMissing(all, existing)
+
+	if len(missing) != 2 {
+		t.Fatalf("expected 2 missing, got %d: %v", len(missing), missing)
+	}
+	if missing[0] != "nvmlDeviceGetCount_v2" || missing[1] != "nvmlDeviceGetName" {
+		t.Errorf("unexpected missing functions: %v", missing)
+	}
+}
+
+func TestFindMissingNoneImplemented(t *testing.T) {
+	all := []string{"a", "b", "c"}
+	existing := map[string]bool{}
+
+	missing := findMissing(all, existing)
+	if len(missing) != 3 {
+		t.Fatalf("expected 3 missing, got %d", len(missing))
+	}
+}
+
+func TestFindMissingAllImplemented(t *testing.T) {
+	all := []string{"a", "b"}
+	existing := map[string]bool{"a": true, "b": true}
+
+	missing := findMissing(all, existing)
+	if len(missing) != 0 {
+		t.Fatalf("expected 0 missing, got %d", len(missing))
+	}
+}
+
+func TestLookupProtoDirectMatch(t *testing.T) {
+	protos := map[string]FuncProto{
+		"nvmlInit_v2": {Name: "nvmlInit_v2", Params: nil},
+	}
+
+	proto, ok := lookupProto("nvmlInit_v2", protos)
+	if !ok {
+		t.Fatal("expected direct match")
+	}
+	if proto.Name != "nvmlInit_v2" {
+		t.Errorf("got name %q, want nvmlInit_v2", proto.Name)
+	}
+}
+
+func TestLookupProtoVersionFallback(t *testing.T) {
+	protos := map[string]FuncProto{
+		"nvmlDeviceGetCount": {
+			Name:   "nvmlDeviceGetCount",
+			Params: []CParam{{CType: "unsigned int *", Name: "deviceCount"}},
+		},
+	}
+
+	proto, ok := lookupProto("nvmlDeviceGetCount_v2", protos)
+	if !ok {
+		t.Fatal("expected fallback match for _v2 → unversioned")
+	}
+	if len(proto.Params) != 1 {
+		t.Errorf("expected 1 param, got %d", len(proto.Params))
+	}
+}
+
+func TestLookupProtoNoMatch(t *testing.T) {
+	protos := map[string]FuncProto{}
+
+	_, ok := lookupProto("nvmlNonexistent", protos)
+	if ok {
+		t.Fatal("expected no match for nonexistent function")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `make generate` target wrapping `go generate`
- Add tests for `scanBridgeExports`, `findMissing`, `lookupProto` (11 new test cases)
- Add `--stats` flag for NVML function coverage report
- Add `--validate` flag to check hand-written export signatures against `nvml.h`

Closes #251

## Test Plan
- [x] `go test ./cmd/generate-bridge/ -v` — 16/16 pass
- [ ] `make generate` runs successfully (requires CGo toolchain)
- [ ] `go run ./cmd/generate-bridge --stats` shows coverage
- [ ] `go run ./cmd/generate-bridge --validate` reports mismatches