### PR TITLE
fix(build): bump Dockerfile GOLANG_VERSION 1.25 -> 1.26 to match go.mod

### DIFF
--- a/deployments/nvml-mock/Dockerfile
+++ b/deployments/nvml-mock/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GOLANG_VERSION=1.25
+ARG GOLANG_VERSION=1.26
 FROM golang:${GOLANG_VERSION}-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/pkg/gpu/mocknvml/Dockerfile
+++ b/pkg/gpu/mocknvml/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GOLANG_VERSION=1.25.0
+ARG GOLANG_VERSION=1.26.0
 
 FROM golang:${GOLANG_VERSION}-bookworm
 

--- a/tests/mocknvml/Dockerfile
+++ b/tests/mocknvml/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GOLANG_VERSION=1.25.0
+ARG GOLANG_VERSION=1.26.0
 FROM golang:${GOLANG_VERSION} AS lib-builder
 
 WORKDIR /build


### PR DESCRIPTION
## Problem

The three Dockerfiles in this repo pinned `GOLANG_VERSION=1.25` (or `1.25.0`), but after #314 merged the k8s.io group bump, `go.mod` declared `go 1.26.0`. The Go toolchain refuses to build a module that requires a version higher than the toolchain, so any in-container build broke.

## Symptom

`nvml-mock Publish` workflow on `main` failed at `Build and push` step with:

```
make: *** [Makefile:61: libnvidia-ml.so.550.163.01] Error 1
ERROR: process "/bin/sh -c cd pkg/gpu/mocknvml && make clean && make" did not complete successfully: exit code: 2
```

This first surfaced on the merge commit of #323 (`e17c8df6`), because that PR's diff included `pkg/gpu/mocknvml/...` paths and triggered the publish path filter. #314 itself didn't trigger publish, so the drift was hidden until now.

## Fix

Bump `GOLANG_VERSION` in all three Dockerfiles to match the module's `go` directive:

- `deployments/nvml-mock/Dockerfile`: `1.25` -> `1.26`
- `pkg/gpu/mocknvml/Dockerfile`: `1.25.0` -> `1.26.0`
- `tests/mocknvml/Dockerfile`: `1.25.0` -> `1.26.0`

The CI test image (`deployments/devel/Dockerfile`) already uses `golang:1.26.2`, so this aligns the publish/test images with what CI was already exercising.

## Verification

- `gh run` for `nvml-mock Publish` on this commit will rebuild the image with Go 1.26 and pass the `make` step.
- No production behavior change; `make` produces the same `libnvidia-ml.so.550.163.01` shared object regardless of toolchain minor version, since the CGo bridge code is forward-compatible.

## Context

Opened as part of a merge-train HALT recovery (Flow C in our internal merge-train spec). Once this lands and `main` goes green, the train resumes with the remaining queued PR (#328 — failure injection feature).
