### PR TITLE
chore: adopt DGXC OSS issue-management policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,56 @@
+name: "Bug report"
+description: "Report a defect (DGXC OSS policy: kind/bug)."
+title: "[Bug]: "
+labels: ["kind/bug", "needs-triage", "priority/unprioritized"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please complete every section. Issues missing reproduction or version data may be re-labeled `needs-triage` and parked.
+  - type: input
+    id: version
+    attributes:
+      label: Component / version
+      description: e.g. holodeck v0.4.2 / k8s-test-infra commit abc1234
+    validations: { required: true }
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: Actual behaviour, including full error output / stack traces.
+      render: shell
+    validations: { required: true }
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations: { required: true }
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal, deterministic. Include manifests, commands, env.
+      render: bash
+    validations: { required: true }
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: OS, kernel, container runtime, k8s version, GPU/driver, hardware.
+      render: yaml
+    validations: { required: true }
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / artefacts
+      description: Attach or paste relevant logs (redact secrets).
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched existing issues and Discussions and this is not a duplicate.
+          required: true
+        - label: This is a defect, not a usage question (questions belong in Discussions).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,13 @@
-blank_issues_enabled: true
+# DGXC OSS Policy: only the four official entry points are exposed.
+# Questions are routed to GitHub Discussions per policy guidance.
+blank_issues_enabled: false
 contact_links:
-  - name: Security Vulnerability
-    url: https://github.com/NVIDIA/k8s-test-infra/security/advisories/new
-    about: Report security vulnerabilities privately via GitHub Security Advisories
+  - name: Question / Help / Usage
+    url: https://github.com/NVIDIA/k8s-test-infra/discussions
+    about: Please use Discussions for usage questions; the issue tracker is for tracked work only.
+  - name: DGXC OSS Working Group (Slack, internal)
+    url: https://nvidia.enterprise.slack.com/archives/C0APQLRC6KD
+    about: Internal-only channel for OSS policy / process questions.
+  - name: Security vulnerability disclosure
+    url: ../blob/main/SECURITY.md
+    about: Do NOT open a public issue for vulnerabilities — see SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,20 @@
+name: "Documentation request or correction"
+description: "Missing, outdated, or incorrect docs (DGXC OSS policy: kind/documentation)."
+title: "[Docs]: "
+labels: ["kind/documentation", "needs-triage", "priority/unprioritized"]
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Location
+      description: URL, file path, or section affected.
+    validations: { required: true }
+  - type: textarea
+    id: issue
+    attributes:
+      label: What is wrong / missing
+    validations: { required: true }
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested correction (optional)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: "Feature request"
+description: "Propose a new capability or enhancement (DGXC OSS policy: kind/feature)."
+title: "[Feature]: "
+labels: ["kind/feature", "needs-triage", "priority/unprioritized"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What user/operator problem does this solve? Cite the use case.
+    validations: { required: true }
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: API, UX, configuration, behavioural change. Include alternatives considered.
+    validations: { required: true }
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope / non-goals
+  - type: dropdown
+    id: tier
+    attributes:
+      label: Audience
+      options: ["Operators / cluster admins", "End users", "Internal NVIDIA teams", "Other"]
+    validations: { required: true }
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched existing issues / Discussions and this is not a duplicate.
+          required: true
+        - label: I understand triage cadence is weekly and Unprioritized SLA is 7 calendric days.
+          required: true

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,54 @@
+# DGXC OSS stale lifecycle — mirrors the policy:
+#   - 90 days inactive  -> label `lifecycle/stale`
+#   - +30 days inactive -> close
+#   - exempt: label `lifecycle/frozen`
+# Reference: https://github.com/NVIDIA/gpu-operator/blob/main/.github/workflows/stale.yaml
+name: "Mark and close stale issues"
+
+on:
+  schedule:
+    - cron: "30 1 * * *"   # daily 01:30 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # --- thresholds (policy) ---
+          days-before-issue-stale: 90
+          days-before-issue-close: 30
+          days-before-pr-stale: 90
+          days-before-pr-close: 30
+
+          # --- labels ---
+          stale-issue-label: "lifecycle/stale"
+          stale-pr-label: "lifecycle/stale"
+          exempt-issue-labels: "lifecycle/frozen"
+          exempt-pr-labels: "lifecycle/frozen"
+
+          # --- messages ---
+          stale-issue-message: |
+            This issue has had no activity for 90 days and is being marked `lifecycle/stale`
+            per the DGXC OSS Issue Mgmt policy. It will be auto-closed in 30 days unless:
+              * a maintainer adds the `lifecycle/frozen` label, or
+              * a comment / commit reactivates it.
+          close-issue-message: |
+            Closing per DGXC OSS stale policy (no activity for 120 days). Re-open with new
+            evidence if still relevant.
+          stale-pr-message: |
+            This PR has had no activity for 90 days and is being marked `lifecycle/stale`.
+            It will be auto-closed in 30 days unless updated or labeled `lifecycle/frozen`.
+          close-pr-message: |
+            Closing per DGXC OSS stale policy (no activity for 120 days).
+
+          # --- behaviour ---
+          remove-stale-when-updated: true
+          operations-per-run: 200
+          ascending: true
+          delete-branch: false


### PR DESCRIPTION
Adopts the DGXC OSS GitHub Issue Mgmt policy: issue templates restricted to the four official kinds, stale lifecycle automation matching the gpu-operator pattern, and Discussions routing for questions.