### PR TITLE
fix(nvml-mock): DRA quick-start — co-locate dev nodes under driver root

### DIFF
--- a/.github/workflows/nvml-mock-e2e.yaml
+++ b/.github/workflows/nvml-mock-e2e.yaml
@@ -111,10 +111,11 @@ jobs:
           # Check library
           docker exec "$NODE_CONTAINER" sh -c "ls /var/lib/nvml-mock/driver/usr/lib64/libnvidia-ml.so.* | head -1"
           docker exec "$NODE_CONTAINER" test -L /var/lib/nvml-mock/driver/usr/lib64/libnvidia-ml.so.1
-          # Check device files
-          docker exec "$NODE_CONTAINER" test -e /var/lib/nvml-mock/dev/nvidia0
-          docker exec "$NODE_CONTAINER" test -e /var/lib/nvml-mock/dev/nvidia1
-          docker exec "$NODE_CONTAINER" test -e /var/lib/nvml-mock/dev/nvidiactl
+          # Check device files (under driver root so the upstream DRA driver's
+          # getDevRoot() resolves; CDI bind-mounts these to /dev/nvidia* in pods)
+          docker exec "$NODE_CONTAINER" test -e /var/lib/nvml-mock/driver/dev/nvidia0
+          docker exec "$NODE_CONTAINER" test -e /var/lib/nvml-mock/driver/dev/nvidia1
+          docker exec "$NODE_CONTAINER" test -e /var/lib/nvml-mock/driver/dev/nvidiactl
           # Check config at both locations
           docker exec "$NODE_CONTAINER" test -f /var/lib/nvml-mock/config/config.yaml
           docker exec "$NODE_CONTAINER" test -f /var/lib/nvml-mock/driver/config/config.yaml

--- a/.github/workflows/nvml-mock-e2e.yaml
+++ b/.github/workflows/nvml-mock-e2e.yaml
@@ -319,13 +319,61 @@ jobs:
               jq '[.items[].spec.devices // [] | length] | add // 0')
             if [ "$COUNT" = "2" ]; then
               echo "PASS: ResourceSlice reports $COUNT GPUs"
-              exit 0
+              break
             fi
             echo "Attempt $i: ResourceSlice GPUs=$COUNT (expected 2), waiting..."
             sleep 2
           done
-          echo "FAIL: Expected 2 GPUs in ResourceSlice, got $COUNT"
-          exit 1
+          if [ "$COUNT" != "2" ]; then
+            echo "FAIL: Expected 2 GPUs in ResourceSlice, got $COUNT"
+            exit 1
+          fi
+
+      - name: Schedule pod with ResourceClaim
+        run: |
+          cat <<'EOF' | kubectl apply -f -
+          apiVersion: resource.k8s.io/v1beta1
+          kind: ResourceClaimTemplate
+          metadata:
+            name: gpu-claim
+          spec:
+            spec:
+              devices:
+                requests:
+                - name: gpu
+                  deviceClassName: gpu.nvidia.com
+          ---
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: gpu-test-pod
+          spec:
+            restartPolicy: Never
+            containers:
+            - name: app
+              image: busybox:1.36
+              command: ["sleep", "300"]
+              resources:
+                claims:
+                - name: gpu
+            resourceClaims:
+            - name: gpu
+              resourceClaimTemplateName: gpu-claim
+          EOF
+
+      - name: Wait for pod Running (proves NodePrepareResources succeeded)
+        run: |
+          if ! kubectl wait --for=jsonpath='{.status.phase}'=Running pod/gpu-test-pod --timeout=120s; then
+            echo "Pod did not reach Running in 120s. Diagnosing..."
+            if kubectl describe pod gpu-test-pod 2>/dev/null | grep -q 'empty device edits'; then
+              echo "FAIL: nvml-mock DRA dev-node layout regression — 'empty device edits' in pod events"
+            else
+              echo "FAIL: pod stuck for unknown reason (not the dev-node layout regression)"
+            fi
+            kubectl describe pod gpu-test-pod || true
+            exit 1
+          fi
+          echo "PASS: pod-with-claim reached Running"
 
       - name: Collect logs on failure
         if: failure()
