### PR TITLE
chore: v0.1.0 open source readiness — community docs, CI hardening, supply chain

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig — https://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.go]
+indent_style = tab
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,16 +2,16 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owners for everything
-* @ArangoGutierrez @kklues @elezar
+* @ArangoGutierrez @klueska @elezar
 
 # Mock NVML library
 /pkg/gpu/mocknvml/ @ArangoGutierrez @elezar
 
 # Helm chart
-/deployments/nvml-mock/ @ArangoGutierrez @kklues
+/deployments/nvml-mock/ @ArangoGutierrez @klueska
 
 # CI workflows
-/.github/workflows/ @ArangoGutierrez @kklues @elezar
+/.github/workflows/ @ArangoGutierrez @klueska @elezar
 
 # E2E tests
-/tests/e2e/ @ArangoGutierrez @kklues
+/tests/e2e/ @ArangoGutierrez @klueska

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# CODEOWNERS — auto-assigns reviewers to PRs
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything
+* @ArangoGutierrez @kklues @elezar
+
+# Mock NVML library
+/pkg/gpu/mocknvml/ @ArangoGutierrez @elezar
+
+# Helm chart
+/deployments/nvml-mock/ @ArangoGutierrez @kklues
+
+# CI workflows
+/.github/workflows/ @ArangoGutierrez @kklues @elezar
+
+# E2E tests
+/tests/e2e/ @ArangoGutierrez @kklues

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Describe the Bug
+
+A clear description of what the bug is.
+
+## Steps to Reproduce
+
+1. ...
+2. ...
+3. ...
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include error messages or logs if applicable.
+
+## Environment
+
+- **OS:** (e.g., Ubuntu 22.04, macOS 14)
+- **Go version:** (e.g., 1.25)
+- **Kubernetes version:** (e.g., 1.32)
+- **Helm version:** (e.g., 3.16)
+- **nvml-mock version/commit:** (e.g., v0.1.0, sha-abc123)
+- **Kind version:** (if applicable)
+
+## Additional Context
+
+Add any other context, screenshots, or log output.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/NVIDIA/k8s-test-infra/security/advisories/new
+    about: Report security vulnerabilities privately via GitHub Security Advisories

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+
+What problem does this feature solve? What use case does it address?
+
+## Proposed Solution
+
+Describe the solution you'd like.
+
+## Alternatives Considered
+
+What alternatives have you considered?
+
+## Additional Context
+
+Add any other context, mockups, or references.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## What This PR Does
+
+<!-- Brief description of the changes -->
+
+## Why
+
+<!-- Link to issue or explain motivation -->
+
+## Checklist
+
+- [ ] Commits are signed off (`git commit -s`)
+- [ ] Tests pass (`go test -v -race ./...`)
+- [ ] Linter passes (`golangci-lint run`)
+- [ ] New code has SPDX license headers
+- [ ] Documentation updated (if applicable)
+- [ ] CHANGELOG.md updated (if user-facing change)

--- a/.github/workflows/basic-checks.yaml
+++ b/.github/workflows/basic-checks.yaml
@@ -13,6 +13,9 @@
 # limitations under the License.
 name: "basic checks"
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     outputs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,9 @@
 # limitations under the License.
 name: CI Pipeline
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/code_scanning.yaml
+++ b/.github/workflows/code_scanning.yaml
@@ -30,15 +30,15 @@ jobs:
       packages: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ inputs.golang_version }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         with:
           languages: go
 
@@ -46,6 +46,6 @@ jobs:
         run: go mod download
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         with:
           category: "/language:go"

--- a/.github/workflows/code_scanning.yaml
+++ b/.github/workflows/code_scanning.yaml
@@ -13,6 +13,8 @@
 # limitations under the License.
 name: "CodeQL"
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -50,3 +50,8 @@ jobs:
     - name: Run unit tests
       run: |
         go test -v -race -coverprofile=coverage.out -covermode=atomic $(go list ./... | grep -v vendor)
+
+    - name: Run govulncheck
+      run: |
+        go install golang.org/x/vuln/cmd/govulncheck@latest
+        govulncheck ./...

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -14,6 +14,9 @@
 
 name: Golang
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -28,16 +28,16 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       name: Checkout code
 
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: ${{ inputs.golang_version }}
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v9
+      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
       with:
         version: latest
         args: -v --timeout 5m

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
       - name: Run chart-testing (lint)
         run: |
@@ -37,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Install helm-unittest plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v1.0.3

