### PR TITLE
docs: fix FGO schema, add missing configs, accuracy sweep

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -304,11 +304,13 @@ nvidia-smi                Bridge              Engine           Device
 pkg/gpu/mocknvml/
 ├── bridge/
 │   ├── cgo_types.go           # Shared CGo type definitions
-│   ├── helpers.go             # Helper functions + main()
+│   ├── helpers.go             # Helper functions + main() + go:generate
 │   ├── init.go                # nvmlInit_v2, nvmlShutdown, etc.
 │   ├── device.go              # Device handle functions
+│   ├── events.go              # Event set/wait functions
 │   ├── system.go              # System functions
 │   ├── internal.go            # Internal export table (nvidia-smi)
+│   ├── nvml_types.h           # C type definitions for CGo preamble
 │   └── stubs_generated.go     # Auto-generated stubs (~289 functions)
 ├── engine/
 │   ├── config.go              # Config loading
@@ -316,16 +318,25 @@ pkg/gpu/mocknvml/
 │   ├── device.go              # ConfigurableDevice
 │   ├── engine.go              # Singleton engine
 │   ├── handles.go             # Handle table
-│   └── utils.go               # Debug logging
+│   ├── invalid_device.go      # Invalid device handle sentinel
+│   ├── utils.go               # Debug logging
+│   ├── version.go             # NVML version responses
+│   └── *_test.go              # Unit tests
 ├── configs/
 │   ├── mock-nvml-config-a100.yaml
-│   └── mock-nvml-config-gb200.yaml
+│   ├── mock-nvml-config-b200.yaml
+│   ├── mock-nvml-config-gb200.yaml
+│   ├── mock-nvml-config-h100.yaml
+│   ├── mock-nvml-config-l40s.yaml
+│   └── mock-nvml-config-t4.yaml
 ├── Dockerfile
 ├── Makefile
 └── README.md
 
 cmd/generate-bridge/
-└── main.go                    # Stub generator
+├── main.go                    # Stub generator (--stats, --validate flags)
+├── parser.go                  # nvml.h prototype parser
+└── main_test.go               # Generator tests
 ```
 
 ## Thread Safety

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -347,15 +347,20 @@ nvlink:
       remote_pci_bus_id: "00000000:0F:00.0"
 ```
 
-## Complete Example: A100 Profile
+## Available GPU Profiles
 
-See `pkg/gpu/mocknvml/configs/mock-nvml-config-a100.yaml` for a complete
-A100 configuration with all 8 devices configured.
+Standalone configuration files are provided for each supported GPU model:
 
-## Complete Example: GB200 Profile
+| File | GPU Model | Memory | Architecture |
+|------|-----------|--------|--------------|
+| `pkg/gpu/mocknvml/configs/mock-nvml-config-a100.yaml` | NVIDIA A100-SXM4-40GB | 40 GiB | Ampere |
+| `pkg/gpu/mocknvml/configs/mock-nvml-config-h100.yaml` | NVIDIA H100 80GB HBM3 | 80 GiB | Hopper |
+| `pkg/gpu/mocknvml/configs/mock-nvml-config-b200.yaml` | NVIDIA B200 | 192 GiB | Blackwell |
+| `pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml` | NVIDIA GB200 NVL | 192 GiB | Blackwell |
+| `pkg/gpu/mocknvml/configs/mock-nvml-config-l40s.yaml` | NVIDIA L40S | 48 GiB | Ada Lovelace |
+| `pkg/gpu/mocknvml/configs/mock-nvml-config-t4.yaml` | NVIDIA T4 | 16 GiB | Turing |
 
-See `pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml` for a Blackwell
-GB200 configuration with 192 GiB HBM3e memory.
+Each file contains a complete configuration with all 8 devices configured.
 
 ## Integration Values
 
@@ -364,7 +369,7 @@ When deploying via Helm, additional values control integration with external pro
 | Key | Default | Description |
 |-----|---------|-------------|
 | `integrations.fakeGpuOperator.enabled` | `false` | Create per-profile ConfigMaps for fake-gpu-operator discovery |
-| `integrations.fakeGpuOperator.profileLabels` | `{"run.ai/gpu-profile": "true"}` | Discovery labels on profile ConfigMaps |
+| `integrations.fakeGpuOperator.profileLabels` | `run.ai/gpu-profile: "true"` | Discovery labels on profile ConfigMaps |
 
 See [fake-gpu-operator integration](integrations/fake-gpu-operator.md) for setup details.
 

