### PR TITLE
docs: fix CRITICAL and MAJOR findings from E2E docs audit

### DIFF
--- a/.github/workflows/nvml-mock-e2e.yaml
+++ b/.github/workflows/nvml-mock-e2e.yaml
@@ -29,7 +29,7 @@ on:
       golang_version:
         description: 'Go version'
         required: true
-        default: '1.23'
+        default: '1.25'
         type: string
       gpu_profiles:
         description: 'GPU profiles to test (JSON array)'
@@ -149,9 +149,10 @@ jobs:
           echo "FAIL: Expected 2 allocatable GPUs, got $GPUS"
           exit 1
 
-      # GFD and CUDA validator steps require NGC-authenticated images (nvcr.io).
-      # Disabled in CI until NGC_API_KEY is configured as a GitHub Actions secret.
-      # See tests/e2e/README.md for running the full E2E suite locally.
+      # GFD and CUDA validator standalone images from nvcr.io may require NGC auth.
+      # The GPU Operator path (e2e-gpu-operator job) bundles these publicly and works
+      # without credentials. These standalone steps are disabled until verified public.
+      # See tests/e2e/README.md for local testing instructions.
       - name: Deploy GPU Feature Discovery
         if: false
         run: |

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -28,7 +28,7 @@ as the NVIDIA driver root and discover GPUs through standard NVML APIs.
 
 **Cluster requirements:**
 - Privileged pods must be allowed (nvml-mock DaemonSet uses `privileged: true` for `mknod`)
-- For DRA: Kubernetes 1.31+ with `DynamicResourceAllocation` feature gate enabled
+- For DRA: Kubernetes 1.32+ with `DynamicResourceAllocation` feature gate enabled
 
 ## Quick Start: Device Plugin on KIND
 
@@ -211,11 +211,46 @@ kind create cluster --name nvml-mock-operator \
   --config tests/e2e/kind-gpu-operator-config.yaml
 ```
 
-> **Note:** The Kind config enables CDI in containerd and registers the nvidia
-> runtime handler. After cluster creation, `nvidia-container-toolkit` must be
-> installed in the control-plane node — see the E2E workflow for the full setup.
+### 2. Install nvidia-container-toolkit in the Kind node
 
-### 2. Load the nvml-mock image
+```bash
+NODE_CONTAINER=nvml-mock-operator-control-plane
+docker exec "$NODE_CONTAINER" bash -c '
+  apt-get update -qq
+  apt-get install -y -qq curl gpg
+  curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
+    | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+  curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
+    | sed "s#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g" \
+    | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+  apt-get update -qq
+  apt-get install -y -qq nvidia-container-toolkit
+'
+```
+
+### 3. Configure CDI mode
+
+```bash
+docker exec "$NODE_CONTAINER" nvidia-ctk runtime configure \
+  --runtime=containerd --cdi.enabled --set-as-default
+docker exec "$NODE_CONTAINER" bash -c 'cat > /etc/nvidia-container-runtime/config.toml << EOF
+[nvidia-container-runtime]
+mode = "cdi"
+
+[nvidia-container-runtime.modes.cdi]
+default-kind = "nvidia.com/gpu"
+spec-dirs = ["/var/run/cdi", "/etc/cdi"]
+EOF'
+```
+
+### 4. Restart containerd
+
+```bash
+docker exec "$NODE_CONTAINER" systemctl restart containerd
+sleep 5
+```
+
+### 5. Load the nvml-mock image
 
 **Option A: Use the published image (recommended)**
 
@@ -230,7 +265,7 @@ docker build -t nvml-mock:local -f deployments/nvml-mock/Dockerfile .
 kind load docker-image nvml-mock:local --name nvml-mock-operator
 ```
 
-### 3. Install nvml-mock
+### 6. Install nvml-mock
 
 **With published image:**
 
@@ -248,7 +283,7 @@ helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
   --wait --timeout 120s
 ```
 
-### 4. Install the GPU Operator
+### 7. Install the GPU Operator
 
 ```bash
 helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
@@ -258,12 +293,10 @@ helm install gpu-operator nvidia/gpu-operator \
   --namespace gpu-operator \
   --create-namespace \
   -f tests/e2e/gpu-operator-values.yaml \
