### PR TITLE
feat(nvml-mock): add InfiniBand sysfs mock

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
       - name: Install helm-unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v1.0.3 # 6f82a998e0b5461762ca959f87f5dd344af5e4eb
+        run: helm plugin install --verify=false https://github.com/helm-unittest/helm-unittest.git --version v1.0.3 # 6f82a998e0b5461762ca959f87f5dd344af5e4eb
 
       - name: Run helm unittest
         run: helm unittest ${{ env.CHART_DIR }}/${{ env.CHART_NAME }}

--- a/.github/workflows/nvml-mock-e2e.yaml
+++ b/.github/workflows/nvml-mock-e2e.yaml
@@ -130,6 +130,15 @@ jobs:
             "${{ steps.gpu-info.outputs.gpu-name }}" \
             2
 
+      - name: Validate ibstat / ibstatus (InfiniBand mock)
+        run: |
+          chmod +x tests/e2e/validate-ibstat.sh
+          POD=$(kubectl get pods -l app.kubernetes.io/name=nvml-mock \
+            -o jsonpath='{.items[0].metadata.name}')
+          # gpu.count=2 in this job; profiles ship hcas_per_gpu=1, so
+          # IB-enabled profiles are expected to expose 2 HCAs.
+          ./tests/e2e/validate-ibstat.sh "$POD" "${{ matrix.gpu-profile }}" 2
+
       - name: Deploy NVIDIA device plugin
         run: |
           kubectl apply -f tests/e2e/device-plugin-mock.yaml
@@ -703,6 +712,18 @@ jobs:
           echo "=== Worker-2 (T4) ==="
           docker exec "${{ steps.nodes.outputs.worker2 }}" ls -la /var/lib/nvml-mock/driver/usr/lib64/libnvidia-ml.so.* | head -2
           docker exec "${{ steps.nodes.outputs.worker2 }}" grep "NVIDIA T4" /var/lib/nvml-mock/config/config.yaml | head -1
+
+      - name: Validate ibstat / ibstatus on both workers
+        run: |
+          chmod +x tests/e2e/validate-ibstat.sh
+          # A100 release: IB enabled, expect gpu.count=2 HCAs.
+          A100_POD=$(kubectl get pods -l app.kubernetes.io/instance=nvml-mock-a100 \
+            -o jsonpath='{.items[0].metadata.name}')
+          ./tests/e2e/validate-ibstat.sh "$A100_POD" a100 2
+          # T4 release: IB disabled by default, expect zero HCAs.
+          T4_POD=$(kubectl get pods -l app.kubernetes.io/instance=nvml-mock-t4 \
+            -o jsonpath='{.items[0].metadata.name}')
+          ./tests/e2e/validate-ibstat.sh "$T4_POD" t4 2
 
       - name: Deploy NVIDIA device plugin
         run: |

--- a/.github/workflows/nvml-mock-e2e.yaml
+++ b/.github/workflows/nvml-mock-e2e.yaml
@@ -131,6 +131,15 @@ jobs:
             "${{ steps.gpu-info.outputs.gpu-name }}" \
             2
 
+      - name: Validate ibstat / ibstatus (InfiniBand mock)
+        run: |
+          chmod +x tests/e2e/validate-ibstat.sh
+          POD=$(kubectl get pods -l app.kubernetes.io/name=nvml-mock \
+            -o jsonpath='{.items[0].metadata.name}')
+          # gpu.count=2 in this job; profiles ship hcas_per_gpu=1, so
+          # IB-enabled profiles are expected to expose 2 HCAs.
+          ./tests/e2e/validate-ibstat.sh "$POD" "${{ matrix.gpu-profile }}" 2
+
       - name: Deploy NVIDIA device plugin
         run: |
           kubectl apply -f tests/e2e/device-plugin-mock.yaml
@@ -756,6 +765,18 @@ jobs:
           echo "=== Worker-2 (T4) ==="
           docker exec "${{ steps.nodes.outputs.worker2 }}" ls -la /var/lib/nvml-mock/driver/usr/lib64/libnvidia-ml.so.* | head -2
           docker exec "${{ steps.nodes.outputs.worker2 }}" grep "NVIDIA T4" /var/lib/nvml-mock/config/config.yaml | head -1
+
+      - name: Validate ibstat / ibstatus on both workers
+        run: |
+          chmod +x tests/e2e/validate-ibstat.sh
+          # A100 release: IB enabled, expect gpu.count=2 HCAs.
+          A100_POD=$(kubectl get pods -l app.kubernetes.io/instance=nvml-mock-a100 \
+            -o jsonpath='{.items[0].metadata.name}')
+          ./tests/e2e/validate-ibstat.sh "$A100_POD" a100 2
+          # T4 release: IB disabled by default, expect zero HCAs.
+          T4_POD=$(kubectl get pods -l app.kubernetes.io/instance=nvml-mock-t4 \
+            -o jsonpath='{.items[0].metadata.name}')
+          ./tests/e2e/validate-ibstat.sh "$T4_POD" t4 2
 
       - name: Deploy NVIDIA device plugin
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- InfiniBand mock: real `ibstat`, `ibstatus`, `iblinkinfo`, and other
+  `infiniband-diags` / `rdma-core` tools now work inside the nvml-mock
+  DaemonSet without IB hardware. Implementation: `LD_PRELOAD` shim
+  (`libibmocksys.so`) redirects libc filesystem accesses against
+  `/sys/class/infiniband*` and `/dev/infiniband` to a fake tree rendered
+  at startup by `render-ib-sysfs` from each profile's new `infiniband:`
+  block. Defaults: `a100` -> ConnectX-6 HDR; `h100` / `b200` / `gb200`
+  -> ConnectX-7 NDR; `l40s` / `t4` -> disabled.
+
 ## [0.1.0] - 2026-04-07
 
 ### Added

