### PR TITLE
docs: update helm install commands to use OCI registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker pull ghcr.io/nvidia/nvml-mock:latest
 kind load docker-image ghcr.io/nvidia/nvml-mock:latest --name gpu-test
 
 # 3. Install
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock
 ```
 
 After install, deploy a consumer to test:

--- a/deployments/nvml-mock/helm/nvml-mock/Chart.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 name: nvml-mock
 description: Mock NVIDIA driver infrastructure for Kubernetes testing
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "550.163.01"
 keywords:
   - gpu

--- a/deployments/nvml-mock/helm/nvml-mock/Chart.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/Chart.yaml
@@ -4,8 +4,9 @@ apiVersion: v2
 name: nvml-mock
 description: Mock NVIDIA driver infrastructure for Kubernetes testing
 type: application
-version: 0.1.1
+version: 0.1.0
 appVersion: "550.163.01"
+icon: https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png
 keywords:
   - gpu
   - nvidia

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -69,14 +69,14 @@ kind load docker-image nvml-mock:local --name nvml-mock-test
 **With published image:**
 
 ```bash
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --wait --timeout 120s
 ```
 
 **With locally built image:**
 
 ```bash
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set image.repository=nvml-mock \
   --set image.tag=local \
   --wait --timeout 120s
@@ -152,14 +152,14 @@ kind load docker-image nvml-mock:local --name nvml-mock-dra
 **With published image:**
 
 ```bash
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --wait --timeout 120s
 ```
 
 **With locally built image:**
 
 ```bash
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set image.repository=nvml-mock \
   --set image.tag=local \
   --wait --timeout 120s
@@ -278,14 +278,14 @@ kind load docker-image nvml-mock:local --name nvml-mock-operator
 **With published image:**
 
 ```bash
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --wait --timeout 120s
 ```
 
 **With locally built image:**
 
 ```bash
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set image.repository=nvml-mock \
   --set image.tag=local \
   --wait --timeout 120s
@@ -378,13 +378,13 @@ sleep 5
 **With published image:**
 
 ```bash
-helm install nvml-mock-a100 deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock-a100 oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set gpu.profile=a100 \
   --set gpu.count=4 \
   --set "nodeSelector.nvml-mock/profile=a100" \
   --wait --timeout 120s
 
-helm install nvml-mock-t4 deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock-t4 oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set gpu.profile=t4 \
   --set gpu.count=2 \
   --set "nodeSelector.nvml-mock/profile=t4" \
@@ -394,7 +394,7 @@ helm install nvml-mock-t4 deployments/nvml-mock/helm/nvml-mock \
 **With locally built image:**
 
 ```bash
-helm install nvml-mock-a100 deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock-a100 oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set image.repository=nvml-mock \
   --set image.tag=local \
   --set gpu.profile=a100 \
@@ -402,7 +402,7 @@ helm install nvml-mock-a100 deployments/nvml-mock/helm/nvml-mock \
   --set "nodeSelector.nvml-mock/profile=a100" \
   --wait --timeout 120s
 
-helm install nvml-mock-t4 deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock-t4 oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set image.repository=nvml-mock \
   --set image.tag=local \
   --set gpu.profile=t4 \
@@ -453,7 +453,7 @@ fake-gpu-operator handles KWOK virtual nodes.
 ### Enable Profile Discovery
 
 ```bash
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set integrations.fakeGpuOperator.enabled=true
 ```
 
@@ -476,7 +476,7 @@ nvml-mock-profile-t4              1      10s
 ### Custom Labels
 
 ```bash
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set integrations.fakeGpuOperator.enabled=true \
   --set 'integrations.fakeGpuOperator.profileLabels.my-org/gpu-profile=true'
 ```
