### PR TITLE
feat: Helm integration layer for fake-gpu-operator

### DIFF
--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -310,6 +310,44 @@ enabling heterogeneous scheduling and topology-aware placement testing.
 
 For a Kind cluster with labeled workers, see `tests/e2e/kind-multi-node-config.yaml`.
 
+## Integration: fake-gpu-operator
+
+[fake-gpu-operator](https://github.com/run-ai/fake-gpu-operator) by Run:ai
+simulates GPUs at the Kubernetes API level for scale testing. nvml-mock
+can provide driver-level fidelity (real NVML API) on real nodes while
+fake-gpu-operator handles KWOK virtual nodes.
+
+### Enable Profile Discovery
+
+```bash
+helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+  --set integrations.fakeGpuOperator.enabled=true
+```
+
+This creates per-profile ConfigMaps discoverable by fake-gpu-operator:
+
+```bash
+kubectl get cm -l run.ai/gpu-profile=true
+```
+
+```
+NAME                              DATA   AGE
+nvml-mock-profile-a100            1      10s
+nvml-mock-profile-h100            1      10s
+nvml-mock-profile-b200            1      10s
+nvml-mock-profile-gb200           1      10s
+nvml-mock-profile-l40s            1      10s
+nvml-mock-profile-t4              1      10s
+```
+
+### Custom Labels
+
+```bash
+helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+  --set integrations.fakeGpuOperator.enabled=true \
+  --set 'integrations.fakeGpuOperator.profileLabels.my-org/gpu-profile=true'
+```
+
 ## Configuration
 
 ### Values
@@ -325,6 +363,8 @@ For a Kind cluster with labeled workers, see `tests/e2e/kind-multi-node-config.y
 | `driverVersion` | `""` (auto) | NVIDIA driver version to mock. When empty, auto-derived from `gpu.profile` (even if `gpu.customConfig` is set): A100/H100/L40S/T4 → `550.163.01`, B200/GB200 → `560.35.03`. For non-standard GPUs configured via `gpu.customConfig`, explicitly set `driverVersion`. |
 | `nodeSelector` | `{}` | Node selector for DaemonSet |
 | `tolerations` | `[{operator: Exists}]` | Pod tolerations (default: tolerate all) |
+| `integrations.fakeGpuOperator.enabled` | `false` | Create per-profile ConfigMaps for fake-gpu-operator discovery |
+| `integrations.fakeGpuOperator.profileLabels` | `{"run.ai/gpu-profile": "true"}` | Labels on profile ConfigMaps for discovery |
 
 ### GPU Profiles
 

--- a/deployments/nvml-mock/helm/nvml-mock/templates/NOTES.txt
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/NOTES.txt
@@ -61,6 +61,14 @@ OPTION C: GPU Operator (UNTESTED — contributions welcome)
   please contribute the test back.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+{{- if .Values.integrations.fakeGpuOperator.enabled }}
+
+fake-gpu-operator integration is enabled.
+6 profile ConfigMaps created. Discover them with:
+
+  kubectl get cm -l run.ai/gpu-profile=true
+
+{{- end }}
 
 Quick check — node labels:
 

--- a/deployments/nvml-mock/helm/nvml-mock/templates/integrations-fgo.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/integrations-fgo.yaml
@@ -1,0 +1,24 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.integrations.fakeGpuOperator.enabled }}
+{{- $profiles := list "a100" "h100" "b200" "gb200" "l40s" "t4" }}
+{{- range $profile := $profiles }}
+{{- $content := $.Files.Get (printf "profiles/%s.yaml" $profile) }}
+{{- if $content }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nvml-mock.fullname" $ }}-profile-{{ $profile }}
+  labels:
+    {{- include "nvml-mock.labels" $ | nindent 4 }}
+    nvml-mock/profile-name: {{ $profile | quote }}
+    {{- range $key, $value := $.Values.integrations.fakeGpuOperator.profileLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+data:
+  config.yaml: |
+    {{- $content | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -18,3 +18,11 @@ tolerations:
   - operator: Exists
 
 resources: {}
+
+# Integration with external projects
+integrations:
+  fakeGpuOperator:
+    enabled: false
+    # Labels applied to per-profile ConfigMaps for discovery
+    profileLabels:
+      run.ai/gpu-profile: "true"


### PR DESCRIPTION
## Summary

Add conditional support for Run:ai's fake-gpu-operator to discover
nvml-mock GPU profiles via labeled ConfigMaps.

## New Values

```yaml
integrations:
  fakeGpuOperator:
    enabled: false    # default: off
    profileLabels:
      run.ai/gpu-profile: "true"
```

## When Enabled

Creates 6 ConfigMaps (one per built-in profile) with:
- Full GPU profile YAML as data
- Configurable discovery labels
- `nvml-mock/profile-name` identifier label

## When Disabled (default)

No change to base chart behavior.

## How fake-gpu-operator Uses This

```bash
kubectl get cm -l run.ai/gpu-profile=true
```

See [fake-gpu-operator](https://github.com/run-ai/fake-gpu-operator)
for their `backend: mock` topology configuration.

## Depends on
- #275: rebrand (merged)
- #274: CI publish (merged)