--- a/.github/workflows/nvml-mock-e2e.yaml
+++ b/.github/workflows/nvml-mock-e2e.yaml
@@ -14,6 +14,9 @@
 
 name: nvml-mock E2E
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/nvml-mock-e2e.yaml
+++ b/.github/workflows/nvml-mock-e2e.yaml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         gpu-profile: ${{ fromJson(inputs.gpu_profiles) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set GPU display name
         id: gpu-info
@@ -64,15 +64,15 @@ jobs:
           esac
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ inputs.golang_version }}
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
       - name: Create Kind cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
           cluster_name: nvml-mock-e2e-${{ matrix.gpu-profile }}
 
@@ -226,7 +226,7 @@ jobs:
       matrix:
         gpu-profile: ${{ fromJson(inputs.gpu_profiles) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set GPU display name
         id: gpu-info
@@ -242,15 +242,15 @@ jobs:
           esac
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ inputs.golang_version }}
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
       - name: Create Kind cluster with DRA
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
           cluster_name: nvml-mock-dra-${{ matrix.gpu-profile }}
           config: tests/e2e/kind-dra-config.yaml
@@ -359,18 +359,18 @@ jobs:
       matrix:
         gpu-profile: ${{ fromJson(inputs.gpu_profiles) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ inputs.golang_version }}
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
       - name: Create Kind cluster for GPU Operator
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
           cluster_name: nvml-mock-op-${{ matrix.gpu-profile }}
           config: tests/e2e/kind-gpu-operator-config.yaml
@@ -611,18 +611,18 @@ jobs:
   e2e-multi-node:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ inputs.golang_version }}
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
       - name: Create multi-node Kind cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
           cluster_name: gpu-fleet
           config: tests/e2e/kind-multi-node-config.yaml

--- a/.github/workflows/nvml-mock-publish.yaml
+++ b/.github/workflows/nvml-mock-publish.yaml
@@ -26,16 +26,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -43,7 +43,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -56,7 +56,7 @@ jobs:
             type=sha,prefix=sha-,format=short
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
           file: deployments/nvml-mock/Dockerfile

--- a/.github/workflows/nvml-mock-publish.yaml
+++ b/.github/workflows/nvml-mock-publish.yaml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write  # needed for keyless cosign signing
 
     steps:
       - name: Checkout
@@ -66,3 +67,13 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@c56c2d3e59e4281cc41dea2217323ba5694b171e # v3.8.0
+
+      - name: Sign container image
+        run: |
+          cosign sign --yes \
+            $(echo "${{ steps.meta.outputs.tags }}" | head -1)
+        env:
+          COSIGN_EXPERIMENTAL: "true"

--- a/.github/workflows/nvml-mock-publish.yaml
+++ b/.github/workflows/nvml-mock-publish.yaml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 name: nvml-mock Publish
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -57,6 +59,7 @@ jobs:
             type=sha,prefix=sha-,format=short
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
@@ -81,7 +84,7 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
         with:
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: spdx-json
           output-file: sbom.spdx.json
 

--- a/.github/workflows/nvml-mock-publish.yaml
+++ b/.github/workflows/nvml-mock-publish.yaml
@@ -77,3 +77,16 @@ jobs:
             $(echo "${{ steps.meta.outputs.tags }}" | head -1)
         env:
           COSIGN_EXPERIMENTAL: "true"
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Attach SBOM to image
+        run: |
+          cosign attest --yes --predicate sbom.spdx.json \
+            --type spdxjson \
+            $(echo "${{ steps.meta.outputs.tags }}" | head -1)

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,38 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+name: OpenSSF Scorecard
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/variables.yaml
+++ b/.github/workflows/variables.yaml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+name: Variables
+
+permissions:
+  contents: read
+
 on:
     workflow_call:
       outputs:

--- a/.github/workflows/variables.yaml
+++ b/.github/workflows/variables.yaml
@@ -35,7 +35,7 @@ jobs:
       golang_version: ${{ steps.golang_version.outputs.golang_version }}
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Generate Commit Short SHA
       id: version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-07
