### PR TITLE
ci: publish nvml-mock container images to GHCR

### DIFF
--- a/.github/workflows/nvml-mock-publish.yaml
+++ b/.github/workflows/nvml-mock-publish.yaml
@@ -1,0 +1,68 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+name: nvml-mock Publish
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+    paths:
+      - 'pkg/gpu/**'
+      - 'deployments/nvml-mock/**'
+      - '.github/workflows/nvml-mock-publish.yaml'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: nvidia/nvml-mock
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # On push to main: tag as "latest"
+            type=raw,value=latest,enable={{is_default_branch}}
+            # On tag push: use the tag (e.g., v0.1.0)
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            # Always: short SHA for traceability
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deployments/nvml-mock/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -9,17 +9,14 @@ Turn any Kubernetes cluster into a multi-GPU environment for testing.
 No physical NVIDIA hardware required.
 
 ```bash
-# 1. Build the image (no published image yet)
-docker build -t nvml-mock:local -f deployments/nvml-mock/Dockerfile .
-
-# 2. Load into KIND
+# 1. Create cluster
 kind create cluster --name gpu-test
-kind load docker-image nvml-mock:local --name gpu-test
+
+# 2. Load the published image (or build locally with: docker build -t nvml-mock:local -f deployments/nvml-mock/Dockerfile .)
+kind load docker-image ghcr.io/nvidia/nvml-mock:latest --name gpu-test
 
 # 3. Install
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
-  --set image.repository=nvml-mock \
-  --set image.tag=local
+helm install nvml-mock deployments/nvml-mock/helm/nvml-mock
 ```
 
 After install, deploy a consumer to test:

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -42,9 +42,15 @@ This path uses the NVIDIA device plugin to expose mock GPUs as
 kind create cluster --name nvml-mock-test
 ```
 
-### 2. Build and load the nvml-mock image
+### 2. Load the nvml-mock image
 
-There is no published image yet. Build from source:
+**Option A: Use the published image (recommended)**
+
+```bash
+kind load docker-image ghcr.io/nvidia/nvml-mock:latest --name nvml-mock-test
+```
+
+**Option B: Build from source**
 
 ```bash
 # From the repository root
@@ -53,6 +59,15 @@ kind load docker-image nvml-mock:local --name nvml-mock-test
 ```
 
 ### 3. Install nvml-mock
+
+**With published image:**
+
+```bash
+helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+  --wait --timeout 120s
+```
+
+**With locally built image:**
 
 ```bash
 helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
@@ -110,7 +125,15 @@ This config enables:
 - CDI (Container Device Interface) in containerd
 - `resource.k8s.io/v1beta1` API
 
-### 2. Build and load the nvml-mock image
+### 2. Load the nvml-mock image
+
+**Option A: Use the published image (recommended)**
+
+```bash
+kind load docker-image ghcr.io/nvidia/nvml-mock:latest --name nvml-mock-dra
+```
+
+**Option B: Build from source**
 
 ```bash
 docker build -t nvml-mock:local -f deployments/nvml-mock/Dockerfile .
@@ -118,6 +141,15 @@ kind load docker-image nvml-mock:local --name nvml-mock-dra
 ```
 
 ### 3. Install nvml-mock
+
+**With published image:**
+
+```bash
+helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+  --wait --timeout 120s
+```
+
+**With locally built image:**
 
 ```bash
 helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
@@ -183,7 +215,15 @@ kind create cluster --name nvml-mock-operator \
 > runtime handler. After cluster creation, `nvidia-container-toolkit` must be
 > installed in the control-plane node — see the E2E workflow for the full setup.
 
-### 2. Build and load the nvml-mock image
+### 2. Load the nvml-mock image
+
+**Option A: Use the published image (recommended)**
+
+```bash
+kind load docker-image ghcr.io/nvidia/nvml-mock:latest --name nvml-mock-operator
+```
+
+**Option B: Build from source**
 
 ```bash
 docker build -t nvml-mock:local -f deployments/nvml-mock/Dockerfile .
@@ -191,6 +231,15 @@ kind load docker-image nvml-mock:local --name nvml-mock-operator
 ```
 
 ### 3. Install nvml-mock
+
+**With published image:**
+
+```bash
+helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+  --wait --timeout 120s
+```
+
+**With locally built image:**
 
 ```bash
 helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
@@ -461,7 +510,7 @@ We are actively working on PCIe sysfs simulation to address this gap — see
 
 ## Troubleshooting
 
-**ImagePullBackOff**: No published image exists yet. Build from source (see Quick Start).
+**ImagePullBackOff**: Verify the image is accessible. The published image is at `ghcr.io/nvidia/nvml-mock:latest`. For local builds, ensure the image is loaded into your cluster (see Quick Start).
 
 **DaemonSet not ready**: Check pod logs: `kubectl logs -l app.kubernetes.io/name=nvml-mock`
 


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow to publish multi-arch container images
to `ghcr.io/nvidia/nvml-mock`.

## Triggers

| Event | Tags Produced |
|-------|--------------|
| Push to `main` | `:latest`, `:sha-<short>` |
| Tag push `v*` | `:v0.1.0`, `:0.1`, `:sha-<short>` |

## Details

- **Multi-arch**: `linux/amd64` + `linux/arm64` via Docker Buildx
- **Cache**: GitHub Actions cache for Docker layers
- **Auth**: `GITHUB_TOKEN` with `packages: write`
- **Path filter**: Only triggers on changes to `pkg/gpu/`, `deployments/nvml-mock/`, or the workflow

## Docs

Updated Helm chart README and top-level README to show published
image (`ghcr.io/nvidia/nvml-mock`) as the primary install method.

## Depends on
- PR1: repo cleanup (#273)
- PR2: rebrand (#275) — needs rebase after merge