--- a/docs/demo/with-fgo/README.md
+++ b/docs/demo/with-fgo/README.md
@@ -92,22 +92,15 @@ metadata:
   namespace: gpu-operator
 data:
   topology.yaml: |
-    nodeGroups:
-      - name: integration
+    nodePools:
+      integration:
         backend: mock
-        nodeSelector:
-          run.ai/simulated-gpu-node-pool: "integration"
         gpuCount: 8
-        gpuModel: NVIDIA H100 80GB HBM3
-        gpuMemory: 80Gi
-
-      - name: scale
+        gpuProfile: h100
+      scale:
         backend: fake
-        nodeSelector:
-          run.ai/simulated-gpu-node-pool: "scale"
         gpuCount: 8
-        gpuModel: NVIDIA H100 80GB HBM3
-        gpuMemory: 80Gi
+        gpuProfile: h100
 EOF
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,7 +34,9 @@ pkg/gpu/mocknvml/
 │   └── *_test.go              # Unit tests
 ├── configs/
 │   ├── mock-nvml-config-a100.yaml
+│   ├── mock-nvml-config-b200.yaml
 │   ├── mock-nvml-config-gb200.yaml
+│   ├── mock-nvml-config-h100.yaml
 │   ├── mock-nvml-config-l40s.yaml
 │   └── mock-nvml-config-t4.yaml
 ├── Dockerfile
@@ -47,7 +49,8 @@ cmd/generate-bridge/
 └── main_test.go               # Generator tests
 
 tests/mocknvml/
-├── main.go                    # Integration test
+├── bridge_tests.go            # Bridge-level integration tests
+├── main.go                    # Integration test (mini device plugin)
 ├── Dockerfile
 ├── Makefile
 └── README.md

--- a/docs/integrations/fake-gpu-operator.md
+++ b/docs/integrations/fake-gpu-operator.md
@@ -76,7 +76,7 @@ helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
 
 ### Step 2: Configure FGO Topology
 
-Create a topology ConfigMap that tells FGO which backend to use for each node group. Real nodes use `backend: mock` (served by nvml-mock), while KWOK virtual nodes use `backend: fake` (served by FGO).
+Create a topology ConfigMap that tells FGO which backend to use for each node pool. Real nodes use `backend: mock` (served by nvml-mock), while KWOK virtual nodes use `backend: fake` (served by FGO).
 
 ```yaml
 apiVersion: v1
@@ -86,23 +86,15 @@ metadata:
   namespace: gpu-operator
 data:
   topology.yaml: |
-    nodeGroups:
-      - name: mock-nodes
+    nodePools:
+      mock-nodes:
         backend: mock
-        nodeSelector:
-          nvidia.com/gpu-driver-mock: "true"
         gpuCount: 8
-        gpuModel: A100-SXM4-80GB
-        gpuMemory: 80Gi
-
-      - name: kwok-nodes
+        gpuProfile: a100
+      kwok-nodes:
         backend: fake
-        nodeSelector:
-          type: kwok
         gpuCount: 8
-        gpuModel: A100-SXM4-80GB
-        gpuMemory: 80Gi
-        nodeCount: 200
+        gpuProfile: a100
 ```
 
 ### Step 3: Verify

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -199,22 +199,6 @@ grep "nvmlDeviceGetXxx" pkg/gpu/mocknvml/bridge/stubs_generated.go
 
 ## Testing Issues
 
-### Tests Fail with "undefined"
-
-**Error**:
-```
-./device_test.go:XX: undefined: EnhancedDevice
-```
-
-**Solution**: Update test file to use `ConfigurableDevice`:
-```go
-// Old
-dev := &EnhancedDevice{...}
-
-// New
-dev := &ConfigurableDevice{...}
-```
-
 ### Integration Test Fails
 
 **Error**:

--- a/pkg/gpu/mocknvml/README.md
+++ b/pkg/gpu/mocknvml/README.md
@@ -77,7 +77,11 @@ config for consistency.
 YAML configs allow full control over GPU properties. See `configs/` for examples:
 
 - `mock-nvml-config-a100.yaml` - DGX A100 (8x A100-SXM4-40GB)
+- `mock-nvml-config-h100.yaml` - HGX H100 (8x H100 80GB HBM3)
+- `mock-nvml-config-b200.yaml` - B200 (8x B200, 192 GiB HBM3e)
 - `mock-nvml-config-gb200.yaml` - GB200 NVL (8x GB200 with 192 GiB HBM3e)
+- `mock-nvml-config-l40s.yaml` - L40S (8x L40S, 48 GiB)
+- `mock-nvml-config-t4.yaml` - T4 (8x T4, 16 GiB)
 
 #### Configuration Structure
 
