### PR TITLE
fix: skip nvidia-smi on arm64 — NVIDIA sbsa repo lacks nvidia-utils-550

### DIFF
--- a/deployments/nvml-mock/Dockerfile
+++ b/deployments/nvml-mock/Dockerfile
@@ -38,27 +38,27 @@ RUN set -eux; \
     echo "$(cat /tmp/kubectl.sha256)  /usr/local/bin/kubectl" | sha256sum --check; \
     chmod +x /usr/local/bin/kubectl; \
     rm /tmp/kubectl.sha256; \
-    # Extract nvidia-smi binary from nvidia-utils package (no full install needed).
-    # Use Ubuntu 22.04 repo (binary-compatible with Debian bookworm, has nvidia-utils-550).
-    # Map TARGETARCH to NVIDIA repo path: amd64 → x86_64, arm64 → sbsa.
-    NVIDIA_REPO_ARCH=$(case ${TARGETARCH} in amd64) echo x86_64;; arm64) echo sbsa;; *) echo x86_64;; esac); \
-    curl -fsSL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/${NVIDIA_REPO_ARCH}/3bf863cc.pub" | \
-      gpg --dearmor -o /usr/share/keyrings/nvidia.gpg; \
-    echo "deb [signed-by=/usr/share/keyrings/nvidia.gpg] https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/${NVIDIA_REPO_ARCH} /" \
-      > /etc/apt/sources.list.d/nvidia.list; \
-    apt-get update; \
-    cd /tmp && apt-get download nvidia-utils-550; \
-    dpkg-deb -x /tmp/nvidia-utils-550*.deb /tmp/nvidia-utils; \
-    cp /tmp/nvidia-utils/usr/bin/nvidia-smi /usr/local/bin/nvidia-smi; \
-    chmod +x /usr/local/bin/nvidia-smi; \
-    # Set RPATH so nvidia-smi finds libs relative to its own location ($ORIGIN/../lib64).
-    # This makes it work in every mount context: /run/nvidia/driver/usr/bin/,
-    # /var/lib/nvml-mock/driver/usr/bin/, and CDI-injected /usr/bin/.
-    apt-get install -y --no-install-recommends patchelf; \
-    patchelf --set-rpath '$ORIGIN/../lib64' /usr/local/bin/nvidia-smi; \
+    # Extract nvidia-smi binary from nvidia-utils package (amd64 only).
+    # The NVIDIA apt repo for arm64 (sbsa) does not carry nvidia-utils-550,
+    # so we conditionally install nvidia-smi only on amd64.
+    if [ "${TARGETARCH}" = "amd64" ]; then \
+      curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub | \
+        gpg --dearmor -o /usr/share/keyrings/nvidia.gpg; \
+      echo "deb [signed-by=/usr/share/keyrings/nvidia.gpg] https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64 /" \
+        > /etc/apt/sources.list.d/nvidia.list; \
+      apt-get update; \
+      cd /tmp && apt-get download nvidia-utils-550; \
+      dpkg-deb -x /tmp/nvidia-utils-550*.deb /tmp/nvidia-utils; \
+      cp /tmp/nvidia-utils/usr/bin/nvidia-smi /usr/local/bin/nvidia-smi; \
+      chmod +x /usr/local/bin/nvidia-smi; \
+      # Set RPATH so nvidia-smi finds libs relative to its own location ($ORIGIN/../lib64).
+      apt-get install -y --no-install-recommends patchelf; \
+      patchelf --set-rpath '$ORIGIN/../lib64' /usr/local/bin/nvidia-smi; \
+      rm -rf /tmp/nvidia-utils /tmp/nvidia-utils-550*.deb \
+             /usr/share/keyrings/nvidia.gpg /etc/apt/sources.list.d/nvidia.list; \
+      apt-get purge -y --auto-remove patchelf; \
+    fi; \
     rm -rf /var/lib/apt/lists/*; \
-    rm -rf /tmp/nvidia-utils /tmp/nvidia-utils-550*.deb \
-           /usr/share/keyrings/nvidia.gpg /etc/apt/sources.list.d/nvidia.list; \
-    apt-get purge -y --auto-remove curl ca-certificates gnupg2 patchelf
+    apt-get purge -y --auto-remove curl ca-certificates gnupg2
 COPY deployments/nvml-mock/scripts/ /scripts/
 RUN chmod +x /scripts/*.sh


### PR DESCRIPTION
## What This PR Does

Makes the nvidia-smi download conditional on amd64. The arm64 (sbsa) NVIDIA apt repo does not carry `nvidia-utils-550`, causing the multi-platform build to fail.

## Why

The v0.1.0 container image publish is blocked. PR #287 correctly mapped the repo URL by architecture, but the sbsa repo simply doesn't have the package.

## Fix

Wraps the nvidia-smi download/patchelf block in `if [ "${TARGETARCH}" = "amd64" ]`. The arm64 image still gets mock NVML/CUDA libraries and kubectl — just no nvidia-smi binary.

## Follow-up

ARM64 nvidia-smi support can be added later when NVIDIA publishes arm64 nvidia-utils packages or we source the binary differently.