### PR TITLE
fix: remove TARGETARCH default so buildx sets it per-platform

### DIFF
--- a/deployments/nvml-mock/Dockerfile
+++ b/deployments/nvml-mock/Dockerfile
@@ -24,7 +24,7 @@ RUN cd pkg/gpu/mockcuda && make clean && make
 
 FROM debian:bookworm-slim
 ARG KUBECTL_VERSION=v1.32.0
-ARG TARGETARCH=amd64
+ARG TARGETARCH
 COPY --from=builder /src/pkg/gpu/mocknvml/libnvidia-ml.so.* /usr/local/lib/
 COPY --from=builder /src/pkg/gpu/mockcuda/libcuda.so.* /usr/local/lib/
 RUN set -eux; \


### PR DESCRIPTION
## Problem

The `nvml-mock Publish` workflow fails on `linux/arm64` with:
```
E: Unable to locate package nvidia-utils-550
```

Despite the `if [ "${TARGETARCH}" = "amd64" ]` conditional from #288, the arm64 build still enters the amd64-only block.

## Root Cause

`ARG TARGETARCH=amd64` in the second stage **overrides** Docker buildx's automatic platform arg. The `=amd64` default takes precedence, so **both** platforms resolve `TARGETARCH` to `amd64`.

Evidence from the build log (run 24095262646):
```
#36 [linux/arm64->amd64 stage-1 4/6] RUN ... if [ "amd64" = "amd64" ]; then ...
```

This also caused the arm64 image to get the amd64 kubectl binary.

## Fix

Remove the default value: `ARG TARGETARCH=amd64` → `ARG TARGETARCH`

Docker buildx populates `TARGETARCH` automatically per-platform when redeclared without a default after `FROM`.

## Testing

After this fix:
- arm64 build: `TARGETARCH=arm64`, conditional is false, nvidia-smi skipped, arm64 kubectl downloaded
- amd64 build: `TARGETARCH=amd64`, conditional is true, nvidia-smi installed, amd64 kubectl downloaded

Fixes publish failure for v0.1.0 container image.