@@ -175,7 +179,7 @@ $ MOCK_NVML_CONFIG=configs/mock-nvml-config-a100.yaml LD_LIBRARY_PATH=. nvidia-s
 ```
 $ MOCK_NVML_CONFIG=configs/mock-nvml-config-gb200.yaml LD_LIBRARY_PATH=. nvidia-smi
 +-----------------------------------------------------------------------------------------+
-| NVIDIA-SMI 550.163.01             Driver Version: 560.35.03      CUDA Version: 12.6     |
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
 |-----------------------------------------+------------------------+----------------------+
 | GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
 |=========================================+========================+======================|
@@ -240,11 +244,13 @@ $ MOCK_NVML_CONFIG=configs/mock-nvml-config-gb200.yaml LD_LIBRARY_PATH=. nvidia-
 pkg/gpu/mocknvml/
 ├── bridge/                        # CGo bridge layer
 │   ├── cgo_types.go               # Shared CGo type definitions
-│   ├── helpers.go                 # Helper functions + main()
+│   ├── helpers.go                 # Helper functions + main() + go:generate
 │   ├── init.go                    # Init/shutdown functions
 │   ├── device.go                  # Device handle functions
+│   ├── events.go                  # Event set/wait functions
 │   ├── system.go                  # System functions
 │   ├── internal.go                # Internal export table (nvidia-smi)
+│   ├── nvml_types.h               # C type definitions for CGo preamble
 │   └── stubs_generated.go         # Auto-generated stubs (~289 functions)
 ├── engine/
 │   ├── config.go                  # Configuration loading
@@ -252,19 +258,28 @@ pkg/gpu/mocknvml/
 │   ├── device.go                  # ConfigurableDevice implementation
 │   ├── engine.go                  # Main engine singleton
 │   ├── handles.go                 # C-compatible handle management
+│   ├── invalid_device.go          # Invalid device handle sentinel
 │   ├── utils.go                   # Debug logging utilities
+│   ├── version.go                 # NVML version responses
 │   └── *_test.go                  # Unit tests
 ├── configs/
 │   ├── mock-nvml-config-a100.yaml
-│   └── mock-nvml-config-gb200.yaml
+│   ├── mock-nvml-config-b200.yaml
+│   ├── mock-nvml-config-gb200.yaml
+│   ├── mock-nvml-config-h100.yaml
+│   ├── mock-nvml-config-l40s.yaml
+│   └── mock-nvml-config-t4.yaml
 ├── Dockerfile                     # Docker build environment
 ├── Makefile                       # Build automation
 └── README.md
 
 cmd/generate-bridge/
-└── main.go                        # Stub generator
+├── main.go                        # Stub generator (--stats, --validate flags)
+├── parser.go                      # nvml.h prototype parser
+└── main_test.go                   # Generator tests
 
 tests/mocknvml/
+├── bridge_tests.go                # Bridge-level integration tests
 ├── main.go                        # Integration test (mini device plugin)
 ├── Dockerfile                     # Test container
 ├── Makefile                       # Test automation
@@ -318,6 +333,7 @@ go generate
 # Or from repo root
 go run ./cmd/generate-bridge \
   -input vendor/github.com/NVIDIA/go-nvml/pkg/nvml/nvml.go \
+  -header vendor/github.com/NVIDIA/go-nvml/pkg/nvml/nvml.h \
   -bridge pkg/gpu/mocknvml/bridge \
   -output pkg/gpu/mocknvml/bridge/stubs_generated.go
 ```

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-b200.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-b200.yaml
@@ -1,0 +1,388 @@
+# Mock NVML Configuration: B200
+# Full configuration for nvidia-smi -x -q compatibility
+# Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
+
+version: "1.0"
+
+# =============================================================================
+# System-level configuration
+# =============================================================================
+system:
+  driver_version: "560.35.03"
+  nvml_version: "12.560.35.03"
+  cuda_version: "12.6"
+  cuda_version_major: 12
+  cuda_version_minor: 6
+
+# =============================================================================
+# Default device configuration (applied to all devices unless overridden)
+# =============================================================================
+device_defaults:
+  # ---------------------------------------------------------------------------
+  # Basic identification
+  # ---------------------------------------------------------------------------
+  name: "NVIDIA B200"
+  brand: "nvidia"
+  serial: "1562849203750"
+  board_part_number: "699-2G540-0200-000"
+  vbios_version: "96.00.A0.00.01"
+
+  # ---------------------------------------------------------------------------
+  # Architecture
+  # ---------------------------------------------------------------------------
+  architecture: "blackwell"
+  compute_capability:
+    major: 10
+    minor: 0
+  num_gpu_cores: 18432              # CUDA cores
+
+  # ---------------------------------------------------------------------------
+  # InfoROM versions
+  # ---------------------------------------------------------------------------
+  inforom:
+    image_version: "B200.0200.00.01"
+    oem_object: "2.1"
+    ecc_object: "7.16"
+    pwr_object: "1.0"
+
+  # ---------------------------------------------------------------------------
+  # Memory configuration - 192 GiB HBM3e
+  # ---------------------------------------------------------------------------
+  memory:
+    total_bytes: 206158430208       # 192 GiB HBM3e
+    reserved_bytes: 1073741824      # ~1 GiB reserved
+    free_bytes: 205084688384        # total - reserved at idle
+    used_bytes: 0
+    memory_bus_width: 8192
+
+  bar1_memory:
+    total_bytes: 274877906944       # 256 GiB (standalone B200, not 512 GiB like GB200)
+    free_bytes: 274877906944
+    used_bytes: 0
+
+  # ---------------------------------------------------------------------------
+  # PCI configuration
+  # ---------------------------------------------------------------------------
+  pci:
+    device_id: 0x234010DE           # B200 standalone
+    subsystem_id: 0x181810DE
+
+  pcie:
+    max_link_gen: 6                 # PCIe Gen6
+    current_link_gen: 6
+    max_link_width: 16              # x16
+    current_link_width: 16
+    replay_counter: 0
+    tx_throughput_kbps: 0
+    rx_throughput_kbps: 0
+
+  # ---------------------------------------------------------------------------
+  # Power configuration - 1000W TDP
+  # ---------------------------------------------------------------------------
+  power:
+    management_supported: true
+    management_mode: "enabled"
+    default_limit_mw: 1000000       # 1000W
+    enforced_limit_mw: 1000000
+    min_limit_mw: 400000            # 400W minimum
+    max_limit_mw: 1200000           # 1200W max
+    current_draw_mw: 130000         # 130W idle
+    power_state: "P0"
+    total_energy_consumption_mj: 900000  # millijoules since boot
+
+  # ---------------------------------------------------------------------------
+  # Thermal configuration
+  # ---------------------------------------------------------------------------
+  thermal:
+    temperature_gpu_c: 35           # Idle temperature
+    temperature_memory_c: 33
+    shutdown_threshold_c: 95
+    slowdown_threshold_c: 90
+    max_operating_c: 85
+    target_temperature_c: 85
+
+  # ---------------------------------------------------------------------------
+  # Fan configuration (N/A - liquid cooled)
+  # ---------------------------------------------------------------------------
+  fan:
+    count: 0                        # Liquid cooled, no fans
+    speed_percent: "N/A"
+    target_speed_percent: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Clock speeds (MHz) - Blackwell
+  # ---------------------------------------------------------------------------
+  clocks:
+    graphics_current: 345           # Idle
+    graphics_max: 2100
+    graphics_app: 2100
+    graphics_app_default: 2100
+    sm_current: 345
+    sm_max: 2100
+    memory_current: 2500            # HBM3e
+    memory_max: 2500
+    memory_app: 2500
+    memory_app_default: 2500
+    video_current: 1200
+    video_max: 2100
+
+  # ---------------------------------------------------------------------------
+  # Clocks throttle reasons
+  # ---------------------------------------------------------------------------
+  clocks_throttle_reasons:
+    gpu_idle: true
+    applications_clocks_setting: false
+    sw_power_cap: false
+    hw_slowdown: false
+    hw_thermal_slowdown: false
+    hw_power_brake_slowdown: false
+    sync_boost: false
+    sw_thermal_slowdown: false
+    display_clocks_setting: false
+
+  # ---------------------------------------------------------------------------
+  # Supported clocks
+  # ---------------------------------------------------------------------------
+  supported_clocks:
+    memory_clocks:
+      - freq_mhz: 2500
+        graphics_clocks: [345, 690, 1035, 1380, 1725, 1890, 2100]
+
+  # ---------------------------------------------------------------------------
+  # Performance state
+  # ---------------------------------------------------------------------------
+  performance_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Utilization (percentage, 0-100)
+  # ---------------------------------------------------------------------------
+  utilization:
+    gpu: 0
+    memory: 0
+    encoder: 0
+    decoder: 0
+    jpeg: 0
+    ofa: 0
+
+  # ---------------------------------------------------------------------------
+  # Encoder/Decoder statistics
+  # ---------------------------------------------------------------------------
+  encoder_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  fbc_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  # ---------------------------------------------------------------------------
+  # ECC configuration
+  # ---------------------------------------------------------------------------
+  ecc:
+    mode_current: "enabled"
+    mode_pending: "enabled"
+    default_mode: "enabled"
+    errors:
+      volatile:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+      aggregate:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+
+  # ---------------------------------------------------------------------------
+  # Retired pages
+  # ---------------------------------------------------------------------------
+  retired_pages:
+    single_bit_retirement:
+      count: 0
+      addresses: []
+    double_bit_retirement:
+      count: 0
+      addresses: []
+    pending_blacklist: false
+    pending_retirement: false
+
+  # ---------------------------------------------------------------------------
+  # Remapped rows
+  # ---------------------------------------------------------------------------
+  remapped_rows:
+    correctable: 0
+    uncorrectable: 0
+    pending: false
+    failure_occurred: false
+
+  # ---------------------------------------------------------------------------
+  # Display configuration
+  # ---------------------------------------------------------------------------
+  display:
+    mode: "disabled"
+    active: "disabled"
+
+  # ---------------------------------------------------------------------------
+  # Persistence mode
+  # ---------------------------------------------------------------------------
+  persistence_mode: "enabled"
+
+  # ---------------------------------------------------------------------------
+  # Compute mode
+  # ---------------------------------------------------------------------------
+  compute_mode: "default"
+
+  # ---------------------------------------------------------------------------
+  # MIG configuration
+  # ---------------------------------------------------------------------------
+  mig:
+    mode_current: "disabled"
+    mode_pending: "disabled"
+    max_gpu_instances: 7
+
+  # ---------------------------------------------------------------------------
+  # GPU operation mode (GOM)
+  # ---------------------------------------------------------------------------
+  gpu_operation_mode:
+    current: "all_on"
+    pending: "all_on"
+
+  # ---------------------------------------------------------------------------
+  # Driver model (Windows only)
+  # ---------------------------------------------------------------------------
+  driver_model:
+    current: "N/A"
+    pending: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Accounting mode
+  # ---------------------------------------------------------------------------
+  accounting:
+    mode: "disabled"
+    buffer_size: 4000
+
+  # ---------------------------------------------------------------------------
+  # Virtualization
+  # ---------------------------------------------------------------------------
+  virtualization:
+    mode: "none"
+    host_vgpu_mode: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # GSP Firmware
+  # ---------------------------------------------------------------------------
+  gsp_firmware:
+    mode: "enabled"
+    version: "560.35.03"
+
+  # ---------------------------------------------------------------------------
+  # Blackwell-specific features (standalone B200 - no NVLink-C2C)
+  # ---------------------------------------------------------------------------
+  features:
+    transformer_engine: true
+    fp4_support: true
+    fp8_support: true
+    confidential_compute: true
+    decompression_engine: true
+    fifth_gen_tensor_cores: true
+
+  # ---------------------------------------------------------------------------
+  # Processes (empty at idle)
+  # ---------------------------------------------------------------------------
+  processes: []
+
+# =============================================================================
+# Device-specific overrides (indexed 0-7 for B200)
+# =============================================================================
+devices:
+  - index: 0
+    uuid: "GPU-B200-0000-0000-0000-000000000000"
+    serial: "1562849203700"
+    pci:
+      bus_id: "00000000:1A:00.0"
+    minor_number: 0
+
+  - index: 1
+    uuid: "GPU-B200-0000-0000-0000-000000000001"
+    serial: "1562849203701"
+    pci:
+      bus_id: "00000000:1B:00.0"
+    minor_number: 1
+
+  - index: 2
+    uuid: "GPU-B200-0000-0000-0000-000000000002"
+    serial: "1562849203702"
+    pci:
+      bus_id: "00000000:4A:00.0"
+    minor_number: 2
+
+  - index: 3
+    uuid: "GPU-B200-0000-0000-0000-000000000003"
+    serial: "1562849203703"
+    pci:
+      bus_id: "00000000:4B:00.0"
+    minor_number: 3
+
+  - index: 4
+    uuid: "GPU-B200-0000-0000-0000-000000000004"
+    serial: "1562849203704"
+    pci:
+      bus_id: "00000000:8A:00.0"
+    minor_number: 4
+
+  - index: 5
+    uuid: "GPU-B200-0000-0000-0000-000000000005"
+    serial: "1562849203705"
+    pci:
+      bus_id: "00000000:8B:00.0"
+    minor_number: 5
+
+  - index: 6
+    uuid: "GPU-B200-0000-0000-0000-000000000006"
+    serial: "1562849203706"
+    pci:
+      bus_id: "00000000:CA:00.0"
+    minor_number: 6
+
+  - index: 7
+    uuid: "GPU-B200-0000-0000-0000-000000000007"
+    serial: "1562849203707"
+    pci:
+      bus_id: "00000000:CB:00.0"
+    minor_number: 7
+
+# =============================================================================
+# NVLink topology - B200 NVLink 5 (GPU-to-GPU only, no C2C)
+# =============================================================================
+nvlink:
+  version: 5
+  links_per_gpu: 18
+  bandwidth_per_link_gbps: 100      # 100 GB/s per link = 1.8 TB/s total per GPU
+  links:
+    - link: 0
+      state: "active"
+      remote_device_type: "gpu"
+      remote_pci_bus_id: "00000000:1B:00.0"

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-h100.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-h100.yaml
@@ -1,0 +1,385 @@
+# Mock NVML Configuration: HGX H100
+# Full configuration for nvidia-smi -x -q compatibility
+# Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
+
+version: "1.0"
+
+# =============================================================================
+# System-level configuration
+# =============================================================================
+system:
+  driver_version: "550.163.01"
+  nvml_version: "12.550.163.01"
+  cuda_version: "12.4"
+  cuda_version_major: 12
+  cuda_version_minor: 4
+
+# =============================================================================
+# Default device configuration (applied to all devices unless overridden)
+# =============================================================================
+device_defaults:
+  # ---------------------------------------------------------------------------
+  # Basic identification
+  # ---------------------------------------------------------------------------
+  name: "NVIDIA H100 80GB HBM3"
+  brand: "nvidia"
+  serial: "1562821083900"
+  board_part_number: "699-21010-0200-000"
+  vbios_version: "96.00.74.00.09"
+
+  # ---------------------------------------------------------------------------
+  # Architecture
+  # ---------------------------------------------------------------------------
+  architecture: "hopper"
+  compute_capability:
+    major: 9
+    minor: 0
+  num_gpu_cores: 16896              # CUDA cores
+
+  # ---------------------------------------------------------------------------
+  # InfoROM versions
+  # ---------------------------------------------------------------------------
+  inforom:
+    image_version: "H100.0200.00.04"
+    oem_object: "2.1"
+    ecc_object: "7.16"
+    pwr_object: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Memory configuration - 80 GiB HBM3
+  # ---------------------------------------------------------------------------
+  memory:
+    total_bytes: 85899345920        # 80 GiB HBM3
+    reserved_bytes: 1073741824      # ~1 GiB reserved
+    free_bytes: 84825604096         # total - reserved at idle
+    used_bytes: 0
+    memory_bus_width: 5120
+
+  bar1_memory:
+    total_bytes: 274877906944       # 256 GiB
+    free_bytes: 274877906944
+    used_bytes: 0
+
+  # ---------------------------------------------------------------------------
+  # PCI configuration
+  # ---------------------------------------------------------------------------
+  pci:
+    device_id: 0x233010DE           # H100 SXM 80GB
+    subsystem_id: 0x165810DE
+
+  pcie:
+    max_link_gen: 5                 # PCIe Gen5
+    current_link_gen: 5
+    max_link_width: 16              # x16
+    current_link_width: 16
+    replay_counter: 0
+    tx_throughput_kbps: 0
+    rx_throughput_kbps: 0
+
+  # ---------------------------------------------------------------------------
+  # Power configuration - 700W TDP
+  # ---------------------------------------------------------------------------
+  power:
+    management_supported: true
+    management_mode: "enabled"
+    default_limit_mw: 700000         # 700W
+    enforced_limit_mw: 700000
+    min_limit_mw: 200000            # 200W minimum
+    max_limit_mw: 700000            # 700W max
+    current_draw_mw: 95000          # 95W idle
+    power_state: "P0"
+    total_energy_consumption_mj: 600000  # millijoules since boot
+
+  # ---------------------------------------------------------------------------
+  # Thermal configuration
+  # ---------------------------------------------------------------------------
+  thermal:
+    temperature_gpu_c: 34           # Idle temperature
+    temperature_memory_c: 32
+    shutdown_threshold_c: 92
+    slowdown_threshold_c: 87
+    max_operating_c: 83
+    target_temperature_c: 83
+
+  # ---------------------------------------------------------------------------
+  # Fan configuration (N/A for SXM form factor)
+  # ---------------------------------------------------------------------------
+  fan:
+    count: 0                        # SXM has no fans (liquid cooled)
+    speed_percent: "N/A"
+    target_speed_percent: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Clock speeds (MHz)
+  # ---------------------------------------------------------------------------
+  clocks:
+    graphics_current: 345           # Idle
+    graphics_max: 1980
+    graphics_app: 1980
+    graphics_app_default: 1980
+    sm_current: 345
+    sm_max: 1980
+    memory_current: 1593            # HBM3
+    memory_max: 1593
+    memory_app: 1593
+    memory_app_default: 1593
+    video_current: 345
+    video_max: 1980
+
+  # ---------------------------------------------------------------------------
+  # Clocks throttle reasons
+  # ---------------------------------------------------------------------------
+  clocks_throttle_reasons:
+    gpu_idle: true
+    applications_clocks_setting: false
+    sw_power_cap: false
+    hw_slowdown: false
+    hw_thermal_slowdown: false
+    hw_power_brake_slowdown: false
+    sync_boost: false
+    sw_thermal_slowdown: false
+    display_clocks_setting: false
+
+  # ---------------------------------------------------------------------------
+  # Supported clocks (for nvidia-smi -q -d SUPPORTED_CLOCKS)
+  # ---------------------------------------------------------------------------
+  supported_clocks:
+    memory_clocks:
+      - freq_mhz: 1593
+        graphics_clocks: [345, 690, 1035, 1380, 1620, 1800, 1980]
+
+  # ---------------------------------------------------------------------------
+  # Performance state
+  # ---------------------------------------------------------------------------
+  performance_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Utilization (percentage, 0-100)
+  # ---------------------------------------------------------------------------
+  utilization:
+    gpu: 0
+    memory: 0
+    encoder: 0
+    decoder: 0
+    jpeg: 0
+    ofa: 0
+
+  # ---------------------------------------------------------------------------
+  # Encoder/Decoder statistics
+  # ---------------------------------------------------------------------------
+  encoder_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  fbc_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  # ---------------------------------------------------------------------------
+  # ECC configuration
+  # ---------------------------------------------------------------------------
+  ecc:
+    mode_current: "enabled"
+    mode_pending: "enabled"
+    default_mode: "enabled"
+    errors:
+      volatile:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+      aggregate:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+
+  # ---------------------------------------------------------------------------
+  # Retired pages
+  # ---------------------------------------------------------------------------
+  retired_pages:
+    single_bit_retirement:
+      count: 0
+      addresses: []
+    double_bit_retirement:
+      count: 0
+      addresses: []
+    pending_blacklist: false
+    pending_retirement: false
+
+  # ---------------------------------------------------------------------------
+  # Remapped rows
+  # ---------------------------------------------------------------------------
+  remapped_rows:
+    correctable: 0
+    uncorrectable: 0
+    pending: false
+    failure_occurred: false
+
+  # ---------------------------------------------------------------------------
+  # Display configuration
+  # ---------------------------------------------------------------------------
+  display:
+    mode: "disabled"
+    active: "disabled"
+
+  # ---------------------------------------------------------------------------
+  # Persistence mode
+  # ---------------------------------------------------------------------------
+  persistence_mode: "enabled"
+
+  # ---------------------------------------------------------------------------
+  # Compute mode
+  # ---------------------------------------------------------------------------
+  compute_mode: "default"
+
+  # ---------------------------------------------------------------------------
+  # MIG configuration
+  # ---------------------------------------------------------------------------
+  mig:
+    mode_current: "disabled"
+    mode_pending: "disabled"
+    max_gpu_instances: 7
+
+  # ---------------------------------------------------------------------------
+  # GPU operation mode (GOM)
+  # ---------------------------------------------------------------------------
+  gpu_operation_mode:
+    current: "all_on"
+    pending: "all_on"
+
+  # ---------------------------------------------------------------------------
+  # Driver model (Windows only)
+  # ---------------------------------------------------------------------------
+  driver_model:
+    current: "N/A"
+    pending: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Accounting mode
+  # ---------------------------------------------------------------------------
+  accounting:
+    mode: "disabled"
+    buffer_size: 4000
+
+  # ---------------------------------------------------------------------------
+  # Virtualization
+  # ---------------------------------------------------------------------------
+  virtualization:
+    mode: "none"
+    host_vgpu_mode: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # GSP Firmware
+  # ---------------------------------------------------------------------------
+  gsp_firmware:
+    mode: "enabled"
+    version: "550.163.01"
+
+  # ---------------------------------------------------------------------------
+  # Hopper-specific features
+  # ---------------------------------------------------------------------------
+  features:
+    transformer_engine: true
+    fp8_support: true
+    confidential_compute: true
+
+  # ---------------------------------------------------------------------------
+  # Processes (empty at idle)
+  # ---------------------------------------------------------------------------
+  processes: []
+
+# =============================================================================
+# Device-specific overrides (indexed 0-7 for HGX H100)
+# =============================================================================
+devices:
+  - index: 0
+    uuid: "GPU-H100-0000-0000-0000-000000000000"
+    serial: "1562821083900"
+    pci:
+      bus_id: "00000000:1A:00.0"
+    minor_number: 0
+
+  - index: 1
+    uuid: "GPU-H100-0000-0000-0000-000000000001"
+    serial: "1562821083901"
+    pci:
+      bus_id: "00000000:1B:00.0"
+    minor_number: 1
+
+  - index: 2
+    uuid: "GPU-H100-0000-0000-0000-000000000002"
+    serial: "1562821083902"
+    pci:
+      bus_id: "00000000:4A:00.0"
+    minor_number: 2
+
+  - index: 3
+    uuid: "GPU-H100-0000-0000-0000-000000000003"
+    serial: "1562821083903"
+    pci:
+      bus_id: "00000000:4B:00.0"
+    minor_number: 3
+
+  - index: 4
+    uuid: "GPU-H100-0000-0000-0000-000000000004"
+    serial: "1562821083904"
+    pci:
+      bus_id: "00000000:8A:00.0"
+    minor_number: 4
+
+  - index: 5
+    uuid: "GPU-H100-0000-0000-0000-000000000005"
+    serial: "1562821083905"
+    pci:
+      bus_id: "00000000:8B:00.0"
+    minor_number: 5
+
+  - index: 6
+    uuid: "GPU-H100-0000-0000-0000-000000000006"
+    serial: "1562821083906"
+    pci:
+      bus_id: "00000000:CA:00.0"
+    minor_number: 6
+
+  - index: 7
+    uuid: "GPU-H100-0000-0000-0000-000000000007"
+    serial: "1562821083907"
+    pci:
+      bus_id: "00000000:CB:00.0"
+    minor_number: 7
+
+# =============================================================================
+# NVLink topology - H100 NVLink 4
+# =============================================================================
+nvlink:
+  version: 4
+  links_per_gpu: 18
+  bandwidth_per_link_gbps: 50       # 50 GB/s per link = 900 GB/s total per GPU
+  links:
+    - link: 0
+      state: "active"
+      remote_device_type: "gpu"
+      remote_pci_bus_id: "00000000:1B:00.0"