@@ -347,6 +395,10 @@ jobs:
           kubectl -n nvidia logs -l app.kubernetes.io/name=nvidia-dra-driver-gpu --tail=100 || true
           echo "=== ResourceSlices ==="
           kubectl get resourceslices -o yaml || true
+          echo "=== gpu-test-pod describe ==="
+          kubectl describe pod gpu-test-pod || true
+          echo "=== resourceclaims (all namespaces) ==="
+          kubectl get resourceclaims -A -o yaml || true
           echo "=== pod status ==="
           kubectl get pods -A || true
           echo "=== node describe ==="

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -8,7 +8,7 @@ NVIDIA hardware required.
 
 Deploys a DaemonSet that creates on every node:
 - Mock `libnvidia-ml.so` shared library at `/var/lib/nvml-mock/driver/usr/lib64/`
-- Device nodes (`/dev/nvidia0`, `/dev/nvidia1`, ..., `/dev/nvidiactl`)
+- Mock device nodes at `/var/lib/nvml-mock/driver/dev/nvidia{N,ctl,-uvm,-uvm-tools}` (consumers see them at `/dev/nvidia*` via CDI bind-mount)
 - GPU configuration at `/var/lib/nvml-mock/driver/config/config.yaml`
 - Node label `nvidia.com/gpu.present=true`
 
@@ -634,7 +634,7 @@ The chart deploys:
 1. **DaemonSet** — runs a privileged container on each node that:
    - Copies `libnvidia-ml.so.{version}` to the host at `/var/lib/nvml-mock/driver/usr/lib64/`
    - Creates symlinks (`libnvidia-ml.so.1` → `libnvidia-ml.so.{version}`)
-   - Creates device nodes (`/dev/nvidia0` ... `/dev/nvidiaX`, `/dev/nvidiactl`)
+   - Creates mock device nodes at `/var/lib/nvml-mock/driver/dev/nvidia{N,ctl,-uvm,-uvm-tools}` (CDI bind-mounts them to `/dev/nvidia*` in consumer containers)
    - Writes GPU config YAML at `/var/lib/nvml-mock/driver/config/config.yaml`
    - Labels the node `nvidia.com/gpu.present=true`
 2. **ConfigMap** — GPU configuration from the selected profile

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -10,7 +10,10 @@ set -e
 
 HOST=/host/var/lib/nvml-mock
 DRIVER_ROOT=$HOST/driver
-DEV_ROOT=$HOST/dev
+# Co-locate device nodes under $DRIVER_ROOT so the upstream DRA driver's
+# getDevRoot() (cmd/gpu-kubelet-plugin/root.go in NVIDIA/k8s-dra-driver-gpu)
+# resolves devRoot to the mock driver root rather than falling back to "/".
+DEV_ROOT=$DRIVER_ROOT/dev
 CONFIG_DIR=$HOST/config
 
 # Validate GPU_COUNT does not exceed profile device count
@@ -74,11 +77,11 @@ kind: "nvidia.com/gpu"
 containerEdits:
   deviceNodes:
     - path: /dev/nvidiactl
-      hostPath: /var/lib/nvml-mock/dev/nvidiactl
+      hostPath: /var/lib/nvml-mock/driver/dev/nvidiactl
     - path: /dev/nvidia-uvm
-      hostPath: /var/lib/nvml-mock/dev/nvidia-uvm
+      hostPath: /var/lib/nvml-mock/driver/dev/nvidia-uvm
     - path: /dev/nvidia-uvm-tools
-      hostPath: /var/lib/nvml-mock/dev/nvidia-uvm-tools
+      hostPath: /var/lib/nvml-mock/driver/dev/nvidia-uvm-tools
   mounts:
     - hostPath: /var/lib/nvml-mock/driver/usr/lib64/libnvidia-ml.so.1
       containerPath: /usr/lib64/libnvidia-ml.so.1
@@ -102,7 +105,7 @@ for i in $(seq 0 $((GPU_COUNT - 1))); do
     containerEdits:
       deviceNodes:
         - path: /dev/nvidia$i
-          hostPath: /var/lib/nvml-mock/dev/nvidia$i
+          hostPath: /var/lib/nvml-mock/driver/dev/nvidia$i
 DEVICE_EOF
 done
 