--- a/cmd/render-ib-sysfs/main.go
+++ b/cmd/render-ib-sysfs/main.go
@@ -1,0 +1,75 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// Command render-ib-sysfs reads the `infiniband:` block from a mock-nvml
+// profile YAML and writes a fake InfiniBand sysfs tree under --output.
+//
+// Pair with libibmocksys.so (LD_PRELOAD) so that real userspace tooling
+// (ibstat, ibstatus, iblinkinfo, libibverbs consumers, ...) reads from the
+// rendered tree instead of /sys directly.
+//
+// Usage:
+//
+//	render-ib-sysfs \
+//	    --config /config/config.yaml \
+//	    --gpu-count "$GPU_COUNT" \
+//	    --node-name "$NODE_NAME" \
+//	    --output /var/lib/nvml-mock
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockibsysfs/config"
+	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockibsysfs/render"
+)
+
+func main() {
+	var (
+		cfgPath   = flag.String("config", "", "path to mock-nvml profile YAML containing an `infiniband:` block")
+		gpuCount  = flag.Int("gpu-count", 0, "number of GPUs (used with hcas_per_gpu when hca_count is unset)")
+		nodeName  = flag.String("node-name", "", "node name (expanded into node_desc_template)")
+		outDir    = flag.String("output", "", "fake-root directory; tree is written under <output>/sys/class/...")
+		printOnly = flag.Bool("dry-run", false, "validate the config and exit without writing files")
+	)
+	flag.Parse()
+
+	if *cfgPath == "" || *outDir == "" {
+		fmt.Fprintln(os.Stderr, "usage: render-ib-sysfs --config <yaml> --output <dir> [--gpu-count N] [--node-name NAME] [--dry-run]")
+		os.Exit(2)
+	}
+
+	data, err := os.ReadFile(*cfgPath)
+	if err != nil {
+		fatalf("read config: %v", err)
+	}
+	var prof config.Profile
+	if err := yaml.Unmarshal(data, &prof); err != nil {
+		fatalf("parse config: %v", err)
+	}
+	if !prof.Infiniband.Enabled {
+		fmt.Fprintf(os.Stderr, "infiniband.enabled=false in %s, nothing to render\n", *cfgPath)
+		return
+	}
+	if *printOnly {
+		fmt.Fprintf(os.Stderr, "infiniband config OK: %+v\n", prof.Infiniband.Defaults())
+		return
+	}
+	if err := render.Render(render.Options{
+		IB:       prof.Infiniband,
+		GPUCount: *gpuCount,
+		NodeName: *nodeName,
+		Output:   *outDir,
+	}); err != nil {
+		fatalf("render: %v", err)
+	}
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "render-ib-sysfs: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/deployments/nvml-mock/Dockerfile
+++ b/deployments/nvml-mock/Dockerfile
@@ -19,17 +19,24 @@ COPY go.mod go.sum ./
 COPY vendor/ vendor/
 COPY pkg/gpu/mocknvml/ pkg/gpu/mocknvml/
 COPY pkg/gpu/mockcuda/ pkg/gpu/mockcuda/
+COPY pkg/network/mockibsysfs/ pkg/network/mockibsysfs/
+COPY cmd/render-ib-sysfs/ cmd/render-ib-sysfs/
 RUN cd pkg/gpu/mocknvml && make clean && make
 RUN cd pkg/gpu/mockcuda && make clean && make
+RUN cd pkg/network/mockibsysfs && make clean && make
+RUN mkdir -p /out && go build -mod=vendor -o /out/render-ib-sysfs ./cmd/render-ib-sysfs
 
 FROM debian:bookworm-slim
 ARG KUBECTL_VERSION=v1.32.0
 ARG TARGETARCH
 COPY --from=builder /src/pkg/gpu/mocknvml/libnvidia-ml.so.* /usr/local/lib/
 COPY --from=builder /src/pkg/gpu/mockcuda/libcuda.so.* /usr/local/lib/
+COPY --from=builder /src/pkg/network/mockibsysfs/libibmocksys.so.* /usr/local/lib/
+COPY --from=builder /out/render-ib-sysfs /usr/local/bin/render-ib-sysfs
 RUN set -eux; \
     apt-get update; \
-    apt-get install -y --no-install-recommends curl ca-certificates gnupg2; \
+    apt-get install -y --no-install-recommends curl ca-certificates gnupg2 \
+        infiniband-diags rdma-core; \
     rm -rf /var/lib/apt/lists/*; \
     curl -fsSLo /usr/local/bin/kubectl \
       "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl"; \

--- a/deployments/nvml-mock/helm/nvml-mock/Chart.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/Chart.yaml
@@ -6,6 +6,11 @@ description: Mock NVIDIA driver infrastructure for Kubernetes testing
 type: application
 version: 0.1.0
 appVersion: "550.163.01"
+# Minimum kubernetes version. Mounting the same hostPath volume at two
+# different mountPaths in one container (used by daemonset.yaml for the
+# IB sysfs mock) has been supported since the dawn of kubernetes, but
+# pin a conservative floor for predictable CI runs.
+kubeVersion: ">= 1.28.0-0"
 icon: https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png
 keywords:
   - gpu

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -11,6 +11,9 @@ Deploys a DaemonSet that creates on every node:
 - Device nodes (`/dev/nvidia0`, `/dev/nvidia1`, ..., `/dev/nvidiactl`)
 - GPU configuration at `/var/lib/nvml-mock/driver/config/config.yaml`
 - Node label `nvidia.com/gpu.present=true`
+- A fake InfiniBand sysfs tree at `/var/lib/nvml-mock/ib/sys/class/infiniband/...`
+  paired with `libibmocksys.so` (`LD_PRELOAD`) so real `ibstat`, `ibstatus`,
+  `iblinkinfo`, ... read mock HCAs
 
 Consumers (DRA driver, device plugin) point at `/var/lib/nvml-mock/driver`
 as the NVIDIA driver root and discover GPUs through standard NVML APIs.
@@ -480,6 +483,63 @@ helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set integrations.fakeGpuOperator.enabled=true \
   --set 'integrations.fakeGpuOperator.profileLabels.my-org/gpu-profile=true'
 ```
+
+## InfiniBand mocking
+
+Each profile carries an `infiniband:` block alongside the GPU config. When the
+DaemonSet starts, `render-ib-sysfs` reads it and writes a fake sysfs tree at
+`/var/lib/nvml-mock/ib/sys/class/infiniband/...`. Inside the container, the
+`LD_PRELOAD` shim `libibmocksys.so` rewrites every access to
+`/sys/class/infiniband*`, `/sys/class/infiniband_mad/`,
+`/sys/class/infiniband_verbs/` and `/dev/infiniband` so real userspace tools
+read from the rendered tree:
+
+```bash
+POD=$(kubectl get pods -l app.kubernetes.io/name=nvml-mock -o jsonpath='{.items[0].metadata.name}')
+kubectl exec "$POD" -- ibstat
+kubectl exec "$POD" -- ibstatus
+```
+
+### Defaults per profile
+
+| Profile | Enabled | HCA | Speed | HCAs per GPU |
+|---|---|---|---|---|
+| `a100`  | yes | ConnectX-6 (`MT4123`) | HDR 200 Gb/s | 1 |
+| `h100`  | yes | ConnectX-7 (`MT4129`) | NDR 400 Gb/s | 1 |
+| `b200`  | yes | ConnectX-7 (`MT4129`) | NDR 400 Gb/s | 1 |
+| `gb200` | yes | ConnectX-7 (`MT4129`) | NDR 400 Gb/s | 1 |
+| `l40s`  | no  | — | — | — |
+| `t4`    | no  | — | — | — |
+
+### `infiniband:` block schema
+
+| Field | Default | Notes |
+|---|---|---|
+| `enabled` | `false` | Must be `true` to render any tree |
+| `hca_type` | `MT4129` | Shows up as `CA type` in `ibstat` output |
+| `fw_version` | `28.39.2048` | Firmware version |
+| `hw_rev` | `0x0` | Hardware revision |
+| `board_id` | `MT_0000000838` | Mellanox board ID |
+| `link_layer` | `InfiniBand` | `InfiniBand` or `Ethernet` |
+| `rate_gbps` | `400` | One of `100` (EDR), `200` (HDR), `400` (NDR), `800` (XDR) |
+| `port_state` | `ACTIVE` | `DOWN`, `INIT`, `ARMED`, `ACTIVE`, `ACTIVE_DEFER` |
+| `phys_state` | `LinkUp` | `Disabled`, `Polling`, `Training`, `LinkUp`, ... |
+| `hcas_per_gpu` | `1` | Total HCAs = `gpu.count * hcas_per_gpu` |
+| `hca_count` | `0` | If non-zero, used instead of `gpu.count * hcas_per_gpu` |
+| `guid_prefix` | `a088c20300ab` | First 12 hex digits of every node/port GUID; HCA index appended |
+| `node_desc_template` | `{node_name} mlx5_{idx}` | `{node_name}` and `{idx}` are interpolated |
+
+### Disable IB on a profile
+
+Set `enabled: false` either inline:
+
+```bash
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
+  --set gpu.profile=h100 \
+  --set-string 'gpu.customConfig=infiniband: { enabled: false }'
+```
+
+…or via a custom profile file (preferred for full control).
 
 ## Configuration
 

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -11,6 +11,9 @@ Deploys a DaemonSet that creates on every node:
 - Mock device nodes at `/var/lib/nvml-mock/driver/dev/nvidia{N,ctl,-uvm,-uvm-tools}` (consumers see them at `/dev/nvidia*` via CDI bind-mount)
 - GPU configuration at `/var/lib/nvml-mock/driver/config/config.yaml`
 - Node label `nvidia.com/gpu.present=true`
+- A fake InfiniBand sysfs tree at `/var/lib/nvml-mock/ib/sys/class/infiniband/...`
+  paired with `libibmocksys.so` (`LD_PRELOAD`) so real `ibstat`, `ibstatus`,
+  `iblinkinfo`, ... read mock HCAs
 
 Consumers (DRA driver, device plugin) point at `/var/lib/nvml-mock/driver`
 as the NVIDIA driver root and discover GPUs through standard NVML APIs.
@@ -480,6 +483,63 @@ helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set integrations.fakeGpuOperator.enabled=true \
   --set 'integrations.fakeGpuOperator.profileLabels.my-org/gpu-profile=true'
 ```
+
+## InfiniBand mocking
+
+Each profile carries an `infiniband:` block alongside the GPU config. When the
+DaemonSet starts, `render-ib-sysfs` reads it and writes a fake sysfs tree at
+`/var/lib/nvml-mock/ib/sys/class/infiniband/...`. Inside the container, the
+`LD_PRELOAD` shim `libibmocksys.so` rewrites every access to
+`/sys/class/infiniband*`, `/sys/class/infiniband_mad/`,
+`/sys/class/infiniband_verbs/` and `/dev/infiniband` so real userspace tools
+read from the rendered tree:
+
+```bash
+POD=$(kubectl get pods -l app.kubernetes.io/name=nvml-mock -o jsonpath='{.items[0].metadata.name}')
+kubectl exec "$POD" -- ibstat
+kubectl exec "$POD" -- ibstatus
+```
+
+### Defaults per profile
+
+| Profile | Enabled | HCA | Speed | HCAs per GPU |
+|---|---|---|---|---|
+| `a100`  | yes | ConnectX-6 (`MT4123`) | HDR 200 Gb/s | 1 |
+| `h100`  | yes | ConnectX-7 (`MT4129`) | NDR 400 Gb/s | 1 |
+| `b200`  | yes | ConnectX-7 (`MT4129`) | NDR 400 Gb/s | 1 |
+| `gb200` | yes | ConnectX-7 (`MT4129`) | NDR 400 Gb/s | 1 |
+| `l40s`  | no  | — | — | — |
+| `t4`    | no  | — | — | — |
+
+### `infiniband:` block schema
+
+| Field | Default | Notes |
+|---|---|---|
+| `enabled` | `false` | Must be `true` to render any tree |
+| `hca_type` | `MT4129` | Shows up as `CA type` in `ibstat` output |
+| `fw_version` | `28.39.2048` | Firmware version |
+| `hw_rev` | `0x0` | Hardware revision |
+| `board_id` | `MT_0000000838` | Mellanox board ID |
+| `link_layer` | `InfiniBand` | `InfiniBand` or `Ethernet` |
+| `rate_gbps` | `400` | One of `100` (EDR), `200` (HDR), `400` (NDR), `800` (XDR) |
+| `port_state` | `ACTIVE` | `DOWN`, `INIT`, `ARMED`, `ACTIVE`, `ACTIVE_DEFER` |
+| `phys_state` | `LinkUp` | `Disabled`, `Polling`, `Training`, `LinkUp`, ... |
+| `hcas_per_gpu` | `1` | Total HCAs = `gpu.count * hcas_per_gpu` |
+| `hca_count` | `0` | If non-zero, used instead of `gpu.count * hcas_per_gpu` |
+| `guid_prefix` | `a088c20300ab` | First 12 hex digits of every node/port GUID; HCA index appended |
+| `node_desc_template` | `{node_name} mlx5_{idx}` | `{node_name}` and `{idx}` are interpolated |
+
+### Disable IB on a profile
+
+Set `enabled: false` either inline:
+
+```bash
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
+  --set gpu.profile=h100 \
+  --set-string 'gpu.customConfig=infiniband: { enabled: false }'
+```
+
+…or via a custom profile file (preferred for full control).
 
 ## Configuration
 

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/a100.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/a100.yaml
@@ -381,3 +381,20 @@ nvlink:
       remote_device_type: "gpu"
       remote_pci_bus_id: "00000000:0F:00.0"
     # ... define all 12 links for full topology
+
+# =============================================================================
+# InfiniBand topology - 1 ConnectX-6 HDR HCA per GPU (typical DGX A100)
+# =============================================================================
+infiniband:
+  enabled: true
+  hca_type: "MT4123"                # ConnectX-6
+  fw_version: "20.36.1010"
+  hw_rev: "0x0"
+  board_id: "MT_0000000223"
+  link_layer: "InfiniBand"
+  rate_gbps: 200                    # HDR
+  port_state: "ACTIVE"
+  phys_state: "LinkUp"
+  hcas_per_gpu: 1
+  guid_prefix: "a288c2:0300:ab"
+  node_desc_template: "{node_name} mlx5_{idx}"

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/b200.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/b200.yaml
@@ -386,3 +386,20 @@ nvlink:
       state: "active"
       remote_device_type: "gpu"
       remote_pci_bus_id: "00000000:1B:00.0"
+
+# =============================================================================
+# InfiniBand topology - 1 ConnectX-7 NDR HCA per GPU (typical HGX B200)
+# =============================================================================
+infiniband:
+  enabled: true
+  hca_type: "MT4129"
+  fw_version: "28.40.1000"
+  hw_rev: "0x0"
+  board_id: "MT_0000000838"
+  link_layer: "InfiniBand"
+  rate_gbps: 400
+  port_state: "ACTIVE"
+  phys_state: "LinkUp"
+  hcas_per_gpu: 1
+  guid_prefix: "b288c2:0300:ab"
+  node_desc_template: "{node_name} mlx5_{idx}"

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
@@ -415,3 +415,20 @@ nvlink:
       remote_device_type: "cpu"     # NVLink-C2C to Grace
       remote_pci_bus_id: "N/A"
     # ... define all 18 links for full topology
+
+# =============================================================================
+# InfiniBand topology - 1 ConnectX-7 NDR HCA per GPU (typical GB200 NVL72)
+# =============================================================================
+infiniband:
+  enabled: true
+  hca_type: "MT4129"
+  fw_version: "28.40.1000"
+  hw_rev: "0x0"
+  board_id: "MT_0000000838"
+  link_layer: "InfiniBand"
+  rate_gbps: 400
+  port_state: "ACTIVE"
+  phys_state: "LinkUp"
+  hcas_per_gpu: 1
+  guid_prefix: "9b88c2:0300:ab"
+  node_desc_template: "{node_name} mlx5_{idx}"

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/h100.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/h100.yaml
@@ -383,3 +383,20 @@ nvlink:
       state: "active"
       remote_device_type: "gpu"
       remote_pci_bus_id: "00000000:1B:00.0"
+
+# =============================================================================
+# InfiniBand topology - 1 ConnectX-7 NDR HCA per GPU (typical HGX H100)
+# =============================================================================
+infiniband:
+  enabled: true
+  hca_type: "MT4129"                # ConnectX-7
+  fw_version: "28.39.2048"
+  hw_rev: "0x0"
+  board_id: "MT_0000000838"
+  link_layer: "InfiniBand"
+  rate_gbps: 400                    # NDR
+  port_state: "ACTIVE"
+  phys_state: "LinkUp"
+  hcas_per_gpu: 1                   # total HCAs = gpu.count * hcas_per_gpu
+  guid_prefix: "a088c2:0300:ab"     # last byte = HCA index
+  node_desc_template: "{node_name} mlx5_{idx}"

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/l40s.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/l40s.yaml
@@ -362,3 +362,10 @@ devices:
     pci:
       bus_id: "00000000:CB:00.0"
     minor_number: 7
+
+# =============================================================================
+# InfiniBand topology - L40S systems typically ship without IB HCAs.
+# Set enabled=true via Helm values to simulate one if needed.
+# =============================================================================
+infiniband:
+  enabled: false

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/t4.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/t4.yaml
@@ -334,3 +334,9 @@ devices:
     pci:
       bus_id: "00000000:D8:00.0"
     minor_number: 3
+
+# =============================================================================
+# InfiniBand topology - T4 systems do not ship with IB HCAs.
+# =============================================================================
+infiniband:
+  enabled: false

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -44,6 +44,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # LD_PRELOAD installs the InfiniBand sysfs redirector in every
+            # process spawned in this container (e.g. `kubectl exec ibstat`).
+            # The shim only rewrites paths under /sys/class/infiniband*,
+            # /sys/class/infiniband_mad/, /sys/class/infiniband_verbs/ and
+            # /dev/infiniband — every other path passes through unchanged.
+            - name: LD_PRELOAD
+              value: "/usr/local/lib/libibmocksys.so.1"
+            - name: MOCK_IB_ROOT
+              value: "/var/lib/nvml-mock/ib"
           lifecycle:
             preStop:
               exec:
@@ -51,6 +60,11 @@ spec:
           volumeMounts:
             - name: host-nvml-mock
               mountPath: /host/var/lib/nvml-mock
+            # Second mount of the same hostPath volume at the canonical path
+            # so MOCK_IB_ROOT=/var/lib/nvml-mock/ib resolves identically in
+            # this pod and in CDI-injected consumer pods.
+            - name: host-nvml-mock
+              mountPath: /var/lib/nvml-mock
             - name: gpu-config
               mountPath: /config
             - name: host-cdi

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -79,7 +79,10 @@ spec:
               mountPath: /host/var/lib/nvml-mock
             # Second mount of the same hostPath volume at the canonical path
             # so MOCK_IB_ROOT=/var/lib/nvml-mock/ib resolves identically in
-            # this pod and in CDI-injected consumer pods.
+            # this pod and in CDI-injected consumer pods. Mounting one
+            # volume at multiple mountPaths in a single container is
+            # standard k8s behavior (supported on every version covered
+            # by Chart.yaml's kubeVersion: ">= 1.28.0-0").
             - name: host-nvml-mock
               mountPath: /var/lib/nvml-mock
             - name: gpu-config

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -61,6 +61,15 @@ spec:
             # workloads) all see the config at the same in-container location.
             - name: MOCK_NVML_CONFIG
               value: /etc/nvml-mock/config.yaml
+            # LD_PRELOAD installs the InfiniBand sysfs redirector in every
+            # process spawned in this container (e.g. `kubectl exec ibstat`).
+            # The shim only rewrites paths under /sys/class/infiniband*,
+            # /sys/class/infiniband_mad/, /sys/class/infiniband_verbs/ and
+            # /dev/infiniband — every other path passes through unchanged.
+            - name: LD_PRELOAD
+              value: "/usr/local/lib/libibmocksys.so.1"
+            - name: MOCK_IB_ROOT
+              value: "/var/lib/nvml-mock/ib"
           lifecycle:
             preStop:
               exec:
@@ -68,6 +77,11 @@ spec:
           volumeMounts:
             - name: host-nvml-mock
               mountPath: /host/var/lib/nvml-mock
+            # Second mount of the same hostPath volume at the canonical path
+            # so MOCK_IB_ROOT=/var/lib/nvml-mock/ib resolves identically in
+            # this pod and in CDI-injected consumer pods.
+            - name: host-nvml-mock
+              mountPath: /var/lib/nvml-mock
             - name: gpu-config
               mountPath: /etc/nvml-mock
             - name: host-cdi

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
@@ -324,56 +324,56 @@ should match snapshot with b200 profile:
         # =============================================================================
         devices:
           - index: 0
-            uuid: "GPU-B200-0000-0000-0000-000000000000"
+            uuid: "GPU-b2000000-0000-0000-0000-000000000000"
             serial: "1562849203700"
             pci:
               bus_id: "00000000:1A:00.0"
             minor_number: 0
 
           - index: 1
-            uuid: "GPU-B200-0000-0000-0000-000000000001"
+            uuid: "GPU-b2000000-0000-0000-0000-000000000001"
             serial: "1562849203701"
             pci:
               bus_id: "00000000:1B:00.0"
             minor_number: 1
 
           - index: 2
-            uuid: "GPU-B200-0000-0000-0000-000000000002"
+            uuid: "GPU-b2000000-0000-0000-0000-000000000002"
             serial: "1562849203702"
             pci:
               bus_id: "00000000:4A:00.0"
             minor_number: 2
 
           - index: 3
-            uuid: "GPU-B200-0000-0000-0000-000000000003"
+            uuid: "GPU-b2000000-0000-0000-0000-000000000003"
             serial: "1562849203703"
             pci:
               bus_id: "00000000:4B:00.0"
             minor_number: 3
 
           - index: 4
-            uuid: "GPU-B200-0000-0000-0000-000000000004"
+            uuid: "GPU-b2000000-0000-0000-0000-000000000004"
             serial: "1562849203704"
             pci:
               bus_id: "00000000:8A:00.0"
             minor_number: 4
 
           - index: 5
-            uuid: "GPU-B200-0000-0000-0000-000000000005"
+            uuid: "GPU-b2000000-0000-0000-0000-000000000005"
             serial: "1562849203705"
             pci:
               bus_id: "00000000:8B:00.0"
             minor_number: 5
 
           - index: 6
-            uuid: "GPU-B200-0000-0000-0000-000000000006"
+            uuid: "GPU-b2000000-0000-0000-0000-000000000006"
             serial: "1562849203706"
             pci:
               bus_id: "00000000:CA:00.0"
             minor_number: 6
 
           - index: 7
-            uuid: "GPU-B200-0000-0000-0000-000000000007"
+            uuid: "GPU-b2000000-0000-0000-0000-000000000007"
             serial: "1562849203707"
             pci:
               bus_id: "00000000:CB:00.0"
@@ -391,6 +391,23 @@ should match snapshot with b200 profile:
               state: "active"
               remote_device_type: "gpu"
               remote_pci_bus_id: "00000000:1B:00.0"
+
+        # =============================================================================
+        # InfiniBand topology - 1 ConnectX-7 NDR HCA per GPU (typical HGX B200)
+        # =============================================================================
+        infiniband:
+          enabled: true
+          hca_type: "MT4129"
+          fw_version: "28.40.1000"
+          hw_rev: "0x0"
+          board_id: "MT_0000000838"
+          link_layer: "InfiniBand"
+          rate_gbps: 400
+          port_state: "ACTIVE"
+          phys_state: "LinkUp"
+          hcas_per_gpu: 1
+          guid_prefix: "b288c2:0300:ab"
+          node_desc_template: "{node_name} mlx5_{idx}"
     kind: ConfigMap
     metadata:
       labels:
@@ -788,6 +805,23 @@ should match snapshot with default a100 profile:
               remote_device_type: "gpu"
               remote_pci_bus_id: "00000000:0F:00.0"
             # ... define all 12 links for full topology
+
+        # =============================================================================
+        # InfiniBand topology - 1 ConnectX-6 HDR HCA per GPU (typical DGX A100)
+        # =============================================================================
+        infiniband:
+          enabled: true
+          hca_type: "MT4123"                # ConnectX-6
+          fw_version: "20.36.1010"
+          hw_rev: "0x0"
+          board_id: "MT_0000000223"
+          link_layer: "InfiniBand"
+          rate_gbps: 200                    # HDR
+          port_state: "ACTIVE"
+          phys_state: "LinkUp"
+          hcas_per_gpu: 1
+          guid_prefix: "a288c2:0300:ab"
+          node_desc_template: "{node_name} mlx5_{idx}"
     kind: ConfigMap
     metadata:
       labels:
@@ -1135,7 +1169,7 @@ should match snapshot with gb200 profile:
         # =============================================================================
         devices:
           - index: 0
-            uuid: "GPU-GB200-0000-0000-0000-000000000000"
+            uuid: "GPU-b200b200-0000-0000-0000-000000000000"
             serial: "1562849103700"
             pci:
               bus_id: "00000000:0A:00.0"
@@ -1143,7 +1177,7 @@ should match snapshot with gb200 profile:
             grace_cpu_pair: 0               # Paired with Grace CPU 0
 
           - index: 1
-            uuid: "GPU-GB200-0000-0000-0000-000000000001"
+            uuid: "GPU-b200b200-0000-0000-0000-000000000001"
             serial: "1562849103701"
             pci:
               bus_id: "00000000:0B:00.0"
@@ -1151,7 +1185,7 @@ should match snapshot with gb200 profile:
             grace_cpu_pair: 0               # Same superchip as GPU 0
 
           - index: 2
-            uuid: "GPU-GB200-0000-0000-0000-000000000002"
+            uuid: "GPU-b200b200-0000-0000-0000-000000000002"
             serial: "1562849103702"
             pci:
               bus_id: "00000000:4A:00.0"
@@ -1159,7 +1193,7 @@ should match snapshot with gb200 profile:
             grace_cpu_pair: 1
 
           - index: 3
-            uuid: "GPU-GB200-0000-0000-0000-000000000003"
+            uuid: "GPU-b200b200-0000-0000-0000-000000000003"
             serial: "1562849103703"
             pci:
               bus_id: "00000000:4B:00.0"
@@ -1167,7 +1201,7 @@ should match snapshot with gb200 profile:
             grace_cpu_pair: 1
 
           - index: 4
-            uuid: "GPU-GB200-0000-0000-0000-000000000004"
+            uuid: "GPU-b200b200-0000-0000-0000-000000000004"
             serial: "1562849103704"
             pci:
               bus_id: "00000000:8A:00.0"
@@ -1175,7 +1209,7 @@ should match snapshot with gb200 profile:
             grace_cpu_pair: 2
 
           - index: 5
-            uuid: "GPU-GB200-0000-0000-0000-000000000005"
+            uuid: "GPU-b200b200-0000-0000-0000-000000000005"
             serial: "1562849103705"
             pci:
               bus_id: "00000000:8B:00.0"
@@ -1183,7 +1217,7 @@ should match snapshot with gb200 profile:
             grace_cpu_pair: 2
 
           - index: 6
-            uuid: "GPU-GB200-0000-0000-0000-000000000006"
+            uuid: "GPU-b200b200-0000-0000-0000-000000000006"
             serial: "1562849103706"
             pci:
               bus_id: "00000000:CA:00.0"
@@ -1191,7 +1225,7 @@ should match snapshot with gb200 profile:
             grace_cpu_pair: 3
 
           - index: 7
-            uuid: "GPU-GB200-0000-0000-0000-000000000007"
+            uuid: "GPU-b200b200-0000-0000-0000-000000000007"
             serial: "1562849103707"
             pci:
               bus_id: "00000000:CB:00.0"
@@ -1219,6 +1253,23 @@ should match snapshot with gb200 profile:
               remote_device_type: "cpu"     # NVLink-C2C to Grace
               remote_pci_bus_id: "N/A"
             # ... define all 18 links for full topology
+
+        # =============================================================================
+        # InfiniBand topology - 1 ConnectX-7 NDR HCA per GPU (typical GB200 NVL72)
+        # =============================================================================
+        infiniband:
+          enabled: true
+          hca_type: "MT4129"
+          fw_version: "28.40.1000"
+          hw_rev: "0x0"
+          board_id: "MT_0000000838"
+          link_layer: "InfiniBand"
+          rate_gbps: 400
+          port_state: "ACTIVE"
+          phys_state: "LinkUp"
+          hcas_per_gpu: 1
+          guid_prefix: "9b88c2:0300:ab"
+          node_desc_template: "{node_name} mlx5_{idx}"
     kind: ConfigMap
     metadata:
       labels:
@@ -1551,56 +1602,56 @@ should match snapshot with h100 profile:
         # =============================================================================
         devices:
           - index: 0
-            uuid: "GPU-H100-0000-0000-0000-000000000000"
+            uuid: "GPU-01000100-0000-0000-0000-000000000000"
             serial: "1562821083900"
             pci:
               bus_id: "00000000:1A:00.0"
             minor_number: 0
 
           - index: 1
-            uuid: "GPU-H100-0000-0000-0000-000000000001"
+            uuid: "GPU-01000100-0000-0000-0000-000000000001"
             serial: "1562821083901"
             pci:
               bus_id: "00000000:1B:00.0"
             minor_number: 1
 
           - index: 2
-            uuid: "GPU-H100-0000-0000-0000-000000000002"
+            uuid: "GPU-01000100-0000-0000-0000-000000000002"
             serial: "1562821083902"
             pci:
               bus_id: "00000000:4A:00.0"
             minor_number: 2
 
           - index: 3
-            uuid: "GPU-H100-0000-0000-0000-000000000003"
+            uuid: "GPU-01000100-0000-0000-0000-000000000003"
             serial: "1562821083903"
             pci:
               bus_id: "00000000:4B:00.0"
             minor_number: 3
 
           - index: 4
-            uuid: "GPU-H100-0000-0000-0000-000000000004"
+            uuid: "GPU-01000100-0000-0000-0000-000000000004"
             serial: "1562821083904"
             pci:
               bus_id: "00000000:8A:00.0"
             minor_number: 4
 
           - index: 5
-            uuid: "GPU-H100-0000-0000-0000-000000000005"
+            uuid: "GPU-01000100-0000-0000-0000-000000000005"
             serial: "1562821083905"
             pci:
               bus_id: "00000000:8B:00.0"
             minor_number: 5
 
           - index: 6
-            uuid: "GPU-H100-0000-0000-0000-000000000006"
+            uuid: "GPU-01000100-0000-0000-0000-000000000006"
             serial: "1562821083906"
             pci:
               bus_id: "00000000:CA:00.0"
             minor_number: 6
 
           - index: 7
-            uuid: "GPU-H100-0000-0000-0000-000000000007"
+            uuid: "GPU-01000100-0000-0000-0000-000000000007"
             serial: "1562821083907"
             pci:
               bus_id: "00000000:CB:00.0"
@@ -1618,6 +1669,23 @@ should match snapshot with h100 profile:
               state: "active"
               remote_device_type: "gpu"
               remote_pci_bus_id: "00000000:1B:00.0"
+
+        # =============================================================================
+        # InfiniBand topology - 1 ConnectX-7 NDR HCA per GPU (typical HGX H100)
+        # =============================================================================
+        infiniband:
+          enabled: true
+          hca_type: "MT4129"                # ConnectX-7
+          fw_version: "28.39.2048"
+          hw_rev: "0x0"
+          board_id: "MT_0000000838"
+          link_layer: "InfiniBand"
+          rate_gbps: 400                    # NDR
+          port_state: "ACTIVE"
+          phys_state: "LinkUp"
+          hcas_per_gpu: 1                   # total HCAs = gpu.count * hcas_per_gpu
+          guid_prefix: "a088c2:0300:ab"     # last byte = HCA index
+          node_desc_template: "{node_name} mlx5_{idx}"
     kind: ConfigMap
     metadata:
       labels:
@@ -1942,60 +2010,67 @@ should match snapshot with l40s profile:
         # =============================================================================
         devices:
           - index: 0
-            uuid: "GPU-L40S-0000-0000-0000-000000000000"
+            uuid: "GPU-14050000-0000-0000-0000-000000000000"
             serial: "1562830094500"
             pci:
               bus_id: "00000000:17:00.0"
             minor_number: 0
 
           - index: 1
-            uuid: "GPU-L40S-0000-0000-0000-000000000001"
+            uuid: "GPU-14050000-0000-0000-0000-000000000001"
             serial: "1562830094501"
             pci:
               bus_id: "00000000:31:00.0"
             minor_number: 1
 
           - index: 2
-            uuid: "GPU-L40S-0000-0000-0000-000000000002"
+            uuid: "GPU-14050000-0000-0000-0000-000000000002"
             serial: "1562830094502"
             pci:
               bus_id: "00000000:B1:00.0"
             minor_number: 2
 
           - index: 3
-            uuid: "GPU-L40S-0000-0000-0000-000000000003"
+            uuid: "GPU-14050000-0000-0000-0000-000000000003"
             serial: "1562830094503"
             pci:
               bus_id: "00000000:CA:00.0"
             minor_number: 3
 
           - index: 4
-            uuid: "GPU-L40S-0000-0000-0000-000000000004"
+            uuid: "GPU-14050000-0000-0000-0000-000000000004"
             serial: "1562830094504"
             pci:
               bus_id: "00000000:18:00.0"
             minor_number: 4
 
           - index: 5
-            uuid: "GPU-L40S-0000-0000-0000-000000000005"
+            uuid: "GPU-14050000-0000-0000-0000-000000000005"
             serial: "1562830094505"
             pci:
               bus_id: "00000000:32:00.0"
             minor_number: 5
 
           - index: 6
-            uuid: "GPU-L40S-0000-0000-0000-000000000006"
+            uuid: "GPU-14050000-0000-0000-0000-000000000006"
             serial: "1562830094506"
             pci:
               bus_id: "00000000:B2:00.0"
             minor_number: 6
 
           - index: 7
-            uuid: "GPU-L40S-0000-0000-0000-000000000007"
+            uuid: "GPU-14050000-0000-0000-0000-000000000007"
             serial: "1562830094507"
             pci:
               bus_id: "00000000:CB:00.0"
             minor_number: 7
+
+        # =============================================================================
+        # InfiniBand topology - L40S systems typically ship without IB HCAs.
+        # Set enabled=true via Helm values to simulate one if needed.
+        # =============================================================================
+        infiniband:
+          enabled: false
     kind: ConfigMap
     metadata:
       labels:
@@ -2320,32 +2395,38 @@ should match snapshot with t4 profile:
         # =============================================================================
         devices:
           - index: 0
-            uuid: "GPU-T4-0000-0000-0000-000000000000"
+            uuid: "GPU-00000074-0000-0000-0000-000000000000"
             serial: "0421819085400"
             pci:
               bus_id: "00000000:3B:00.0"
             minor_number: 0
 
           - index: 1
-            uuid: "GPU-T4-0000-0000-0000-000000000001"
+            uuid: "GPU-00000074-0000-0000-0000-000000000001"
             serial: "0421819085401"
             pci:
               bus_id: "00000000:86:00.0"
             minor_number: 1
 
           - index: 2
-            uuid: "GPU-T4-0000-0000-0000-000000000002"
+            uuid: "GPU-00000074-0000-0000-0000-000000000002"
             serial: "0421819085402"
             pci:
               bus_id: "00000000:AF:00.0"
             minor_number: 2
 
           - index: 3
-            uuid: "GPU-T4-0000-0000-0000-000000000003"
+            uuid: "GPU-00000074-0000-0000-0000-000000000003"
             serial: "0421819085403"
             pci:
               bus_id: "00000000:D8:00.0"
             minor_number: 3
+
+        # =============================================================================
+        # InfiniBand topology - T4 systems do not ship with IB HCAs.
+        # =============================================================================
+        infiniband:
+          enabled: false
     kind: ConfigMap
     metadata:
       labels:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
@@ -391,6 +391,23 @@ should match snapshot with b200 profile:
               state: "active"
               remote_device_type: "gpu"
               remote_pci_bus_id: "00000000:1B:00.0"
+
+        # =============================================================================
+        # InfiniBand topology - 1 ConnectX-7 NDR HCA per GPU (typical HGX B200)
+        # =============================================================================
+        infiniband:
+          enabled: true
+          hca_type: "MT4129"
+          fw_version: "28.40.1000"
+          hw_rev: "0x0"
+          board_id: "MT_0000000838"
+          link_layer: "InfiniBand"
+          rate_gbps: 400
+          port_state: "ACTIVE"
+          phys_state: "LinkUp"
+          hcas_per_gpu: 1
+          guid_prefix: "b288c2:0300:ab"
+          node_desc_template: "{node_name} mlx5_{idx}"
     kind: ConfigMap
     metadata:
       labels:
@@ -788,6 +805,23 @@ should match snapshot with default a100 profile:
               remote_device_type: "gpu"
               remote_pci_bus_id: "00000000:0F:00.0"
             # ... define all 12 links for full topology
+
+        # =============================================================================
+        # InfiniBand topology - 1 ConnectX-6 HDR HCA per GPU (typical DGX A100)
+        # =============================================================================
+        infiniband:
+          enabled: true
+          hca_type: "MT4123"                # ConnectX-6
+          fw_version: "20.36.1010"
+          hw_rev: "0x0"
+          board_id: "MT_0000000223"
+          link_layer: "InfiniBand"
+          rate_gbps: 200                    # HDR
+          port_state: "ACTIVE"
+          phys_state: "LinkUp"
+          hcas_per_gpu: 1
+          guid_prefix: "a288c2:0300:ab"
+          node_desc_template: "{node_name} mlx5_{idx}"
     kind: ConfigMap
     metadata:
       labels:
@@ -1219,6 +1253,23 @@ should match snapshot with gb200 profile:
               remote_device_type: "cpu"     # NVLink-C2C to Grace
               remote_pci_bus_id: "N/A"
             # ... define all 18 links for full topology
+
+        # =============================================================================
+        # InfiniBand topology - 1 ConnectX-7 NDR HCA per GPU (typical GB200 NVL72)
+        # =============================================================================
+        infiniband:
+          enabled: true
+          hca_type: "MT4129"
+          fw_version: "28.40.1000"
+          hw_rev: "0x0"
+          board_id: "MT_0000000838"
+          link_layer: "InfiniBand"
+          rate_gbps: 400
+          port_state: "ACTIVE"
+          phys_state: "LinkUp"
+          hcas_per_gpu: 1
+          guid_prefix: "9b88c2:0300:ab"
+          node_desc_template: "{node_name} mlx5_{idx}"
     kind: ConfigMap
     metadata:
       labels:
@@ -1618,6 +1669,23 @@ should match snapshot with h100 profile:
               state: "active"
               remote_device_type: "gpu"
               remote_pci_bus_id: "00000000:1B:00.0"
+
+        # =============================================================================
+        # InfiniBand topology - 1 ConnectX-7 NDR HCA per GPU (typical HGX H100)
+        # =============================================================================
+        infiniband:
+          enabled: true
+          hca_type: "MT4129"                # ConnectX-7
+          fw_version: "28.39.2048"
+          hw_rev: "0x0"
+          board_id: "MT_0000000838"
+          link_layer: "InfiniBand"
+          rate_gbps: 400                    # NDR
+          port_state: "ACTIVE"
+          phys_state: "LinkUp"
+          hcas_per_gpu: 1                   # total HCAs = gpu.count * hcas_per_gpu
+          guid_prefix: "a088c2:0300:ab"     # last byte = HCA index
+          node_desc_template: "{node_name} mlx5_{idx}"
     kind: ConfigMap
     metadata:
       labels:
@@ -1996,6 +2064,13 @@ should match snapshot with l40s profile:
             pci:
               bus_id: "00000000:CB:00.0"
             minor_number: 7
+
+        # =============================================================================
+        # InfiniBand topology - L40S systems typically ship without IB HCAs.
+        # Set enabled=true via Helm values to simulate one if needed.
+        # =============================================================================
+        infiniband:
+          enabled: false
     kind: ConfigMap
     metadata:
       labels:
@@ -2346,6 +2421,12 @@ should match snapshot with t4 profile:
             pci:
               bus_id: "00000000:D8:00.0"
             minor_number: 3
+
+        # =============================================================================
+        # InfiniBand topology - T4 systems do not ship with IB HCAs.
+        # =============================================================================
+        infiniband:
+          enabled: false
     kind: ConfigMap
     metadata:
       labels:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -33,6 +33,10 @@ should match snapshot with all overrides:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
+                - name: LD_PRELOAD
+                  value: /usr/local/lib/libibmocksys.so.1
+                - name: MOCK_IB_ROOT
+                  value: /var/lib/nvml-mock/ib
               image: custom-registry/nvml-mock:v2.0.0
               imagePullPolicy: Always
               lifecycle:
@@ -52,6 +56,8 @@ should match snapshot with all overrides:
                 privileged: true
               volumeMounts:
                 - mountPath: /host/var/lib/nvml-mock
+                  name: host-nvml-mock
+                - mountPath: /var/lib/nvml-mock
                   name: host-nvml-mock
                 - mountPath: /config
                   name: gpu-config
@@ -117,6 +123,10 @@ should match snapshot with b200 profile:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
+                - name: LD_PRELOAD
+                  value: /usr/local/lib/libibmocksys.so.1
+                - name: MOCK_IB_ROOT
+                  value: /var/lib/nvml-mock/ib
               image: ghcr.io/nvidia/nvml-mock:latest
               imagePullPolicy: IfNotPresent
               lifecycle:
@@ -129,6 +139,8 @@ should match snapshot with b200 profile:
                 privileged: true
               volumeMounts:
                 - mountPath: /host/var/lib/nvml-mock
+                  name: host-nvml-mock
+                - mountPath: /var/lib/nvml-mock
                   name: host-nvml-mock
                 - mountPath: /config
                   name: gpu-config
@@ -190,6 +202,10 @@ should match snapshot with default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
+                - name: LD_PRELOAD
+                  value: /usr/local/lib/libibmocksys.so.1
+                - name: MOCK_IB_ROOT
+                  value: /var/lib/nvml-mock/ib
               image: ghcr.io/nvidia/nvml-mock:latest
               imagePullPolicy: IfNotPresent
               lifecycle:
@@ -202,6 +218,8 @@ should match snapshot with default values:
                 privileged: true
               volumeMounts:
                 - mountPath: /host/var/lib/nvml-mock
+                  name: host-nvml-mock
+                - mountPath: /var/lib/nvml-mock
                   name: host-nvml-mock
                 - mountPath: /config
                   name: gpu-config

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -37,6 +37,10 @@ should match snapshot with all overrides:
                       fieldPath: spec.nodeName
                 - name: MOCK_NVML_CONFIG
                   value: /etc/nvml-mock/config.yaml
+                - name: LD_PRELOAD
+                  value: /usr/local/lib/libibmocksys.so.1
+                - name: MOCK_IB_ROOT
+                  value: /var/lib/nvml-mock/ib
               image: custom-registry/nvml-mock:v2.0.0
               imagePullPolicy: Always
               lifecycle:
@@ -56,6 +60,8 @@ should match snapshot with all overrides:
                 privileged: true
               volumeMounts:
                 - mountPath: /host/var/lib/nvml-mock
+                  name: host-nvml-mock
+                - mountPath: /var/lib/nvml-mock
                   name: host-nvml-mock
                 - mountPath: /etc/nvml-mock
                   name: gpu-config
@@ -130,6 +136,10 @@ should match snapshot with b200 profile:
                       fieldPath: spec.nodeName
                 - name: MOCK_NVML_CONFIG
                   value: /etc/nvml-mock/config.yaml
+                - name: LD_PRELOAD
+                  value: /usr/local/lib/libibmocksys.so.1
+                - name: MOCK_IB_ROOT
+                  value: /var/lib/nvml-mock/ib
               image: ghcr.io/nvidia/nvml-mock:latest
               imagePullPolicy: IfNotPresent
               lifecycle:
@@ -142,6 +152,8 @@ should match snapshot with b200 profile:
                 privileged: true
               volumeMounts:
                 - mountPath: /host/var/lib/nvml-mock
+                  name: host-nvml-mock
+                - mountPath: /var/lib/nvml-mock
                   name: host-nvml-mock
                 - mountPath: /etc/nvml-mock
                   name: gpu-config
@@ -212,6 +224,10 @@ should match snapshot with default values:
                       fieldPath: spec.nodeName
                 - name: MOCK_NVML_CONFIG
                   value: /etc/nvml-mock/config.yaml
+                - name: LD_PRELOAD
+                  value: /usr/local/lib/libibmocksys.so.1
+                - name: MOCK_IB_ROOT
+                  value: /var/lib/nvml-mock/ib
               image: ghcr.io/nvidia/nvml-mock:latest
               imagePullPolicy: IfNotPresent
               lifecycle:
@@ -224,6 +240,8 @@ should match snapshot with default values:
                 privileged: true
               volumeMounts:
                 - mountPath: /host/var/lib/nvml-mock
+                  name: host-nvml-mock
+                - mountPath: /var/lib/nvml-mock
                   name: host-nvml-mock
                 - mountPath: /etc/nvml-mock
                   name: gpu-config

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -18,7 +18,7 @@ should match snapshot with all overrides:
       template:
         metadata:
           annotations:
-            checksum/config: a9dac7aa968f973518f4685fc2b41ca907c356337f88a38859184767ad1b4aa2
+            checksum/config: 204e5d4ea3a64ec98af544c7d6623ba71a2839c2761c1678c655def226cdba68
           labels:
             app.kubernetes.io/instance: custom
             app.kubernetes.io/name: nvml-mock
@@ -117,7 +117,7 @@ should match snapshot with b200 profile:
       template:
         metadata:
           annotations:
-            checksum/config: 28998b50ef728ae5b194d8847eadc34fcc675e27fdf9f0bc2350a86e39473b9c
+            checksum/config: e77c39d7b16109bdf1a87a46bdfa0048811dae86863c83116d3a6b6978ddab5d
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: nvml-mock
@@ -205,7 +205,7 @@ should match snapshot with default values:
       template:
         metadata:
           annotations:
-            checksum/config: 8cc02ebbe7fb41275c40abc60753dc5cf974ef4dae475c8fea3c6c49d156e99d
+            checksum/config: 5c9770a3246c869d6a5fdcfe2648f185529cc0ea0528548468550be85dad3d63
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: nvml-mock

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -194,4 +194,16 @@ fi
 mkdir -p /host/run/nvidia
 ln -sfn /var/lib/nvml-mock/driver /host/run/nvidia/driver
 
+# 9. Render fake InfiniBand sysfs tree (consumed via libibmocksys.so LD_PRELOAD).
+#    Only writes anything when the profile has `infiniband.enabled: true`.
+IB_ROOT="$HOST/ib"
+mkdir -p "$IB_ROOT"
+if [ -x /usr/local/bin/render-ib-sysfs ]; then
+  /usr/local/bin/render-ib-sysfs \
+    --config /config/config.yaml \
+    --gpu-count "$GPU_COUNT" \
+    --node-name "$NODE_NAME" \
+    --output "$IB_ROOT" || echo "WARNING: render-ib-sysfs failed (non-fatal)"
+fi
+
 echo "Mock GPU environment ready: $GPU_COUNT GPUs at $HOST"

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -205,4 +205,16 @@ fi
 mkdir -p /host/run/nvidia
 ln -sfn /var/lib/nvml-mock/driver /host/run/nvidia/driver
 
+# 9. Render fake InfiniBand sysfs tree (consumed via libibmocksys.so LD_PRELOAD).
+#    Only writes anything when the profile has `infiniband.enabled: true`.
+IB_ROOT="$HOST/ib"
+mkdir -p "$IB_ROOT"
+if [ -x /usr/local/bin/render-ib-sysfs ]; then
+  /usr/local/bin/render-ib-sysfs \
+    --config /config/config.yaml \
+    --gpu-count "$GPU_COUNT" \
+    --node-name "$NODE_NAME" \
+    --output "$IB_ROOT" || echo "WARNING: render-ib-sysfs failed (non-fatal)"
+fi
+
 echo "Mock GPU environment ready: $GPU_COUNT GPUs at $HOST"

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -207,14 +207,17 @@ ln -sfn /var/lib/nvml-mock/driver /host/run/nvidia/driver
 
 # 9. Render fake InfiniBand sysfs tree (consumed via libibmocksys.so LD_PRELOAD).
 #    Only writes anything when the profile has `infiniband.enabled: true`.
+#    Failures are fatal under `set -e`: a profile typo here would otherwise
+#    silently produce an empty IB tree and `ibstat` would report zero HCAs
+#    with no signal in pod logs.
 IB_ROOT="$HOST/ib"
 mkdir -p "$IB_ROOT"
 if [ -x /usr/local/bin/render-ib-sysfs ]; then
   /usr/local/bin/render-ib-sysfs \
-    --config /config/config.yaml \
+    --config /etc/nvml-mock/config.yaml \
     --gpu-count "$GPU_COUNT" \
     --node-name "$NODE_NAME" \
-    --output "$IB_ROOT" || echo "WARNING: render-ib-sysfs failed (non-fatal)"
+    --output "$IB_ROOT"
 fi
 
 echo "Mock GPU environment ready: $GPU_COUNT GPUs at $HOST"

--- a/docs/demo/standalone/README.md
+++ b/docs/demo/standalone/README.md
@@ -2,8 +2,8 @@
 
 This demo deploys nvml-mock on a local Kind cluster with FGO-style labels
 enabled. It does not require any external GPU operator -- nvml-mock itself
-generates the GPU profile ConfigMaps and node labels that downstream
-consumers expect.
+generates the GPU profile ConfigMaps, the fake InfiniBand sysfs tree, and
+the node labels that downstream consumers expect.
 
 ## What it does
 
@@ -17,6 +17,8 @@ consumers expect.
    - DaemonSet pods are running on all workers.
    - Six GPU profile ConfigMaps are created (one per profile field group).
    - `nvidia-smi` runs successfully inside a pod.
+   - `ibstat` lists 8 simulated ConnectX-7 NDR HCAs (see
+     [`pkg/network/mockibsysfs/README.md`](../../../pkg/network/mockibsysfs/README.md)).
    - Node labels are present.
 
 ## Quick start

--- a/docs/demo/standalone/demo.sh
+++ b/docs/demo/standalone/demo.sh
@@ -75,7 +75,22 @@ POD=$(kubectl get pods -l app.kubernetes.io/name=nvml-mock -o jsonpath='{.items[
 kubectl exec "${POD}" -- nvidia-smi
 
 ###############################################################################
-# Step 8 -- Show node labels
+# Step 8 -- Verify: InfiniBand mock (libibmocksys.so + render-ib-sysfs)
+###############################################################################
+info "Listing simulated InfiniBand HCAs (ibstat -l)"
+kubectl exec "${POD}" -- ibstat -l
+
+info "Running ibstatus inside the DaemonSet pod"
+kubectl exec "${POD}" -- ibstatus | head -40
+
+HCA_COUNT=$(kubectl exec "${POD}" -- ibstat -l | wc -l | tr -d ' ')
+if [[ "${HCA_COUNT}" -lt 1 ]]; then
+  fail "Expected at least 1 mock HCA, found ${HCA_COUNT}"
+fi
+info "Found ${HCA_COUNT} mock HCA(s)"
+
+###############################################################################
+# Step 9 -- Show node labels
 ###############################################################################
 info "Node labels"
 kubectl get nodes --show-labels
@@ -88,8 +103,9 @@ WORKERS=($(kubectl get nodes --no-headers -o custom-columns=":metadata.name" \
 ###############################################################################
 echo
 info "Demo complete."
-info "  Cluster : ${CLUSTER_NAME}"
-info "  Workers : ${#WORKERS[@]}"
+info "  Cluster   : ${CLUSTER_NAME}"
+info "  Workers   : ${#WORKERS[@]}"
 info "  ConfigMaps: ${CM_COUNT}"
+info "  Mock HCAs : ${HCA_COUNT} per pod"
 info ""
 info "To tear down: kind delete cluster --name ${CLUSTER_NAME}"

--- a/docs/demo/standalone/demo.sh
+++ b/docs/demo/standalone/demo.sh
@@ -76,7 +76,22 @@ POD=$(kubectl get pods -l app.kubernetes.io/name=nvml-mock -o jsonpath='{.items[
 kubectl exec "${POD}" -- nvidia-smi
 
 ###############################################################################
-# Step 8 -- Show node labels
+# Step 8 -- Verify: InfiniBand mock (libibmocksys.so + render-ib-sysfs)
+###############################################################################
+info "Listing simulated InfiniBand HCAs (ibstat -l)"
+kubectl exec "${POD}" -- ibstat -l
+
+info "Running ibstatus inside the DaemonSet pod"
+kubectl exec "${POD}" -- ibstatus | head -40
+
+HCA_COUNT=$(kubectl exec "${POD}" -- ibstat -l | wc -l | tr -d ' ')
+if [[ "${HCA_COUNT}" -lt 1 ]]; then
+  fail "Expected at least 1 mock HCA, found ${HCA_COUNT}"
+fi
+info "Found ${HCA_COUNT} mock HCA(s)"
+
+###############################################################################
+# Step 9 -- Show node labels
 ###############################################################################
 info "Node labels"
 kubectl get nodes --show-labels
@@ -89,8 +104,9 @@ WORKERS=($(kubectl get nodes --no-headers -o custom-columns=":metadata.name" \
 ###############################################################################
 echo
 info "Demo complete."
-info "  Cluster : ${CLUSTER_NAME}"
-info "  Workers : ${#WORKERS[@]}"
+info "  Cluster   : ${CLUSTER_NAME}"
+info "  Workers   : ${#WORKERS[@]}"
 info "  ConfigMaps: ${CM_COUNT}"
+info "  Mock HCAs : ${HCA_COUNT} per pod"
 info ""
 info "To tear down: kind delete cluster --name ${CLUSTER_NAME}"

--- a/docs/demo/with-fgo/README.md
+++ b/docs/demo/with-fgo/README.md
@@ -83,6 +83,10 @@ kubectl get configmaps -l run.ai/gpu-profile=true
 POD=$(kubectl get pods -l app.kubernetes.io/name=nvml-mock \
   -o jsonpath='{.items[0].metadata.name}')
 kubectl exec "${POD}" -- nvidia-smi
+
+# InfiniBand diagnostic tools see one mock ConnectX-7 NDR HCA per GPU.
+kubectl exec "${POD}" -- ibstat
+kubectl exec "${POD}" -- ibstatus
 ```
 
 ### Scale pool (fake-gpu-operator)

--- a/pkg/network/mockibsysfs/.gitignore
+++ b/pkg/network/mockibsysfs/.gitignore
@@ -1,0 +1,5 @@
+# Build artifacts produced by `make` (libibmocksys.so* are built into the
+# nvml-mock image via the Dockerfile; never check binaries into git).
+libibmocksys.so
+libibmocksys.so.*
+*.o

--- a/pkg/network/mockibsysfs/Makefile
+++ b/pkg/network/mockibsysfs/Makefile
@@ -1,0 +1,25 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+CC      ?= gcc
+CFLAGS  ?= -O2 -Wall -Wextra -fPIC -fvisibility=default
+LDFLAGS ?= -shared -Wl,-soname,libibmocksys.so.1 -ldl
+
+LIB_NAME    := libibmocksys.so
+LIB_SONAME  := $(LIB_NAME).1
+LIB_VERSION ?= 1.0.0
+LIB_REAL    := $(LIB_NAME).$(LIB_VERSION)
+
+.PHONY: all clean
+
+all: $(LIB_NAME)
+
+$(LIB_REAL): shim.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $<
+
+$(LIB_NAME): $(LIB_REAL)
+	ln -sf $(LIB_REAL) $(LIB_SONAME)
+	ln -sf $(LIB_SONAME) $(LIB_NAME)
+
+clean:
+	rm -f $(LIB_NAME)*

--- a/pkg/network/mockibsysfs/README.md
+++ b/pkg/network/mockibsysfs/README.md
@@ -1,0 +1,183 @@
+# mockibsysfs
+
+Mock InfiniBand fabric for Kubernetes testing. Lets unmodified userspace
+tools (`ibstat`, `ibstatus`, `iblinkinfo`, `libibverbs` consumers, ...)
+read realistic per-HCA topology data on hosts that have no IB hardware.
+
+This package is the InfiniBand counterpart of [`pkg/gpu/mocknvml`](../../gpu/mocknvml/):
+mocknvml ships a fake `libnvidia-ml.so` so `nvidia-smi` works without
+GPUs; mockibsysfs ships a fake sysfs tree so `ibstat` works without HCAs.
+
+## Components
+
+```
+pkg/network/mockibsysfs/
+├── shim.c            # LD_PRELOAD library: redirects libc filesystem calls
+├── Makefile          # builds libibmocksys.so from shim.c
+├── config/           # YAML schema for the `infiniband:` profile block
+└── render/           # writes a kernel-faithful sysfs tree from the schema
+
+cmd/render-ib-sysfs/  # CLI wrapper that reads a profile YAML and invokes render
+```
+
+Two pieces work together:
+
+1. **`libibmocksys.so` (LD_PRELOAD shim, C).** Hooks ~15 libc functions
+   (`open`, `openat`, `opendir`, `scandir`/`scandir64`, `stat`, `lstat`,
+   `fstatat`, `statx`, `fopen`, `access`, `faccessat`, `readlink`,
+   `readlinkat`, `chdir`) and rewrites paths starting with
+   `/sys/class/infiniband*`, `/sys/class/infiniband_mad/`,
+   `/sys/class/infiniband_verbs/`, or `/dev/infiniband` to point under
+   `$MOCK_IB_ROOT/...`. Everything else passes through to real libc via
+   `dlsym(RTLD_NEXT, ...)`. C is the right choice here — see
+   [Why C, not Go](#why-c-not-go).
+
+2. **`render-ib-sysfs` (Go binary).** Reads the `infiniband:` block from
+   the active mock-nvml profile YAML and writes a kernel-faithful tree
+   under `--output`: per-CA `node_type`, `node_guid`, `sys_image_guid`,
+   `fw_ver`, `hw_rev`, `board_id`, `hca_type`, `node_desc`; per-port
+   `state`, `phys_state`, `rate`, `lid`, `sm_lid`, `cap_mask`,
+   `link_layer`, `gids/0`, `pkeys/0`, `counters/*`; plus
+   `infiniband_mad/{abi_version,umad*,issm*}` for `libibumad`,
+   `infiniband_verbs/{abi_version,uverbs*}` for `libibverbs`, and the
+   matching `dev/infiniband/*` files.
+
+In the nvml-mock DaemonSet:
+
+- The Dockerfile builds both pieces and installs `infiniband-diags` +
+  `rdma-core` for the real userspace tools.
+- `setup.sh` invokes `render-ib-sysfs` once at startup against
+  `/host/var/lib/nvml-mock/ib`.
+- The pod env sets `LD_PRELOAD=/usr/local/lib/libibmocksys.so.1` and
+  `MOCK_IB_ROOT=/var/lib/nvml-mock/ib`, so every process in the
+  container — including `kubectl exec ... ibstat` — sees the fake fabric.
+
+Set `MOCK_IB_DISABLE=1` in any process to bypass the shim (escape hatch
+for debugging the host filesystem).
+
+## YAML schema
+
+The renderer consumes the `infiniband:` block of a mock-nvml profile.
+Defaults are applied per-field, so `enabled: true` is the minimum useful
+configuration.
+
+| Field                | Default              | Description                                                                |
+|----------------------|----------------------|----------------------------------------------------------------------------|
+| `enabled`            | `false`              | Must be `true` to render any tree.                                         |
+| `hca_type`           | `MT4129`             | Mellanox HCA model. Shows up as `CA type` in `ibstat`.                     |
+| `fw_version`         | `28.39.2048`         | Firmware version string.                                                   |
+| `hw_rev`             | `0x0`                | Hardware revision.                                                         |
+| `board_id`           | `MT_0000000838`      | Mellanox board ID.                                                         |
+| `link_layer`         | `InfiniBand`         | `InfiniBand` (true IB) or `Ethernet` (RoCE).                               |
+| `rate_gbps`          | `400`                | One of `100` (EDR), `200` (HDR), `400` (NDR), `800` (XDR).                 |
+| `port_state`         | `ACTIVE`             | `DOWN`, `INIT`, `ARMED`, `ACTIVE`, `ACTIVE_DEFER`.                         |
+| `phys_state`         | `LinkUp`             | `Disabled`, `Polling`, `Training`, `LinkUp`, `LinkErrorRecovery`, ...      |
+| `hcas_per_gpu`       | `1`                  | Total HCAs = `gpu.count * hcas_per_gpu`.                                   |
+| `hca_count`          | `0`                  | If non-zero, used instead of `gpu.count * hcas_per_gpu`.                   |
+| `guid_prefix`        | `a088c2:0300:ab`     | First 12 hex digits of every node/port GUID; HCA index encodes lower bytes. |
+| `node_desc_template` | `{node_name} mlx5_{idx}` | `{node_name}` and `{idx}` are interpolated.                            |
+
+### Defaults per built-in profile
+
+| Profile  | Enabled | HCA model              | Speed        | HCAs / GPU |
+|----------|---------|------------------------|--------------|------------|
+| `a100`   | yes     | ConnectX-6 (`MT4123`)  | HDR 200 Gb/s | 1          |
+| `h100`   | yes     | ConnectX-7 (`MT4129`)  | NDR 400 Gb/s | 1          |
+| `b200`   | yes     | ConnectX-7 (`MT4129`)  | NDR 400 Gb/s | 1          |
+| `gb200`  | yes     | ConnectX-7 (`MT4129`)  | NDR 400 Gb/s | 1          |
+| `l40s`   | no      | —                      | —            | —          |
+| `t4`     | no      | —                      | —            | —          |
+
+## Standalone usage
+
+You can use mockibsysfs outside the nvml-mock chart — for example, in a
+unit test or on a developer laptop running Linux.
+
+### 1. Build the shim
+
+```bash
+cd pkg/network/mockibsysfs
+make
+# produces libibmocksys.so -> libibmocksys.so.1 -> libibmocksys.so.1.0.0
+```
+
+The shim only builds on Linux (uses `dlfcn.h`, glibc-specific signatures
+like `statx`). On macOS, build inside a Linux container:
+
+```bash
+docker run --rm -v "$PWD/../../..:/work" -w /work/pkg/network/mockibsysfs \
+  debian:bookworm-slim sh -c \
+  'apt-get update -qq && apt-get install -y -qq build-essential >/dev/null && make'
+```
+
+### 2. Render a tree
+
+```bash
+go build -o /tmp/render-ib-sysfs ./cmd/render-ib-sysfs
+
+cat > /tmp/profile.yaml <<EOF
+infiniband:
+  enabled: true
+  hca_type: MT4129
+  rate_gbps: 400
+  hcas_per_gpu: 1
+EOF
+
+/tmp/render-ib-sysfs \
+  --config /tmp/profile.yaml \
+  --gpu-count 4 \
+  --node-name dev-laptop \
+  --output /tmp/ibroot
+```
+
+### 3. Run real `ibstat` against it
+
+```bash
+sudo apt-get install -y infiniband-diags
+
+LD_PRELOAD=$PWD/libibmocksys.so.1 \
+  MOCK_IB_ROOT=/tmp/ibroot \
+  ibstat
+```
+
+You should see four `mlx5_X` HCAs reported as `Active` / `LinkUp` at
+400 Gb/sec (4X NDR).
+
+## Tests
+
+```bash
+# Unit tests (renderer only, no shim required)
+go test ./pkg/network/mockibsysfs/...
+
+# Integration test: builds the shim, runs real ibstat against a rendered
+# tree, asserts on the output. Linux-only; skipped otherwise.
+make -C pkg/network/mockibsysfs                       # build shim
+go test -tags=integration ./pkg/network/mockibsysfs/render/...
+```
+
+## Why C, not Go
+
+The shim is loaded into **every process** in the container via
+`LD_PRELOAD` — `bash`, `cat`, `kubectl`, `nvidia-smi`, every probe. A
+Go-based `c-shared` library would inject the entire Go runtime
+(scheduler, GC, signal handlers, ~5–10 MB resident, multiple pthreads)
+into every one of those processes. Concretely:
+
+- Go's runtime calls `mmap`, `open`, `stat` during init — our hooks would
+  intercept its own filesystem accesses, risking re-entrancy / deadlock.
+- Go installs its own `SIGSEGV`/`SIGURG`/`SIGPROF` handlers, which would
+  hijack signal handling in unrelated host binaries.
+- Variadic and function-pointer signatures (`open(..., flags, ...)`,
+  `scandir(path, namelist, filter, compar)`, `statx(...)`) cannot be
+  expressed cleanly through cgo — we'd write C trampolines anyway.
+- Each cgo barrier crossing costs ~100 ns vs. ~5 ns for a direct call;
+  `ls -R /` would slow down measurably.
+
+The current C file is ~300 lines, mechanical, and isolated. Path-rewrite
+logic is the only state. This is the textbook LD_PRELOAD-shim shape.
+
+## See also
+
+- [Helm chart README](../../../deployments/nvml-mock/helm/nvml-mock/README.md) — install instructions, profile reference, troubleshooting.
+- [Standalone demo](../../../docs/demo/standalone/README.md) — full Kind walkthrough that exercises both `nvidia-smi` and `ibstat`.
+- [`pkg/gpu/mocknvml`](../../gpu/mocknvml/) — sister package that mocks the NVML library.

--- a/pkg/network/mockibsysfs/config/types.go
+++ b/pkg/network/mockibsysfs/config/types.go
@@ -1,0 +1,87 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// Package config defines the YAML schema for the InfiniBand block embedded
+// in mock-nvml profile configs. The renderer consumes this to populate the
+// fake sysfs tree under MOCK_IB_ROOT.
+package config
+
+// Profile is the minimal slice of the mock-nvml profile YAML that the
+// InfiniBand renderer cares about. It deliberately ignores all GPU fields.
+type Profile struct {
+	Infiniband Infiniband `json:"infiniband" yaml:"infiniband"`
+}
+
+// Infiniband describes the simulated HCA topology rendered into sysfs. All
+// fields have sensible zero-value defaults applied by ApplyDefaults so that
+// minimal profile blocks (e.g. {enabled: true}) still produce realistic
+// output.
+type Infiniband struct {
+	Enabled bool `json:"enabled" yaml:"enabled"`
+
+	// Per-CA static metadata.
+	HCAType   string `json:"hca_type"   yaml:"hca_type"`   // e.g. "MT4129" (ConnectX-7)
+	FWVersion string `json:"fw_version" yaml:"fw_version"` // e.g. "28.39.2048"
+	HWRev     string `json:"hw_rev"     yaml:"hw_rev"`     // e.g. "0x0"
+	BoardID   string `json:"board_id"   yaml:"board_id"`   // e.g. "MT_0000000838"
+
+	// NodeDescTemplate supports placeholders {node_name} and {idx}.
+	NodeDescTemplate string `json:"node_desc_template" yaml:"node_desc_template"`
+
+	// Per-port settings.
+	LinkLayer string `json:"link_layer" yaml:"link_layer"` // "InfiniBand" | "Ethernet"
+	RateGbps  int    `json:"rate_gbps"  yaml:"rate_gbps"`  // 100, 200, 400, ...
+	PortState string `json:"port_state" yaml:"port_state"` // "ACTIVE" | "INIT" | "DOWN"
+	PhysState string `json:"phys_state" yaml:"phys_state"` // "LinkUp" | "Disabled" | ...
+
+	// Topology shape.
+	HCAsPerGPU int `json:"hcas_per_gpu" yaml:"hcas_per_gpu"` // total = gpu_count * hcas_per_gpu
+	HCACountOverride int `json:"hca_count" yaml:"hca_count"` // if >0, used instead of gpu_count*hcas_per_gpu
+
+	// GUIDPrefix is the upper 6 bytes of every node/port GUID, in hex
+	// (with optional ':' separators). The lower 2 bytes encode the HCA
+	// index. Example: "a088c2:0300:ab" -> "a088c20300ab" -> per-HCA GUID
+	// "a088:c203:00ab:00<idx>".
+	GUIDPrefix string `json:"guid_prefix" yaml:"guid_prefix"`
+}
+
+// Defaults returns a copy of the InfiniBand block with reasonable fallback
+// values applied for any unset string/int fields. The returned value is safe
+// to render directly.
+func (ib Infiniband) Defaults() Infiniband {
+	out := ib
+	if out.HCAType == "" {
+		out.HCAType = "MT4129" // ConnectX-7 NDR
+	}
+	if out.FWVersion == "" {
+		out.FWVersion = "28.39.2048"
+	}
+	if out.HWRev == "" {
+		out.HWRev = "0x0"
+	}
+	if out.BoardID == "" {
+		out.BoardID = "MT_0000000838"
+	}
+	if out.NodeDescTemplate == "" {
+		out.NodeDescTemplate = "{node_name} mlx5_{idx}"
+	}
+	if out.LinkLayer == "" {
+		out.LinkLayer = "InfiniBand"
+	}
+	if out.RateGbps == 0 {
+		out.RateGbps = 400
+	}
+	if out.PortState == "" {
+		out.PortState = "ACTIVE"
+	}
+	if out.PhysState == "" {
+		out.PhysState = "LinkUp"
+	}
+	if out.HCAsPerGPU == 0 {
+		out.HCAsPerGPU = 1
+	}
+	if out.GUIDPrefix == "" {
+		out.GUIDPrefix = "a088c20300ab"
+	}
+	return out
+}

--- a/pkg/network/mockibsysfs/render/integration_test.go
+++ b/pkg/network/mockibsysfs/render/integration_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+// Integration test that renders a fake sysfs tree and runs the real ibstat
+// binary against it via libibmocksys.so. Skipped unless the integration tag
+// is set AND we are on a Linux host with infiniband-diags + the prebuilt
+// shim available.
+//
+// Run with:
+//
+//	make -C pkg/network/mockibsysfs                       # build libibmocksys.so
+//	go test -tags=integration ./pkg/network/mockibsysfs/render/...
+package render
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockibsysfs/config"
+)
+
+func TestIbstat_Integration(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("integration test requires linux")
+	}
+	ibstat, err := exec.LookPath("ibstat")
+	if err != nil {
+		t.Skip("ibstat not installed (apt-get install infiniband-diags)")
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	shim := filepath.Join(wd, "..", "libibmocksys.so")
+	if _, err := os.Stat(shim); err != nil {
+		t.Skipf("shim not built: %v (run `make -C pkg/network/mockibsysfs`)", err)
+	}
+
+	root := t.TempDir()
+	if err := Render(Options{
+		IB: config.Infiniband{
+			Enabled:   true,
+			HCAType:   "MT4129",
+			FWVersion: "28.39.2048",
+			RateGbps:  400,
+		},
+		GPUCount: 2,
+		NodeName: "test-node",
+		Output:   root,
+	}); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	cmd := exec.Command(ibstat)
+	cmd.Env = append(os.Environ(),
+		"LD_PRELOAD="+shim,
+		"MOCK_IB_ROOT="+root,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ibstat failed: %v\noutput:\n%s", err, out)
+	}
+	want := []string{
+		"CA 'mlx5_0'",
+		"CA 'mlx5_1'",
+		"CA type: MT4129",
+		"Firmware version: 28.39.2048",
+		"State: Active",
+		"Physical state: LinkUp",
+		"Rate: 400",
+		"Link layer: InfiniBand",
+	}
+	got := string(out)
+	for _, s := range want {
+		if !strings.Contains(got, s) {
+			t.Errorf("ibstat output missing %q\nfull output:\n%s", s, got)
+		}
+	}
+}

--- a/pkg/network/mockibsysfs/render/integration_test.go
+++ b/pkg/network/mockibsysfs/render/integration_test.go
@@ -82,4 +82,18 @@ func TestIbstat_Integration(t *testing.T) {
 			t.Errorf("ibstat output missing %q\nfull output:\n%s", s, got)
 		}
 	}
+
+	// Spot-check end-to-end that branches not exercised by `ibstat` are
+	// rendered: per-HCA counter files (read by perfquery / iblinkinfo)
+	// and the global infiniband_mad/abi_version (read by libibumad init).
+	for _, rel := range []string{
+		"sys/class/infiniband/mlx5_0/ports/1/counters/port_xmit_data",
+		"sys/class/infiniband/mlx5_0/ports/1/counters/port_rcv_data",
+		"sys/class/infiniband/mlx5_1/ports/1/counters/port_xmit_packets",
+		"sys/class/infiniband_mad/abi_version",
+	} {
+		if _, err := os.Stat(filepath.Join(root, rel)); err != nil {
+			t.Errorf("expected rendered file %s: %v", rel, err)
+		}
+	}
 }

--- a/pkg/network/mockibsysfs/render/render.go
+++ b/pkg/network/mockibsysfs/render/render.go
@@ -1,0 +1,299 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// Package render writes a fake InfiniBand sysfs tree from an
+// [config.Infiniband] specification.
+//
+// Layout matches what the kernel ib_core driver exposes at runtime, so real
+// userspace tools (ibstat, ibstatus, iblinkinfo, libibverbs consumers, ...)
+// can read it through libibmocksys.so's path redirection.
+package render
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockibsysfs/config"
+)
+
+// Options controls a single rendering pass.
+type Options struct {
+	IB       config.Infiniband
+	GPUCount int    // used when IB.HCACountOverride == 0
+	NodeName string // expanded into NodeDescTemplate
+	Output   string // fake-root directory; subtree rooted at <Output>/sys/class/...
+}
+
+// Render writes the entire tree. It is idempotent: existing files are
+// truncated and rewritten, existing directories are reused.
+func Render(o Options) error {
+	if !o.IB.Enabled {
+		return nil
+	}
+	ib := o.IB.Defaults()
+	guidPrefix := normalizeGUIDPrefix(ib.GUIDPrefix)
+	if len(guidPrefix) != 12 {
+		return fmt.Errorf("guid_prefix must be 12 hex digits after stripping ':' (got %q -> %q)", ib.GUIDPrefix, guidPrefix)
+	}
+
+	hcaCount := ib.HCACountOverride
+	if hcaCount <= 0 {
+		hcaCount = o.GPUCount * ib.HCAsPerGPU
+	}
+	if hcaCount <= 0 {
+		return fmt.Errorf("infiniband: hca_count is 0 (gpu_count=%d, hcas_per_gpu=%d)", o.GPUCount, ib.HCAsPerGPU)
+	}
+
+	root := o.Output
+	if err := mkdirAll(root, "sys/class/infiniband"); err != nil {
+		return err
+	}
+	if err := mkdirAll(root, "sys/class/infiniband_mad"); err != nil {
+		return err
+	}
+	if err := mkdirAll(root, "sys/class/infiniband_verbs"); err != nil {
+		return err
+	}
+	if err := mkdirAll(root, "dev/infiniband"); err != nil {
+		return err
+	}
+
+	if err := writeFile(root, "sys/class/infiniband_mad/abi_version", "5\n"); err != nil {
+		return err
+	}
+	if err := writeFile(root, "sys/class/infiniband_verbs/abi_version", "6\n"); err != nil {
+		return err
+	}
+
+	for i := 0; i < hcaCount; i++ {
+		if err := renderHCA(root, ib, guidPrefix, i, o.NodeName); err != nil {
+			return fmt.Errorf("rendering mlx5_%d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func renderHCA(root string, ib config.Infiniband, guidPrefix string, idx int, nodeName string) error {
+	caName := fmt.Sprintf("mlx5_%d", idx)
+	caDir := filepath.Join("sys/class/infiniband", caName)
+	if err := mkdirAll(root, caDir); err != nil {
+		return err
+	}
+
+	guid := perHCAGUID(guidPrefix, idx)
+	portGUID := perHCAPortGUID(guidPrefix, idx)
+	nodeDesc := strings.NewReplacer(
+		"{node_name}", nodeName,
+		"{idx}", fmt.Sprintf("%d", idx),
+	).Replace(ib.NodeDescTemplate)
+
+	caFiles := map[string]string{
+		"node_type":       "1: CA\n",
+		"node_guid":       guid + "\n",
+		"sys_image_guid":  guid + "\n",
+		"fw_ver":          ib.FWVersion + "\n",
+		"hw_rev":          ib.HWRev + "\n",
+		"board_id":        ib.BoardID + "\n",
+		"hca_type":        ib.HCAType + "\n",
+		"node_desc":       nodeDesc + "\n",
+	}
+	for name, val := range caFiles {
+		if err := writeFile(root, filepath.Join(caDir, name), val); err != nil {
+			return err
+		}
+	}
+
+	portDir := filepath.Join(caDir, "ports/1")
+	if err := mkdirAll(root, portDir); err != nil {
+		return err
+	}
+	if err := mkdirAll(root, filepath.Join(portDir, "gids")); err != nil {
+		return err
+	}
+	if err := mkdirAll(root, filepath.Join(portDir, "pkeys")); err != nil {
+		return err
+	}
+	if err := mkdirAll(root, filepath.Join(portDir, "counters")); err != nil {
+		return err
+	}
+
+	portFiles := map[string]string{
+		"state":          formatPortState(ib.PortState),
+		"phys_state":     formatPhysState(ib.PhysState),
+		"rate":           formatRate(ib.RateGbps) + "\n",
+		"lid":            fmt.Sprintf("0x%04x\n", idx+1),
+		"lid_mask_count": "0\n",
+		"sm_lid":         "0x0001\n",
+		"sm_sl":          "0\n",
+		"cap_mask":       "0x2651e848\n",
+		"link_layer":     ib.LinkLayer + "\n",
+		"gid_attrs":      "",
+	}
+	for name, val := range portFiles {
+		if err := writeFile(root, filepath.Join(portDir, name), val); err != nil {
+			return err
+		}
+	}
+
+	gid := fmt.Sprintf("fe80:0000:0000:0000:%s:%s:%s:%s",
+		guidPrefix[0:4], guidPrefix[4:8], guidPrefix[8:12], fmt.Sprintf("%04x", idx))
+	if err := writeFile(root, filepath.Join(portDir, "gids/0"), gid+"\n"); err != nil {
+		return err
+	}
+	if err := writeFile(root, filepath.Join(portDir, "pkeys/0"), "0xffff\n"); err != nil {
+		return err
+	}
+
+	// Counters that diag tools optionally read.
+	zeroCounters := []string{
+		"port_xmit_data", "port_rcv_data", "port_xmit_packets", "port_rcv_packets",
+		"port_xmit_discards", "port_rcv_errors", "symbol_error", "link_error_recovery",
+		"link_downed", "port_rcv_remote_physical_errors", "port_rcv_switch_relay_errors",
+		"local_link_integrity_errors", "excessive_buffer_overrun_errors",
+		"VL15_dropped", "port_xmit_constraint_errors", "port_rcv_constraint_errors",
+	}
+	for _, c := range zeroCounters {
+		if err := writeFile(root, filepath.Join(portDir, "counters", c), "0\n"); err != nil {
+			return err
+		}
+	}
+
+	// libibumad device-name registration.
+	madDir := fmt.Sprintf("sys/class/infiniband_mad/umad%d", idx)
+	if err := mkdirAll(root, madDir); err != nil {
+		return err
+	}
+	if err := writeFile(root, filepath.Join(madDir, "ibdev"), caName+"\n"); err != nil {
+		return err
+	}
+	if err := writeFile(root, filepath.Join(madDir, "port"), "1\n"); err != nil {
+		return err
+	}
+	issmDir := fmt.Sprintf("sys/class/infiniband_mad/issm%d", idx)
+	if err := mkdirAll(root, issmDir); err != nil {
+		return err
+	}
+	if err := writeFile(root, filepath.Join(issmDir, "ibdev"), caName+"\n"); err != nil {
+		return err
+	}
+	if err := writeFile(root, filepath.Join(issmDir, "port"), "1\n"); err != nil {
+		return err
+	}
+
+	// libibverbs device-name registration.
+	verbsDir := fmt.Sprintf("sys/class/infiniband_verbs/uverbs%d", idx)
+	if err := mkdirAll(root, verbsDir); err != nil {
+		return err
+	}
+	if err := writeFile(root, filepath.Join(verbsDir, "ibdev"), caName+"\n"); err != nil {
+		return err
+	}
+	if err := writeFile(root, filepath.Join(verbsDir, "abi_version"), "1\n"); err != nil {
+		return err
+	}
+
+	// /dev/infiniband device files. Real char-dev creation requires
+	// CAP_MKNOD; regular files are sufficient for sysfs-only consumers
+	// (ibstat, ibstatus, iblinkinfo). umad_open_port / ibv_open_device
+	// will fail at ioctl time, which is out of scope.
+	for _, f := range []string{
+		fmt.Sprintf("dev/infiniband/umad%d", idx),
+		fmt.Sprintf("dev/infiniband/issm%d", idx),
+		fmt.Sprintf("dev/infiniband/uverbs%d", idx),
+	} {
+		if err := writeFile(root, f, ""); err != nil {
+			return err
+		}
+	}
+
+	_ = portGUID // currently unused; reserved for future port-GUID-specific files
+	return nil
+}
+
+// formatPortState turns "ACTIVE" / "INIT" / etc. into the kernel's
+// "<num>: <NAME>" sysfs format.
+func formatPortState(s string) string {
+	switch strings.ToUpper(s) {
+	case "DOWN":
+		return "1: DOWN\n"
+	case "INIT":
+		return "2: INIT\n"
+	case "ARMED":
+		return "3: ARMED\n"
+	case "ACTIVE", "":
+		return "4: ACTIVE\n"
+	case "ACTIVE_DEFER":
+		return "5: ACTIVE_DEFER\n"
+	default:
+		return "4: ACTIVE\n"
+	}
+}
+
+func formatPhysState(s string) string {
+	switch strings.ToUpper(s) {
+	case "DISABLED":
+		return "3: Disabled\n"
+	case "POLLING":
+		return "2: Polling\n"
+	case "TRAINING":
+		return "4: Training\n"
+	case "LINKUP", "":
+		return "5: LinkUp\n"
+	case "LINKERRORRECOVERY":
+		return "6: LinkErrorRecovery\n"
+	case "PHYTEST":
+		return "7: Phy Test\n"
+	default:
+		return "5: LinkUp\n"
+	}
+}
+
+// formatRate renders the kernel's "<num> Gb/sec (<width> <speed>)" string
+// for a few common InfiniBand speeds.
+func formatRate(gbps int) string {
+	switch gbps {
+	case 100:
+		return "100 Gb/sec (4X EDR)"
+	case 200:
+		return "200 Gb/sec (4X HDR)"
+	case 400:
+		return "400 Gb/sec (4X NDR)"
+	case 800:
+		return "800 Gb/sec (4X XDR)"
+	default:
+		return fmt.Sprintf("%d Gb/sec (4X)", gbps)
+	}
+}
+
+// normalizeGUIDPrefix strips ':' separators and lowercases the result.
+func normalizeGUIDPrefix(s string) string {
+	return strings.ToLower(strings.ReplaceAll(s, ":", ""))
+}
+
+// perHCAGUID renders the colon-separated 8-byte node GUID for HCA index idx.
+func perHCAGUID(guidPrefix string, idx int) string {
+	// prefix is 12 hex chars; pad with 4 hex chars for the lower bytes.
+	return fmt.Sprintf("%s:%s:%s:%04x",
+		guidPrefix[0:4], guidPrefix[4:8], guidPrefix[8:12], idx)
+}
+
+// perHCAPortGUID derives a port GUID by flipping a single byte (matches
+// real Mellanox HCAs where node and port GUIDs differ in the U/L bit).
+func perHCAPortGUID(guidPrefix string, idx int) string {
+	return fmt.Sprintf("%s:%s:%s:%04x",
+		guidPrefix[0:4], guidPrefix[4:8], guidPrefix[8:12], idx+1)
+}
+
+func mkdirAll(root, rel string) error {
+	return os.MkdirAll(filepath.Join(root, rel), 0o755)
+}
+
+func writeFile(root, rel, contents string) error {
+	full := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(full, []byte(contents), 0o644)
+}

--- a/pkg/network/mockibsysfs/render/render.go
+++ b/pkg/network/mockibsysfs/render/render.go
@@ -89,18 +89,21 @@ func renderHCA(root string, ib config.Infiniband, guidPrefix string, idx int, no
 		"{idx}", fmt.Sprintf("%d", idx),
 	).Replace(ib.NodeDescTemplate)
 
-	caFiles := map[string]string{
-		"node_type":       "1: CA\n",
-		"node_guid":       guid + "\n",
-		"sys_image_guid":  guid + "\n",
-		"fw_ver":          ib.FWVersion + "\n",
-		"hw_rev":          ib.HWRev + "\n",
-		"board_id":        ib.BoardID + "\n",
-		"hca_type":        ib.HCAType + "\n",
-		"node_desc":       nodeDesc + "\n",
+	// Slice (not map) so file creation order is deterministic — useful when
+	// diffing rendered trees across runs and when reasoning about partial
+	// failures from later in the function.
+	caFiles := []nameValue{
+		{"node_type", "1: CA\n"},
+		{"node_guid", guid + "\n"},
+		{"sys_image_guid", guid + "\n"},
+		{"fw_ver", ib.FWVersion + "\n"},
+		{"hw_rev", ib.HWRev + "\n"},
+		{"board_id", ib.BoardID + "\n"},
+		{"hca_type", ib.HCAType + "\n"},
+		{"node_desc", nodeDesc + "\n"},
 	}
-	for name, val := range caFiles {
-		if err := writeFile(root, filepath.Join(caDir, name), val); err != nil {
+	for _, f := range caFiles {
+		if err := writeFile(root, filepath.Join(caDir, f.name), f.value); err != nil {
 			return err
 		}
 	}
@@ -118,21 +121,30 @@ func renderHCA(root string, ib config.Infiniband, guidPrefix string, idx int, no
 	if err := mkdirAll(root, filepath.Join(portDir, "counters")); err != nil {
 		return err
 	}
-
-	portFiles := map[string]string{
-		"state":          formatPortState(ib.PortState),
-		"phys_state":     formatPhysState(ib.PhysState),
-		"rate":           formatRate(ib.RateGbps) + "\n",
-		"lid":            fmt.Sprintf("0x%04x\n", idx+1),
-		"lid_mask_count": "0\n",
-		"sm_lid":         "0x0001\n",
-		"sm_sl":          "0\n",
-		"cap_mask":       "0x2651e848\n",
-		"link_layer":     ib.LinkLayer + "\n",
-		"gid_attrs":      "",
+	// In real Linux sysfs `gid_attrs` is a directory containing per-GID
+	// attribute files (ndevs, types, ...). Create it as a directory so
+	// libibverbs / iblinkinfo opendir() succeeds; ibstat doesn't read it.
+	if err := mkdirAll(root, filepath.Join(portDir, "gid_attrs")); err != nil {
+		return err
 	}
-	for name, val := range portFiles {
-		if err := writeFile(root, filepath.Join(portDir, name), val); err != nil {
+
+	portFiles := []nameValue{
+		{"state", formatPortState(ib.PortState)},
+		{"phys_state", formatPhysState(ib.PhysState)},
+		{"rate", formatRate(ib.RateGbps) + "\n"},
+		{"lid", fmt.Sprintf("0x%04x\n", idx+1)},
+		{"lid_mask_count", "0\n"},
+		{"sm_lid", "0x0001\n"},
+		{"sm_sl", "0\n"},
+		{"cap_mask", "0x2651e848\n"},
+		{"link_layer", ib.LinkLayer + "\n"},
+		// Real mlx5 ports expose port_guid alongside node_guid (typically
+		// differing only in the U/L bit). Surface it so tools that key off
+		// per-port identity (e.g. perftest, NCCL topology probes) work.
+		{"port_guid", portGUID + "\n"},
+	}
+	for _, f := range portFiles {
+		if err := writeFile(root, filepath.Join(portDir, f.name), f.value); err != nil {
 			return err
 		}
 	}
@@ -207,9 +219,14 @@ func renderHCA(root string, ib config.Infiniband, guidPrefix string, idx int, no
 			return err
 		}
 	}
-
-	_ = portGUID // currently unused; reserved for future port-GUID-specific files
 	return nil
+}
+
+// nameValue is a (filename, contents) pair used to keep file creation
+// order deterministic; map iteration in Go is randomized.
+type nameValue struct {
+	name  string
+	value string
 }
 
 // formatPortState turns "ACTIVE" / "INIT" / etc. into the kernel's
@@ -287,13 +304,19 @@ func perHCAPortGUID(guidPrefix string, idx int) string {
 }
 
 func mkdirAll(root, rel string) error {
-	return os.MkdirAll(filepath.Join(root, rel), 0o755)
+	if err := os.MkdirAll(filepath.Join(root, rel), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", rel, err)
+	}
+	return nil
 }
 
 func writeFile(root, rel, contents string) error {
 	full := filepath.Join(root, rel)
 	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-		return err
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(rel), err)
 	}
-	return os.WriteFile(full, []byte(contents), 0o644)
+	if err := os.WriteFile(full, []byte(contents), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", rel, err)
+	}
+	return nil
 }

--- a/pkg/network/mockibsysfs/render/render_test.go
+++ b/pkg/network/mockibsysfs/render/render_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package render
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockibsysfs/config"
+)
+
+func TestRender_Disabled(t *testing.T) {
+	dir := t.TempDir()
+	if err := Render(Options{IB: config.Infiniband{Enabled: false}, Output: dir, GPUCount: 8}); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Fatalf("expected no output when disabled, got %d entries", len(entries))
+	}
+}
+
+func TestRender_DefaultsAndCount(t *testing.T) {
+	dir := t.TempDir()
+	err := Render(Options{
+		IB:       config.Infiniband{Enabled: true},
+		GPUCount: 4,
+		NodeName: "host1",
+		Output:   dir,
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	for i := 0; i < 4; i++ {
+		caDir := filepath.Join(dir, "sys/class/infiniband", "mlx5_"+itoa(i))
+		if _, err := os.Stat(caDir); err != nil {
+			t.Errorf("missing CA dir mlx5_%d: %v", i, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "sys/class/infiniband", "mlx5_4")); !os.IsNotExist(err) {
+		t.Errorf("unexpected mlx5_4 (gpu_count=4 hcas_per_gpu=1): %v", err)
+	}
+
+	mustRead := func(rel, want string) {
+		t.Helper()
+		got, err := os.ReadFile(filepath.Join(dir, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if strings.TrimSpace(string(got)) != strings.TrimSpace(want) {
+			t.Errorf("%s: got %q want %q", rel, string(got), want)
+		}
+	}
+
+	mustRead("sys/class/infiniband/mlx5_0/hca_type", "MT4129")
+	mustRead("sys/class/infiniband/mlx5_0/fw_ver", "28.39.2048")
+	mustRead("sys/class/infiniband/mlx5_0/node_desc", "host1 mlx5_0")
+	mustRead("sys/class/infiniband/mlx5_0/ports/1/state", "4: ACTIVE")
+	mustRead("sys/class/infiniband/mlx5_0/ports/1/phys_state", "5: LinkUp")
+	mustRead("sys/class/infiniband/mlx5_0/ports/1/rate", "400 Gb/sec (4X NDR)")
+	mustRead("sys/class/infiniband/mlx5_0/ports/1/link_layer", "InfiniBand")
+	mustRead("sys/class/infiniband_mad/abi_version", "5")
+	mustRead("sys/class/infiniband_mad/umad0/ibdev", "mlx5_0")
+}
+
+func TestRender_HCAsPerGPU(t *testing.T) {
+	dir := t.TempDir()
+	err := Render(Options{
+		IB:       config.Infiniband{Enabled: true, HCAsPerGPU: 2},
+		GPUCount: 4,
+		Output:   dir,
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	for i := 0; i < 8; i++ {
+		caDir := filepath.Join(dir, "sys/class/infiniband", "mlx5_"+itoa(i))
+		if _, err := os.Stat(caDir); err != nil {
+			t.Errorf("missing CA dir mlx5_%d: %v", i, err)
+		}
+	}
+}
+
+func TestRender_HCACountOverride(t *testing.T) {
+	dir := t.TempDir()
+	err := Render(Options{
+		IB:       config.Infiniband{Enabled: true, HCACountOverride: 2},
+		GPUCount: 16, // ignored
+		Output:   dir,
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		caDir := filepath.Join(dir, "sys/class/infiniband", "mlx5_"+itoa(i))
+		if _, err := os.Stat(caDir); err != nil {
+			t.Errorf("missing CA dir mlx5_%d: %v", i, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "sys/class/infiniband", "mlx5_2")); !os.IsNotExist(err) {
+		t.Errorf("override should cap count: mlx5_2 exists: %v", err)
+	}
+}
+
+func TestRender_RateMapping(t *testing.T) {
+	cases := []struct{ in int; want string }{
+		{100, "100 Gb/sec (4X EDR)"},
+		{200, "200 Gb/sec (4X HDR)"},
+		{400, "400 Gb/sec (4X NDR)"},
+		{800, "800 Gb/sec (4X XDR)"},
+		{50, "50 Gb/sec (4X)"},
+	}
+	for _, tc := range cases {
+		if got := formatRate(tc.in); got != tc.want {
+			t.Errorf("formatRate(%d): got %q want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRender_GUIDPrefixNormalization(t *testing.T) {
+	dir := t.TempDir()
+	err := Render(Options{
+		IB:       config.Infiniband{Enabled: true, GUIDPrefix: "AA:BB:CC:00:11:22"},
+		GPUCount: 1,
+		Output:   dir,
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, "sys/class/infiniband/mlx5_0/node_guid"))
+	want := "aabb:cc00:1122:0000\n"
+	if string(got) != want {
+		t.Errorf("node_guid: got %q want %q", string(got), want)
+	}
+}
+
+func TestRender_BadGUIDPrefix(t *testing.T) {
+	dir := t.TempDir()
+	err := Render(Options{
+		IB:       config.Infiniband{Enabled: true, GUIDPrefix: "tooshort"},
+		GPUCount: 1,
+		Output:   dir,
+	})
+	if err == nil {
+		t.Fatalf("expected error for bad guid_prefix, got nil")
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	for i > 0 {
+		digits = append([]byte{byte('0' + i%10)}, digits...)
+		i /= 10
+	}
+	return string(digits)
+}

--- a/pkg/network/mockibsysfs/render/render_test.go
+++ b/pkg/network/mockibsysfs/render/render_test.go
@@ -6,6 +6,7 @@ package render
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -14,7 +15,25 @@ import (
 
 func TestRender_Disabled(t *testing.T) {
 	dir := t.TempDir()
-	if err := Render(Options{IB: config.Infiniband{Enabled: false}, Output: dir, GPUCount: 8}); err != nil {
+	// Populate every Infiniband field except `Enabled` so the test would
+	// catch a regression where `Enabled` is ignored and Render() proceeds
+	// based on the rest of the struct alone.
+	ib := config.Infiniband{
+		Enabled:          false,
+		HCAType:          "MT4129",
+		FWVersion:        "28.39.2048",
+		HWRev:            "0",
+		BoardID:          "MT_0000000884",
+		GUIDPrefix:       "001122334455",
+		HCAsPerGPU:       2,
+		HCACountOverride: 4,
+		RateGbps:         400,
+		PortState:        "ACTIVE",
+		PhysState:        "LinkUp",
+		LinkLayer:        "InfiniBand",
+		NodeDescTemplate: "{node_name} mlx5_{idx}",
+	}
+	if err := Render(Options{IB: ib, Output: dir, GPUCount: 8, NodeName: "host1"}); err != nil {
 		t.Fatalf("Render: %v", err)
 	}
 	entries, _ := os.ReadDir(dir)
@@ -35,7 +54,7 @@ func TestRender_DefaultsAndCount(t *testing.T) {
 		t.Fatalf("Render: %v", err)
 	}
 	for i := 0; i < 4; i++ {
-		caDir := filepath.Join(dir, "sys/class/infiniband", "mlx5_"+itoa(i))
+		caDir := filepath.Join(dir, "sys/class/infiniband", "mlx5_"+strconv.Itoa(i))
 		if _, err := os.Stat(caDir); err != nil {
 			t.Errorf("missing CA dir mlx5_%d: %v", i, err)
 		}
@@ -64,6 +83,22 @@ func TestRender_DefaultsAndCount(t *testing.T) {
 	mustRead("sys/class/infiniband/mlx5_0/ports/1/link_layer", "InfiniBand")
 	mustRead("sys/class/infiniband_mad/abi_version", "5")
 	mustRead("sys/class/infiniband_mad/umad0/ibdev", "mlx5_0")
+
+	// `gid_attrs` must be a directory in real Linux sysfs; libibverbs and
+	// iblinkinfo opendir() it. A regular file would yield ENOTDIR.
+	gidAttrs := filepath.Join(dir, "sys/class/infiniband/mlx5_0/ports/1/gid_attrs")
+	if st, err := os.Stat(gidAttrs); err != nil {
+		t.Errorf("missing gid_attrs: %v", err)
+	} else if !st.IsDir() {
+		t.Errorf("gid_attrs must be a directory, got mode %v", st.Mode())
+	}
+
+	// port_guid is exposed by real mlx5 ports and must follow node_guid's
+	// formatting. The default GUID prefix is "a088c20300ab" and the lower
+	// 16 bits encode (idx+1), so mlx5_0's port_guid ends in 0001 (its
+	// node_guid ends in 0000) — matches real Mellanox U/L-bit behavior.
+	mustRead("sys/class/infiniband/mlx5_0/node_guid", "a088:c203:00ab:0000")
+	mustRead("sys/class/infiniband/mlx5_0/ports/1/port_guid", "a088:c203:00ab:0001")
 }
 
 func TestRender_HCAsPerGPU(t *testing.T) {
@@ -77,7 +112,7 @@ func TestRender_HCAsPerGPU(t *testing.T) {
 		t.Fatalf("Render: %v", err)
 	}
 	for i := 0; i < 8; i++ {
-		caDir := filepath.Join(dir, "sys/class/infiniband", "mlx5_"+itoa(i))
+		caDir := filepath.Join(dir, "sys/class/infiniband", "mlx5_"+strconv.Itoa(i))
 		if _, err := os.Stat(caDir); err != nil {
 			t.Errorf("missing CA dir mlx5_%d: %v", i, err)
 		}
@@ -95,7 +130,7 @@ func TestRender_HCACountOverride(t *testing.T) {
 		t.Fatalf("Render: %v", err)
 	}
 	for i := 0; i < 2; i++ {
-		caDir := filepath.Join(dir, "sys/class/infiniband", "mlx5_"+itoa(i))
+		caDir := filepath.Join(dir, "sys/class/infiniband", "mlx5_"+strconv.Itoa(i))
 		if _, err := os.Stat(caDir); err != nil {
 			t.Errorf("missing CA dir mlx5_%d: %v", i, err)
 		}
@@ -149,14 +184,3 @@ func TestRender_BadGUIDPrefix(t *testing.T) {
 	}
 }
 
-func itoa(i int) string {
-	if i == 0 {
-		return "0"
-	}
-	digits := []byte{}
-	for i > 0 {
-		digits = append([]byte{byte('0' + i%10)}, digits...)
-		i /= 10
-	}
-	return string(digits)
-}

--- a/pkg/network/mockibsysfs/shim.c
+++ b/pkg/network/mockibsysfs/shim.c
@@ -1,0 +1,417 @@
+/*
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * libibmocksys.so -- LD_PRELOAD shim that redirects InfiniBand sysfs/dev
+ * lookups to a fake tree under $MOCK_IB_ROOT (default /var/lib/nvml-mock).
+ *
+ * Real `ibstat`, `ibstatus`, `iblinkinfo`, `ibv_devinfo`, ... read from
+ * /sys/class/infiniband*, /sys/class/infiniband_mad*,
+ * /sys/class/infiniband_verbs*, /sys/class/infiniband_cm*, and
+ * /dev/infiniband*. We hook the libc syscall wrappers, and for any path
+ * starting with one of those prefixes we splice $MOCK_IB_ROOT in front and
+ * forward to the next libc.
+ *
+ * Design notes:
+ *   - dlsym(RTLD_NEXT, ...) is resolved lazily on first call and cached.
+ *   - Path rewriting uses a thread-local fixed buffer (PATH_MAX) -- no
+ *     allocations on the hot path.
+ *   - When MOCK_IB_DISABLE=1 (or root is unset and "/var/lib/nvml-mock" does
+ *     not exist) the shim becomes a true no-op.
+ *   - Variadic open()/openat() are handled with the `mode_t` extraction
+ *     pattern recommended by glibc's headers (only valid when O_CREAT or
+ *     O_TMPFILE is set in flags).
+ *
+ * Targeted at glibc 2.36+ (Debian bookworm). Older `__xstat` family symbols
+ * are also intercepted for safety; if libc does not export them the linker
+ * resolves to NULL and our fallback path is taken.
+ */
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+static const char *const k_prefixes[] = {
+    "/sys/class/infiniband/",
+    "/sys/class/infiniband_mad/",
+    "/sys/class/infiniband_verbs/",
+    "/sys/class/infiniband_cm/",
+    "/dev/infiniband/",
+    /* Bare-directory forms (no trailing slash) for opendir/stat. */
+    "/sys/class/infiniband",
+    "/sys/class/infiniband_mad",
+    "/sys/class/infiniband_verbs",
+    "/sys/class/infiniband_cm",
+    "/dev/infiniband",
+    NULL,
+};
+
+static const char *root_cached = NULL;
+static size_t root_len_cached = 0;
+static int disabled_cached = -1;
+static pthread_once_t init_once = PTHREAD_ONCE_INIT;
+
+static void init_root(void) {
+    const char *disable = getenv("MOCK_IB_DISABLE");
+    if (disable && disable[0] != '\0' && disable[0] != '0') {
+        disabled_cached = 1;
+        return;
+    }
+    const char *root = getenv("MOCK_IB_ROOT");
+    if (!root || root[0] == '\0') {
+        root = "/var/lib/nvml-mock";
+    }
+    root_cached = root;
+    root_len_cached = strlen(root);
+    disabled_cached = 0;
+}
+
+/*
+ * Returns 1 if `path` starts with any redirected prefix and writes the
+ * rewritten path into `out` (size `out_size`). Returns 0 otherwise (and
+ * leaves `out` untouched). Returns -1 on overflow (caller should fall back
+ * to the original path; errno is preserved).
+ */
+static int rewrite_path(const char *path, char *out, size_t out_size) {
+    if (!path) return 0;
+    pthread_once(&init_once, init_root);
+    if (disabled_cached) return 0;
+    if (path[0] != '/') return 0; /* only absolute paths */
+
+    for (size_t i = 0; k_prefixes[i] != NULL; ++i) {
+        const char *p = k_prefixes[i];
+        size_t plen = strlen(p);
+        /* Match if path == prefix, or path starts with prefix+'/', or
+         * prefix ends in '/' and path starts with prefix. */
+        if (p[plen - 1] == '/') {
+            if (strncmp(path, p, plen) != 0) continue;
+        } else {
+            if (strncmp(path, p, plen) != 0) continue;
+            if (path[plen] != '\0' && path[plen] != '/') continue;
+        }
+        size_t total = root_len_cached + strlen(path);
+        if (total + 1 > out_size) return -1;
+        memcpy(out, root_cached, root_len_cached);
+        memcpy(out + root_len_cached, path, strlen(path) + 1);
+        return 1;
+    }
+    return 0;
+}
+
+#define REAL(name) static __typeof__(name) *real_##name = NULL
+#define LOAD_REAL(name)                                          \
+    do {                                                         \
+        if (!real_##name) {                                      \
+            real_##name = (__typeof__(name) *)dlsym(RTLD_NEXT, #name); \
+        }                                                        \
+    } while (0)
+
+/* ---------- open / openat ---------- */
+
+REAL(open);
+REAL(open64);
+REAL(openat);
+REAL(openat64);
+
+static int extract_mode(int flags, va_list ap) {
+    if ((flags & O_CREAT) || (flags & __O_TMPFILE)) {
+        return va_arg(ap, int);
+    }
+    return 0;
+}
+
+int open(const char *path, int flags, ...) {
+    LOAD_REAL(open);
+    char buf[PATH_MAX];
+    int mode = 0;
+    va_list ap;
+    va_start(ap, flags);
+    mode = extract_mode(flags, ap);
+    va_end(ap);
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    if (rc == 1) {
+        return real_open(buf, flags, mode);
+    }
+    return real_open(path, flags, mode);
+}
+
+int open64(const char *path, int flags, ...) {
+    LOAD_REAL(open64);
+    char buf[PATH_MAX];
+    int mode = 0;
+    va_list ap;
+    va_start(ap, flags);
+    mode = extract_mode(flags, ap);
+    va_end(ap);
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    if (rc == 1) {
+        return real_open64(buf, flags, mode);
+    }
+    return real_open64(path, flags, mode);
+}
+
+int openat(int dirfd, const char *path, int flags, ...) {
+    LOAD_REAL(openat);
+    char buf[PATH_MAX];
+    int mode = 0;
+    va_list ap;
+    va_start(ap, flags);
+    mode = extract_mode(flags, ap);
+    va_end(ap);
+    /* Only rewrite absolute paths; relative paths use dirfd which already
+     * points at a redirected directory if appropriate. */
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    if (rc == 1) {
+        return real_openat(dirfd, buf, flags, mode);
+    }
+    return real_openat(dirfd, path, flags, mode);
+}
+
+int openat64(int dirfd, const char *path, int flags, ...) {
+    LOAD_REAL(openat64);
+    char buf[PATH_MAX];
+    int mode = 0;
+    va_list ap;
+    va_start(ap, flags);
+    mode = extract_mode(flags, ap);
+    va_end(ap);
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    if (rc == 1) {
+        return real_openat64(dirfd, buf, flags, mode);
+    }
+    return real_openat64(dirfd, path, flags, mode);
+}
+
+/* ---------- fopen ---------- */
+
+REAL(fopen);
+REAL(fopen64);
+
+FILE *fopen(const char *path, const char *mode) {
+    LOAD_REAL(fopen);
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real_fopen(rc == 1 ? buf : path, mode);
+}
+
+FILE *fopen64(const char *path, const char *mode) {
+    LOAD_REAL(fopen64);
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real_fopen64(rc == 1 ? buf : path, mode);
+}
+
+/* ---------- opendir / scandir ---------- */
+
+REAL(opendir);
+REAL(scandir);
+REAL(scandir64);
+
+DIR *opendir(const char *name) {
+    LOAD_REAL(opendir);
+    char buf[PATH_MAX];
+    int rc = rewrite_path(name, buf, sizeof(buf));
+    return real_opendir(rc == 1 ? buf : name);
+}
+
+/* glibc's scandir() internally uses a hidden __opendir symbol that bypasses
+ * our opendir() hook -- libibumad uses scandir() to enumerate HCAs and ports,
+ * so we must intercept here too. */
+int scandir(const char *path, struct dirent ***namelist,
+            int (*filter)(const struct dirent *),
+            int (*compar)(const struct dirent **, const struct dirent **)) {
+    LOAD_REAL(scandir);
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real_scandir(rc == 1 ? buf : path, namelist, filter, compar);
+}
+
+int scandir64(const char *path, struct dirent64 ***namelist,
+              int (*filter)(const struct dirent64 *),
+              int (*compar)(const struct dirent64 **, const struct dirent64 **)) {
+    LOAD_REAL(scandir64);
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real_scandir64(rc == 1 ? buf : path, namelist, filter, compar);
+}
+
+/* ---------- stat / lstat / fstatat ---------- */
+
+REAL(stat);
+REAL(stat64);
+REAL(lstat);
+REAL(lstat64);
+REAL(fstatat);
+REAL(fstatat64);
+
+int stat(const char *path, struct stat *st) {
+    LOAD_REAL(stat);
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real_stat(rc == 1 ? buf : path, st);
+}
+
+int stat64(const char *path, struct stat64 *st) {
+    LOAD_REAL(stat64);
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real_stat64(rc == 1 ? buf : path, st);
+}
+
+int lstat(const char *path, struct stat *st) {
+    LOAD_REAL(lstat);
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real_lstat(rc == 1 ? buf : path, st);
+}
+
+int lstat64(const char *path, struct stat64 *st) {
+    LOAD_REAL(lstat64);
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real_lstat64(rc == 1 ? buf : path, st);
+}
+
+int fstatat(int dirfd, const char *path, struct stat *st, int flags) {
+    LOAD_REAL(fstatat);
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real_fstatat(dirfd, rc == 1 ? buf : path, st, flags);
+}
+
+int fstatat64(int dirfd, const char *path, struct stat64 *st, int flags) {
+    LOAD_REAL(fstatat64);
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real_fstatat64(dirfd, rc == 1 ? buf : path, st, flags);
+}
+
+/* statx(2) -- used directly by modern coreutils (ls, stat, ...) bypassing
+ * the classic stat() glibc wrapper. Exported by glibc 2.28+. */
+int statx(int dirfd, const char *path, int flags, unsigned int mask,
+          struct statx *st) {
+    static int (*real)(int, const char *, int, unsigned int, struct statx *) = NULL;
+    if (!real) real = dlsym(RTLD_NEXT, "statx");
+    if (!real) { errno = ENOSYS; return -1; }
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real(dirfd, rc == 1 ? buf : path, flags, mask, st);
+}
+
+/* Legacy __xstat family (glibc < 2.33). On modern systems these may not be
+ * exported by libc.so.6; in that case dlsym returns NULL and we just don't
+ * register the hook (the binary won't call us either). */
+
+int __xstat(int ver, const char *path, struct stat *st) {
+    static int (*real)(int, const char *, struct stat *) = NULL;
+    if (!real) real = dlsym(RTLD_NEXT, "__xstat");
+    if (!real) { errno = ENOSYS; return -1; }
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real(ver, rc == 1 ? buf : path, st);
+}
+
+int __xstat64(int ver, const char *path, struct stat64 *st) {
+    static int (*real)(int, const char *, struct stat64 *) = NULL;
+    if (!real) real = dlsym(RTLD_NEXT, "__xstat64");
+    if (!real) { errno = ENOSYS; return -1; }
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real(ver, rc == 1 ? buf : path, st);
+}
+
+int __lxstat(int ver, const char *path, struct stat *st) {
+    static int (*real)(int, const char *, struct stat *) = NULL;
+    if (!real) real = dlsym(RTLD_NEXT, "__lxstat");
+    if (!real) { errno = ENOSYS; return -1; }
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real(ver, rc == 1 ? buf : path, st);
+}
+
+int __lxstat64(int ver, const char *path, struct stat64 *st) {
+    static int (*real)(int, const char *, struct stat64 *) = NULL;
+    if (!real) real = dlsym(RTLD_NEXT, "__lxstat64");
+    if (!real) { errno = ENOSYS; return -1; }
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real(ver, rc == 1 ? buf : path, st);
+}
+
+int __fxstatat(int ver, int dirfd, const char *path, struct stat *st, int flag) {
+    static int (*real)(int, int, const char *, struct stat *, int) = NULL;
+    if (!real) real = dlsym(RTLD_NEXT, "__fxstatat");
+    if (!real) { errno = ENOSYS; return -1; }
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real(ver, dirfd, rc == 1 ? buf : path, st, flag);
+}
+
+int __fxstatat64(int ver, int dirfd, const char *path, struct stat64 *st, int flag) {
+    static int (*real)(int, int, const char *, struct stat64 *, int) = NULL;
+    if (!real) real = dlsym(RTLD_NEXT, "__fxstatat64");
+    if (!real) { errno = ENOSYS; return -1; }
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real(ver, dirfd, rc == 1 ? buf : path, st, flag);
+}
+
+/* ---------- chdir ---------- */
+
+REAL(chdir);
+
+int chdir(const char *path) {
+    LOAD_REAL(chdir);
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real_chdir(rc == 1 ? buf : path);
+}
+
+/* ---------- access / readlink ---------- */
+
+REAL(access);
+REAL(faccessat);
+REAL(readlink);
+REAL(readlinkat);
+
+int access(const char *path, int mode) {
+    LOAD_REAL(access);
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real_access(rc == 1 ? buf : path, mode);
+}
+
+int faccessat(int dirfd, const char *path, int mode, int flags) {
+    LOAD_REAL(faccessat);
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real_faccessat(dirfd, rc == 1 ? buf : path, mode, flags);
+}
+
+ssize_t readlink(const char *path, char *out, size_t out_size) {
+    LOAD_REAL(readlink);
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real_readlink(rc == 1 ? buf : path, out, out_size);
+}
+
+ssize_t readlinkat(int dirfd, const char *path, char *out, size_t out_size) {
+    LOAD_REAL(readlinkat);
+    char buf[PATH_MAX];
+    int rc = rewrite_path(path, buf, sizeof(buf));
+    return real_readlinkat(dirfd, rc == 1 ? buf : path, out, out_size);
+}

--- a/pkg/network/mockibsysfs/shim.c
+++ b/pkg/network/mockibsysfs/shim.c
@@ -19,8 +19,11 @@
  *   - When MOCK_IB_DISABLE=1 (or root is unset and "/var/lib/nvml-mock" does
  *     not exist) the shim becomes a true no-op.
  *   - Variadic open()/openat() are handled with the `mode_t` extraction
- *     pattern recommended by glibc's headers (only valid when O_CREAT or
- *     O_TMPFILE is set in flags).
+ *     pattern recommended by glibc's headers: read as `unsigned int` from
+ *     va_arg (post default-argument-promotion) and cast back to mode_t.
+ *     Only valid when O_CREAT is set or (flags & O_TMPFILE) == O_TMPFILE
+ *     -- O_TMPFILE includes O_DIRECTORY in its bit pattern so a simple
+ *     `flags & O_TMPFILE` test would false-positive on O_DIRECTORY alone.
  *
  * Targeted at glibc 2.36+ (Debian bookworm). Older `__xstat` family symbols
  * are also intercepted for safety; if libc does not export them the linker