### PR DESCRIPTION
## Summary

- Correct fake-gpu-operator topology schema (`nodeGroups` array → `nodePools` map)
- Add standalone h100 and b200 config files (were in Helm profiles but missing from `pkg/gpu/mocknvml/configs/`)
- Fix file structure listings in architecture.md and development.md
- Fix GB200 nvidia-smi version inconsistency
- Update configuration.md with all 6 available profiles
- Remove stale troubleshooting reference
- Fix generator flag inconsistency

## Problem

A documentation blindfold test revealed the FGO integration guide used the wrong topology ConfigMap schema (`nodeGroups` array with `gpuModel`/`gpuMemory` fields instead of the correct `nodePools` map with `gpuProfile`). Additionally, h100 and b200 standalone config files were missing, and several docs had inaccurate file listings and inconsistent example outputs.

## Files Changed

| File | Changes |
|------|---------|
| `docs/integrations/fake-gpu-operator.md` | Fix topology schema to `nodePools` map format |
| `docs/demo/with-fgo/README.md` | Add namespace, fix topology format |
| `pkg/gpu/mocknvml/configs/mock-nvml-config-h100.yaml` | New file (from Helm profile) |
| `pkg/gpu/mocknvml/configs/mock-nvml-config-b200.yaml` | New file (from Helm profile) |
| `docs/configuration.md` | Add all 6 profiles, fix syntax |
| `docs/architecture.md` | Fix file structure listings |
| `docs/development.md` | Fix file structure listings |
| `pkg/gpu/mocknvml/README.md` | Fix GB200 version, generator flag, file listings |
| `docs/troubleshooting.md` | Remove stale EnhancedDevice reference |

## Test Plan

- [x] New YAML config files match Helm profile format
- [x] FGO schema matches upstream fake-gpu-operator API
- [x] Documentation-only changes (except 2 new config files)