-  --set nfd.enabled=false \
-  --set operator.defaultRuntime=containerd \
   --wait --timeout 300s
 ```
 
-### 5. Verify
+### 8. Verify
 
 ```bash
 kubectl -n gpu-operator wait --for=condition=ready pod --all --timeout=180s
@@ -272,43 +305,134 @@ kubectl get nodes -o jsonpath='{.items[0].status.allocatable.nvidia\.com/gpu}'
 
 Expected: `8` (default gpu.count).
 
-### 6. Clean up
+### 9. Clean up
 
 ```bash
 kind delete cluster --name nvml-mock-operator
 ```
 
-## Multi-Node Heterogeneous GPU Fleet
+## Quick Start: Multi-Node Heterogeneous GPU Fleet
 
 Simulate a cluster with different GPU types on different nodes by installing
-multiple Helm releases with `nodeSelector`:
+multiple Helm releases with `nodeSelector`. Each release creates its own
+DaemonSet, ConfigMap, and RBAC resources. The device plugin (or DRA driver)
+discovers different GPU types on each node, enabling heterogeneous scheduling
+and topology-aware placement testing.
+
+### 1. Create a Kind cluster with labeled workers
 
 ```bash
-# Label your nodes (Kind does this via cluster config)
-kubectl label node worker-1 nvml-mock/profile=a100
-kubectl label node worker-2 nvml-mock/profile=t4
+kind create cluster --name gpu-fleet --config tests/e2e/kind-multi-node-config.yaml
+```
 
-# Install a different GPU profile per node
+This creates 1 control-plane + 2 workers. The workers are pre-labeled
+`nvml-mock/profile=a100` and `nvml-mock/profile=t4` respectively.
+
+### 2. Build and load the nvml-mock image
+
+**Option A: Use the published image (recommended)**
+
+```bash
+kind load docker-image ghcr.io/nvidia/nvml-mock:latest --name gpu-fleet
+```
+
+**Option B: Build from source**
+
+```bash
+docker build -t nvml-mock:local -f deployments/nvml-mock/Dockerfile .
+kind load docker-image nvml-mock:local --name gpu-fleet
+```
+
+### 3. Install nvidia-container-toolkit on workers
+
+```bash
+for NODE in $(kind get nodes --name gpu-fleet | grep worker); do
+  echo "Installing nvidia-container-toolkit on $NODE..."
+  docker exec "$NODE" bash -c '
+    apt-get update -qq &&
+    apt-get install -y -qq curl gpg > /dev/null &&
+    curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey |
+      gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg &&
+    curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list |
+      sed "s#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g" |
+      tee /etc/apt/sources.list.d/nvidia-container-toolkit.list &&
+    apt-get update -qq &&
+    apt-get install -y -qq nvidia-container-toolkit > /dev/null
+  '
+  docker exec "$NODE" systemctl restart containerd
+done
+sleep 5
+```
+
+### 4. Install nvml-mock on each node
+
+**With published image:**
+
+```bash
+helm install nvml-mock-a100 deployments/nvml-mock/helm/nvml-mock \
+  --set gpu.profile=a100 \
+  --set gpu.count=4 \
+  --set "nodeSelector.nvml-mock/profile=a100" \
+  --wait --timeout 120s
+
+helm install nvml-mock-t4 deployments/nvml-mock/helm/nvml-mock \
+  --set gpu.profile=t4 \
+  --set gpu.count=2 \
+  --set "nodeSelector.nvml-mock/profile=t4" \
+  --wait --timeout 120s
+```
+
+**With locally built image:**
+
+```bash
 helm install nvml-mock-a100 deployments/nvml-mock/helm/nvml-mock \
   --set image.repository=nvml-mock \
   --set image.tag=local \
   --set gpu.profile=a100 \
   --set gpu.count=4 \
-  --set "nodeSelector.nvml-mock/profile=a100"
+  --set "nodeSelector.nvml-mock/profile=a100" \
+  --wait --timeout 120s
 
 helm install nvml-mock-t4 deployments/nvml-mock/helm/nvml-mock \
   --set image.repository=nvml-mock \
   --set image.tag=local \
   --set gpu.profile=t4 \
   --set gpu.count=2 \
-  --set "nodeSelector.nvml-mock/profile=t4"
+  --set "nodeSelector.nvml-mock/profile=t4" \
+  --wait --timeout 120s
 ```
 
