### PR TITLE
chore: remove klueska from CODEOWNERS and OWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,16 +2,16 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owners for everything
-* @ArangoGutierrez @klueska
+* @ArangoGutierrez
 
 # Mock NVML library
 /pkg/gpu/mocknvml/ @ArangoGutierrez
 
 # Helm chart
-/deployments/nvml-mock/ @ArangoGutierrez @klueska
+/deployments/nvml-mock/ @ArangoGutierrez
 
 # CI workflows
-/.github/workflows/ @ArangoGutierrez @klueska
+/.github/workflows/ @ArangoGutierrez
 
 # E2E tests
-/tests/e2e/ @ArangoGutierrez @klueska
+/tests/e2e/ @ArangoGutierrez

--- a/OWNERS
+++ b/OWNERS
@@ -2,9 +2,7 @@
 
 reviewers:
   - ArangoGutierrez
-  - kklues
   - elezar
 approvers:
   - ArangoGutierrez
-  - kklues
   - elezar


### PR DESCRIPTION
## What This PR Does

Removes klueska from `.github/CODEOWNERS` and `OWNERS` — klueska is no longer a project maintainer and owner.

## Why

Same pattern as #308 (elezar removal from CODEOWNERS), extended to also clean up the `OWNERS` file.

## Files Changed

- `.github/CODEOWNERS` — removed `@klueska` from all sections
- `OWNERS` — removed `kklues` from reviewers and approvers lists