### PR TITLE
fix: disable sbom-action dependency snapshot upload

### DIFF
--- a/.github/workflows/nvml-mock-publish.yaml
+++ b/.github/workflows/nvml-mock-publish.yaml
@@ -87,6 +87,8 @@ jobs:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: spdx-json
           output-file: sbom.spdx.json
+          upload-artifact: false
+          dependency-snapshot: false
 
       - name: Attach SBOM to image
         run: |


### PR DESCRIPTION
## Problem

The `nvml-mock Publish` workflow fails on tag pushes with:
```
Resource not accessible by integration
```

The `anchore/sbom-action` v0.24.0 (bumped in #291) defaults to uploading a dependency snapshot to the GitHub API, which requires `contents: write`. The publish job only has `contents: read`.

Branch pushes succeed because they don't trigger the snapshot upload path.

## Fix

Add `upload-artifact: false` and `dependency-snapshot: false` to the sbom-action step. We only need the SBOM file for cosign attestation.