-Each release creates its own DaemonSet, ConfigMap, and RBAC resources. The
-device plugin (or DRA driver) discovers different GPU types on each node,
-enabling heterogeneous scheduling and topology-aware placement testing.
+### 5. Deploy the device plugin
 
-For a Kind cluster with labeled workers, see `tests/e2e/kind-multi-node-config.yaml`.
+```bash
+kubectl apply -f tests/e2e/device-plugin-mock.yaml
+kubectl -n kube-system wait --for=condition=ready \
+  pod -l name=nvidia-device-plugin-mock --timeout=120s
+```
+
+### 6. Verify GPUs on both nodes
+
+```bash
+for NODE in $(kubectl get nodes -l nvml-mock/profile -o jsonpath='{.items[*].metadata.name}'); do
+  echo -n "$NODE: "
+  for i in $(seq 1 12); do
+    COUNT=$(kubectl get node "$NODE" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}' 2>/dev/null)
+    if [ -n "$COUNT" ] && [ "$COUNT" != "0" ]; then
+      echo "${COUNT} GPUs"
+      break
+    fi
+    sleep 5
+  done
+done
+```
+
+Expected: worker with `a100` profile shows `4` GPUs, worker with `t4` profile shows `2` GPUs.
+
+### 7. Clean up
+
+```bash
+kind delete cluster --name gpu-fleet
+```
 
 ## Integration: fake-gpu-operator
 

--- a/docs/demo/with-fgo/README.md
+++ b/docs/demo/with-fgo/README.md
@@ -61,6 +61,7 @@ helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
   --set integrations.fakeGpuOperator.enabled=true \
   --set gpu.profile=h100 \
   --set gpu.count=8 \
+  --set "nodeSelector.run\.ai/simulated-gpu-node-pool=integration" \
   --wait --timeout 120s
 ```
 
@@ -82,28 +83,32 @@ Create a topology ConfigMap that tells FGO which backend each pool uses.
 The `integration` pool uses `backend: mock` (nvml-mock provides the NVML
 shim), and the `scale` pool uses `backend: fake` (FGO provides the shim).
 
-```yaml
+```bash
+kubectl apply -f - <<'EOF'
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: fake-gpu-operator-topology
+  namespace: gpu-operator
 data:
   topology.yaml: |
-    nodePools:
-      integration:
+    nodeGroups:
+      - name: integration
         backend: mock
+        nodeSelector:
+          run.ai/simulated-gpu-node-pool: "integration"
         gpuCount: 8
-        gpuProfile: h100
-      scale:
+        gpuModel: NVIDIA H100 80GB HBM3
+        gpuMemory: 80Gi
+
+      - name: scale
         backend: fake
+        nodeSelector:
+          run.ai/simulated-gpu-node-pool: "scale"
         gpuCount: 8
-        gpuProfile: h100
-```
-
-Apply the ConfigMap:
-
-```bash
-kubectl apply -f topology.yaml
+        gpuModel: NVIDIA H100 80GB HBM3
+        gpuMemory: 80Gi
+EOF
 ```
 
 ## Step 7 -- Verify

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,6 +18,7 @@ pkg/gpu/mocknvml/
 │   ├── helpers.go             # Helper functions + main() + go:generate
 │   ├── init.go                # nvmlInit_v2, nvmlShutdown, etc.
 │   ├── device.go              # Device handle functions
+│   ├── events.go              # Event set/wait functions
 │   ├── system.go              # System functions
 │   ├── internal.go            # Internal export table (nvidia-smi)
 │   └── stubs_generated.go     # Auto-generated stubs (~289 functions)
@@ -27,11 +28,15 @@ pkg/gpu/mocknvml/
 │   ├── device.go              # ConfigurableDevice implementation
 │   ├── engine.go              # Singleton engine
 │   ├── handles.go             # C↔Go handle mapping
+│   ├── invalid_device.go      # Invalid device handle sentinel
 │   ├── utils.go               # Debug utilities
+│   ├── version.go             # NVML version responses
 │   └── *_test.go              # Unit tests
 ├── configs/
 │   ├── mock-nvml-config-a100.yaml
