### PR TITLE
feat(dashboard): 5y window + duration selector (PR-C of 3)

### DIFF
--- a/artifact_fetcher.go
+++ b/artifact_fetcher.go
@@ -1218,7 +1218,8 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 	}
 	owner, name := parts[0], parts[1]
 	now := time.Now().UTC()
-	twelveWeeksAgo := now.AddDate(0, 0, -84)
+	fiveYearsAgo := now.AddDate(-5, 0, 0)
+	oneYearAgo := now.AddDate(-1, 0, 0)
 
 	// Fetch all open issues (GitHub issues endpoint includes PRs, filter them out)
 	var openIssues []*github.Issue
@@ -1264,7 +1265,7 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 	var closedItems []*github.Issue
 	closedOpt := &github.IssueListByRepoOptions{
 		State:       "closed",
-		Since:       twelveWeeksAgo,
+		Since:       fiveYearsAgo,
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
 	for {
@@ -1299,7 +1300,7 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 			if pr.GetMergedAt().IsZero() {
 				continue
 			}
-			if pr.GetMergedAt().Before(twelveWeeksAgo) {
+			if pr.GetMergedAt().Before(fiveYearsAgo) {
 				pastCutoff = true
 				continue // process remaining PRs on this page
 			}
@@ -1337,27 +1338,38 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 		}
 	}
 
-	// Issue velocity: opened + closed per week
+	// Issue velocity: opened + closed per week (5y window) and per day (1y window)
 	issueOpenedByWeek := make(map[string]int)
 	issueClosedByWeek := make(map[string]int)
+	issueOpenedByDay := make(map[string]int)
+	issueClosedByDay := make(map[string]int)
 
 	for _, iss := range openIssues {
-		if iss.GetCreatedAt().Time.After(twelveWeeksAgo) {
-			w := isoWeek(iss.GetCreatedAt().Time)
-			issueOpenedByWeek[w]++
+		if iss.GetCreatedAt().Time.After(fiveYearsAgo) {
+			t := iss.GetCreatedAt().Time
+			issueOpenedByWeek[isoWeek(t)]++
+			if t.After(oneYearAgo) {
+				issueOpenedByDay[t.UTC().Format("2006-01-02")]++
+			}
 		}
 	}
 	for _, iss := range closedItems {
 		if iss.PullRequestLinks != nil {
 			continue
 		}
-		if iss.GetCreatedAt().Time.After(twelveWeeksAgo) {
-			w := isoWeek(iss.GetCreatedAt().Time)
-			issueOpenedByWeek[w]++
+		if iss.GetCreatedAt().Time.After(fiveYearsAgo) {
+			t := iss.GetCreatedAt().Time
+			issueOpenedByWeek[isoWeek(t)]++
+			if t.After(oneYearAgo) {
+				issueOpenedByDay[t.UTC().Format("2006-01-02")]++
+			}
 		}
-		if iss.ClosedAt != nil && iss.GetClosedAt().Time.After(twelveWeeksAgo) {
-			w := isoWeek(iss.GetClosedAt().Time)
-			issueClosedByWeek[w]++
+		if iss.ClosedAt != nil && iss.GetClosedAt().Time.After(fiveYearsAgo) {
+			t := iss.GetClosedAt().Time
+			issueClosedByWeek[isoWeek(t)]++
+			if t.After(oneYearAgo) {
+				issueClosedByDay[t.UTC().Format("2006-01-02")]++
+			}
 		}
 	}
 
@@ -1398,33 +1410,48 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 		}
 	}
 
-	// PR velocity
+	// PR velocity (5y weekly + 1y daily)
 	prOpenedByWeek := make(map[string]int)
 	prClosedByWeek := make(map[string]int)
 	prMergedByWeek := make(map[string]int)
+	prOpenedByDay := make(map[string]int)
+	prClosedByDay := make(map[string]int)
+	prMergedByDay := make(map[string]int)
 
 	for _, pr := range openPRs {
-		if pr.GetCreatedAt().Time.After(twelveWeeksAgo) {
-			w := isoWeek(pr.GetCreatedAt().Time)
-			prOpenedByWeek[w]++
+		if pr.GetCreatedAt().Time.After(fiveYearsAgo) {
+			t := pr.GetCreatedAt().Time
+			prOpenedByWeek[isoWeek(t)]++
+			if t.After(oneYearAgo) {
+				prOpenedByDay[t.UTC().Format("2006-01-02")]++
+			}
 		}
 	}
 	for _, iss := range closedItems {
 		if iss.PullRequestLinks == nil {
 			continue
 		}
-		if iss.GetCreatedAt().Time.After(twelveWeeksAgo) {
-			w := isoWeek(iss.GetCreatedAt().Time)
-			prOpenedByWeek[w]++
+		if iss.GetCreatedAt().Time.After(fiveYearsAgo) {
+			t := iss.GetCreatedAt().Time
+			prOpenedByWeek[isoWeek(t)]++
+			if t.After(oneYearAgo) {
+				prOpenedByDay[t.UTC().Format("2006-01-02")]++
+			}
 		}
-		if iss.ClosedAt != nil && iss.GetClosedAt().Time.After(twelveWeeksAgo) {
-			w := isoWeek(iss.GetClosedAt().Time)
-			prClosedByWeek[w]++
+		if iss.ClosedAt != nil && iss.GetClosedAt().Time.After(fiveYearsAgo) {
+			t := iss.GetClosedAt().Time
+			prClosedByWeek[isoWeek(t)]++
+			if t.After(oneYearAgo) {
+				prClosedByDay[t.UTC().Format("2006-01-02")]++
+			}
 		}
 	}
 	for _, pr := range mergedPRs {
-		w := isoWeek(pr.GetMergedAt().Time)
-		prMergedByWeek[w]++
+		t := pr.GetMergedAt().Time
+		prMergedByWeek[isoWeek(t)]++
+		if t.After(oneYearAgo) {
+			prMergedByDay[t.UTC().Format("2006-01-02")]++
+		}
 	}
 
 	// Avg days to merge
@@ -1465,8 +1492,10 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 		avgDaysToFirstReview = totalFirstReviewDays / float64(reviewedCount)
 	}
 
-	issueVelocityWeekly := buildVelocitySlice(issueOpenedByWeek, issueClosedByWeek, nil, twelveWeeksAgo, now)
-	prVelocityWeekly := buildVelocitySlice(prOpenedByWeek, prClosedByWeek, prMergedByWeek, twelveWeeksAgo, now)
+	issueVelocityWeekly := buildVelocitySlice(issueOpenedByWeek, issueClosedByWeek, nil, fiveYearsAgo, now)
+	prVelocityWeekly := buildVelocitySlice(prOpenedByWeek, prClosedByWeek, prMergedByWeek, fiveYearsAgo, now)
+	issueVelocityDaily := bucketByDay(issueOpenedByDay, issueClosedByDay, nil, oneYearAgo, now)
+	prVelocityDaily := bucketByDay(prOpenedByDay, prClosedByDay, prMergedByDay, oneYearAgo, now)
 
 	return RepoIssuesPRs{
 		FetchedAt: now.Format(time.RFC3339),
@@ -1475,7 +1504,7 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 			Categories: issueCats,
 			AgeBuckets: issueAgeBuckets,
 			Velocity: Velocity{
-				Daily:  nil, // populated in subsequent task (Task 5) by bucketByDay
+				Daily:  issueVelocityDaily,
 				Weekly: issueVelocityWeekly,
 			},
 		},
@@ -1484,7 +1513,7 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 			Categories: prCats,
 			AgeBuckets: prAgeBuckets,
 			Velocity: Velocity{
-				Daily:  nil, // populated in subsequent task (Task 5) by bucketByDay
+				Daily:  prVelocityDaily,
 				Weekly: prVelocityWeekly,
 			},
 			Review: PRReviewMetrics{

--- a/artifact_fetcher.go
+++ b/artifact_fetcher.go
@@ -212,7 +212,7 @@ func loadPreviousIssuesPRs(path string, logger *slog.Logger) (IssuesPRsFile, err
 			"path", path,
 			"err", jerr.Error())
 		// Visible workflow annotation so degraded runs aren't silent.
-		fmt.Println("::warning title=issues_prs cache::malformed prior issues_prs.json — degraded fallback in effect (per-repo failures will omit, not use stale data)")
+		fmt.Println("::warning title=issues_prs cache::malformed or schema-mismatched prior issues_prs.json — degraded fallback in effect (per-repo failures will omit). This is expected on the first run after PR-C lands due to the velocity-shape change.")
 		return empty, nil
 	}
 
@@ -383,6 +383,29 @@ type VelocityWeek struct {
 	Merged *int   `json:"merged,omitempty"`
 }
 
+// VelocityDay carries day-bucketed counts. Used for sub-weekly views
+// (currently the 7d duration; D2 retains 365 days so future specs can
+// add historical-offset views without re-fetching).
+type VelocityDay struct {
+	Date   string `json:"date"` // RFC 3339 date in UTC, e.g. "2026-04-23"
+	Opened int    `json:"opened"`
+	Closed int    `json:"closed"`
+	Merged *int   `json:"merged,omitempty"`
+}
+
+// Velocity bundles the daily and weekly arrays for a single Issue or PR
+// stream. Daily covers the last 365 days (UTC-bucketed). Weekly covers the
+// last ~260 weeks at ISO-week granularity. Consumers select the array
+// matching the active duration:
+//   - 7d         → daily.slice(-7)
+//   - 4w / 12w   → weekly.slice(-4) / -12
+//   - 6m / 1y    → weekly.slice(-26) / -52
+//   - 5y         → weekly.slice(-260)
+type Velocity struct {
+	Daily  []VelocityDay  `json:"daily"`
+	Weekly []VelocityWeek `json:"weekly"`
+}
+
 type PRReviewMetrics struct {
 	AwaitingReview       int     `json:"awaitingReview"`
 	NoReviewer           int     `json:"noReviewer"`
@@ -394,14 +417,14 @@ type IssueStats struct {
 	Total      int            `json:"total"`
 	Categories map[string]int `json:"categories"`
 	AgeBuckets AgeBuckets     `json:"ageBuckets"`
-	Velocity   []VelocityWeek `json:"velocity"`
+	Velocity   Velocity       `json:"velocity"`
 }
 
 type PRStats struct {
 	Total      int             `json:"total"`
 	Categories map[string]int  `json:"categories"`
 	AgeBuckets AgeBuckets      `json:"ageBuckets"`
-	Velocity   []VelocityWeek  `json:"velocity"`
+	Velocity   Velocity        `json:"velocity"`
 	Review     PRReviewMetrics `json:"review"`
 }
 
@@ -1404,8 +1427,8 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 		avgDaysToFirstReview = totalFirstReviewDays / float64(reviewedCount)
 	}
 
-	issueVelocity := buildVelocitySlice(issueOpenedByWeek, issueClosedByWeek, nil, twelveWeeksAgo, now)
-	prVelocity := buildVelocitySlice(prOpenedByWeek, prClosedByWeek, prMergedByWeek, twelveWeeksAgo, now)
+	issueVelocityWeekly := buildVelocitySlice(issueOpenedByWeek, issueClosedByWeek, nil, twelveWeeksAgo, now)
+	prVelocityWeekly := buildVelocitySlice(prOpenedByWeek, prClosedByWeek, prMergedByWeek, twelveWeeksAgo, now)
 
 	return RepoIssuesPRs{
 		FetchedAt: now.Format(time.RFC3339),
@@ -1413,13 +1436,19 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 			Total:      len(openIssues),
 			Categories: issueCats,
 			AgeBuckets: issueAgeBuckets,
-			Velocity:   issueVelocity,
+			Velocity: Velocity{
+				Daily:  nil, // populated in subsequent task (Task 5) by bucketByDay
+				Weekly: issueVelocityWeekly,
+			},
 		},
 		PullRequests: PRStats{
 			Total:      len(openPRs),
 			Categories: prCats,
 			AgeBuckets: prAgeBuckets,
-			Velocity:   prVelocity,
+			Velocity: Velocity{
+				Daily:  nil, // populated in subsequent task (Task 5) by bucketByDay
+				Weekly: prVelocityWeekly,
+			},
 			Review: PRReviewMetrics{
 				AwaitingReview:       awaitingReview,
 				NoReviewer:           noReviewer,

--- a/artifact_fetcher.go
+++ b/artifact_fetcher.go
@@ -550,6 +550,44 @@ func buildVelocitySlice(opened, closed, merged map[string]int, from, to time.Tim
 	return result
 }
 
+// bucketByDay emits a continuous range of VelocityDay entries for [from, to)
+// in UTC. Days with no events get zero counts. The opened/closed/merged
+// input maps are keyed by RFC 3339 date strings ("YYYY-MM-DD") in UTC; the
+// caller is responsible for populating the keys with UTC dates (e.g.,
+// `t.UTC().Format("2006-01-02")`).
+//
+// merged may be nil for streams that don't track merges (Issues); the
+// resulting VelocityDay.Merged field is left nil in that case.
+//
+// Spec: docs/plans/2026-04-30-dashboard-duration-options-design.md
+// (component bucketByDay; D2 — 1-year retention).
+func bucketByDay(opened, closed, merged map[string]int, from, to time.Time) []VelocityDay {
+	from = from.UTC().Truncate(24 * time.Hour)
+	to = to.UTC().Truncate(24 * time.Hour)
+	if !from.Before(to) {
+		return []VelocityDay{}
+	}
+	days := int(to.Sub(from) / (24 * time.Hour))
+	out := make([]VelocityDay, 0, days)
+	for i := 0; i < days; i++ {
+		d := from.AddDate(0, 0, i)
+		key := d.Format("2006-01-02")
+		entry := VelocityDay{
+			Date:   key,
+			Opened: opened[key],
+			Closed: closed[key],
+		}
+		if merged != nil {
+			if m, ok := merged[key]; ok {
+				v := m
+				entry.Merged = &v
+			}
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
 // -----------------------------------------------------------------------------
 func main() {
 	log.SetFlags(0)

--- a/artifact_fetcher_bucket_test.go
+++ b/artifact_fetcher_bucket_test.go
@@ -94,3 +94,71 @@ func TestBucketByDay_UTCAlignment(t *testing.T) {
 		t.Fatalf("Opened = %d; want 7", got[0].Opened)
 	}
 }
+
+// TestBucketByDay_EmptyInput asserts the helper returns the right
+// continuous-zeros range when none of the input maps have entries.
+// This is the path most production days will take for low-traffic repos.
+//
+// Mutation check: returning an empty slice on empty input fails the
+// length assertion (the spec says "continuous range with zeros"; an
+// empty slice would let the UI's "no velocity data" placeholder fire
+// for repos that genuinely have zero events, which is wrong).
+func TestBucketByDay_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	from := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC)
+
+	got := bucketByDay(map[string]int{}, map[string]int{}, map[string]int{}, from, to)
+
+	if len(got) != 3 {
+		t.Fatalf("len = %d; want 3 (3-day continuous range with zeros)", len(got))
+	}
+	for i, d := range got {
+		if d.Opened != 0 || d.Closed != 0 || d.Merged != nil {
+			t.Errorf("day[%d] = %+v; want all-zero", i, d)
+		}
+	}
+}
+
+// TestBucketByDay_OneYearRetention asserts the helper returns 365 (or
+// 366 for leap years) entries when invoked over a 1-year window. PR-C's
+// fetchIssuesPRs caller passes a 1-year span; this test pins the length
+// invariant so a future bug shrinking the window is caught.
+//
+// Mutation check: a regression that hard-codes "30 days" returns 30
+// entries; assertion fails.
+func TestBucketByDay_OneYearRetention(t *testing.T) {
+	t.Parallel()
+
+	to := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
+	from := to.AddDate(-1, 0, 0)
+
+	got := bucketByDay(nil, nil, nil, from, to)
+
+	wantDays := int(to.Sub(from) / (24 * time.Hour))
+	if len(got) != wantDays {
+		t.Fatalf("len = %d; want %d (one full year)", len(got), wantDays)
+	}
+	if got[0].Date != "2025-04-30" {
+		t.Fatalf("first entry Date = %q; want %q", got[0].Date, "2025-04-30")
+	}
+	if got[len(got)-1].Date != "2026-04-29" {
+		t.Fatalf("last entry Date = %q; want %q", got[len(got)-1].Date, "2026-04-29")
+	}
+}
+
+// TestBucketByDay_FromAfterTo returns an empty slice (defensive — the
+// caller shouldn't ever do this, but a misconfigured `from > to` should
+// not panic or return random entries).
+func TestBucketByDay_FromAfterTo(t *testing.T) {
+	t.Parallel()
+
+	from := time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+
+	got := bucketByDay(nil, nil, nil, from, to)
+	if len(got) != 0 {
+		t.Fatalf("len = %d; want 0", len(got))
+	}
+}

--- a/artifact_fetcher_bucket_test.go
+++ b/artifact_fetcher_bucket_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestBucketByDay_Correctness covers the core daily-bucketing contract:
+//   - Output length is exactly to.Sub(from)/24h (continuous, no gaps).
+//   - Each entry has the correct UTC date string.
+//   - opened/closed/merged counts are taken from the input maps,
+//     keyed by the UTC YYYY-MM-DD date.
+//   - Days with no events have zero counts (continuous-zeros invariant).
+//
+// Mutation check: an off-by-one on `from` or `to` flips the boundary
+// count (test fixture spans known boundary dates). Using TZ-local dates
+// instead of UTC.Format would produce different keys for events near
+// 23:59:59 UTC; subtests cover this explicitly.
+func TestBucketByDay_Correctness(t *testing.T) {
+	t.Parallel()
+
+	// Fixture: 5-day window 2026-04-20 .. 2026-04-25 (inclusive of from,
+	// exclusive of to). Expected length: 5.
+	from := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC)
+
+	opened := map[string]int{
+		"2026-04-20": 3,
+		"2026-04-22": 1,
+		// 2026-04-21, 2026-04-23, 2026-04-24 deliberately absent → expect 0.
+	}
+	closed := map[string]int{
+		"2026-04-22": 2,
+		"2026-04-24": 1,
+	}
+	merged := map[string]int{}
+
+	got := bucketByDay(opened, closed, merged, from, to)
+
+	want := []VelocityDay{
+		{Date: "2026-04-20", Opened: 3, Closed: 0},
+		{Date: "2026-04-21", Opened: 0, Closed: 0},
+		{Date: "2026-04-22", Opened: 1, Closed: 2},
+		{Date: "2026-04-23", Opened: 0, Closed: 0},
+		{Date: "2026-04-24", Opened: 0, Closed: 1},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("len = %d; want %d (got: %v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Date != want[i].Date {
+			t.Errorf("day[%d] Date = %q; want %q", i, got[i].Date, want[i].Date)
+		}
+		if got[i].Opened != want[i].Opened {
+			t.Errorf("day[%d] Opened = %d; want %d", i, got[i].Opened, want[i].Opened)
+		}
+		if got[i].Closed != want[i].Closed {
+			t.Errorf("day[%d] Closed = %d; want %d", i, got[i].Closed, want[i].Closed)
+		}
+		if got[i].Merged != nil {
+			t.Errorf("day[%d] Merged = %v; want nil (Issue stream)", i, got[i].Merged)
+		}
+	}
+}
+
+// TestBucketByDay_UTCAlignment asserts events keyed by UTC date are
+// placed in the right bucket regardless of an input timestamp's clock
+// hour. The bucket for 2026-04-23 23:59:59 UTC must be "2026-04-23",
+// not "2026-04-24" (which TZ-local rendering with PST would produce).
+//
+// Because bucketByDay accepts pre-keyed maps (string → int), the
+// caller is responsible for using UTC dates in the keys; this test
+// verifies the helper's BEHAVIOR by feeding both a "correct" and an
+// "incorrect" key and asserting the helper trusts the input verbatim.
+// Together with the call-site tests in fetchIssuesPRs (Task 7), this
+// closes the UTC contract end-to-end.
+func TestBucketByDay_UTCAlignment(t *testing.T) {
+	t.Parallel()
+
+	from := time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+
+	opened := map[string]int{"2026-04-23": 7}
+	got := bucketByDay(opened, nil, nil, from, to)
+
+	if len(got) != 1 {
+		t.Fatalf("len = %d; want 1", len(got))
+	}
+	if got[0].Date != "2026-04-23" {
+		t.Fatalf("Date = %q; want %q", got[0].Date, "2026-04-23")
+	}
+	if got[0].Opened != 7 {
+		t.Fatalf("Opened = %d; want 7", got[0].Opened)
+	}
+}

--- a/artifact_fetcher_cache_test.go
+++ b/artifact_fetcher_cache_test.go
@@ -94,8 +94,8 @@ func TestLoadPreviousIssuesPRs_ValidFile(t *testing.T) {
   "repos": {
     "nvidia/gpu-operator": {
       "fetchedAt": "2026-04-29T12:00:00Z",
-      "issues": {"total": 42, "categories": {"bug": 12}, "ageBuckets": {"fresh":5,"recent":10,"aging":12,"stale":8,"ancient":7}, "velocity": []},
-      "pullRequests": {"total": 8, "categories": {}, "ageBuckets": {"fresh":3,"recent":2,"aging":2,"stale":1,"ancient":0}, "velocity": [], "review": {"awaitingReview":3,"noReviewer":1,"avgDaysToFirstReview":1.5,"avgDaysToMerge":3.2}}
+      "issues": {"total": 42, "categories": {"bug": 12}, "ageBuckets": {"fresh":5,"recent":10,"aging":12,"stale":8,"ancient":7}, "velocity": {"daily": [], "weekly": []}},
+      "pullRequests": {"total": 8, "categories": {}, "ageBuckets": {"fresh":3,"recent":2,"aging":2,"stale":1,"ancient":0}, "velocity": {"daily": [], "weekly": []}, "review": {"awaitingReview":3,"noReviewer":1,"avgDaysToFirstReview":1.5,"avgDaysToMerge":3.2}}
     }
   }
 }`
@@ -270,11 +270,11 @@ func TestRunIssuesPRsPhase_CacheFallback(t *testing.T) {
 					Total:      99,
 					Categories: map[string]int{"bug": 50},
 					AgeBuckets: AgeBuckets{Fresh: 10, Recent: 20, Aging: 30, Stale: 25, Ancient: 14},
-					Velocity:   []VelocityWeek{},
+					Velocity:   Velocity{Daily: []VelocityDay{}, Weekly: []VelocityWeek{}},
 				},
 				PullRequests: PRStats{
 					Total: 5, Categories: map[string]int{}, AgeBuckets: AgeBuckets{},
-					Velocity: []VelocityWeek{}, Review: PRReviewMetrics{},
+					Velocity: Velocity{Daily: []VelocityDay{}, Weekly: []VelocityWeek{}}, Review: PRReviewMetrics{},
 				},
 			},
 		},

--- a/artifact_fetcher_e2e_test.go
+++ b/artifact_fetcher_e2e_test.go
@@ -11,30 +11,77 @@ import (
 	"time"
 )
 
-// TestFetchIssuesPRs_EndToEnd_DeterministicFixture exercises fetchIssuesPRs
-// against a stub server returning multi-page paginated responses with
-// Link: <...>; rel="next" headers. Asserts:
-//   - velocity.Daily length is exactly the days-in-1y count.
-//   - velocity.Weekly length is exactly the expected ~260 weeks.
-//   - Totals match the fixture's exact counts (not "approximately").
-//   - Categories are populated from the fixture's labels.
-//
-// Mutation check: dropping the pagination loop (break after page 1)
-// undercounts events; assertions on totals fail.
-//
-// Label note: uses bare `bug` / `feature` labels (mapped under _default in
-// labelCategories at artifact_fetcher.go); the original plan used
-// `kind/bug` / `kind/feature` which only map under repo-specific overrides.
-func TestFetchIssuesPRs_EndToEnd_DeterministicFixture(t *testing.T) {
-	t.Parallel()
+// e2eFixtureTimes carries the concrete event timestamps used by the
+// deterministic e2e fixture so that assertions can locate the expected
+// daily-bucket index without reverse-engineering the math.
+type e2eFixtureTimes struct {
+	Now            time.Time
+	ClosedIssue1At time.Time // plain closed issue, ~10d ago
+	ClosedIssue2At time.Time // plain closed issue, ~30d ago
+	ClosedPRAsIss  time.Time // closed PR-as-issue, ~5d ago
+	MergedPR1At    time.Time // merged PR, ~7d ago
+	MergedPR2At    time.Time // merged PR, ~50d ago
+}
 
+// runE2EClosedAndMerged spins up a stub GitHub server with two pages of
+// open issues, three closed items (2 plain issues + 1 PR-as-issue), and
+// two merged PRs, then drives fetchIssuesPRs against it. Returns the
+// aggregated result and the fixture timestamps so the caller can assert
+// on bucket placement.
+func runE2EClosedAndMerged(t *testing.T) (RepoIssuesPRs, e2eFixtureTimes) {
+	t.Helper()
 	now := time.Now().UTC()
+	ft := e2eFixtureTimes{
+		Now:            now,
+		ClosedIssue1At: now.Add(-10 * 24 * time.Hour),
+		ClosedIssue2At: now.Add(-30 * 24 * time.Hour),
+		ClosedPRAsIss:  now.Add(-5 * 24 * time.Hour),
+		MergedPR1At:    now.Add(-7 * 24 * time.Hour),
+		MergedPR2At:    now.Add(-50 * 24 * time.Hour),
+	}
+
 	openIssuesPage1 := buildIssuesJSON([]issueFixture{
 		{Number: 100, State: "open", CreatedAt: now.Add(-3 * 24 * time.Hour), Labels: []string{"bug"}},
 		{Number: 101, State: "open", CreatedAt: now.Add(-30 * 24 * time.Hour), Labels: []string{"feature"}},
 	})
 	openIssuesPage2 := buildIssuesJSON([]issueFixture{
 		{Number: 102, State: "open", CreatedAt: now.Add(-100 * 24 * time.Hour), Labels: []string{"bug"}},
+	})
+	closedIssuesJSON := buildIssuesJSON([]issueFixture{
+		{
+			Number:    200,
+			State:     "closed",
+			CreatedAt: ft.ClosedIssue1At.Add(-2 * 24 * time.Hour),
+			ClosedAt:  &ft.ClosedIssue1At,
+			Labels:    []string{"bug"},
+		},
+		{
+			Number:    201,
+			State:     "closed",
+			CreatedAt: ft.ClosedIssue2At.Add(-3 * 24 * time.Hour),
+			ClosedAt:  &ft.ClosedIssue2At,
+			Labels:    []string{"feature"},
+		},
+		{
+			Number:        300,
+			State:         "closed",
+			CreatedAt:     ft.ClosedPRAsIss.Add(-1 * 24 * time.Hour),
+			ClosedAt:      &ft.ClosedPRAsIss,
+			IsPullRequest: true,
+			Labels:        []string{"bug"},
+		},
+	})
+	mergedPRsJSON := buildPRsJSON([]prFixture{
+		{
+			Number:    400,
+			CreatedAt: ft.MergedPR1At.Add(-30 * 24 * time.Hour),
+			MergedAt:  ft.MergedPR1At,
+		},
+		{
+			Number:    401,
+			CreatedAt: ft.MergedPR2At.Add(-30 * 24 * time.Hour),
+			MergedAt:  ft.MergedPR2At,
+		},
 	})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -52,9 +99,16 @@ func TestFetchIssuesPRs_EndToEnd_DeterministicFixture(t *testing.T) {
 			return
 		case strings.Contains(r.URL.Path, "/issues") && r.URL.Query().Get("state") == "closed":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = io.WriteString(w, "[]")
+			_, _ = io.WriteString(w, closedIssuesJSON)
 			return
 		case strings.Contains(r.URL.Path, "/pulls"):
+			// Branch on state: state=open is the open-PRs path (empty in
+			// this fixture), state=closed is the merged-PRs path.
+			if r.URL.Query().Get("state") == "closed" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, mergedPRsJSON)
+				return
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, "[]")
 			return
@@ -76,6 +130,35 @@ func TestFetchIssuesPRs_EndToEnd_DeterministicFixture(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fetchIssuesPRs: %v", err)
 	}
+	return got, ft
+}
+
+// TestFetchIssuesPRs_EndToEnd_DeterministicFixture exercises fetchIssuesPRs
+// against a stub server returning multi-page paginated responses with
+// Link: <...>; rel="next" headers. Asserts:
+//   - velocity.Daily length is exactly the days-in-1y count.
+//   - velocity.Weekly length is exactly the expected ~260 weeks.
+//   - Totals match the fixture's exact counts (not "approximately").
+//   - Categories are populated from the fixture's labels.
+//   - Closed-issue + closed-PR (PR-as-issue) aggregation paths produce the
+//     correct daily-bucket sums and land in the expected day indices.
+//   - Merged-PR aggregation produces correct daily-bucket sums and lands in
+//     the expected day index.
+//
+// Mutation check: dropping the open-issues pagination loop (break after
+// page 1) undercounts events; assertions on totals fail.
+// Mutation check: removing the closed-events loop (artifact_fetcher.go
+// `for _, iss := range closedItems`) fails the closed/merged sum
+// assertions for issues and PR-as-issue.
+// Mutation check: removing the merged-events loop (artifact_fetcher.go
+// `for _, pr := range mergedPRs`) fails the merged-sum assertions.
+//
+// Label note: uses bare `bug` / `feature` labels (mapped under _default in
+// labelCategories at artifact_fetcher.go); the original plan used
+// `kind/bug` / `kind/feature` which only map under repo-specific overrides.
+func TestFetchIssuesPRs_EndToEnd_DeterministicFixture(t *testing.T) {
+	t.Parallel()
+	got, ft := runE2EClosedAndMerged(t)
 
 	if got.Issues.Total != 3 {
 		t.Fatalf("Issues.Total = %d; want 3 (fixture has 3 open across 2 pages)", got.Issues.Total)
@@ -92,15 +175,95 @@ func TestFetchIssuesPRs_EndToEnd_DeterministicFixture(t *testing.T) {
 	if len(got.Issues.Velocity.Weekly) < 260 || len(got.Issues.Velocity.Weekly) > 261 {
 		t.Fatalf("Issues.Velocity.Weekly length = %d; want 260-261", len(got.Issues.Velocity.Weekly))
 	}
+
+	// --- Closed-issue aggregation: two plain closed issues should land in
+	// the issue daily-velocity stream, the PR-as-issue should NOT.
+	var issueClosedSum int
+	for _, d := range got.Issues.Velocity.Daily {
+		issueClosedSum += d.Closed
+	}
+	if issueClosedSum != 2 {
+		t.Fatalf("sum(Issues.Velocity.Daily[*].Closed) = %d; want 2 (two plain closed issues at -10d and -30d)", issueClosedSum)
+	}
+
+	// --- PR-as-issue aggregation: the closed PR-as-issue should land in
+	// the PR daily-velocity stream's Closed field.
+	var prClosedSum int
+	for _, d := range got.PullRequests.Velocity.Daily {
+		prClosedSum += d.Closed
+	}
+	if prClosedSum != 1 {
+		t.Fatalf("sum(PullRequests.Velocity.Daily[*].Closed) = %d; want 1 (one closed PR-as-issue at -5d)", prClosedSum)
+	}
+
+	// --- Merged-PR aggregation: two merged PRs should land in the PR
+	// daily-velocity stream's Merged field.
+	var prMergedSum int
+	prMergedHasNonZero := false
+	for _, d := range got.PullRequests.Velocity.Daily {
+		if d.Merged != nil {
+			prMergedSum += *d.Merged
+			if *d.Merged > 0 {
+				prMergedHasNonZero = true
+			}
+		}
+	}
+	if !prMergedHasNonZero {
+		t.Fatalf("PullRequests.Velocity.Daily contained no Merged>0 entries; want at least one (fixture has 2 merged PRs in 1y window)")
+	}
+	if prMergedSum != 2 {
+		t.Fatalf("sum(*PullRequests.Velocity.Daily[*].Merged) = %d; want 2 (two merged PRs at -7d and -50d)", prMergedSum)
+	}
+
+	// --- Spot-check specific date buckets. The Daily array spans
+	// [oneYearAgo, now) UTC, truncated to day. Index i corresponds to
+	// from.AddDate(0, 0, i) in bucketByDay, where from = oneYearAgo
+	// truncated to day.
+	dailyIndexFor := func(eventAt time.Time) int {
+		from := ft.Now.UTC().AddDate(-1, 0, 0).Truncate(24 * time.Hour)
+		evDay := eventAt.UTC().Truncate(24 * time.Hour)
+		return int(evDay.Sub(from) / (24 * time.Hour))
+	}
+	idxClosed1 := dailyIndexFor(ft.ClosedIssue1At)
+	if idxClosed1 < 0 || idxClosed1 >= len(got.Issues.Velocity.Daily) {
+		t.Fatalf("computed bucket index %d for ClosedIssue1At=%s out of range [0,%d)", idxClosed1, ft.ClosedIssue1At.Format(time.RFC3339), len(got.Issues.Velocity.Daily))
+	}
+	if got.Issues.Velocity.Daily[idxClosed1].Closed < 1 {
+		t.Errorf("Issues.Velocity.Daily[%d] (date=%s) Closed = %d; want >=1 (event at -10d should land here)",
+			idxClosed1, got.Issues.Velocity.Daily[idxClosed1].Date, got.Issues.Velocity.Daily[idxClosed1].Closed)
+	}
+
+	idxMerged1 := dailyIndexFor(ft.MergedPR1At)
+	if idxMerged1 < 0 || idxMerged1 >= len(got.PullRequests.Velocity.Daily) {
+		t.Fatalf("computed bucket index %d for MergedPR1At=%s out of range [0,%d)", idxMerged1, ft.MergedPR1At.Format(time.RFC3339), len(got.PullRequests.Velocity.Daily))
+	}
+	mergedAtIdx := got.PullRequests.Velocity.Daily[idxMerged1].Merged
+	if mergedAtIdx == nil || *mergedAtIdx < 1 {
+		var observed string
+		if mergedAtIdx == nil {
+			observed = "nil"
+		} else {
+			observed = fmt.Sprintf("%d", *mergedAtIdx)
+		}
+		t.Errorf("PullRequests.Velocity.Daily[%d] (date=%s) Merged = %s; want >=1 (event at -7d should land here)",
+			idxMerged1, got.PullRequests.Velocity.Daily[idxMerged1].Date, observed)
+	}
 }
 
 // issueFixture is a minimal subset of the GitHub Issue API shape that
 // tests need. buildIssuesJSON marshals it to JSON for the stub server.
+//
+// ClosedAt, when non-nil, emits the JSON field `closed_at`. IsPullRequest,
+// when true, emits a `pull_request` object so go-github sets
+// PullRequestLinks non-nil — that's how the Issues endpoint distinguishes
+// PR-as-issue rows from plain issues.
 type issueFixture struct {
-	Number    int
-	State     string
-	CreatedAt time.Time
-	Labels    []string
+	Number        int
+	State         string
+	CreatedAt     time.Time
+	ClosedAt      *time.Time
+	Labels        []string
+	IsPullRequest bool
 }
 
 func buildIssuesJSON(items []issueFixture) string {
@@ -119,8 +282,41 @@ func buildIssuesJSON(items []issueFixture) string {
 		}
 		labels += "]"
 		b.WriteString(fmt.Sprintf(
-			`{"number":%d,"state":"%s","created_at":"%s","labels":%s}`,
+			`{"number":%d,"state":"%s","created_at":"%s","labels":%s`,
 			it.Number, it.State, it.CreatedAt.Format(time.RFC3339), labels,
+		))
+		if it.ClosedAt != nil {
+			b.WriteString(fmt.Sprintf(`,"closed_at":"%s"`, it.ClosedAt.Format(time.RFC3339)))
+		}
+		if it.IsPullRequest {
+			b.WriteString(`,"pull_request":{"url":"http://example/pr"}`)
+		}
+		b.WriteString("}")
+	}
+	b.WriteString("]")
+	return b.String()
+}
+
+// prFixture is a minimal subset of the GitHub PullRequest API shape used
+// by the merged-PR aggregation path. CreatedAt and MergedAt must both be
+// set; MergedAt should be inside the 5y window so the fetcher's
+// pastCutoff break does not fire prematurely.
+type prFixture struct {
+	Number    int
+	CreatedAt time.Time
+	MergedAt  time.Time
+}
+
+func buildPRsJSON(items []prFixture) string {
+	var b strings.Builder
+	b.WriteString("[")
+	for i, it := range items {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(fmt.Sprintf(
+			`{"number":%d,"state":"closed","created_at":"%s","merged_at":"%s"}`,
+			it.Number, it.CreatedAt.Format(time.RFC3339), it.MergedAt.Format(time.RFC3339),
 		))
 	}
 	b.WriteString("]")

--- a/artifact_fetcher_e2e_test.go
+++ b/artifact_fetcher_e2e_test.go
@@ -273,20 +273,23 @@ func buildIssuesJSON(items []issueFixture) string {
 		if i > 0 {
 			b.WriteString(",")
 		}
-		labels := "["
+		var labels strings.Builder
+		labels.WriteString("[")
 		for j, l := range it.Labels {
 			if j > 0 {
-				labels += ","
+				labels.WriteString(",")
 			}
-			labels += `{"name":"` + l + `"}`
+			labels.WriteString(`{"name":"`)
+			labels.WriteString(l)
+			labels.WriteString(`"}`)
 		}
-		labels += "]"
-		b.WriteString(fmt.Sprintf(
+		labels.WriteString("]")
+		fmt.Fprintf(&b,
 			`{"number":%d,"state":"%s","created_at":"%s","labels":%s`,
-			it.Number, it.State, it.CreatedAt.Format(time.RFC3339), labels,
-		))
+			it.Number, it.State, it.CreatedAt.Format(time.RFC3339), labels.String(),
+		)
 		if it.ClosedAt != nil {
-			b.WriteString(fmt.Sprintf(`,"closed_at":"%s"`, it.ClosedAt.Format(time.RFC3339)))
+			fmt.Fprintf(&b, `,"closed_at":"%s"`, it.ClosedAt.Format(time.RFC3339))
 		}
 		if it.IsPullRequest {
 			b.WriteString(`,"pull_request":{"url":"http://example/pr"}`)
@@ -314,10 +317,10 @@ func buildPRsJSON(items []prFixture) string {
 		if i > 0 {
 			b.WriteString(",")
 		}
-		b.WriteString(fmt.Sprintf(
+		fmt.Fprintf(&b,
 			`{"number":%d,"state":"closed","created_at":"%s","merged_at":"%s"}`,
 			it.Number, it.CreatedAt.Format(time.RFC3339), it.MergedAt.Format(time.RFC3339),
-		))
+		)
 	}
 	b.WriteString("]")
 	return b.String()

--- a/artifact_fetcher_e2e_test.go
+++ b/artifact_fetcher_e2e_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFetchIssuesPRs_EndToEnd_DeterministicFixture exercises fetchIssuesPRs
+// against a stub server returning multi-page paginated responses with
+// Link: <...>; rel="next" headers. Asserts:
+//   - velocity.Daily length is exactly the days-in-1y count.
+//   - velocity.Weekly length is exactly the expected ~260 weeks.
+//   - Totals match the fixture's exact counts (not "approximately").
+//   - Categories are populated from the fixture's labels.
+//
+// Mutation check: dropping the pagination loop (break after page 1)
+// undercounts events; assertions on totals fail.
+//
+// Label note: uses bare `bug` / `feature` labels (mapped under _default in
+// labelCategories at artifact_fetcher.go); the original plan used
+// `kind/bug` / `kind/feature` which only map under repo-specific overrides.
+func TestFetchIssuesPRs_EndToEnd_DeterministicFixture(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	openIssuesPage1 := buildIssuesJSON([]issueFixture{
+		{Number: 100, State: "open", CreatedAt: now.Add(-3 * 24 * time.Hour), Labels: []string{"bug"}},
+		{Number: 101, State: "open", CreatedAt: now.Add(-30 * 24 * time.Hour), Labels: []string{"feature"}},
+	})
+	openIssuesPage2 := buildIssuesJSON([]issueFixture{
+		{Number: 102, State: "open", CreatedAt: now.Add(-100 * 24 * time.Hour), Labels: []string{"bug"}},
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/issues") && r.URL.Query().Get("state") == "open":
+			page := r.URL.Query().Get("page")
+			if page == "" || page == "1" {
+				w.Header().Set("Link", `<`+srvURLOf(r)+`/repos/test/repo/issues?state=open&page=2>; rel="next"`)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, openIssuesPage1)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, openIssuesPage2)
+			return
+		case strings.Contains(r.URL.Path, "/issues") && r.URL.Query().Get("state") == "closed":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, "[]")
+			return
+		case strings.Contains(r.URL.Path, "/pulls"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, "[]")
+			return
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, "[]")
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	client, ctx := buildClient(ctx, "fake-token", silentLogger())
+	parsed, _ := client.BaseURL.Parse(srv.URL + "/")
+	client.BaseURL = parsed
+
+	got, err := fetchIssuesPRs(ctx, client, "test/repo")
+	if err != nil {
+		t.Fatalf("fetchIssuesPRs: %v", err)
+	}
+
+	if got.Issues.Total != 3 {
+		t.Fatalf("Issues.Total = %d; want 3 (fixture has 3 open across 2 pages)", got.Issues.Total)
+	}
+	if got.Issues.Categories["bug"] != 2 {
+		t.Fatalf("Issues.Categories[bug] = %d; want 2", got.Issues.Categories["bug"])
+	}
+	if got.Issues.Categories["feature-request"] != 1 {
+		t.Fatalf("Issues.Categories[feature-request] = %d; want 1", got.Issues.Categories["feature-request"])
+	}
+	if len(got.Issues.Velocity.Daily) != 365 {
+		t.Fatalf("Issues.Velocity.Daily length = %d; want 365", len(got.Issues.Velocity.Daily))
+	}
+	if len(got.Issues.Velocity.Weekly) < 260 || len(got.Issues.Velocity.Weekly) > 261 {
+		t.Fatalf("Issues.Velocity.Weekly length = %d; want 260-261", len(got.Issues.Velocity.Weekly))
+	}
+}
+
+// issueFixture is a minimal subset of the GitHub Issue API shape that
+// tests need. buildIssuesJSON marshals it to JSON for the stub server.
+type issueFixture struct {
+	Number    int
+	State     string
+	CreatedAt time.Time
+	Labels    []string
+}
+
+func buildIssuesJSON(items []issueFixture) string {
+	var b strings.Builder
+	b.WriteString("[")
+	for i, it := range items {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		labels := "["
+		for j, l := range it.Labels {
+			if j > 0 {
+				labels += ","
+			}
+			labels += `{"name":"` + l + `"}`
+		}
+		labels += "]"
+		b.WriteString(fmt.Sprintf(
+			`{"number":%d,"state":"%s","created_at":"%s","labels":%s}`,
+			it.Number, it.State, it.CreatedAt.Format(time.RFC3339), labels,
+		))
+	}
+	b.WriteString("]")
+	return b.String()
+}
+
+func srvURLOf(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return scheme + "://" + r.Host
+}
+
+// TestFetchIssuesPRs_EmptyResponse asserts that a stub returning empty
+// arrays yields velocity.Daily and Weekly with exact zero entries (not
+// nil), so the dashboard's empty-state placeholder triggers correctly.
+//
+// Mutation check: a special-case "if no events, return nil arrays"
+// fails the length assertion.
+func TestFetchIssuesPRs_EmptyResponse(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, "[]")
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	client, ctx := buildClient(ctx, "fake-token", silentLogger())
+	parsed, _ := client.BaseURL.Parse(srv.URL + "/")
+	client.BaseURL = parsed
+
+	got, err := fetchIssuesPRs(ctx, client, "test/empty")
+	if err != nil {
+		t.Fatalf("fetchIssuesPRs: %v", err)
+	}
+	if got.Issues.Total != 0 {
+		t.Fatalf("Issues.Total = %d; want 0", got.Issues.Total)
+	}
+	if len(got.Issues.Velocity.Daily) != 365 {
+		t.Fatalf("Daily length = %d; want 365 (continuous-zeros)", len(got.Issues.Velocity.Daily))
+	}
+	for i, d := range got.Issues.Velocity.Daily {
+		if d.Opened != 0 || d.Closed != 0 || d.Merged != nil {
+			t.Errorf("daily[%d] = %+v; want all-zero", i, d)
+		}
+	}
+}

--- a/artifact_fetcher_velocity_test.go
+++ b/artifact_fetcher_velocity_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestBuildVelocitySlice_5YearWindow asserts the existing
+// buildVelocitySlice helper handles a 5-year span with the expected
+// length and ISO-week boundary correctness.
+//
+// Mutation check: a bug that hard-codes a 12-week window (the previous
+// behavior) returns ~12 entries; this test asserts ~260 and fails.
+// A bug in isoWeek() that uses calendar year instead of ISO year
+// produces wrong week strings at known boundary dates; subtests assert
+// exact strings to catch this.
+func TestBuildVelocitySlice_5YearWindow(t *testing.T) {
+	t.Parallel()
+
+	to := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
+	from := to.AddDate(-5, 0, 0)
+
+	// Pre-populate maps so the union-of-keys logic in buildVelocitySlice
+	// has SOME data; the empty-day continuous-range invariant is a separate
+	// concern (existing buildVelocitySlice emits union-of-seen-weeks, not
+	// every-week-in-range; we accept that and pin the count).
+	opened := map[string]int{}
+	closed := map[string]int{}
+	merged := map[string]int{}
+
+	for w := from; w.Before(to); w = w.AddDate(0, 0, 7) {
+		key := isoWeek(w)
+		opened[key] = 1
+		closed[key] = 1
+		merged[key] = 1
+	}
+
+	got := buildVelocitySlice(opened, closed, merged, from, to)
+
+	// Expect ~260 weeks. The exact number depends on ISO-week alignment
+	// at the boundaries (between 260 and 261 inclusive).
+	if len(got) < 260 || len(got) > 261 {
+		t.Fatalf("len = %d; want 260 or 261 (5-year window)", len(got))
+	}
+}
+
+// TestBuildVelocitySlice_ISOWeekYearBoundary pins exact ISO-week strings
+// at known calendar/ISO-year-divergence boundaries. 2024-12-30 (a Monday)
+// is ISO week 1 of 2025, NOT week 53 of 2024. A bug that uses
+// time.Time.Year() (calendar year) instead of t.ISOWeek()'s year
+// produces "2024-12-30" for the Monday, which a test pinning the
+// expected key WOULD catch.
+//
+// We probe two neighboring weeks straddling the year boundary and assert
+// the helper's bucketing matches what t.ISOWeek() returns directly.
+func TestBuildVelocitySlice_ISOWeekYearBoundary(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		monday     time.Time
+		wantPrefix string // first 4 chars of the resulting key (the year part of YYYY-MM-DD week-Monday format)
+	}{
+		{
+			name:       "Monday in last calendar week of 2024 belongs to ISO 2025",
+			monday:     time.Date(2024, 12, 30, 0, 0, 0, 0, time.UTC),
+			wantPrefix: "2024", // the Monday IS December 30, 2024
+		},
+		{
+			name:       "Monday in first calendar week of 2025",
+			monday:     time.Date(2025, 1, 6, 0, 0, 0, 0, time.UTC),
+			wantPrefix: "2025",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := isoWeek(tc.monday)
+			if got[:4] != tc.wantPrefix {
+				t.Fatalf("isoWeek(%s) = %q; expected to start with %q (per ISO 8601 week-year rules)",
+					tc.monday.Format("2006-01-02"), got, tc.wantPrefix)
+			}
+			// Sanity: the result is a valid YYYY-MM-DD string parseable
+			// back to a Monday close to the input.
+			parsed, err := time.Parse("2006-01-02", got)
+			if err != nil {
+				t.Fatalf("isoWeek result %q is not parseable as YYYY-MM-DD: %v", got, err)
+			}
+			if parsed.Weekday() != time.Monday {
+				t.Fatalf("isoWeek result %q is %s, not Monday", got, parsed.Weekday())
+			}
+		})
+	}
+}

--- a/src/components/IssuesPRsDashboard.tsx
+++ b/src/components/IssuesPRsDashboard.tsx
@@ -18,10 +18,9 @@ import { useTheme } from './ThemeProvider';
 import VelocitySparkline from './VelocitySparkline';
 import { AGE_COLORS, getCategoryColor, getChartStyles, formatWeekTick, computeTrend } from '../utils/chartStyles';
 import type { Trend } from '../utils/chartStyles';
+import { DURATIONS, pickVelocity, type Duration } from '../utils/duration';
 import { projects } from '../data/projects';
 import type { IssuesPRsData, RepoIssuesPRs } from '../types';
-
-type TimeRange = 4 | 8 | 12;
 
 interface Props {
   data: IssuesPRsData;
@@ -43,24 +42,24 @@ interface RowData {
 
 function ExpandedRowDetail({
   repoData,
-  timeRange,
+  duration,
   tooltipStyle,
   tickStyle,
   gridStroke,
 }: {
   repoData: RepoIssuesPRs;
-  timeRange: TimeRange;
+  duration: Duration;
   tooltipStyle: React.CSSProperties;
   tickStyle: { fontSize: number; fill: string };
   gridStroke: string;
 }) {
   const issueVelocity = useMemo(
-    () => repoData.issues.velocity.weekly.slice(-timeRange),
-    [repoData.issues.velocity.weekly, timeRange],
+    () => pickVelocity(repoData.issues.velocity, duration).points,
+    [repoData.issues.velocity, duration],
   );
   const prVelocity = useMemo(
-    () => repoData.pullRequests.velocity.weekly.slice(-timeRange),
-    [repoData.pullRequests.velocity.weekly, timeRange],
+    () => pickVelocity(repoData.pullRequests.velocity, duration).points,
+    [repoData.pullRequests.velocity, duration],
   );
   const issueCategories = useMemo(
     () =>
@@ -129,7 +128,7 @@ function ExpandedRowDetail({
         {/* Issue Velocity */}
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
           <h4 className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">
-            Issue Velocity ({timeRange}w)
+            Issue Velocity ({duration})
           </h4>
           {issueVelocity.length > 0 ? (
             <ResponsiveContainer width="100%" height={160}>
@@ -142,7 +141,7 @@ function ExpandedRowDetail({
                   stroke={gridStroke}
                 />
                 <XAxis
-                  dataKey="week"
+                  dataKey="label"
                   tick={tickStyle}
                   tickFormatter={formatWeekTick}
                 />
@@ -251,7 +250,7 @@ function ExpandedRowDetail({
             </div>
           </div>
           <h4 className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">
-            PR Velocity ({timeRange}w)
+            PR Velocity ({duration})
           </h4>
           {prVelocity.length > 0 ? (
             <ResponsiveContainer width="100%" height={100}>
@@ -260,7 +259,7 @@ function ExpandedRowDetail({
                 margin={{ top: 4, right: 16, bottom: 0, left: 0 }}
               >
                 <XAxis
-                  dataKey="week"
+                  dataKey="label"
                   tick={tickStyle}
                   tickFormatter={formatWeekTick}
                 />
@@ -296,7 +295,7 @@ function ExpandedRowDetail({
 export default function IssuesPRsDashboard({ data }: Props) {
   const { resolved } = useTheme();
   const dark = resolved === 'dark';
-  const [timeRange, setTimeRange] = useState<TimeRange>(12);
+  const [duration, setDuration] = useState<Duration>('12w');
   const [expandedSlug, setExpandedSlug] = useState<string | null>(null);
 
   const rows = useMemo<RowData[]>(() => {
@@ -316,8 +315,6 @@ export default function IssuesPRsDashboard({ data }: Props) {
 
   const { tooltipStyle, tickStyle, gridStroke } = getChartStyles(dark);
 
-  const ranges: TimeRange[] = [4, 8, 12];
-
   return (
     <section className="mb-6">
       {/* Header with time range selector */}
@@ -325,20 +322,20 @@ export default function IssuesPRsDashboard({ data }: Props) {
         <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-200">
           Issues &amp; PRs Overview
         </h2>
-        <div className="flex gap-1">
-          {ranges.map((r) => (
+        <div className="flex gap-1" role="group" aria-label="Velocity duration">
+          {DURATIONS.map((d) => (
             <button
-              key={r}
-              onClick={() => setTimeRange(r)}
-              aria-pressed={timeRange === r}
-              aria-label={`Show ${r} weeks of data`}
+              key={d}
+              onClick={() => setDuration(d)}
+              aria-pressed={duration === d}
+              aria-label={`Show ${d} of velocity data`}
               className={`px-2 py-1 text-xs rounded ${
-                timeRange === r
+                duration === d
                   ? 'bg-nvidia-green text-white'
                   : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
               }`}
             >
-              {r}w
+              {d}
             </button>
           ))}
         </div>
@@ -403,7 +400,7 @@ export default function IssuesPRsDashboard({ data }: Props) {
                       {row.repoData.pullRequests.total}
                     </td>
                     <td className="p-3 text-center">
-                      <VelocitySparkline velocity={row.repoData.issues.velocity} duration="12w" />
+                      <VelocitySparkline velocity={row.repoData.issues.velocity} duration={duration} />
                     </td>
                     <td className="p-3 text-right">
                       <span
@@ -438,7 +435,7 @@ export default function IssuesPRsDashboard({ data }: Props) {
                       <td colSpan={8} className="p-0">
                         <ExpandedRowDetail
                           repoData={row.repoData}
-                          timeRange={timeRange}
+                          duration={duration}
                           tooltipStyle={tooltipStyle}
                           tickStyle={tickStyle}
                           gridStroke={gridStroke}

--- a/src/components/IssuesPRsDashboard.tsx
+++ b/src/components/IssuesPRsDashboard.tsx
@@ -411,10 +411,16 @@ export default function IssuesPRsDashboard({ data }: Props) {
                         {row.name}
                       </Link>
                     </td>
-                    <td className="p-3 text-right text-gray-700 dark:text-gray-300">
+                    <td
+                      className="p-3 text-right text-gray-700 dark:text-gray-300"
+                      data-testid={`open-issues-${row.slug}`}
+                    >
                       {row.repoData.issues.total}
                     </td>
-                    <td className="p-3 text-right text-gray-700 dark:text-gray-300">
+                    <td
+                      className="p-3 text-right text-gray-700 dark:text-gray-300"
+                      data-testid={`open-prs-${row.slug}`}
+                    >
                       {row.repoData.pullRequests.total}
                     </td>
                     <td className="p-3 text-center">

--- a/src/components/IssuesPRsDashboard.tsx
+++ b/src/components/IssuesPRsDashboard.tsx
@@ -403,7 +403,7 @@ export default function IssuesPRsDashboard({ data }: Props) {
                       {row.repoData.pullRequests.total}
                     </td>
                     <td className="p-3 text-center">
-                      <VelocitySparkline data={row.repoData.issues.velocity.weekly} weeks={timeRange} />
+                      <VelocitySparkline velocity={row.repoData.issues.velocity} duration="12w" />
                     </td>
                     <td className="p-3 text-right">
                       <span

--- a/src/components/IssuesPRsDashboard.tsx
+++ b/src/components/IssuesPRsDashboard.tsx
@@ -16,7 +16,7 @@ import {
 import { ChevronDown, ChevronRight, ArrowUp, ArrowDown, ArrowRight } from 'lucide-react';
 import { useTheme } from './ThemeProvider';
 import VelocitySparkline from './VelocitySparkline';
-import { AGE_COLORS, getCategoryColor, getChartStyles, formatWeekTick, computeTrend } from '../utils/chartStyles';
+import { AGE_COLORS, getCategoryColor, getChartStyles, formatWeekTick, formatDayTick, computeTrend } from '../utils/chartStyles';
 import type { Trend } from '../utils/chartStyles';
 import { DURATIONS, pickVelocity, type Duration } from '../utils/duration';
 import { projects } from '../data/projects';
@@ -53,14 +53,16 @@ function ExpandedRowDetail({
   tickStyle: { fontSize: number; fill: string };
   gridStroke: string;
 }) {
-  const issueVelocity = useMemo(
-    () => pickVelocity(repoData.issues.velocity, duration).points,
+  const { points: issueVelocity, granularity: issueGranularity } = useMemo(
+    () => pickVelocity(repoData.issues.velocity, duration),
     [repoData.issues.velocity, duration],
   );
-  const prVelocity = useMemo(
-    () => pickVelocity(repoData.pullRequests.velocity, duration).points,
+  const { points: prVelocity, granularity: prGranularity } = useMemo(
+    () => pickVelocity(repoData.pullRequests.velocity, duration),
     [repoData.pullRequests.velocity, duration],
   );
+  const issueTickFormatter = issueGranularity === 'day' ? formatDayTick : formatWeekTick;
+  const prTickFormatter = prGranularity === 'day' ? formatDayTick : formatWeekTick;
   const issueCategories = useMemo(
     () =>
       Object.entries(repoData.issues.categories)
@@ -143,7 +145,13 @@ function ExpandedRowDetail({
                 <XAxis
                   dataKey="label"
                   tick={tickStyle}
-                  tickFormatter={formatWeekTick}
+                  tickFormatter={issueTickFormatter}
+                  label={{
+                    value: issueGranularity === 'day' ? 'Day (UTC)' : 'Week (UTC)',
+                    position: 'insideBottom',
+                    offset: -5,
+                    style: { fontSize: tickStyle.fontSize, fill: tickStyle.fill },
+                  }}
                 />
                 <YAxis tick={tickStyle} allowDecimals={false} />
                 <Tooltip contentStyle={tooltipStyle} />
@@ -258,10 +266,20 @@ function ExpandedRowDetail({
                 data={prVelocity}
                 margin={{ top: 4, right: 16, bottom: 0, left: 0 }}
               >
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  stroke={gridStroke}
+                />
                 <XAxis
                   dataKey="label"
                   tick={tickStyle}
-                  tickFormatter={formatWeekTick}
+                  tickFormatter={prTickFormatter}
+                  label={{
+                    value: prGranularity === 'day' ? 'Day (UTC)' : 'Week (UTC)',
+                    position: 'insideBottom',
+                    offset: -5,
+                    style: { fontSize: tickStyle.fontSize, fill: tickStyle.fill },
+                  }}
                 />
                 <YAxis tick={tickStyle} allowDecimals={false} />
                 <Tooltip contentStyle={tooltipStyle} />
@@ -318,11 +336,11 @@ export default function IssuesPRsDashboard({ data }: Props) {
   return (
     <section className="mb-6">
       {/* Header with time range selector */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-3">
         <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-200">
           Issues &amp; PRs Overview
         </h2>
-        <div className="flex gap-1" role="group" aria-label="Velocity duration">
+        <div className="flex flex-wrap gap-1" role="group" aria-label="Velocity duration">
           {DURATIONS.map((d) => (
             <button
               key={d}

--- a/src/components/IssuesPRsDashboard.tsx
+++ b/src/components/IssuesPRsDashboard.tsx
@@ -55,12 +55,12 @@ function ExpandedRowDetail({
   gridStroke: string;
 }) {
   const issueVelocity = useMemo(
-    () => repoData.issues.velocity.slice(-timeRange),
-    [repoData.issues.velocity, timeRange],
+    () => repoData.issues.velocity.weekly.slice(-timeRange),
+    [repoData.issues.velocity.weekly, timeRange],
   );
   const prVelocity = useMemo(
-    () => repoData.pullRequests.velocity.slice(-timeRange),
-    [repoData.pullRequests.velocity, timeRange],
+    () => repoData.pullRequests.velocity.weekly.slice(-timeRange),
+    [repoData.pullRequests.velocity.weekly, timeRange],
   );
   const issueCategories = useMemo(
     () =>
@@ -309,7 +309,7 @@ export default function IssuesPRsDashboard({ data }: Props) {
           name: p.name,
           repo: p.repo,
           repoData,
-          trend: computeTrend(repoData.issues.velocity),
+          trend: computeTrend(repoData.issues.velocity.weekly),
         };
       });
   }, [data]);
@@ -403,7 +403,7 @@ export default function IssuesPRsDashboard({ data }: Props) {
                       {row.repoData.pullRequests.total}
                     </td>
                     <td className="p-3 text-center">
-                      <VelocitySparkline data={row.repoData.issues.velocity} weeks={timeRange} />
+                      <VelocitySparkline data={row.repoData.issues.velocity.weekly} weeks={timeRange} />
                     </td>
                     <td className="p-3 text-right">
                       <span

--- a/src/components/IssuesPRsSection.tsx
+++ b/src/components/IssuesPRsSection.tsx
@@ -48,14 +48,14 @@ export default function IssuesPRsSection({ data }: Props) {
   }, [data.issues.ageBuckets, data.pullRequests.ageBuckets]);
 
   const velocityData = useMemo(() => {
-    const source = velocityView === 'issues' ? data.issues.velocity : data.pullRequests.velocity;
+    const source = velocityView === 'issues' ? data.issues.velocity.weekly : data.pullRequests.velocity.weekly;
     return source.map((v) => ({
       week: v.week,
       opened: v.opened,
       closed: v.closed,
       ...(v.merged !== undefined ? { merged: v.merged } : {}),
     }));
-  }, [velocityView, data.issues.velocity, data.pullRequests.velocity]);
+  }, [velocityView, data.issues.velocity.weekly, data.pullRequests.velocity.weekly]);
 
   const { tooltipStyle, tickStyle, gridStroke } = getChartStyles(dark);
 

--- a/src/components/IssuesPRsSection.tsx
+++ b/src/components/IssuesPRsSection.tsx
@@ -47,6 +47,11 @@ export default function IssuesPRsSection({ data }: Props) {
     }));
   }, [data.issues.ageBuckets, data.pullRequests.ageBuckets]);
 
+  // Velocity here is rendered as the default detail view at weekly
+  // granularity; UI redesign spec 3 may add a per-page duration selector
+  // later. Until then, this section reads the last 12 weeks straight from
+  // velocity.weekly — the daily array (velocity.daily) is consumed by the
+  // home dashboard's 7d view.
   const velocityData = useMemo(() => {
     const source = velocityView === 'issues' ? data.issues.velocity.weekly : data.pullRequests.velocity.weekly;
     return source.map((v) => ({
@@ -204,6 +209,12 @@ export default function IssuesPRsSection({ data }: Props) {
                 dataKey="week"
                 tick={tickStyle}
                 tickFormatter={formatWeekTick}
+                label={{
+                  value: 'Week (UTC)',
+                  position: 'insideBottom',
+                  offset: -5,
+                  style: { fontSize: 11, fill: tickStyle.fill },
+                }}
               />
               <YAxis tick={tickStyle} allowDecimals={false} />
               <Tooltip contentStyle={tooltipStyle} />

--- a/src/components/VelocitySparkline.tsx
+++ b/src/components/VelocitySparkline.tsx
@@ -1,19 +1,23 @@
 import { ResponsiveContainer, LineChart, Line } from 'recharts';
-import type { VelocityWeek } from '../types';
+import type { Velocity } from '../types';
+import { pickVelocity, type Duration } from '../utils/duration';
 
 interface Props {
-  data: VelocityWeek[];
-  weeks?: number;
+  velocity: Velocity;
+  duration: Duration;
 }
 
-export default function VelocitySparkline({ data, weeks = 12 }: Props) {
-  const sliced = data.slice(-weeks);
-  if (sliced.length === 0) return <span className="text-gray-400 text-xs">&mdash;</span>;
+export default function VelocitySparkline({ velocity, duration }: Props) {
+  const { points } = pickVelocity(velocity, duration);
+
+  if (points.length === 0) {
+    return <span className="text-gray-400 text-xs" data-testid="sparkline-empty">&mdash;</span>;
+  }
 
   return (
-    <div className="inline-block w-[60px] h-[20px]">
+    <div className="inline-block w-[60px] h-[20px]" data-testid="sparkline">
       <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={sliced}>
+        <LineChart data={points}>
           <Line type="monotone" dataKey="opened" stroke="#ef4444" strokeWidth={1} dot={false} isAnimationActive={false} />
           <Line type="monotone" dataKey="closed" stroke="#22c55e" strokeWidth={1} dot={false} isAnimationActive={false} />
         </LineChart>

--- a/src/components/__tests__/IssuesPRsDashboard.test.tsx
+++ b/src/components/__tests__/IssuesPRsDashboard.test.tsx
@@ -60,12 +60,12 @@ function makeData(): IssuesPRsData {
             daily: Array.from({ length: 365 }, (_, i) => ({
               date: `2026-day-${i}`,
               opened: 1000 + i,
-              closed: 0,
+              closed: 500 + i,
             })),
             weekly: Array.from({ length: 260 }, (_, i) => ({
               week: `wk-${i}`,
               opened: i,
-              closed: 0,
+              closed: 500 - i,
             })),
           },
         },
@@ -77,12 +77,12 @@ function makeData(): IssuesPRsData {
             daily: Array.from({ length: 365 }, (_, i) => ({
               date: `2026-day-${i}`,
               opened: 0,
-              closed: 0,
+              closed: 200 + i,
             })),
             weekly: Array.from({ length: 260 }, (_, i) => ({
               week: `wk-${i}`,
               opened: 0,
-              closed: 0,
+              closed: 200 - i,
             })),
           },
           review: { awaitingReview: 3, noReviewer: 1, avgDaysToFirstReview: 1.5, avgDaysToMerge: 3.2 },
@@ -133,30 +133,28 @@ describe('IssuesPRsDashboard', () => {
   });
 
   // Q3 invariant (snapshot regression test, strengthened per QA review).
-  // The fixture is deliberately constructed so daily-7 slice values do NOT
-  // coincide with snapshot values: snapshot Open Issues = 42, daily-7
-  // values are in the 1000s. Asserts displayed text is BYTE-IDENTICAL
-  // before and after each duration click.
+  // Uses stable test IDs (not text content) so a regression can't pass by
+  // coincidence with another element rendering the same number — e.g. the
+  // categories bar chart can render '8' for the feature-request count,
+  // which would collide with pullRequests.total === 8 if querying by text.
   it('snapshot stats do not change when duration changes (Q3 invariant)', async () => {
     const user = userEvent.setup();
     renderDashboard(makeData());
 
-    // Capture displayed snapshot stats from the comparison row.
-    // The exact text element selectors depend on IssuesPRsDashboard.tsx's
-    // rendering — adjust to data-testid if the implementation needs hooks.
-    const openIssuesCells = screen.getAllByText('42');
-    const openPRsCells = screen.getAllByText('8');
-    const initialIssuesText = openIssuesCells.map((el) => el.textContent).join('|');
-    const initialPRsText = openPRsCells.map((el) => el.textContent).join('|');
+    const openIssuesCell = screen.getByTestId('open-issues-gpu-operator');
+    const openPRsCell = screen.getByTestId('open-prs-gpu-operator');
+    const initialIssuesText = openIssuesCell.textContent;
+    const initialPRsText = openPRsCell.textContent;
+
+    expect(initialIssuesText).toBe('42');
+    expect(initialPRsText).toBe('8');
 
     for (const label of ['7d', '4w', '12w', '6m', '1y', '5y']) {
       const btn = screen.getByRole('button', { name: new RegExp(`Show ${label} of velocity data`) });
       await user.click(btn);
 
-      const afterIssuesText = screen.getAllByText('42').map((el) => el.textContent).join('|');
-      const afterPRsText = screen.getAllByText('8').map((el) => el.textContent).join('|');
-      expect(afterIssuesText).toBe(initialIssuesText);
-      expect(afterPRsText).toBe(initialPRsText);
+      expect(openIssuesCell.textContent).toBe(initialIssuesText);
+      expect(openPRsCell.textContent).toBe(initialPRsText);
     }
   });
 });

--- a/src/components/__tests__/IssuesPRsDashboard.test.tsx
+++ b/src/components/__tests__/IssuesPRsDashboard.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import IssuesPRsDashboard from '../IssuesPRsDashboard';
+import ThemeProvider from '../ThemeProvider';
+import type { IssuesPRsData } from '../../types';
+
+// jsdom 28 + vitest 4: window.localStorage is not auto-instantiated for
+// the default about:blank URL, and matchMedia is famously not implemented.
+// ThemeProvider touches both on mount, so install minimal in-memory shims.
+beforeAll(() => {
+  if (typeof globalThis.localStorage === 'undefined' ||
+      typeof globalThis.localStorage.getItem !== 'function') {
+    const store = new Map<string, string>();
+    const stub: Storage = {
+      get length() { return store.size; },
+      clear: () => store.clear(),
+      getItem: (k) => (store.has(k) ? store.get(k)! : null),
+      key: (i) => Array.from(store.keys())[i] ?? null,
+      removeItem: (k) => { store.delete(k); },
+      setItem: (k, v) => { store.set(k, String(v)); },
+    };
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: stub,
+    });
+  }
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: (query: string): MediaQueryList => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+});
+
+// Build distinguishable fixture data so daily and weekly slices yield
+// non-overlapping values — required for the snapshot-regression test
+// to detect filtering through pickVelocity.
+function makeData(): IssuesPRsData {
+  return {
+    repos: {
+      'nvidia/gpu-operator': {
+        fetchedAt: '2026-04-30T12:00:00Z',
+        issues: {
+          total: 42,
+          categories: { bug: 12, 'feature-request': 8 },
+          ageBuckets: { fresh: 5, recent: 10, aging: 12, stale: 8, ancient: 7 },
+          velocity: {
+            daily: Array.from({ length: 365 }, (_, i) => ({
+              date: `2026-day-${i}`,
+              opened: 1000 + i,
+              closed: 0,
+            })),
+            weekly: Array.from({ length: 260 }, (_, i) => ({
+              week: `wk-${i}`,
+              opened: i,
+              closed: 0,
+            })),
+          },
+        },
+        pullRequests: {
+          total: 8,
+          categories: {},
+          ageBuckets: { fresh: 3, recent: 2, aging: 2, stale: 1, ancient: 0 },
+          velocity: {
+            daily: Array.from({ length: 365 }, (_, i) => ({
+              date: `2026-day-${i}`,
+              opened: 0,
+              closed: 0,
+            })),
+            weekly: Array.from({ length: 260 }, (_, i) => ({
+              week: `wk-${i}`,
+              opened: 0,
+              closed: 0,
+            })),
+          },
+          review: { awaitingReview: 3, noReviewer: 1, avgDaysToFirstReview: 1.5, avgDaysToMerge: 3.2 },
+        },
+      },
+    },
+  };
+}
+
+function renderDashboard(data: IssuesPRsData) {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider>
+        <IssuesPRsDashboard data={data} />
+      </ThemeProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('IssuesPRsDashboard', () => {
+  it('defaults to the 12w duration', () => {
+    renderDashboard(makeData());
+    const btn = screen.getByRole('button', { name: /Show 12w of velocity data/ });
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('renders all 6 duration buttons in display order', () => {
+    renderDashboard(makeData());
+    const labels = ['7d', '4w', '12w', '6m', '1y', '5y'];
+    for (const label of labels) {
+      expect(screen.getByRole('button', { name: new RegExp(`Show ${label} of velocity data`) }))
+        .toBeInTheDocument();
+    }
+  });
+
+  it('clicking a duration button updates aria-pressed', async () => {
+    const user = userEvent.setup();
+    renderDashboard(makeData());
+
+    const btn7d = screen.getByRole('button', { name: /Show 7d of velocity data/ });
+    expect(btn7d).toHaveAttribute('aria-pressed', 'false');
+
+    await user.click(btn7d);
+
+    expect(btn7d).toHaveAttribute('aria-pressed', 'true');
+    const btn12w = screen.getByRole('button', { name: /Show 12w of velocity data/ });
+    expect(btn12w).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  // Q3 invariant (snapshot regression test, strengthened per QA review).
+  // The fixture is deliberately constructed so daily-7 slice values do NOT
+  // coincide with snapshot values: snapshot Open Issues = 42, daily-7
+  // values are in the 1000s. Asserts displayed text is BYTE-IDENTICAL
+  // before and after each duration click.
+  it('snapshot stats do not change when duration changes (Q3 invariant)', async () => {
+    const user = userEvent.setup();
+    renderDashboard(makeData());
+
+    // Capture displayed snapshot stats from the comparison row.
+    // The exact text element selectors depend on IssuesPRsDashboard.tsx's
+    // rendering — adjust to data-testid if the implementation needs hooks.
+    const openIssuesCells = screen.getAllByText('42');
+    const openPRsCells = screen.getAllByText('8');
+    const initialIssuesText = openIssuesCells.map((el) => el.textContent).join('|');
+    const initialPRsText = openPRsCells.map((el) => el.textContent).join('|');
+
+    for (const label of ['7d', '4w', '12w', '6m', '1y', '5y']) {
+      const btn = screen.getByRole('button', { name: new RegExp(`Show ${label} of velocity data`) });
+      await user.click(btn);
+
+      const afterIssuesText = screen.getAllByText('42').map((el) => el.textContent).join('|');
+      const afterPRsText = screen.getAllByText('8').map((el) => el.textContent).join('|');
+      expect(afterIssuesText).toBe(initialIssuesText);
+      expect(afterPRsText).toBe(initialPRsText);
+    }
+  });
+});

--- a/src/components/__tests__/VelocitySparkline.test.tsx
+++ b/src/components/__tests__/VelocitySparkline.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import VelocitySparkline from '../VelocitySparkline';
+import type { Velocity } from '../../types';
+
+function makeFixture(): Velocity {
+  const daily = Array.from({ length: 365 }, (_, i) => ({
+    date: `2026-${String((i % 12) + 1).padStart(2, '0')}-01`,
+    opened: 1000 + i,
+    closed: 0,
+  }));
+  const weekly = Array.from({ length: 260 }, (_, i) => ({
+    week: `wk-${i}`,
+    opened: i,
+    closed: 0,
+  }));
+  return { daily, weekly };
+}
+
+describe('VelocitySparkline', () => {
+  it('renders for 7d using daily data', () => {
+    const v = makeFixture();
+    render(<VelocitySparkline velocity={v} duration="7d" />);
+    expect(screen.getByTestId('sparkline')).toBeInTheDocument();
+  });
+
+  it('renders for 5y using weekly data', () => {
+    const v = makeFixture();
+    render(<VelocitySparkline velocity={v} duration="5y" />);
+    expect(screen.getByTestId('sparkline')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when both arrays are empty', () => {
+    render(<VelocitySparkline velocity={{ daily: [], weekly: [] }} duration="7d" />);
+    expect(screen.getByTestId('sparkline-empty')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/VelocitySparkline.test.tsx
+++ b/src/components/__tests__/VelocitySparkline.test.tsx
@@ -1,18 +1,46 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import VelocitySparkline from '../VelocitySparkline';
 import type { Velocity } from '../../types';
 
+// Mock recharts so the data prop passed into <LineChart> is exposed as a
+// queryable DOM attribute. This lets us assert the actual slice/granularity
+// chosen by pickVelocity rather than mere container presence.
+//
+// vi.mock is hoisted by vitest, so this is in place before VelocitySparkline
+// imports recharts.
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  LineChart: ({ data, children }: { data: unknown[]; children: React.ReactNode }) => (
+    <div data-testid="line-chart-mock" data-points={JSON.stringify(data)}>{children}</div>
+  ),
+  Line: () => null,
+}));
+
+interface ChartPoint {
+  label: string;
+  opened: number;
+  closed: number;
+}
+
+function readChartData(): ChartPoint[] {
+  const raw = screen.getByTestId('line-chart-mock').getAttribute('data-points');
+  if (!raw) throw new Error('line-chart-mock has no data-points attribute');
+  return JSON.parse(raw) as ChartPoint[];
+}
+
 function makeFixture(): Velocity {
+  // Daily and weekly opened/closed ranges are intentionally disjoint so a
+  // wrong-source regression (e.g. weekly returned for 7d) is unambiguous.
   const daily = Array.from({ length: 365 }, (_, i) => ({
-    date: `2026-${String((i % 12) + 1).padStart(2, '0')}-01`,
-    opened: 1000 + i,
-    closed: 0,
+    date: `D${i}`,
+    opened: 10000 + i, // 10000..10364
+    closed: 1000 + i,  // 1000..1364 — distinct from opened, guards `closed` series
   }));
   const weekly = Array.from({ length: 260 }, (_, i) => ({
-    week: `wk-${i}`,
-    opened: i,
-    closed: 0,
+    week: `W${i}`,
+    opened: 100 + i,   // 100..359 — disjoint from daily.opened range
+    closed: 50 + i,    // 50..309
   }));
   return { daily, weekly };
 }
@@ -21,13 +49,38 @@ describe('VelocitySparkline', () => {
   it('renders for 7d using daily data', () => {
     const v = makeFixture();
     render(<VelocitySparkline velocity={v} duration="7d" />);
-    expect(screen.getByTestId('sparkline')).toBeInTheDocument();
+
+    const data = readChartData();
+    // Length: pickVelocity('7d') slices daily by -7.
+    expect(data).toHaveLength(7);
+    // Last 7 of daily (length 365) is indices 358..364.
+    expect(data[0].label).toBe('D358');
+    expect(data[6].label).toBe('D364');
+    // Source: opened values must come from daily (10000-range), not weekly (100-range).
+    // If pickVelocity wrongly returned weekly for 7d, opened would be in 100..359.
+    expect(data[0].opened).toBe(10358);
+    expect(data[6].opened).toBe(10364);
+    // Closed series must also come from daily (1000-range), not weekly (50-range).
+    expect(data[0].closed).toBe(1358);
   });
 
   it('renders for 5y using weekly data', () => {
     const v = makeFixture();
     render(<VelocitySparkline velocity={v} duration="5y" />);
-    expect(screen.getByTestId('sparkline')).toBeInTheDocument();
+
+    const data = readChartData();
+    // Length: pickVelocity('5y') slices weekly by -260; weekly is exactly 260 long.
+    expect(data).toHaveLength(260);
+    // slice(-260) on a 260-length array is the whole array.
+    expect(data[0].label).toBe('W0');
+    expect(data[259].label).toBe('W259');
+    // Source: opened values must come from weekly (100-range), not daily (10000-range).
+    // If pickVelocity wrongly returned daily for 5y, opened would be in 10000..10364
+    // and length would be 7, not 260.
+    expect(data[0].opened).toBe(100);
+    expect(data[259].opened).toBe(359);
+    // Closed series must come from weekly (50-range).
+    expect(data[0].closed).toBe(50);
   });
 
   it('renders the empty state when both arrays are empty', () => {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -59,7 +59,7 @@ export default function Home() {
         else if (buckets.fresh > 0) oldestBucket = '<7d';
         else oldestBucket = 'none';
 
-        const trend = computeTrend(repoData.issues.velocity);
+        const trend = computeTrend(repoData.issues.velocity.weekly);
 
         return {
           project: p,

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,18 @@ export interface VelocityWeek {
   merged?: number;
 }
 
+export interface VelocityDay {
+  date: string;        // "YYYY-MM-DD" (UTC)
+  opened: number;
+  closed: number;
+  merged?: number;
+}
+
+export interface Velocity {
+  daily: VelocityDay[];
+  weekly: VelocityWeek[];
+}
+
 export interface PRReviewMetrics {
   awaitingReview: number;
   noReviewer: number;
@@ -109,14 +121,14 @@ export interface IssueStats {
   total: number;
   categories: IssuePRCategory;
   ageBuckets: AgeBuckets;
-  velocity: VelocityWeek[];
+  velocity: Velocity;
 }
 
 export interface PRStats {
   total: number;
   categories: IssuePRCategory;
   ageBuckets: AgeBuckets;
-  velocity: VelocityWeek[];
+  velocity: Velocity;
   review: PRReviewMetrics;
 }
 

--- a/src/utils/__tests__/chartStyles.test.ts
+++ b/src/utils/__tests__/chartStyles.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { formatDayTick, formatWeekTick } from '../chartStyles';
+
+describe('formatDayTick', () => {
+  it('formats a YYYY-MM-DD UTC string as "MMM dd"', () => {
+    // 2026-04-23 UTC should render the same MMM dd regardless of viewer TZ
+    // because the formatter pins timeZone: 'UTC'.
+    expect(formatDayTick('2026-04-23')).toBe('Apr 23');
+  });
+
+  it('formats early-month dates with zero-padded day', () => {
+    // Catches a bug where day: 'numeric' would render "Jan 1" instead of "Jan 01".
+    expect(formatDayTick('2026-01-01')).toBe('Jan 01');
+  });
+
+  it('crosses month boundaries correctly under UTC', () => {
+    // 2026-12-31 UTC must format as "Dec 31", not Jan 1 (which would happen
+    // if the formatter let the local-tz boundary slide a day).
+    expect(formatDayTick('2026-12-31')).toBe('Dec 31');
+  });
+});
+
+describe('formatWeekTick', () => {
+  it('formats a parseable date string as M/D', () => {
+    // Sanity check against the existing helper to lock its contract while
+    // formatDayTick lives next to it.
+    expect(formatWeekTick('2026-04-23')).toMatch(/^4\/2[23]$/);
+  });
+
+  it('returns the input verbatim when the date is unparseable', () => {
+    expect(formatWeekTick('not-a-date')).toBe('not-a-date');
+  });
+});

--- a/src/utils/__tests__/duration.test.ts
+++ b/src/utils/__tests__/duration.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { pickVelocity, DURATIONS, type Duration } from '../duration';
+import type { Velocity, VelocityDay, VelocityWeek } from '../../types';
+
+// Build distinguishable fixtures so daily and weekly arrays return DIFFERENT
+// values for any given index. This catches a bug where pickVelocity maps a
+// daily-granularity duration ('7d') to the weekly array.
+function makeFixture(): Velocity {
+  const daily: VelocityDay[] = Array.from({ length: 365 }, (_, i) => ({
+    date: `2026-${String(Math.floor(i / 31) + 1).padStart(2, '0')}-${String((i % 28) + 1).padStart(2, '0')}`,
+    opened: 1000 + i, // distinct values starting at 1000
+    closed: 0,
+  }));
+  const weekly: VelocityWeek[] = Array.from({ length: 260 }, (_, i) => ({
+    week: `2026-week-${i}`,
+    opened: i, // distinct values starting at 0
+    closed: 0,
+  }));
+  return { daily, weekly };
+}
+
+describe('pickVelocity', () => {
+  it.each<[Duration, 'day' | 'week', number]>([
+    ['7d', 'day', 7],
+    ['4w', 'week', 4],
+    ['12w', 'week', 12],
+    ['6m', 'week', 26],
+    ['1y', 'week', 52],
+    ['5y', 'week', 260],
+  ])('duration=%s → granularity=%s, length=%d', (duration, wantGranularity, wantLength) => {
+    const v = makeFixture();
+    const got = pickVelocity(v, duration);
+
+    expect(got.granularity).toBe(wantGranularity);
+    expect(got.points).toHaveLength(wantLength);
+
+    // Each duration's points must come from the matching array; spot-check
+    // the first and last point to catch off-by-one slicing bugs.
+    if (wantGranularity === 'day') {
+      // 7d → daily.slice(-7); first point's `opened` is 1000 + (365-7)
+      expect(got.points[0].opened).toBe(1000 + (365 - wantLength));
+      expect(got.points[wantLength - 1].opened).toBe(1000 + 364);
+    } else {
+      expect(got.points[0].opened).toBe(260 - wantLength);
+      expect(got.points[wantLength - 1].opened).toBe(259);
+    }
+  });
+
+  it('exposes DURATIONS in display order', () => {
+    expect(DURATIONS).toEqual(['7d', '4w', '12w', '6m', '1y', '5y']);
+  });
+});

--- a/src/utils/__tests__/duration.test.ts
+++ b/src/utils/__tests__/duration.test.ts
@@ -4,17 +4,18 @@ import type { Velocity, VelocityDay, VelocityWeek } from '../../types';
 
 // Build distinguishable fixtures so daily and weekly arrays return DIFFERENT
 // values for any given index. This catches a bug where pickVelocity maps a
-// daily-granularity duration ('7d') to the weekly array.
+// daily-granularity duration ('7d') to the weekly array. `closed` values
+// are also distinct from `opened` to catch a swap regression.
 function makeFixture(): Velocity {
   const daily: VelocityDay[] = Array.from({ length: 365 }, (_, i) => ({
     date: `2026-${String(Math.floor(i / 31) + 1).padStart(2, '0')}-${String((i % 28) + 1).padStart(2, '0')}`,
     opened: 1000 + i, // distinct values starting at 1000
-    closed: 0,
+    closed: 500 + i, // distinct from opened
   }));
   const weekly: VelocityWeek[] = Array.from({ length: 260 }, (_, i) => ({
     week: `2026-week-${i}`,
     opened: i, // distinct values starting at 0
-    closed: 0,
+    closed: 500 - i, // distinct from opened
   }));
   return { daily, weekly };
 }
@@ -35,14 +36,19 @@ describe('pickVelocity', () => {
     expect(got.points).toHaveLength(wantLength);
 
     // Each duration's points must come from the matching array; spot-check
-    // the first and last point to catch off-by-one slicing bugs.
+    // the first and last point to catch off-by-one slicing bugs. Also assert
+    // on `closed` to catch an opened/closed swap regression.
     if (wantGranularity === 'day') {
       // 7d → daily.slice(-7); first point's `opened` is 1000 + (365-7)
       expect(got.points[0].opened).toBe(1000 + (365 - wantLength));
       expect(got.points[wantLength - 1].opened).toBe(1000 + 364);
+      expect(got.points[0].closed).toBe(500 + (365 - wantLength));
+      expect(got.points[wantLength - 1].closed).toBe(500 + 364);
     } else {
       expect(got.points[0].opened).toBe(260 - wantLength);
       expect(got.points[wantLength - 1].opened).toBe(259);
+      expect(got.points[0].closed).toBe(500 - (260 - wantLength));
+      expect(got.points[wantLength - 1].closed).toBe(500 - 259);
     }
   });
 

--- a/src/utils/chartStyles.ts
+++ b/src/utils/chartStyles.ts
@@ -45,6 +45,17 @@ export function formatWeekTick(v: string): string {
   return `${d.getMonth() + 1}/${d.getDate()}`;
 }
 
+/**
+ * formatDayTick formats a YYYY-MM-DD UTC date string for chart x-axes
+ * showing daily granularity. Returns "MMM dd" (e.g., "Apr 23"). UTC is
+ * indicated separately via the "(UTC)" axis label set on the chart.
+ */
+export function formatDayTick(value: string): string {
+  // value is "YYYY-MM-DD"; render as locale-independent "MMM dd".
+  const d = new Date(value + 'T00:00:00Z');
+  return d.toLocaleDateString('en-US', { month: 'short', day: '2-digit', timeZone: 'UTC' });
+}
+
 export type Trend = 'growing' | 'shrinking' | 'stable';
 
 export function computeTrend(velocity: VelocityWeek[]): Trend {

--- a/src/utils/duration.ts
+++ b/src/utils/duration.ts
@@ -1,0 +1,61 @@
+import type { Velocity } from '../types';
+
+export type Duration = '7d' | '4w' | '12w' | '6m' | '1y' | '5y';
+
+export const DURATIONS: Duration[] = ['7d', '4w', '12w', '6m', '1y', '5y'];
+
+export interface VelocityPoint {
+  label: string;
+  opened: number;
+  closed: number;
+  merged?: number;
+}
+
+export interface PickedVelocity {
+  points: VelocityPoint[];
+  granularity: 'day' | 'week';
+}
+
+const DURATION_TABLE: Record<Duration, { granularity: 'day' | 'week'; n: number }> = {
+  '7d':  { granularity: 'day',  n: 7   },
+  '4w':  { granularity: 'week', n: 4   },
+  '12w': { granularity: 'week', n: 12  },
+  '6m':  { granularity: 'week', n: 26  },
+  '1y':  { granularity: 'week', n: 52  },
+  '5y':  { granularity: 'week', n: 260 },
+};
+
+/**
+ * pickVelocity selects the right velocity array (daily or weekly) for the
+ * requested duration and slices it to the appropriate length. The labels
+ * come from the underlying entry's `date` (daily) or `week` (weekly).
+ *
+ * Snapshot stats (Open Issues, age buckets, categories) deliberately do
+ * NOT pass through this helper — they always reflect "right now" per the
+ * Q3 invariant in the spec.
+ */
+export function pickVelocity(v: Velocity, d: Duration): PickedVelocity {
+  const cfg = DURATION_TABLE[d];
+  if (cfg.granularity === 'day') {
+    const slice = v.daily.slice(-cfg.n);
+    return {
+      granularity: 'day',
+      points: slice.map((day) => ({
+        label: day.date,
+        opened: day.opened,
+        closed: day.closed,
+        merged: day.merged,
+      })),
+    };
+  }
+  const slice = v.weekly.slice(-cfg.n);
+  return {
+    granularity: 'week',
+    points: slice.map((wk) => ({
+      label: wk.week,
+      opened: wk.opened,
+      closed: wk.closed,
+      merged: wk.merged,
+    })),
+  };
+}


### PR DESCRIPTION
## What

PR-C of 3 from spec `docs/plans/2026-04-30-dashboard-duration-options-design.md`.

Extends the Issues & PRs dashboard with a 6-position duration selector (7d / 4w / 12w / 6m / 1y / 5y) and the data-side machinery to feed it.

**Data side (Go fetcher):**
- Extends the historical window from 1y to 5y.
- Emits velocity in a nested shape `{daily, weekly}` so the UI can pick granularity per duration. `daily` is exactly 365 entries (1y, continuous-zeros), `weekly` is exactly 260 entries (5y).
- New `bucketByDay` helper for the daily-granularity path.
- Closed/merged events now flow into both daily and weekly buckets (covered by the e2e test enrichment in fix Batch 3).

**UI side (React/TypeScript):**
- New `Duration` type + `pickVelocity(velocity, duration) → {points, granularity}` helper. Single source of truth for duration→slice mapping; lives in `src/utils/duration.ts`.
- `VelocitySparkline` rewritten to take `velocity: Velocity, duration: Duration` props.
- `IssuesPRsDashboard` switched to the Duration model; expanded velocity charts wire `formatDayTick` based on granularity and label both axes with `(UTC)`.
- Button row uses `flex-col sm:flex-row` + `flex-wrap` so the 6 buttons don't overflow at 375px.

**Stacked on PR-A (#317) and PR-B (#318).** This PR's diff currently includes both of those PRs' commits. Once they merge into `feat/dashboard-enhancements`, GitHub auto-cleans the diff to show only the 17 commits unique to PR-C.

## How tested

- **`bucketByDay` edge cases** — DST transitions, leap-day, year boundary, ISO week-year drift.
- **`buildVelocitySlice` 5y window + ISO week-year boundary** — week 1 / week 53 handling.
- **`TestFetchIssuesPRs_EndToEnd_DeterministicFixture`** (Batch 3) — paginated open-issues + closed-issues + closed-PR-as-issue + merged-PRs fixtures, asserts `Issues.Velocity.Daily[*].Closed` sums correctly, asserts `PullRequests.Velocity.Daily[*].Merged` non-nil with correct sums, spot-checks specific date buckets. Mutation-reproduced by commenting out either the closed-events loop (lines 1356–1374) or the merged-events loop (lines 1449–1455) in `artifact_fetcher.go`.
- **`pickVelocity`** unit tests — distinct opened/closed values per fixture index, asserts both source array (daily vs weekly) AND slice length per duration.
- **`IssuesPRsDashboard` integration tests** — Q3 invariant (snapshot stats stay constant across duration changes); uses `data-testid="open-issues-${slug}"` + `getByTestId().textContent` instead of fragile `getAllByText('8')` (which collided with `categories: { 'feature-request': 8 }`). Mutation: injecting `pickVelocity(...).points.length` in place of `total` causes Q3 test to fail with `expected '12' to be '42'`.
- **`VelocitySparkline` behavioral tests** (Batch 4) — recharts mocked so `LineChart`'s `data` prop is observable in DOM. 7d test asserts length 7 + first/last labels `D358`/`D364` + `opened` values 10358/10364 (proves daily source). 5y test asserts length 260 + first/last labels `W0`/`W259` + `opened` values 100/359 (proves weekly source). Mutations: forcing daily-for-5y → 5y test fails; slicing -260 in daily branch → 7d test fails.
- Local `go test -race -count=1 ./...` clean (Go side, both packages); `go vet` clean; `gofmt -l .` clean. `npx tsc -b --noEmit` clean. Vitest 36/36. `npm run build` succeeds.

## Final 4-reviewer pass

After the 11-commit feature series was pushed, a final review trio (DE / QA / Devil's Advocate) plus a Frontend Designer reviewed everything. The consensus identified 7 fix items (A–G) plus a CartesianGrid micro-fix on the PR velocity chart. All resolved across 4 fix commits at the tip of this branch:

| Item | Resolution | Commit |
|---|---|---|
| **A** `formatDayTick` was dead code in expanded charts | Wired by granularity in `IssuesPRsDashboard.tsx` | `f2c7e078` |
| **B** `(UTC)` axis label missing on dashboard expanded charts | Added to both expanded velocity charts | `f2c7e078` |
| **C** 6-button row overflowed at 375px viewport | `flex-col sm:flex-row` parent + `flex-wrap` on buttons | `f2c7e078` |
| **CartesianGrid** missing on PR velocity expanded chart (visual asymmetry vs Issues chart) | Added matching `<CartesianGrid>` | `f2c7e078` |
| **D** Q3 invariant test brittle (`getAllByText('8')` collided with category count) | `data-testid="open-issues-${slug}"` + `getByTestId().textContent` exact match | `336acf23` |
| **G** Test fixtures had `closed = 0` (masks swap regressions) | `daily/weekly[i].closed` now distinct from opened across all duration tests | `336acf23` |
| **E** e2e test only exercised open-issues path; closed/merged loops untested | New closed-issue + merged-PR fixtures with concrete dates; assertions on `Velocity.Daily[*].Closed` and `[*].Merged`. Independent mutation reproduction. | `ddb92337` |
| (Batch 3 lint nits: stringsbuilder + QF1012) | Refactored `buildIssuesJSON`/`buildPRsJSON` to `strings.Builder` + `fmt.Fprintf` | `8d718a32` |
| **F** Sparkline 7d/5y tests both asserted only `data-testid="sparkline"` (indistinguishable) | Mocked recharts `LineChart` to expose `data` prop; per-duration assertions on length, labels, and source-array values. Independent mutation reproduction. | `1a669955` |

## Plan-execution deviations recorded in plan

`docs/plans/2026-05-01-pr-c-five-year-window-and-duration-ui-plan.md` records:

- **Task 6** uses bare `bug` / `feature` labels (not `kind/bug` / `kind/feature`) — only the bare forms map under `_default` in `labelCategories`; `kind/`-prefixed forms only map under repo-specific overrides.
- **Task 7** "intentionally broken commit" replaced by stub `.velocity.weekly` fixes to keep compile green (the no-`--no-verify` rule made a deliberately-broken intermediate commit incompatible with our hooks).
- **Task 12** ThemeProvider is a default export (not named); jsdom needs `localStorage` + `matchMedia` shims at the top of `IssuesPRsDashboard.test.tsx`.
- **Final review fix Batch 3 lint follow-up** committed separately rather than amending — per the project's "prefer new commits over amend" rule.

## PR series

- [ ] PR-A: rate-limit middleware integration (#317)
- [ ] PR-B: cache fallback + workflow restore + DRA migration (#318)
- [ ] PR-C: this PR

## Review focus

- The `Velocity = {daily, weekly}` shape — is the nesting clean enough, or would a flat `{daily, weekly}` at one level higher read better in consumers?
- The `pickVelocity` location (`src/utils/duration.ts`) and the duration table — is the table small enough to keep here, or should it move to a config file?
- The recharts mock in `VelocitySparkline.test.tsx` — acceptable pattern for behavioral testing of chart components, or should we use a different testing approach (e.g., `react-test-renderer` snapshot)?
- The Q3 invariant approach (`data-testid` on snapshot cells + exact `textContent` match) — robust enough, or worth migrating to `aria-label` queries?
- The 5y data-fetch cost: ~1000 GitHub API calls per worst-case run for 9 repos (~20% of the 5000/hour authenticated quota). PR-A's rate-limit middleware caps the blast radius.

Closes review items: DE/QA/DA/FD final-pass items A / B / C / D / E / F / G + CartesianGrid asymmetry.
