### PR TITLE
docs: fix critical quickstart path for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ No physical NVIDIA hardware required.
 kind create cluster --name gpu-test
 
 # 2. Load the published image (or build locally with: docker build -t nvml-mock:local -f deployments/nvml-mock/Dockerfile .)
+docker pull ghcr.io/nvidia/nvml-mock:latest
 kind load docker-image ghcr.io/nvidia/nvml-mock:latest --name gpu-test
 
 # 3. Install

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -26,6 +26,11 @@ as the NVIDIA driver root and discover GPUs through standard NVML APIs.
 | [Go](https://go.dev/dl/) | 1.25+ | Building from source |
 | [jq](https://jqlang.github.io/jq/) | any | DRA verification only |
 
+**Published image:** The nvml-mock container image is published at
+`ghcr.io/nvidia/nvml-mock:latest` and is built automatically on pushes to
+`main`. If the image is not yet available (e.g., before the first release),
+use "Option B: Build from source" in the quick start sections below.
+
 **Cluster requirements:**
 - Privileged pods must be allowed (nvml-mock DaemonSet uses `privileged: true` for `mknod`)
 - For DRA: Kubernetes 1.32+ with `DynamicResourceAllocation` feature gate enabled
@@ -47,6 +52,7 @@ kind create cluster --name nvml-mock-test
 **Option A: Use the published image (recommended)**
 
 ```bash
+docker pull ghcr.io/nvidia/nvml-mock:latest
 kind load docker-image ghcr.io/nvidia/nvml-mock:latest --name nvml-mock-test
 ```
 
@@ -130,6 +136,7 @@ This config enables:
 **Option A: Use the published image (recommended)**
 
 ```bash
+docker pull ghcr.io/nvidia/nvml-mock:latest
 kind load docker-image ghcr.io/nvidia/nvml-mock:latest --name nvml-mock-dra
 ```
 
@@ -255,6 +262,7 @@ sleep 5
 **Option A: Use the published image (recommended)**
 
 ```bash
+docker pull ghcr.io/nvidia/nvml-mock:latest
 kind load docker-image ghcr.io/nvidia/nvml-mock:latest --name nvml-mock-operator
 ```
 
@@ -333,6 +341,7 @@ This creates 1 control-plane + 2 workers. The workers are pre-labeled
 **Option A: Use the published image (recommended)**
 
 ```bash
+docker pull ghcr.io/nvidia/nvml-mock:latest
 kind load docker-image ghcr.io/nvidia/nvml-mock:latest --name gpu-fleet
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,8 @@ Linux system -- no hardware required.
 
 ```bash
 kind create cluster --name test
+docker pull ghcr.io/nvidia/nvml-mock:latest
+kind load docker-image ghcr.io/nvidia/nvml-mock:latest --name test
 helm install nvml-mock deployments/nvml-mock/helm/nvml-mock
 ```
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -274,6 +274,8 @@ jobs:
         run: go test ./... -tags=gpu -v
       
       - name: Verify nvidia-smi
+        # Requires nvidia-smi binary (self-hosted runner with NVIDIA drivers,
+        # or extract from container image)
         env:
           LD_LIBRARY_PATH: ./pkg/gpu/mocknvml
           MOCK_NVML_CONFIG: ./pkg/gpu/mocknvml/configs/mock-nvml-config-a100.yaml

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,8 @@ Get Mock NVML running in 5 minutes.
 - Linux (x86_64 or arm64)
 - Go 1.25+ with CGo
 - GCC toolchain (`build-essential` on Debian/Ubuntu)
-- `nvidia-smi` binary (from NVIDIA driver or CUDA toolkit)
+- `nvidia-smi` binary (optional -- only needed for local nvidia-smi output;
+  the Kubernetes deployment includes it automatically)
 
 ## Option 1: Local Build (Linux)
 
@@ -50,6 +51,10 @@ Build Linux binaries from macOS or other platforms:
 cd pkg/gpu/mocknvml
 make docker-build
 ```
+
+Build artifacts (shared libraries) are placed in `pkg/gpu/mocknvml/`:
+`libnvidia-ml.so`, `libnvidia-ml.so.1`, `libnvidia-ml.so.{version}`, and
+`nvidia-smi`.
 
 ## Verification
 
@@ -116,6 +121,7 @@ Deploy on a Kind cluster using the published container image:
 
 ```bash
 kind create cluster --name nvml-mock-test
+docker pull ghcr.io/nvidia/nvml-mock:latest
 kind load docker-image ghcr.io/nvidia/nvml-mock:latest --name nvml-mock-test
 helm install nvml-mock deployments/nvml-mock/helm/nvml-mock --wait --timeout 120s
 ```


### PR DESCRIPTION
## Summary

- Add missing `docker pull` before `kind load` across all quickstart docs
- Add GHCR image availability note to Helm chart README
- Fix nvidia-smi prerequisite (optional for local builds, included in K8s deployment)
- Add build artifacts location note for `make docker-build`
- Fix CI example to note nvidia-smi requirement

## Problem

A documentation blindfold test revealed that every "Option A: Use the published image" quickstart path was missing a `docker pull` step before `kind load docker-image`. `kind load` loads from the local Docker daemon — it does NOT pull from a registry. This silently fails for any new user.

## Files Changed

| File | Changes |
|------|---------|
| `README.md` | Add `docker pull` to root quickstart |
| `deployments/nvml-mock/helm/nvml-mock/README.md` | Add `docker pull` to 4 Option A sections + GHCR note |
| `docs/quickstart.md` | Fix nvidia-smi prereq + add `docker pull` + document build output |
| `docs/README.md` | Add missing `kind load` + `docker pull` to snippet |
| `docs/examples.md` | Note nvidia-smi CI requirement |

## Test Plan

- [x] Documentation-only changes — no code affected
- [x] All markdown syntax valid