-│   └── mock-nvml-config-gb200.yaml
+│   ├── mock-nvml-config-gb200.yaml
+│   ├── mock-nvml-config-l40s.yaml
+│   └── mock-nvml-config-t4.yaml
 ├── Dockerfile
 ├── Makefile
 └── README.md
@@ -47,14 +52,20 @@ tests/mocknvml/
 ├── Makefile
 └── README.md
 
-
+docs/
 ├── README.md
 ├── quickstart.md
 ├── architecture.md
 ├── configuration.md
-├── examples.md
+├── cuda-mock.md
 ├── development.md
-└── troubleshooting.md
+├── examples.md
+├── troubleshooting.md
+├── demo/
+│   ├── standalone/
+│   └── with-fgo/
+└── integrations/
+    └── fake-gpu-operator.md
 ```
 
 ## Building
@@ -391,9 +402,9 @@ go run ./cmd/generate-bridge --stats
 Output:
 ```
 NVML Function Coverage:
-  Total functions:               400
-  Hand-written implementations:  111 (27.8%)
-  Generated stubs:               289 (72.2%)
+  Total functions:               396
+  Hand-written implementations:  107 (27.0%)
+  Generated stubs:               289 (73.0%)
 
   By file:
     device.go:           94 functions

--- a/docs/integrations/fake-gpu-operator.md
+++ b/docs/integrations/fake-gpu-operator.md
@@ -222,3 +222,19 @@ If the libraries are missing, check the DaemonSet pod logs for errors:
 ```bash
 kubectl logs -l app.kubernetes.io/name=nvml-mock --tail=50
 ```
+
+## Cleanup
+
+To remove the FGO + nvml-mock setup, uninstall both Helm releases and delete
+the topology ConfigMap:
+
+```bash
+# Uninstall nvml-mock
+helm uninstall nvml-mock
+
+# Uninstall fake-gpu-operator
+helm uninstall fake-gpu-operator -n gpu-operator
+
+# Delete the topology ConfigMap
+kubectl delete configmap fake-gpu-operator-topology -n gpu-operator
+```

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -12,52 +12,51 @@ They verify:
 - NVIDIA device plugin discovers mock GPUs and registers `nvidia.com/gpu`
 - DRA driver discovers mock GPUs and publishes ResourceSlices
 
-## What requires NGC credentials
+## Standalone GFD/validator steps (disabled)
 
-GFD and CUDA validator tests are **disabled in CI** (`if: false`) because
-their container images live on `nvcr.io` which requires authentication.
+The `e2e-device-plugin` job has standalone GFD and CUDA validator steps that
+pull directly from `nvcr.io`. These are disabled (`if: false`) because the
+standalone images may require NGC authentication. GPU Operator images are
+public and do not require NGC credentials -- the separate `e2e-gpu-operator`
+job uses that path and works without auth.
 
-To run the full suite locally:
+To run the standalone steps locally (NGC auth may be needed):
 
 ```bash
-# 1. Authenticate with NGC
-docker login nvcr.io -u '$oauthtoken' -p <NGC_API_KEY>
-
-# 2. Create Kind cluster
+# 1. Create Kind cluster
 kind create cluster --name nvml-mock-e2e
 
-# 3. Build and load nvml-mock image
+# 2. Build and load nvml-mock image
 docker build -t nvml-mock:e2e -f deployments/nvml-mock/Dockerfile .
 kind load docker-image nvml-mock:e2e --name nvml-mock-e2e
 
-# 4. Install nvml-mock chart
+# 3. Install nvml-mock chart
 helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
   --set image.repository=nvml-mock --set image.tag=e2e --set gpu.count=2 \
   --wait --timeout 120s
 
-# 5. Deploy device plugin
+# 4. Deploy device plugin
 kubectl apply -f tests/e2e/device-plugin-mock.yaml
 kubectl -n kube-system wait --for=condition=ready pod -l name=nvidia-device-plugin-mock --timeout=120s
 
-# 6. Pull, load, and deploy GFD
+# 5. Pull, load, and deploy GFD (may require: docker login nvcr.io)
 docker pull nvcr.io/nvidia/gpu-feature-discovery:v0.17.0
 kind load docker-image nvcr.io/nvidia/gpu-feature-discovery:v0.17.0 --name nvml-mock-e2e
 kubectl apply -f tests/e2e/gfd-mock.yaml
 
-# 7. Pull, load, and run CUDA validator
+# 6. Pull, load, and run CUDA validator (may require: docker login nvcr.io)
 docker pull nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0
 kind load docker-image nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0 --name nvml-mock-e2e
 kubectl apply -f tests/e2e/validator-mock.yaml
 kubectl wait --for=condition=complete job/gpu-validator-mock --timeout=120s
 ```
 