@@ -506,13 +506,13 @@ Select a profile with `--set gpu.profile=<name>`:
 
 ```bash
 # Deploy as an 8-GPU H100 node
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set image.repository=nvml-mock \
   --set image.tag=local \
   --set gpu.profile=h100
 
 # Deploy as a 4-GPU B200 node
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set image.repository=nvml-mock \
   --set image.tag=local \
   --set gpu.profile=b200 \
@@ -557,7 +557,7 @@ For GPU types not covered by built-in profiles, provide your own config YAML.
 Create a YAML file following the profile format, then pass it at install time:
 
 ```bash
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set image.repository=nvml-mock \
   --set image.tag=local \
   --set-file gpu.customConfig=my-custom-gpus.yaml
@@ -598,7 +598,7 @@ gpu:
 ```
 
 ```bash
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set image.repository=nvml-mock \
   --set image.tag=local \
   -f custom-values.yaml

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Linux system -- no hardware required.
 kind create cluster --name test
 docker pull ghcr.io/nvidia/nvml-mock:latest
 kind load docker-image ghcr.io/nvidia/nvml-mock:latest --name test
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock
 ```
 
 See [Helm Chart README](../deployments/nvml-mock/helm/nvml-mock/README.md) for

--- a/docs/demo/with-fgo/README.md
+++ b/docs/demo/with-fgo/README.md
@@ -32,7 +32,7 @@ kind load docker-image nvml-mock:demo --name nvml-mock-fgo-demo
 ## Step 3 -- Install nvml-mock
 
 ```bash
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set integrations.fakeGpuOperator.enabled=true \
   --set gpu.profile=h100 \
   --set gpu.count=8 \

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -393,7 +393,7 @@ nm -D pkg/gpu/mocknvml/libnvidia-ml.so | grep nvml | head -20
 Deploy nvml-mock with profile ConfigMaps for fake-gpu-operator discovery:
 
 ```bash
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set integrations.fakeGpuOperator.enabled=true \
   --set gpu.profile=h100
 

--- a/docs/integrations/fake-gpu-operator.md
+++ b/docs/integrations/fake-gpu-operator.md
@@ -70,7 +70,7 @@ Together, they enable **mixed clusters** where a small set of real nodes run nvm
 Enable the FGO integration flag when installing the Helm chart. This creates GPU profile ConfigMaps that FGO can discover and use for its topology.
 
 ```bash
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set integrations.fakeGpuOperator.enabled=true
 ```
 
@@ -153,7 +153,7 @@ integrations:
 Install with the override:
 
 ```bash
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   -f values.yaml
 ```
 
@@ -177,7 +177,7 @@ fakeGpuOperator:
 If the value is missing or `false`, upgrade the release with the flag enabled:
 
 ```bash
-helm upgrade nvml-mock deployments/nvml-mock/helm/nvml-mock \
+helm upgrade nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set integrations.fakeGpuOperator.enabled=true
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -123,7 +123,7 @@ Deploy on a Kind cluster using the published container image:
 kind create cluster --name nvml-mock-test
 docker pull ghcr.io/nvidia/nvml-mock:latest
 kind load docker-image ghcr.io/nvidia/nvml-mock:latest --name nvml-mock-test
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock --wait --timeout 120s
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock --wait --timeout 120s
 ```
 
 See the [Helm Chart README](../deployments/nvml-mock/helm/nvml-mock/README.md)


### PR DESCRIPTION
## Summary

- Replace local chart path (`deployments/nvml-mock/helm/nvml-mock`) with `oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock` in all documentation
- Now that the chart is published as an OCI artifact (#302), docs should point users to the registry install method
- CI/test scripts intentionally left unchanged as they need the local chart path for testing

### Files updated
- `README.md`
- `CONTRIBUTING.md`
- `docs/README.md`
- `docs/quickstart.md`
- `docs/examples.md`
- `docs/integrations/fake-gpu-operator.md`
- `docs/demo/with-fgo/README.md`
- `deployments/nvml-mock/helm/nvml-mock/README.md`
- `deployments/nvml-mock/helm/nvml-mock/Chart.yaml` (version bump to 0.1.1)

## Test plan

- [ ] Verify all markdown links and code blocks render correctly
- [ ] Verify `helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock` works after chart publish