@@ -127,9 +130,14 @@ REAL(open64);
 REAL(openat);
 REAL(openat64);
 
-static int extract_mode(int flags, va_list ap) {
-    if ((flags & O_CREAT) || (flags & __O_TMPFILE)) {
-        return va_arg(ap, int);
+static mode_t extract_mode(int flags, va_list ap) {
+    /* Avoid the glibc-internal __O_TMPFILE symbol; O_TMPFILE is the public
+     * macro and matching its full bit pattern (it includes O_DIRECTORY) is
+     * the documented test. POSIX `mode_t` is promoted to `int`/`unsigned`
+     * through varargs, so extracting as `unsigned int` is the canonical
+     * pattern (matches glibc's own `fcntl.h` inline open()). */
+    if ((flags & O_CREAT) || (flags & O_TMPFILE) == O_TMPFILE) {
+        return (mode_t)va_arg(ap, unsigned int);
     }
     return 0;
 }
@@ -137,7 +145,7 @@ static int extract_mode(int flags, va_list ap) {
 int open(const char *path, int flags, ...) {
     LOAD_REAL(open);
     char buf[PATH_MAX];
-    int mode = 0;
+    mode_t mode = 0;
     va_list ap;
     va_start(ap, flags);
     mode = extract_mode(flags, ap);
@@ -152,7 +160,7 @@ int open(const char *path, int flags, ...) {
 int open64(const char *path, int flags, ...) {
     LOAD_REAL(open64);
     char buf[PATH_MAX];
-    int mode = 0;
+    mode_t mode = 0;
     va_list ap;
     va_start(ap, flags);
     mode = extract_mode(flags, ap);
@@ -167,7 +175,7 @@ int open64(const char *path, int flags, ...) {
 int openat(int dirfd, const char *path, int flags, ...) {
     LOAD_REAL(openat);
     char buf[PATH_MAX];
-    int mode = 0;
+    mode_t mode = 0;
     va_list ap;
     va_start(ap, flags);
     mode = extract_mode(flags, ap);
@@ -184,7 +192,7 @@ int openat(int dirfd, const char *path, int flags, ...) {
 int openat64(int dirfd, const char *path, int flags, ...) {
     LOAD_REAL(openat64);
     char buf[PATH_MAX];
-    int mode = 0;
+    mode_t mode = 0;
     va_list ap;
     va_start(ap, flags);
     mode = extract_mode(flags, ap);

--- a/tests/e2e/validate-ibstat.sh
+++ b/tests/e2e/validate-ibstat.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Validate the InfiniBand sysfs mock by running real ibstat / ibstatus
+# inside the nvml-mock DaemonSet pod and asserting on the output.
+#
+# Usage:
+#   validate-ibstat.sh <pod-name> <profile> <expected-hcas>
+#
+# Profiles that ship with infiniband.enabled=false (l40s, t4) are expected
+# to report zero HCAs regardless of <expected-hcas>.
+set -euo pipefail
+
+POD="${1:?Usage: $0 <pod-name> <profile> <expected-hcas>}"
+PROFILE="${2:?}"
+EXPECTED="${3:?}"
+
+# Profiles where the bundled defaults disable IB. Keep in sync with
+# deployments/nvml-mock/helm/nvml-mock/profiles/*.yaml.
+case "$PROFILE" in
+  l40s|t4) EXPECTED=0 ;;
+esac
+
+echo "=== Validating ibstat on pod=$POD profile=$PROFILE expected=$EXPECTED ==="
+
+# 1. ibstat -l must list one mlx5_<n> per HCA.
+LIST=$(kubectl exec "$POD" -- ibstat -l 2>&1 || true)
+echo "--- ibstat -l ---"
+printf '%s\n' "$LIST"
+ACTUAL=$(printf '%s\n' "$LIST" | grep -c '^mlx' || true)
+if [ "$ACTUAL" -ne "$EXPECTED" ]; then
+  echo "FAIL: ibstat -l reported $ACTUAL HCAs, expected $EXPECTED"
+  exit 1
+fi
+echo "PASS: $ACTUAL HCAs listed by ibstat -l"
+
+if [ "$EXPECTED" -eq 0 ]; then
+  echo "=== ibstat validation PASSED (IB disabled for $PROFILE) ==="
+  exit 0
+fi
+
+# 2. ibstatus must show every port in state ACTIVE.
+STATUS=$(kubectl exec "$POD" -- ibstatus 2>&1)
+echo "--- ibstatus ---"
+printf '%s\n' "$STATUS"
+ACTIVE=$(printf '%s\n' "$STATUS" | grep -Ec 'state:[[:space:]]+[0-9]+:[[:space:]]+ACTIVE' || true)
+if [ "$ACTIVE" -ne "$EXPECTED" ]; then
+  echo "FAIL: ibstatus shows $ACTIVE ACTIVE ports, expected $EXPECTED"
+  exit 1
+fi
+echo "PASS: $ACTIVE ports ACTIVE"
+
+# 3. ibstat (no args) must contain a CA section per HCA.
+FULL=$(kubectl exec "$POD" -- ibstat 2>&1)
+CAS=$(printf '%s\n' "$FULL" | grep -c "^CA '" || true)
+if [ "$CAS" -ne "$EXPECTED" ]; then
+  echo "FAIL: ibstat reported $CAS CA sections, expected $EXPECTED"
+  printf '%s\n' "$FULL"
+  exit 1
+fi
+echo "PASS: $CAS CA sections in ibstat output"
+
+echo "=== ibstat validation PASSED ==="


### PR DESCRIPTION
## What This PR Does

Adds a fake InfiniBand fabric to the nvml-mock DaemonSet so real userspace tools (`ibstat`, `ibstatus`, `iblinkinfo`, libibverbs consumers, ...) report a realistic per-HCA topology on hosts with no IB hardware. Same model as the existing `nvidia-smi` mock — real binary backed by a fake kernel surface.

```bash
$ kubectl exec nvml-mock-xxxxx -- ibstat
CA 'mlx5_0'
        CA type: MT4129
        Number of ports: 1
        Firmware version: 28.39.2048
        Node GUID: 0xa088c20300ab0000
        Port 1:
                State: Active
                Physical state: LinkUp
                Rate: 400
                Link layer: InfiniBand
... (one CA per GPU)
```

### Architecture

Two pieces in `pkg/network/mockibsysfs/`:

- **`libibmocksys.so` (LD_PRELOAD shim, C)** — intercepts ~15 libc filesystem functions (`open`/`openat`/`opendir`/`scandir`/`stat`/`statx`/`chdir`/...) and rewrites paths under `/sys/class/infiniband*`, `/sys/class/infiniband_mad/`, `/sys/class/infiniband_verbs/`, and `/dev/infiniband` to point at `$MOCK_IB_ROOT`. Everything else passes through to real libc via `dlsym(RTLD_NEXT, ...)`. Set `MOCK_IB_DISABLE=1` to bypass.
- **`render-ib-sysfs` (Go binary)** — reads the new `infiniband:` block of each mock-nvml profile YAML and writes a kernel-faithful tree: per-CA `node_type`/`node_guid`/`sys_image_guid`/`fw_ver`/`hw_rev`/`board_id`/`hca_type`/`node_desc`; per-port `state`/`phys_state`/`rate`/`lid`/`sm_lid`/`cap_mask`/`link_layer`/`port_guid`/`gids/0`/`gid_attrs/`/`pkeys/0`/`counters/*`; plus `infiniband_mad/{abi_version,umad*,issm*}` for libibumad and `infiniband_verbs/{abi_version,uverbs*}` for libibverbs.

Why C for the shim (not Go): a Go `c-shared` library would inject the entire Go runtime (scheduler, GC, signal handlers, ~5–10 MB resident) into every process loaded with LD_PRELOAD, hijack signal handlers (SIGSEGV/SIGURG/SIGPROF), and risk re-entrancy with the runtime's own `open`/`stat` calls during init. Variadic and function-pointer signatures (`open(..., flags, ...)`, `scandir`, `statx`) cannot be expressed cleanly through cgo. C trampolines forwarding to `dlsym(RTLD_NEXT, ...)` are the textbook shape for this. The renderer (one-shot, complex logic, runs at startup) stays in Go.

### Wiring

- Dockerfile builds both pieces and installs `infiniband-diags` + `rdma-core` for the real userspace tools.
- `setup.sh` invokes `render-ib-sysfs` after the GPU mock setup.
- DaemonSet exports `LD_PRELOAD=/usr/local/lib/libibmocksys.so.1` and `MOCK_IB_ROOT=/var/lib/nvml-mock/ib` so every process in the container — including `kubectl exec ... ibstat` — sees the fake fabric.

### Profile defaults

| Profile  | Enabled | HCA model              | Speed        | HCAs / GPU |
|----------|---------|------------------------|--------------|------------|
| `a100`   | yes     | ConnectX-6 (`MT4123`)  | HDR 200 Gb/s | 1          |
| `h100`   | yes     | ConnectX-7 (`MT4129`)  | NDR 400 Gb/s | 1          |
| `b200`   | yes     | ConnectX-7 (`MT4129`)  | NDR 400 Gb/s | 1          |
| `gb200`  | yes     | ConnectX-7 (`MT4129`)  | NDR 400 Gb/s | 1          |
| `l40s`   | no      | —                      | —            | —          |
| `t4`     | no      | —                      | —            | —          |

All knobs (`hca_type`, `fw_version`, `link_layer`, `rate_gbps`, `port_state`, `phys_state`, `hcas_per_gpu`, `hca_count`, `guid_prefix`, `node_desc_template`) can be overridden per profile or via `gpu.customConfig`.

## Why

The mock-nvml stack covers GPU discovery very thoroughly, but most NCCL / training workloads also probe the InfiniBand fabric (`ibv_get_device_list`, `ibstat`, NCCL's `nccl-tests`, k8s GPU Operator's network operator validators). Today these probes either fail or are skipped in CI, which means we can't exercise GPU + IB topology end-to-end against the mock. This PR closes that gap with the same "real-tool-on-fake-kernel" approach that already works for `nvidia-smi`.

## Rebase notes

The branch was rebased on `upstream/main` (latest: `87ae8025`) to clear the `BLOCKED` state:

- **#326 (DRA quick-start: co-locate dev nodes under driver root)** — accepted upstream's `DEV_ROOT=$DRIVER_ROOT/dev` change in `setup.sh` and re-applied the IB rendering block on top.
- **#323 (dynamic metrics: temperature, power, utilization)** — kept upstream's `MOCK_NVML_CONFIG` env var and `/etc/nvml-mock` configmap mount; layered the IB-mock `LD_PRELOAD` / `MOCK_IB_ROOT` env vars and the second `host-nvml-mock` mount alongside.
- **`helm-unittest --verify=false`** — landed upstream as `ce6dcfc0`, so the previously-included CI commit dropped automatically during rebase. This PR is now scoped purely to the InfiniBand mock.
- **#306 (Mock NVML: hex UUIDs, IsMigDeviceHandle, SONAME, device visibility filtering)** — refreshed the helm `__snapshot__/*.yaml.snap` files to match the post-#306 / post-#323 daemonset shape. The diff that looks like "snapshot churn" is the merge of three orthogonal changes (UUID format, `MOCK_NVML_CONFIG` env, IB env + double-mount) into a single rendered baseline.

## Review feedback addressed (commit `8b0059d9`)

Blockers from the changes-requested review (#315):

- **`gid_attrs` as directory** (`render.go`): real Linux sysfs has it as a directory containing per-GID attribute files. Was previously written as an empty regular file (would yield `ENOTDIR` for libibverbs / iblinkinfo `opendir()`); now created via `mkdirAll`. Test added.
- **`port_guid` wired in** (`render.go`): `perHCAPortGUID` is now written to `ports/1/port_guid` instead of being computed and discarded. Real mlx5 ports expose this alongside `node_guid` (lower 16 bits differ to mimic the U/L bit). Test added.
- **Error wrapping** (`render.go`): `mkdirAll` and `writeFile` now return `fmt.Errorf("mkdir %s: %w", rel, err)` / `fmt.Errorf("write %s: %w", rel, err)` so a permission-denied at deep paths surfaces with call-site context instead of a bare `os` error.
- **`setup.sh` failure handling**: removed the `|| echo "WARNING: render-ib-sysfs failed (non-fatal)"` swallowing; failures are fatal under `set -e` (a profile-YAML typo would otherwise silently produce an empty IB tree). Also fixed the post-rebase `--config` path to `/etc/nvml-mock/config.yaml`.

Non-blocking nits also addressed:

- **Deterministic file order**: `caFiles` / `portFiles` converted from `map[string]string` to slices of `(name, value)` pairs (Go map iteration is randomized).
- **`strconv.Itoa`**: replaced the hand-rolled `itoa` test helper.
- **`shim.c`**: replaced the glibc-internal `__O_TMPFILE` with public `O_TMPFILE` matching its full bit pattern (it includes `O_DIRECTORY`); switched the `va_arg` mode extraction to `(mode_t)va_arg(ap, unsigned int)` matching glibc's own `fcntl.h` inline `open()` pattern.
- **Integration test**: now also asserts on per-HCA counter files (`port_xmit_data`, `port_rcv_data`, `port_xmit_packets`) and `infiniband_mad/abi_version` so non-`ibstat` consumers (perfquery, iblinkinfo, libibumad init) are exercised end-to-end.
- **`TestRender_Disabled`**: now populates every `Infiniband` field except `Enabled`, so a regression where `Enabled` is ignored and `Render()` proceeds based on the rest of the struct alone is now caught.
- **`Chart.yaml`**: added `kubeVersion: ">= 1.28.0-0"`. The two-mountPath pattern for one hostPath has worked since k8s 1.0, but pinning a floor surfaces the requirement. The `daemonset.yaml` comment now points at `kubeVersion` rather than reading as "this is unusual".

## Tests

- Unit tests for the renderer (defaults, GUID normalization, count override, rate-string mapping, error paths, `gid_attrs` directory, `port_guid`, disabled-with-fully-populated-struct) — `go test ./pkg/network/mockibsysfs/...` (passes).
- Integration test (`-tags=integration`, Linux-only, skipped otherwise) builds the shim, renders a tree, runs real `ibstat` from `infiniband-diags`, and asserts on output, per-HCA counter files, and `infiniband_mad/abi_version`. Verified passing in `linux/amd64` Docker.
- Helm unittest snapshots regenerated; all 79 tests / 14 snapshots pass post-rebase.
- End-to-end smoke against the actual built image: `setup.sh` followed by `ibstat` / `ibstatus` produces correct output for the H100 default (8x ConnectX-7 NDR HCAs).

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`go test -race ./pkg/network/mockibsysfs/... ./cmd/render-ib-sysfs/...`)
- [x] Helm unittest passes (`helm unittest deployments/nvml-mock/helm/nvml-mock` — 79 tests, 14 snapshots)
- [ ] Linter passes (`golangci-lint run`) — not installed locally; relying on CI
- [x] New code has SPDX license headers
- [x] Documentation updated (Helm chart README, `pkg/network/mockibsysfs/README.md`, standalone + with-fgo demos)
- [x] CHANGELOG.md updated under `[Unreleased]`
