### PR TITLE
fix: add CodeQL permissions to CI pipeline + bump action versions

### DIFF
--- a/.github/workflows/basic-checks.yaml
+++ b/.github/workflows/basic-checks.yaml
@@ -15,6 +15,9 @@ name: "basic checks"
 
 permissions:
   contents: read
+  security-events: write
+  actions: read
+  packages: read
 
 on:
   workflow_call:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,9 @@ name: CI Pipeline
 
 permissions:
   contents: read
+  security-events: write
+  actions: read
+  packages: read
 
 on:
   push:

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
       - name: Install helm-unittest plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v1.0.3

--- a/.github/workflows/nvml-mock-publish.yaml
+++ b/.github/workflows/nvml-mock-publish.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4


### PR DESCRIPTION
## Problem

The **CI Pipeline** and **basic checks** workflows have shown `startup_failure` on every run since PR #286 (v0.1.0 OS readiness). Zero jobs execute — the workflow is rejected before starting.

## Root Cause

PR #286 added `permissions: contents: read` to `ci.yaml` and `basic-checks.yaml` for OpenSSF Scorecard compliance. However, the `code_scanning.yaml` reusable workflow (called via `basic-checks.yaml`) requires:
- `security-events: write` — for CodeQL to upload SARIF results
- `actions: read` — for CodeQL action access
- `packages: read` — for Go module downloads

GitHub Actions validates that reusable workflows' permission requirements don't exceed the caller's `permissions` block. Since the caller only granted `contents: read`, the workflow was rejected at startup.

## Fix

1. Add `security-events: write`, `actions: read`, `packages: read` to both `ci.yaml` and `basic-checks.yaml`
2. Bump `azure/setup-helm` v4 → v5 (SHA: `dda3372f`) in `helm.yaml`
3. Bump `docker/setup-qemu-action` v3 → v4 (SHA: `ce360397`) in `nvml-mock-publish.yaml`

## Verification

After merge, the CI Pipeline should complete successfully on the next push to main (no more startup_failure).