+
+### Added
+- Mock NVML library (`libnvidia-ml.so`) with 396 C API exports (107 hand-written,
+  289 auto-generated stubs)
+- Mock CUDA library (`libcuda.so.1`) with 15 functions
+- Real `nvidia-smi` binary with RPATH patch backed by mock NVML
+- YAML-configurable GPU profiles: A100, H100, B200, GB200, L40S, T4
+- Helm chart for DaemonSet deployment on Kubernetes
+- CDI (Container Device Interface) spec generation for GPU Operator
+- E2E test suites: Device Plugin, DRA Driver, GPU Operator, Multi-Node Fleet
+- fake-gpu-operator integration (FGO-style labels and ConfigMaps)
+- Standalone and with-fgo demo scripts
+- Comprehensive documentation: quickstart, architecture, configuration,
+  development guide, troubleshooting
+
+### Changed
+- Rebranded from gpu-mock to nvml-mock (PRs #273, #274, #275, #281, #282)
+
+[Unreleased]: https://github.com/NVIDIA/k8s-test-infra/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/NVIDIA/k8s-test-infra/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2026-04-07
 
 ### Added
-- Mock NVML library (`libnvidia-ml.so`) with 396 C API exports (107 hand-written,
+- Mock NVML library (`libnvidia-ml.so`) with 400 C API exports (111 hand-written,
   289 auto-generated stubs)
 - Mock CUDA library (`libcuda.so.1`) with 15 functions
 - Real `nvidia-smi` binary with RPATH patch backed by mock NVML

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,86 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at psirt@nvidia.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,60 +1,129 @@
-# Contribute to the NVIDIA k8s-test-infra Project
+# Contributing to NVIDIA k8s-test-infra
 
-Want to hack on the NVIDIA k8s-test-infra Project? Awesome!
-We only require you to sign your work, the below section describes this!
+Thank you for your interest in contributing! This guide covers everything you
+need to get started.
 
-## Sign your work
+## Code of Conduct
 
-The sign-off is a simple line at the end of the explanation for the patch. Your
-signature certifies that you wrote the patch or otherwise have the right to pass
-it on as an open-source patch. The rules are pretty simple: if you can certify
-the below (from [developercertificate.org](http://developercertificate.org/)):
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
+By participating, you agree to uphold this code.
 
-```
-Developer Certificate of Origin
-Version 1.1
+## Getting Started
 
-Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-1 Letterman Drive
-Suite D4700
-San Francisco, CA, 94129
+### Prerequisites
 
-Everyone is permitted to copy and distribute verbatim copies of this
-license document, but changing it is not allowed.
+- Go 1.25+
+- Docker 20.10+
+- Helm 3.x
+- Kind (for E2E testing)
+- Make
 
-Developer's Certificate of Origin 1.1
+### Development Setup
 
-By making a contribution to this project, I certify that:
+```bash
+# Clone the repository
+git clone https://github.com/NVIDIA/k8s-test-infra.git
+cd k8s-test-infra
 
-(a) The contribution was created in whole or in part by me and I
-    have the right to submit it under the open source license
-    indicated in the file; or
+# Verify Go version
+go version  # must be >= 1.25
 
-(b) The contribution is based upon previous work that, to the best
-    of my knowledge, is covered under an appropriate open source
-    license and I have the right under that license to submit that
-    work with modifications, whether created in whole or in part
-    by me, under the same open source license (unless I am
-    permitted to submit under a different license), as indicated
-    in the file; or
+# Run unit tests
+go test -v -race $(go list ./... | grep -v vendor)
 
-(c) The contribution was provided directly to me by some other
-    person who certified (a), (b) or (c) and I have not modified
-    it.
+# Run linter
+golangci-lint run -v --timeout 5m
 
-(d) I understand and agree that this project and the contribution
-    are public and that a record of the contribution (including all
-    personal information I submit with it, including my sign-off) is
-    maintained indefinitely and may be redistributed consistent with
-    this project or the open source license(s) involved.
+# Check Go modules
+make check-modules
 ```
 
-Then you just add a line to every git commit message:
+### Building the Mock NVML Library
 
-    Signed-off-by: Joe Smith <joe.smith@email.com>
+```bash
+cd pkg/gpu/mocknvml
+make
+# Produces libnvidia-ml.so.1, libnvidia-ml.so.1.550.163.01, and symlinks
+```
 
-Use your real name (sorry, no pseudonyms or anonymous contributions.)
+### Running nvidia-smi Locally
 
-If you set your `user.name` and `user.email` git configs, you can sign your
-commit automatically with `git commit -s`.
+```bash
+cd pkg/gpu/mocknvml
+LD_LIBRARY_PATH=. nvidia-smi
+```
 
+## How to Contribute
+
+### Reporting Bugs
+
+Open an issue using the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md).
+Include steps to reproduce, expected vs actual behavior, and your environment.
+
+### Suggesting Features
+
+Open an issue using the [feature request template](.github/ISSUE_TEMPLATE/feature_request.md).
+
+### Submitting Changes
+
+1. Fork the repository
+2. Create a feature branch from `main`
+3. Make your changes with tests
+4. Ensure all checks pass (see Testing below)
+5. Submit a pull request
+
+## Pull Request Process
+
+1. **One concern per PR** — keep PRs focused and reviewable
+2. **Tests required** — new features need tests; bug fixes need regression tests
+3. **CI must pass** — all checks (lint, unit tests, E2E) must be green
+4. **Review required** — at least one maintainer approval from [OWNERS](OWNERS)
+
+## Testing
+
+### Unit Tests
+
+```bash
+go test -v -race $(go list ./... | grep -v vendor)
+```
+
+### Helm Chart Tests
+
+```bash
+# Lint
+ct lint --chart-dirs deployments/nvml-mock/helm --all
+
+# Unit tests
+helm unittest deployments/nvml-mock/helm/nvml-mock
+```
+
+### E2E Tests
+
+E2E tests run on Kind clusters. See [tests/e2e/README.md](tests/e2e/README.md)
+for the full guide.
+
+## Coding Standards
+
+- Follow existing code patterns in the repository
+- Use `golangci-lint` for Go code
+- Add SPDX license headers to new files:
+  ```
+  // SPDX-License-Identifier: Apache-2.0
+  // SPDX-FileCopyrightText: Copyright 2026 NVIDIA CORPORATION
+  ```
+
+## Sign Your Work (DCO)
+
+All commits must be signed off per the
+[Developer Certificate of Origin](http://developercertificate.org/).
+
+Add a sign-off line to every git commit message:
+
+    Signed-off-by: Your Name <your.email@example.com>
+
+Use your real name. If you set `user.name` and `user.email` in your git config,
+you can sign automatically with:
+
+```bash
+git commit -s
+```

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,50 @@
+# Governance
+
+## Overview
+
+The NVIDIA k8s-test-infra project (including nvml-mock) uses a maintainer-based
+governance model. All major decisions are made through consensus among maintainers,
+with discussion on GitHub issues and pull requests.
+
+## Roles
+
+### Maintainers
+
+Maintainers have write access to the repository and are responsible for:
+- Reviewing and merging pull requests
+- Triaging issues
+- Making architectural decisions
+- Cutting releases
+
+Current maintainers are listed in the [OWNERS](OWNERS) file.
+
+### Contributors
+
+Anyone who contributes code, documentation, bug reports, or other improvements.
+Contributors must sign off their commits per the [DCO](CONTRIBUTING.md).
+
+### Reviewers
+
+Reviewers are listed in `OWNERS` and are expected to review PRs in their area
+of expertise. Reviewers may be promoted to maintainers by consensus of existing
+maintainers.
+
+## Decision Making
+
+- **Code changes:** Require at least one approving review from a maintainer
+  listed in `OWNERS`.
+- **Architectural decisions:** Discussed in GitHub issues; decided by maintainer
+  consensus. If no consensus after 7 days, the majority of maintainers decides.
+- **Adding/removing maintainers:** Requires consensus of existing maintainers.
+
+## Conflict Resolution
+
+If contributors disagree on a decision, the process is:
+
+1. Discussion on the relevant GitHub issue or PR
+2. If unresolved, maintainers vote (majority wins)
+3. If still unresolved, NVIDIA's open source office mediates
+
+## Changes to Governance
+
+Changes to this document require approval from all active maintainers.

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSES/CC-BY-4.0.txt
+++ b/LICENSES/CC-BY-4.0.txt
@@ -1,0 +1,396 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+     wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+     wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its public
+licenses to material it publishes and in those instances will be
+considered the “Licensor.” The text of the Creative Commons public
+licenses is dedicated to the public domain under the CC0 Public Domain
+Dedication. Except for the limited purpose of indicating that material
+is shared under a Creative Commons public license or as otherwise
+permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the public
+licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # k8s-test-infra
 
+[![CI](https://github.com/NVIDIA/k8s-test-infra/actions/workflows/ci.yaml/badge.svg)](https://github.com/NVIDIA/k8s-test-infra/actions/workflows/ci.yaml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/NVIDIA/k8s-test-infra/badge)](https://scorecard.dev/viewer/?uri=github.com/NVIDIA/k8s-test-infra)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+
 Kubernetes test infrastructure for NVIDIA GPU software — mock GPU environments,
 CI tooling, and testing utilities.
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+
+version = 1
+
+[[annotations]]
+path = ["**.go", "**.yaml", "**.yml", "**.sh", "**.toml", "Makefile", "Dockerfile"]
+SPDX-FileCopyrightText = "Copyright 2024-2026 NVIDIA CORPORATION"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ["**.md"]
+SPDX-FileCopyrightText = "Copyright 2024-2026 NVIDIA CORPORATION"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ["go.sum", "vendor/**", ".gitignore", ".editorconfig"]
+SPDX-FileCopyrightText = "Copyright 2024-2026 NVIDIA CORPORATION"
+SPDX-License-Identifier = "Apache-2.0"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -3,9 +3,14 @@
 version = 1
 
 [[annotations]]
-path = ["**.go", "**.yaml", "**.yml", "**.sh", "**.toml", "Makefile", "Dockerfile"]
+path = ["**.go", "**.h", "**.yaml", "**.yml", "**.sh", "**.toml", "Makefile", "Dockerfile"]
 SPDX-FileCopyrightText = "Copyright 2024-2026 NVIDIA CORPORATION"
 SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ["CODE_OF_CONDUCT.md"]
+SPDX-FileCopyrightText = "Copyright Contributors to the Contributor Covenant project"
+SPDX-License-Identifier = "CC-BY-4.0"
 
 [[annotations]]
 path = ["**.md"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| 0.1.x   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it
+responsibly.
+
+**Please do NOT open a public GitHub issue for security vulnerabilities.**
+
+Instead, please report them via GitHub's private vulnerability reporting:
+
+1. Go to the [Security Advisories page](https://github.com/NVIDIA/k8s-test-infra/security/advisories)
+2. Click **"Report a vulnerability"**
+3. Fill in the details
+
+Alternatively, email **psirt@nvidia.com** with:
+- Description of the vulnerability
+- Steps to reproduce
+- Affected versions
+- Any potential impact
+
+## Response Timeline
+
+- **Acknowledgment:** within 3 business days
+- **Initial assessment:** within 10 business days
+- **Fix timeline:** depends on severity, typically within 30-90 days
+
+## Scope
+
+This project provides **mock GPU infrastructure for testing**. It does not
+handle real GPU workloads or sensitive data. However, we take security of
+our CI/CD pipelines, container images, and supply chain seriously.
+
+Areas of particular interest:
+- Container image vulnerabilities
+- GitHub Actions workflow security
+- Supply chain integrity (dependencies, build process)
+- Helm chart security (RBAC, privileges)

--- a/pkg/gpu/mocknvml/engine/fuzz_test.go
+++ b/pkg/gpu/mocknvml/engine/fuzz_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 NVIDIA CORPORATION
+
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func FuzzLoadYAMLConfig(f *testing.F) {
+	// Seed corpus with known-good configs
+	f.Add([]byte(`
+gpu_name: "Tesla T4"
+architecture: "Turing"
+num_devices: 2
+total_memory_mib: 16384
+`))
+	f.Add([]byte(`
+gpu_name: "A100-SXM4-40GB"
+architecture: "Ampere"
+num_devices: 8
+total_memory_mib: 40960
+`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(``))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Write fuzzed data to a temp file
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.yaml")
+		if err := os.WriteFile(path, data, 0644); err != nil {
+			t.Fatal(err)
+		}
+		// LoadYAMLConfig should never panic on any input
+		_, _ = LoadYAMLConfig(path)
+	})
+}


### PR DESCRIPTION
## Summary

Closes all 32 MISSING and 14 PARTIAL gaps from the v0.1.0 readiness report to achieve OpenSSF Scorecard ~8/10 and CNCF Sandbox eligibility.

### Community Docs
- `SECURITY.md` — vulnerability disclosure via GitHub Security Advisories + NVIDIA PSIRT
- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1
- `GOVERNANCE.md` — maintainer roles, decision model, conflict resolution
- `CONTRIBUTING.md` — expanded with dev setup, build instructions, PR workflow, testing guide
- `CHANGELOG.md` — Keep a Changelog format for v0.1.0

### GitHub Templates
- `CODEOWNERS` — auto-assigns reviewers by path
- Issue templates (bug report, feature request) + PR template

### CI Hardening
- Top-level `permissions: contents: read` on all workflows (Token-Permissions)
- All third-party GitHub Actions pinned to full commit SHA (Pinned-Dependencies)
- OpenSSF Scorecard weekly scan workflow
- `govulncheck` added to Go CI pipeline

### Supply Chain Security
- Keyless cosign container image signing via GitHub OIDC
- SPDX JSON SBOM generation + cosign attestation

### Polish
- REUSE.toml + LICENSES/ for SPDX compliance (Apache-2.0 + CC-BY-4.0)
- `.editorconfig` for consistent formatting
- CI, Scorecard, and License badges in README
- Go fuzz test for YAML config parsing

## Test Plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `go vet ./...` clean (pre-existing unsafe.Pointer warnings only)
- [x] All 10 workflow YAML files parse correctly
- [x] No mutable `@vN` tags remain on third-party actions
- [x] All commits signed (`-s -S`)

Ref: `docs/plans/2026-04-07-v010-os-readiness-plan.md`