### PR TITLE
docs: comprehensive documentation overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ After install, deploy a consumer to test:
 |----------|-------|
 | **NVIDIA Device Plugin** | [Quick Start](deployments/gpu-mock/helm/gpu-mock/README.md#quick-start-device-plugin-on-kind) |
 | **NVIDIA DRA Driver** | [Quick Start](deployments/gpu-mock/helm/gpu-mock/README.md#quick-start-dra-driver-on-kind) |
+| **NVIDIA GPU Operator** | [Quick Start](deployments/gpu-mock/helm/gpu-mock/README.md#quick-start-gpu-operator-on-kind) |
 
 **Full documentation:** [gpu-mock Helm chart README](deployments/gpu-mock/helm/gpu-mock/README.md)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ on PRs.
 |------------|-------------------|----------|
 | **Device Plugin** | `nvidia.com/gpu` allocatable resources | A100, H100, T4 |
 | **DRA Driver** | ResourceSlices via Dynamic Resource Allocation | A100, H100, T4 |
-| **GPU Operator** | Full stack: device plugin + toolkit + validator (CDI) | A100, H100, T4 |
+| **GPU Operator** | Operator components: device plugin + GFD + validator (CDI injection) | A100, H100, T4 |
 | **Multi-Node Fleet** | Cross-node scheduling with heterogeneous GPUs | A100 + T4 |
 
 Manual dispatch supports all 6 profiles: `a100`, `h100`, `b200`, `gb200`, `l40s`, `t4`.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ After install, deploy a consumer to test:
 
 **Full documentation:** [gpu-mock Helm chart README](deployments/gpu-mock/helm/gpu-mock/README.md)
 
+## E2E Testing
+
+The gpu-mock E2E workflow tests all GPU consumers across multiple profiles
+and node topologies. Run manually via `workflow_dispatch` or automatically
+on PRs.
+
+| Test Suite | What It Validates | Profiles |
+|------------|-------------------|----------|
+| **Device Plugin** | `nvidia.com/gpu` allocatable resources | A100, H100, T4 |
+| **DRA Driver** | ResourceSlices via Dynamic Resource Allocation | A100, H100, T4 |
+| **GPU Operator** | Full stack: device plugin + toolkit + validator (CDI) | A100, H100, T4 |
+| **Multi-Node Fleet** | Cross-node scheduling with heterogeneous GPUs | A100 + T4 |
+
+Manual dispatch supports all 6 profiles: `a100`, `h100`, `b200`, `gb200`, `l40s`, `t4`.
+
+See [`.github/workflows/gpu-mock-e2e.yaml`](.github/workflows/gpu-mock-e2e.yaml) for details.
+
 ## Mock NVML Library
 
 The underlying CGo-based mock `libnvidia-ml.so` that powers gpu-mock.
@@ -43,6 +60,8 @@ Use standalone for local development and CI pipelines.
 | [Quick Start](docs/mocknvml/quickstart.md) | Build and run in 5 minutes |
 | [Configuration](docs/mocknvml/configuration.md) | YAML configuration reference |
 | [Architecture](docs/mocknvml/architecture.md) | System design and components |
+| [Development](docs/mocknvml/development.md) | Contributing and extending the library |
+| [Troubleshooting](docs/mocknvml/troubleshooting.md) | Common issues and solutions |
 
 ## License
 

--- a/deployments/gpu-mock/helm/gpu-mock/README.md
+++ b/deployments/gpu-mock/helm/gpu-mock/README.md
@@ -165,6 +165,67 @@ Expected: `8` (default gpu.count).
 kind delete cluster --name gpu-mock-dra
 ```
 
+## Quick Start: GPU Operator on KIND
+
+This path validates the full NVIDIA GPU Operator stack (device plugin, toolkit,
+validator) using CDI mode with mock GPUs. Tested in CI via
+`.github/workflows/gpu-mock-e2e.yaml` → `e2e-gpu-operator` job.
+
+### 1. Create a KIND cluster
+
+```bash
+kind create cluster --name gpu-mock-operator
+```
+
+### 2. Build and load the gpu-mock image
+
+```bash
+docker build -t gpu-mock:local -f deployments/gpu-mock/Dockerfile .
+kind load docker-image gpu-mock:local --name gpu-mock-operator
+```
+
+### 3. Install gpu-mock
+
+```bash
+helm install gpu-mock deployments/gpu-mock/helm/gpu-mock \
+  --set image.repository=gpu-mock \
+  --set image.tag=local \
+  --wait --timeout 120s
+```
+
+### 4. Install the GPU Operator
+
+```bash
+helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+helm repo update
+
+helm install gpu-operator nvidia/gpu-operator \
+  --namespace gpu-operator \
+  --create-namespace \
+  --set cdi.enabled=true \
+  --set driver.enabled=false \
+  --set toolkit.enabled=false \
+  --set devicePlugin.config.name="" \
+  --set nfd.enabled=false \
+  --set operator.defaultRuntime=containerd \
+  --wait --timeout 300s
+```
+
+### 5. Verify
+
+```bash
+kubectl -n gpu-operator wait --for=condition=ready pod --all --timeout=180s
+kubectl get nodes -o jsonpath='{.items[0].status.allocatable.nvidia\.com/gpu}'
+```
+
+Expected: `8` (default gpu.count).
+
+### 6. Clean up
+
+```bash
+kind delete cluster --name gpu-mock-operator
+```
+
 ## Multi-Node Heterogeneous GPU Fleet
 
 Simulate a cluster with different GPU types on different nodes by installing
@@ -209,7 +270,7 @@ For a Kind cluster with labeled workers, see `tests/e2e/kind-multi-node-config.y
 | `image.repository` | `ghcr.io/nvidia/gpu-mock` | Container image repository |
 | `image.tag` | `latest` | Container image tag |
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy |
-| `driverVersion` | `""` (auto) | NVIDIA driver version to mock. When empty, auto-derived from `gpu.profile` (even if `gpu.customConfig` is set): A100/H100 → `550.163.01`, B200/GB200 → `560.35.03`. For non-standard GPUs configured via `gpu.customConfig`, explicitly set `driverVersion`. |
+| `driverVersion` | `""` (auto) | NVIDIA driver version to mock. When empty, auto-derived from `gpu.profile` (even if `gpu.customConfig` is set): A100/H100/L40S/T4 → `550.163.01`, B200/GB200 → `560.35.03`. For non-standard GPUs configured via `gpu.customConfig`, explicitly set `driverVersion`. |
 | `nodeSelector` | `{}` | Node selector for DaemonSet |
 | `tolerations` | `[{operator: Exists}]` | Pod tolerations (default: tolerate all) |
 

--- a/deployments/gpu-mock/helm/gpu-mock/README.md
+++ b/deployments/gpu-mock/helm/gpu-mock/README.md
@@ -167,15 +167,21 @@ kind delete cluster --name gpu-mock-dra
 
 ## Quick Start: GPU Operator on KIND
 
-This path validates the full NVIDIA GPU Operator stack (device plugin, toolkit,
-validator) using CDI mode with mock GPUs. Tested in CI via
-`.github/workflows/gpu-mock-e2e.yaml` → `e2e-gpu-operator` job.
+This path validates the NVIDIA GPU Operator stack (device plugin, GFD, validator)
+using CDI mode with mock GPUs. The CI `e2e-gpu-operator` job uses a more complete
+setup — see `tests/e2e/kind-gpu-operator-config.yaml` and
+`tests/e2e/gpu-operator-values.yaml` for the exact CI configuration.
 
 ### 1. Create a KIND cluster
 
 ```bash
-kind create cluster --name gpu-mock-operator
+kind create cluster --name gpu-mock-operator \
+  --config tests/e2e/kind-gpu-operator-config.yaml
 ```
+
+> **Note:** The Kind config enables CDI in containerd and registers the nvidia
+> runtime handler. After cluster creation, `nvidia-container-toolkit` must be
+> installed in the control-plane node — see the E2E workflow for the full setup.
 
 ### 2. Build and load the gpu-mock image
 
@@ -202,10 +208,7 @@ helm repo update
 helm install gpu-operator nvidia/gpu-operator \
   --namespace gpu-operator \
   --create-namespace \
-  --set cdi.enabled=true \
-  --set driver.enabled=false \
-  --set toolkit.enabled=false \
-  --set devicePlugin.config.name="" \
+  -f tests/e2e/gpu-operator-values.yaml \
   --set nfd.enabled=false \
   --set operator.defaultRuntime=containerd \
   --wait --timeout 300s

--- a/docs/mocknvml/README.md
+++ b/docs/mocknvml/README.md
@@ -116,20 +116,28 @@ LD_LIBRARY_PATH=. nvidia-smi
 | Category | Functions | Status | Notes |
 |----------|-----------|--------|-------|
 | Initialization | `nvmlInit`, `nvmlShutdown` | ✅ Full | |
+| System Info | `SystemGetDriverVersion`, `SystemGetCudaDriverVersion` | ✅ Full | |
 | Device Enumeration | `GetCount`, `GetHandleByIndex/UUID/PCI` | ✅ Full | |
-| Device Info | `GetName`, `GetUUID`, `GetMemoryInfo` | ✅ Full | |
+| Device Info | `GetName`, `GetUUID`, `GetMemoryInfo`, `GetMemoryBusWidth` | ✅ Full | |
 | Thermal | `GetTemperature`, `GetTemperatureThreshold` | ✅ Full | |
-| Power | `GetPowerUsage`, `GetPowerManagementLimit` | ✅ Full | |
-| Clocks | `GetClockInfo`, `GetMaxClockInfo` | ✅ Full | |
-| ECC | `GetEccMode`, `GetTotalEccErrors` | ✅ Full | |
-| PCIe | `GetPciInfo`, `GetCurrPcieLinkGeneration` | ✅ Full | |
+| Power | `GetPowerUsage`, `GetPowerManagementLimit`, `GetTotalEnergyConsumption` | ✅ Full | |
+| Clocks | `GetClockInfo`, `GetMaxClockInfo`, `GetAutoBoostedClocksEnabled` | ✅ Full | |
+| ECC | `GetEccMode`, `GetDefaultEccMode`, `GetTotalEccErrors`, `GetDetailedEccErrors` | ✅ Full | |
+| PCIe | `GetPciInfo`, `GetCurrPcieLinkGeneration/Width` | ✅ Full | |
 | Utilization | `GetUtilizationRates` | ✅ Full | |
-| MIG | `GetMigMode` | ✅ Basic | Returns disabled |
-| Other | 340+ additional functions | ⚠️ Returns `NOT_SUPPORTED` | See note below |
+| Topology | `GetTopologyCommonAncestor`, `GetTopologyNearestGpus` | ✅ Full | |
+| NVLink | `GetNvLinkState`, `GetNvLinkVersion`, `GetNvLinkCapability` | ✅ Full | |
+| Persistence | `GetPersistenceMode`, `SetPersistenceMode` | ✅ Full | |
+| Process | `GetComputeRunningProcesses`, `GetGraphicsRunningProcesses` | ✅ Full | Returns empty list |
+| MIG | `GetMigMode`, `GetGpuInstanceProfileInfo` | ✅ Basic | Returns disabled |
+| GSP Firmware | `GetGspFirmwareVersion`, `GetGspFirmwareMode` | ✅ Full | |
+| nvidia-smi | `-q`, `-x -q`, default display, CSV queries | ✅ Full | Real binary, mock data |
+| Other | ~289 additional functions | ⚠️ Returns `NOT_SUPPORTED` | See note below |
 
 ### Stub Function Behavior
 
-Functions marked with ⚠️ are **not implemented** and return `NVML_ERROR_NOT_SUPPORTED` (error code 3). This is distinct from:
+The mock library implements ~111 NVML functions with configurable behavior.
+The remaining ~289 functions return `NVML_ERROR_NOT_SUPPORTED` (error code 3). This is distinct from:
 - `NVML_SUCCESS` (0) - Operation succeeded
 - `NVML_ERROR_NOT_FOUND` (6) - Device/object not found
 

--- a/docs/mocknvml/README.md
+++ b/docs/mocknvml/README.md
@@ -129,7 +129,7 @@ LD_LIBRARY_PATH=. nvidia-smi
 | NVLink | `GetNvLinkState`, `GetNvLinkVersion`, `GetNvLinkCapability` | ✅ Full | |
 | Persistence | `GetPersistenceMode`, `SetPersistenceMode` | ✅ Full | |
 | Process | `GetComputeRunningProcesses`, `GetGraphicsRunningProcesses` | ✅ Full | Returns empty list |
-| MIG | `GetMigMode`, `GetGpuInstanceProfileInfo` | ✅ Basic | Returns disabled |
+| MIG | `GetMigMode` | ✅ Basic | Returns disabled; profile info functions return `NOT_SUPPORTED` |
 | GSP Firmware | `GetGspFirmwareVersion`, `GetGspFirmwareMode` | ✅ Full | |
 | nvidia-smi | `-q`, `-x -q`, default display, CSV queries | ✅ Full | Real binary, mock data |
 | Other | ~289 additional functions | ⚠️ Returns `NOT_SUPPORTED` | See note below |

--- a/docs/mocknvml/development.md
+++ b/docs/mocknvml/development.md
@@ -37,7 +37,9 @@ pkg/gpu/mocknvml/
 └── README.md
 
 cmd/generate-bridge/
-└── main.go                    # Stub generator (generates stubs_generated.go)
+├── main.go                    # Stub generator (--stats, --validate flags)
+├── parser.go                  # nvml.h prototype parser
+└── main_test.go               # Generator tests (16 test cases)
 
 tests/mocknvml/
 ├── main.go                    # Integration test
@@ -353,28 +355,66 @@ The stub generator creates `stubs_generated.go` with stub implementations for
 NVML functions that don't have hand-written implementations:
 
 ```bash
-# From bridge directory (uses go:generate directive)
+# Preferred: use Makefile target from repo root
+make generate
+
+# Or from bridge directory (uses go:generate directive)
 cd pkg/gpu/mocknvml/bridge
 go generate
 
-# Or from repo root
-go generate ./pkg/gpu/mocknvml/bridge/...
-
-# Or run generator directly
+# Or run generator directly with all flags
 go run ./cmd/generate-bridge \
   -input vendor/github.com/NVIDIA/go-nvml/pkg/nvml/nvml.go \
+  -header vendor/github.com/NVIDIA/go-nvml/pkg/nvml/nvml.h \
   -bridge pkg/gpu/mocknvml/bridge \
   -output pkg/gpu/mocknvml/bridge/stubs_generated.go
 ```
 
 The generator:
-1. Parses all NVML function names from `nvml.go` (~396 functions)
-2. Scans `bridge/*.go` for existing `//export` directives
-3. Generates stubs only for functions NOT already implemented
-4. Outputs to `stubs_generated.go`
+1. Parses all NVML function names from `nvml.go`
+2. Parses C prototypes from `nvml.h` for ABI-correct signatures
+3. Scans `bridge/*.go` for existing `//export` directives
+4. Generates stubs only for functions NOT already implemented
+5. Outputs to `stubs_generated.go`
 
 When you add a new implementation to a bridge file, regenerate stubs to
 automatically remove the corresponding stub.
+
+### Coverage Statistics
+
+View current implementation coverage:
+
+```bash
+go run ./cmd/generate-bridge --stats
+```
+
+Output:
+```
+NVML Function Coverage:
+  Total functions:               400
+  Hand-written implementations:  111 (27.8%)
+  Generated stubs:               289 (72.2%)
+
+  By file:
+    device.go:           94 functions
+    events.go:            6 functions
+    init.go:              5 functions
+    system.go:            4 functions
+    helpers.go:           1 function
+    internal.go:          1 function
+```
+
+### Signature Validation
+
+Check that hand-written exports match nvml.h parameter counts:
+
+```bash
+go run ./cmd/generate-bridge --validate
+```
+
+This compares the number of Go parameters in each `//export` function against
+the corresponding C prototype in `nvml.h`. Exits non-zero on mismatch — useful
+in CI to catch signature drift.
 
 ## Release Checklist
 

--- a/docs/mocknvml/development.md
+++ b/docs/mocknvml/development.md
@@ -39,7 +39,7 @@ pkg/gpu/mocknvml/
 cmd/generate-bridge/
 ├── main.go                    # Stub generator (--stats, --validate flags)
 ├── parser.go                  # nvml.h prototype parser
-└── main_test.go               # Generator tests (16 test cases)
+└── main_test.go               # Generator tests
 
 tests/mocknvml/
 ├── main.go                    # Integration test

--- a/docs/mocknvml/examples.md
+++ b/docs/mocknvml/examples.md
@@ -45,6 +45,20 @@ GPU 1: NVIDIA A100-SXM4-40GB (UUID: GPU-12345678-1234-1234-1234-123456780001)
 LD_LIBRARY_PATH=. MOCK_NVML_CONFIG=configs/mock-nvml-config-a100.yaml nvidia-smi -q
 ```
 
+The mock library supports all fields in `nvidia-smi -q` output including
+temperature, power, clocks, ECC, PCIe, memory, utilization, persistence mode,
+GSP firmware, and energy consumption. Fields backed by configuration return
+profile values; unimplemented fields show "N/A".
+
+### XML Query
+
+```bash
+LD_LIBRARY_PATH=. nvidia-smi -x -q > gpu-report.xml
+```
+
+Produces valid XML output parseable by automated tools. Useful for testing
+GPU monitoring pipelines that consume `nvidia-smi -x -q`.
+
 ### Query Specific Details
 
 ```bash

--- a/docs/mocknvml/examples.md
+++ b/docs/mocknvml/examples.md
@@ -84,12 +84,6 @@ LD_LIBRARY_PATH=. nvidia-smi -q -d PCIE
 LD_LIBRARY_PATH=. nvidia-smi -q -d UTILIZATION
 ```
 
-### XML Output
-
-```bash
-LD_LIBRARY_PATH=. nvidia-smi -x -q > gpu-info.xml
-```
-
 ### CSV Output
 
 ```bash

--- a/docs/mocknvml/troubleshooting.md
+++ b/docs/mocknvml/troubleshooting.md
@@ -338,8 +338,9 @@ expected files.
 
 **Solution**: Ensure the mock driver root has all required files:
 ```bash
-NODE_CONTAINER=$(docker ps --filter name=control-plane -q)
-docker exec "$NODE_CONTAINER" ls -la /var/lib/nvidia-mock/driver/usr/lib64/libnvidia-ml.so*
+# Use the specific Kind cluster and node name (adjust cluster name as needed)
+NODE_CONTAINER="gpu-mock-operator-control-plane"
+docker exec "$NODE_CONTAINER" ls -la /run/nvidia/driver/usr/lib64/libnvidia-ml.so*
 docker exec "$NODE_CONTAINER" cat /var/lib/nvidia-mock/driver/config/config.yaml
 ```
 

--- a/docs/mocknvml/troubleshooting.md
+++ b/docs/mocknvml/troubleshooting.md
@@ -326,6 +326,45 @@ docker run ... which nvidia-smi
 GOARCH=amd64 make -C pkg/gpu/mocknvml
 ```
 
+## GPU Operator Issues
+
+### Validator Pod in CrashLoopBackOff
+
+**Problem**: The GPU Operator validator pod repeatedly crashes.
+
+**Explanation**: The GPU Operator validator (`/usr/bin/nvidia-validator`) is a
+statically-linked Go binary with no shell. It probes the driver root for
+expected files.
+
+**Solution**: Ensure the mock driver root has all required files:
+```bash
+NODE_CONTAINER=$(docker ps --filter name=control-plane -q)
+docker exec "$NODE_CONTAINER" ls -la /var/lib/nvidia-mock/driver/usr/lib64/libnvidia-ml.so*
+docker exec "$NODE_CONTAINER" cat /var/lib/nvidia-mock/driver/config/config.yaml
+```
+
+### CDI Spec Not Generated
+
+**Problem**: CDI specs are not appearing in `/var/run/cdi/`.
+
+**Solution**: Check gpu-mock DaemonSet logs for CDI generation errors:
+```bash
+kubectl logs -l app.kubernetes.io/name=gpu-mock | grep -i cdi
+```
+
+### Device Plugin Shows 0 GPUs with GPU Operator
+
+**Problem**: The GPU Operator-managed device plugin reports 0 GPUs.
+
+**Solution**: Verify the device plugin is using the mock driver root:
+```bash
+kubectl -n gpu-operator logs -l app=nvidia-device-plugin-daemonset | head -20
+```
+
+The GPU Operator must be installed with `--set driver.enabled=false` and
+`--set toolkit.enabled=false` when using mock GPUs, since there is no real
+NVIDIA driver to manage.
+
 ## Getting Help
 
 ### Debug Information to Collect


### PR DESCRIPTION
## Summary
- Add GPU Operator CDI validation quick start to Helm README
- Update driverVersion auto-derive docs to include L40S/T4
- Add GPU Operator to main README consumer table
- Update feature support matrix (37+ newly implemented functions, ~289 stubs)
- Document generator `--stats` and `--validate` flags in development guide
- Add E2E testing overview with test suite table to main README
- Expand Mock NVML doc index with Development and Troubleshooting links
- Add `nvidia-smi -q` and XML query examples
- Add GPU Operator troubleshooting section (validator, CDI, device plugin)

Closes #253

## Test Plan
- [ ] All documentation links resolve correctly
- [ ] Profile table renders correctly in GitHub markdown
- [ ] No broken relative links