@@ -112,7 +115,7 @@ echo '    containerEdits:' >> "$CDI_DIR/nvidia.yaml"
 echo '      deviceNodes:' >> "$CDI_DIR/nvidia.yaml"
 for i in $(seq 0 $((GPU_COUNT - 1))); do
   echo "        - path: /dev/nvidia$i" >> "$CDI_DIR/nvidia.yaml"
-  echo "          hostPath: /var/lib/nvml-mock/dev/nvidia$i" >> "$CDI_DIR/nvidia.yaml"
+  echo "          hostPath: /var/lib/nvml-mock/driver/dev/nvidia$i" >> "$CDI_DIR/nvidia.yaml"
 done
 
 echo "CDI spec generated at $CDI_DIR/nvidia.yaml ($GPU_COUNT devices)"

--- a/tests/poc-validation/setup-kind-cluster.sh
+++ b/tests/poc-validation/setup-kind-cluster.sh
@@ -102,7 +102,7 @@ echo "=== Step 6: Verifying mock files on node ==="
 NODE_CONTAINER="${CLUSTER_NAME}-control-plane"
 docker exec "$NODE_CONTAINER" test -L /var/lib/nvml-mock/driver/usr/lib64/libnvidia-ml.so.1
 docker exec "$NODE_CONTAINER" test -f /var/lib/nvml-mock/driver/config/config.yaml
-docker exec "$NODE_CONTAINER" test -e /var/lib/nvml-mock/dev/nvidia0
+docker exec "$NODE_CONTAINER" test -e /var/lib/nvml-mock/driver/dev/nvidia0
 echo "Mock files verified on node"
 
 # Step 7: Verify node labels


### PR DESCRIPTION
## Problem
nvml-mock's DRA quick-start (chart README) fails when a user follows it past `kubectl get resourceslices`. Scheduling a pod with a `ResourceClaim` makes kubelet call the NVIDIA DRA driver's `NodePrepareResources`, which returns:

```
unable to create CDI spec file for claim:
  failed to write spec: invalid CDI Spec:
  failed add device "<uuid>-gpu-N": invalid device, empty device edits
```

Reported by Eliran Wolff in Slack on 2026-05-04.

## Root cause
The upstream DRA driver's `cmd/gpu-kubelet-plugin/root.go` `getDevRoot()` checks `${nvidiaDriverRoot}/dev/` and falls back to `/` when absent. nvml-mock previously placed device nodes at `/var/lib/nvml-mock/dev/` — *sibling* of the driver root — so the check failed silently and per-claim CDI specs referenced `/dev/nvidiaN` on the kind host (which doesn't exist).

The README quick-start already passes `--set nvidiaDriverRoot=/var/lib/nvml-mock/driver` (line 176) — the flag was correct; the chart just didn't honor it because dev nodes were in the wrong place.

## Fix
Three changes (one PR, three commits — test → fix → docs):
1. **`setup.sh`**: relocate `DEV_ROOT` under `$DRIVER_ROOT` (one shell variable + six CDI hostPath strings).
2. **`README.md`**: correct two misleading claims about where device nodes live on the host.
3. **`nvml-mock-e2e.yaml`**: extend the `e2e-dra` job to schedule a pod with a `ResourceClaim` and assert it reaches Running. CI previously stopped at counting ResourceSlices, leaving this entire path untested.

No upstream DRA driver changes. No new helm values. No new container image dependencies.

## Testing
Local kind cluster verification on 2 GPUs (a100 profile, default):
- **Pre-fix**: pod stuck in `ContainerCreating`; `Using devRoot=/` in kubelet-plugin logs; `empty device edits` in pod events.
- **Post-fix**: pod reaches `Running` in ~10s; `Using devRoot=/driver-root`; pod events clean.

CI will run the new assertions across the full matrix (a100, h100, b200, gb200, l40s, t4).

## Notes
- The new `e2e-dra` flow uses a generic `busybox:1.36` image — the test asserts `NodePrepareResources` builds a valid CDI spec, not NVML behavior inside the user pod (which is exercised by `e2e-device-plugin` and `e2e-gpu-operator`).
- The "Verify ResourceSlice GPU count" step changes `exit 0` → `break` so subsequent steps can run; existing semantics preserved on PASS/FAIL.