### PR TITLE
ci(helm): harden chart version parsing in publish workflow

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Read chart version
         id: chart
         run: |
-          version=$(helm show chart ${{ env.CHART_DIR }}/${{ env.CHART_NAME }} | grep '^version:' | awk '{print $2}')
+          version=$(helm show chart ${{ env.CHART_DIR }}/${{ env.CHART_NAME }} -o json | jq -er .version)
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR


### PR DESCRIPTION
## What This PR Does
Hardens chart version parsing in the Helm publish workflow to handle 
edge cases that could cause the CI pipeline to fail or produce incorrect 
version strings.

## Why
Closes #310

## Checklist
- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`go test -v -race ./...`)
- [ ] Linter passes (`golangci-lint run`)
- [x] New code has SPDX license headers
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (if user-facing change)