-## Enabling GFD/validator in CI
+## Enabling standalone GFD/validator in CI
 
-When `NGC_API_KEY` is added as a GitHub Actions secret:
+Once confirmed that the standalone `nvcr.io` images are publicly accessible:
 
-1. Add a docker login step before the GFD/validator steps
-2. Remove the `if: false` conditions from the GFD and validator steps
-3. The image pull + kind load is already embedded in the step scripts
+1. Remove the `if: false` conditions from the GFD and validator steps
+2. The image pull + kind load is already embedded in the step scripts
 
 ## Files
 

--- a/tests/mocknvml/Dockerfile
+++ b/tests/mocknvml/Dockerfile
@@ -37,7 +37,7 @@ WORKDIR /build
 COPY tests/mocknvml/go.mod tests/mocknvml/go.sum* ./
 RUN go mod download
 
-COPY tests/mocknvml/main.go ./
+COPY tests/mocknvml/*.go ./
 RUN CGO_ENABLED=1 go build -o mocknvml-test main.go
 
 # Runtime stage

--- a/tests/mocknvml/go.mod
+++ b/tests/mocknvml/go.mod
@@ -1,5 +1,5 @@
 module github.com/NVIDIA/k8s-test-infra/tests/mocknvml
 
-go 1.23
+go 1.25
 
 require github.com/NVIDIA/go-nvml v0.13.0-1


### PR DESCRIPTION
## Summary

End-to-end docs audit found **4 CRITICAL**, **7 MAJOR**, and **14 MINOR** findings across all documentation paths. This PR fixes all CRITICAL and MAJOR findings, plus several MINOR ones.

## Findings Fixed

### CRITICAL
- **C1**: GPU Operator Quick Start was not self-contained — inlined nvidia-container-toolkit install, CDI config, containerd restart
- **C2**: tests/mocknvml/Dockerfile broken — only copied main.go, missing bridge_tests.go (added in PR #269)
- **C3**: with-fgo demo missing nodeSelector — DaemonSet ran everywhere instead of integration pool
- **C4**: Inconsistent FGO topology schemas between demo and integration guide

### MAJOR
- **M1**: --stats counts wrong in development.md (400/111 to 396/107)
- **M2**: DRA prerequisite wrong: Kubernetes 1.31+ to 1.32+ (chart requires >=1.32.0)
- **M3**: GPU Operator helm flags diverge from CI — removed extra flags
- **M4**: CI workflow_dispatch default Go version 1.23 to 1.25 (go.mod requires 1.25)
- **M5**: Stale NGC credential claims — GPU Operator images are public
- **M6**: Multi-node section expanded from snippet to complete 7-step Quick Start
- **M7**: topology.yaml reference pointed to nonexistent file — converted to heredoc

### MINOR (included)
- **m1**: Project structure tree in development.md missing files
- **m5**: tests/mocknvml/go.mod Go version 1.23 to 1.25
- **m8**: Integration guide missing cleanup section
- **m14**: Topology ConfigMap missing namespace

## Files Changed (8)

- tests/mocknvml/Dockerfile — Fix broken build (C2)
- tests/mocknvml/go.mod — Go 1.23 to 1.25 (m5)
- .github/workflows/nvml-mock-e2e.yaml — Default Go version + NGC comments (M4, M5)
- tests/e2e/README.md — Remove stale NGC claims (M5)
- deployments/nvml-mock/helm/nvml-mock/README.md — GPU Operator + multi-node guides (C1, M2, M3, M6)
- docs/demo/with-fgo/README.md — nodeSelector, topology schema, heredoc (C3, C4, M7, m14)
- docs/integrations/fake-gpu-operator.md — Cleanup section (m8)
- docs/development.md — Stats + project tree (M1, m1)