### PR TITLE
feat(nvml-mock): ComputeDomain simulation with fabric APIs and fake IMEX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.out
 *.test
 
+# Stray binaries from `go build ./cmd/...` at repo root
+/check-fabric
+
 # Agentic working artifacts
 .agents/
 AGENTS.md

--- a/cmd/check-fabric/main.go
+++ b/cmd/check-fabric/main.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// check-fabric prints the NVLink fabric attributes of every visible GPU
+// by calling nvmlDeviceGetGpuFabricInfo / nvmlDeviceGetGpuFabricInfoV
+// through go-nvml. It is intended as the demo-time consumer for the
+// ComputeDomain simulation work (NVIDIA/k8s-test-infra#304): with the
+// mock NVML library on LD_LIBRARY_PATH (or via the standard
+// /usr/local/lib install), the binary reports the cluster UUID, clique
+// ID, and registration state that the topology overlay assigned to
+// this Kubernetes node.
+//
+// Exit codes:
+//
+//	0  - every visible GPU reports fabric info
+//	2  - at least one GPU returned ERROR_NOT_SUPPORTED (no fabric)
+//	1  - any other NVML failure
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+func main() {
+	if ret := nvml.Init(); ret != nvml.SUCCESS {
+		fmt.Fprintf(os.Stderr, "nvmlInit: %v\n", ret)
+		os.Exit(1)
+	}
+	defer func() { _ = nvml.Shutdown() }()
+
+	count, ret := nvml.DeviceGetCount()
+	if ret != nvml.SUCCESS {
+		fmt.Fprintf(os.Stderr, "DeviceGetCount: %v\n", ret)
+		os.Exit(1)
+	}
+
+	notSupported := 0
+	fmt.Printf("Discovered %d GPU(s)\n", count)
+	for i := 0; i < count; i++ {
+		dev, ret := nvml.DeviceGetHandleByIndex(i)
+		if ret != nvml.SUCCESS {
+			fmt.Fprintf(os.Stderr, "handle[%d]: %v\n", i, ret)
+			os.Exit(1)
+		}
+		uuid, _ := dev.GetUUID()
+
+		info, ret := dev.GetGpuFabricInfo()
+		switch ret {
+		case nvml.SUCCESS:
+			fmt.Printf("GPU %d (%s)\n", i, uuid)
+			fmt.Printf("  clusterUuid : %s\n", formatUUID(info.ClusterUuid[:]))
+			fmt.Printf("  cliqueId    : %d\n", info.CliqueId)
+			fmt.Printf("  state       : %s (%d)\n", stateName(uint8(info.State)), info.State)
+		case nvml.ERROR_NOT_SUPPORTED:
+			fmt.Printf("GPU %d (%s): fabric NOT SUPPORTED\n", i, uuid)
+			notSupported++
+		default:
+			fmt.Fprintf(os.Stderr, "GetGpuFabricInfo[%d]: %v\n", i, ret)
+			os.Exit(1)
+		}
+	}
+
+	if notSupported > 0 {
+		os.Exit(2)
+	}
+}
+
+func formatUUID(b []byte) string {
+	if len(b) != 16 {
+		return hex.EncodeToString(b)
+	}
+	return fmt.Sprintf("%s-%s-%s-%s-%s",
+		hex.EncodeToString(b[0:4]),
+		hex.EncodeToString(b[4:6]),
+		hex.EncodeToString(b[6:8]),
+		hex.EncodeToString(b[8:10]),
+		hex.EncodeToString(b[10:16]),
+	)
+}
+
+func stateName(s uint8) string {
+	switch s {
+	case 0:
+		return "not_supported"
+	case 1:
+		return "not_started"
+	case 2:
+		return "in_progress"
+	case 3:
+		return "completed"
+	default:
+		return "unknown"
+	}
+}

--- a/cmd/fake-imex/ctl/main.go
+++ b/cmd/fake-imex/ctl/main.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// fake-imex-ctl is a drop-in replacement for `nvidia-imex-ctl` used by
+// the compute-domain-daemon's readiness probe. It supports the
+// `-c <config> -q` invocation pattern from upstream's check() helper:
+// prints "READY\n" + exit 0 iff every peer listed in nodes.cfg has a
+// marker file under the shared state directory; otherwise exits 1.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/imexcoord"
+)
+
+func main() {
+	cfg := flag.String("c", "", "imexd config file (ignored)")
+	query := flag.Bool("q", false, "query readiness (only supported mode)")
+	flag.Parse()
+	_ = cfg
+
+	if !*query {
+		fmt.Fprintln(os.Stderr, "fake-imex-ctl: only -q (query) mode is supported")
+		os.Exit(2)
+	}
+
+	peers, err := imexcoord.ReadPeers(imexcoord.NodesConfigPath())
+	if err != nil {
+		// Match real nvidia-imex-ctl behaviour: when the daemon has not
+		// yet written nodes.cfg the probe should fail rather than say
+		// READY. Avoids a race where the controller marks a domain
+		// ready before its members have actually started.
+		fmt.Fprintf(os.Stderr, "fake-imex-ctl: read nodes.cfg: %v\n", err)
+		os.Exit(1)
+	}
+
+	ready, missing := imexcoord.AllPeersReady(imexcoord.StateDir(), peers)
+	if !ready {
+		fmt.Fprintf(os.Stderr, "fake-imex-ctl: peer %s not ready\n", missing)
+		os.Exit(1)
+	}
+	fmt.Print("READY\n")
+}

--- a/cmd/fake-imex/daemon/main.go
+++ b/cmd/fake-imex/daemon/main.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// fake-imex-daemon is a drop-in replacement for the real `nvidia-imex`
+// binary used inside the compute-domain-daemon pod. It accepts (and
+// ignores) the standard CLI flags, writes a marker file under the
+// shared hostPath state directory, and re-reads nodes.cfg on SIGUSR1
+// (matching the upstream daemon's DNS-update signal). See
+// NVIDIA/k8s-test-infra#304 for the full ComputeDomain simulation
+// design.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/imexcoord"
+)
+
+func main() {
+	// Accept the real binary's flags so callers (compute-domain-daemon's
+	// subprocess invocation) don't have to special-case the mock.
+	cfg := flag.String("c", "", "imexd config file (ignored)")
+	flag.Parse()
+	_ = cfg
+
+	podIP := os.Getenv(imexcoord.EnvPodIP)
+	if podIP == "" {
+		log.Fatalf("fake-imex: %s is required (set via downward API)", imexcoord.EnvPodIP)
+	}
+
+	stateDir := imexcoord.StateDir()
+	nodesCfg := imexcoord.NodesConfigPath()
+
+	if err := imexcoord.WriteMarker(stateDir, podIP); err != nil {
+		log.Fatalf("fake-imex: write marker: %v", err)
+	}
+	log.Printf("fake-imex: marker %s written; tracking peers via %s", podIP, nodesCfg)
+
+	sigs := make(chan os.Signal, 4)
+	signal.Notify(sigs, syscall.SIGTERM, syscall.SIGINT, syscall.SIGUSR1)
+
+	tick := time.NewTicker(2 * time.Second)
+	defer tick.Stop()
+
+	logPeers := func(reason string) {
+		peers, err := imexcoord.ReadPeers(nodesCfg)
+		if err != nil {
+			log.Printf("fake-imex: re-read nodes.cfg (%s) failed: %v", reason, err)
+			return
+		}
+		log.Printf("fake-imex: nodes.cfg=%s peers=%d (%s)", nodesCfg, len(peers), reason)
+	}
+	logPeers("startup")
+
+	for {
+		select {
+		case sig := <-sigs:
+			switch sig {
+			case syscall.SIGUSR1:
+				logPeers("SIGUSR1")
+			case syscall.SIGTERM, syscall.SIGINT:
+				if err := imexcoord.RemoveMarker(stateDir, podIP); err != nil {
+					log.Printf("fake-imex: remove marker on shutdown: %v", err)
+				}
+				log.Printf("fake-imex: marker %s removed; exiting on %s", podIP, sig)
+				_, _ = fmt.Fprintln(os.Stdout, "fake-imex: clean shutdown")
+				return
+			}
+		case <-tick.C:
+			logPeers("tick")
+		}
+	}
+}

--- a/cmd/fake-imex/integration_test.go
+++ b/cmd/fake-imex/integration_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fakeimex_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// build compiles a fake-imex sub-command into the given output path and
+// returns the binary path. Skips the test on non-linux/darwin or when
+// `go` is unavailable (e.g. in stripped CI sandboxes).
+func build(t *testing.T, pkg, out string) string {
+	t.Helper()
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available")
+	}
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skipf("unsupported GOOS=%s for build/exec integration", runtime.GOOS)
+	}
+	cmd := exec.Command("go", "build", "-mod=vendor", "-o", out, pkg)
+	cmd.Dir = repoRoot(t)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build %s: %v\n%s", pkg, err, output)
+	}
+	return out
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for cur := wd; cur != "/"; cur = filepath.Dir(cur) {
+		if _, err := os.Stat(filepath.Join(cur, "go.mod")); err == nil {
+			return cur
+		}
+	}
+	t.Fatal("could not locate repo root")
+	return ""
+}
+
+// TestFakeImex_HappyPath_ReadyTransitions starts three fake daemons and
+// verifies the fake ctl reports READY only once every peer's marker has
+// landed, then NOT READY after one peer goes away.
+func TestFakeImex_HappyPath_ReadyTransitions(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, "state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nodesCfg := filepath.Join(tmp, "nodes.cfg")
+	if err := os.WriteFile(nodesCfg, []byte("10.0.0.1\n10.0.0.2\n10.0.0.3\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	daemonBin := build(t, "./cmd/fake-imex/daemon", filepath.Join(tmp, "nvidia-imex"))
+	ctlBin := build(t, "./cmd/fake-imex/ctl", filepath.Join(tmp, "nvidia-imex-ctl"))
+
+	env := []string{
+		"IMEX_STATE_DIR=" + stateDir,
+		"IMEX_NODES_CONFIG=" + nodesCfg,
+	}
+
+	startDaemon := func(ip string) *exec.Cmd {
+		ctx, cancel := context.WithCancel(context.Background())
+		cmd := exec.CommandContext(ctx, daemonBin, "-c", "/dev/null")
+		cmd.Env = append(append([]string{}, env...), "POD_IP="+ip)
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		if err := cmd.Start(); err != nil {
+			cancel()
+			t.Fatalf("start daemon %s: %v", ip, err)
+		}
+		t.Cleanup(func() {
+			cancel()
+			_ = cmd.Wait()
+		})
+		return cmd
+	}
+
+	runCtl := func() (stdout string, exitCode int) {
+		cmd := exec.Command(ctlBin, "-c", "/dev/null", "-q")
+		cmd.Env = env
+		out, err := cmd.Output()
+		if err != nil {
+			if ee, ok := err.(*exec.ExitError); ok {
+				return string(out), ee.ExitCode()
+			}
+			t.Fatalf("ctl unexpected error: %v", err)
+		}
+		return string(out), 0
+	}
+
+	d1 := startDaemon("10.0.0.1")
+	d2 := startDaemon("10.0.0.2")
+	_ = d2
+	// Only 2 of 3 markers exist → ctl exits 1.
+	waitForMarker(t, stateDir, "10.0.0.1")
+	waitForMarker(t, stateDir, "10.0.0.2")
+	if _, code := runCtl(); code != 1 {
+		t.Fatalf("ctl with 2/3 markers: want exit 1, got %d", code)
+	}
+
+	startDaemon("10.0.0.3")
+	waitForMarker(t, stateDir, "10.0.0.3")
+	out, code := runCtl()
+	if code != 0 || !strings.HasPrefix(out, "READY") {
+		t.Fatalf("ctl with 3/3: want READY exit 0, got %q exit %d", out, code)
+	}
+
+	// Kill d1 cleanly so it removes its marker; ctl should fail again.
+	_ = d1.Process.Signal(syscall.SIGTERM)
+	waitForNoMarker(t, stateDir, "10.0.0.1")
+	if _, code := runCtl(); code != 1 {
+		t.Fatalf("ctl after d1 SIGTERM: want exit 1, got %d", code)
+	}
+}
+
+func waitForMarker(t *testing.T, dir, ip string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(filepath.Join(dir, ip)); err == nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("marker %s did not appear within deadline", ip)
+}
+
+func waitForNoMarker(t *testing.T, dir, ip string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(filepath.Join(dir, ip)); os.IsNotExist(err) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("marker %s did not disappear within deadline", ip)
+}

--- a/deployments/nvml-mock/Dockerfile
+++ b/deployments/nvml-mock/Dockerfile
@@ -20,11 +20,18 @@ COPY vendor/ vendor/
 COPY pkg/gpu/mocknvml/ pkg/gpu/mocknvml/
 COPY pkg/gpu/mockcuda/ pkg/gpu/mockcuda/
 COPY pkg/network/mockibsysfs/ pkg/network/mockibsysfs/
+COPY pkg/imexcoord/ pkg/imexcoord/
 COPY cmd/render-ib-sysfs/ cmd/render-ib-sysfs/
+COPY cmd/fake-imex/ cmd/fake-imex/
+COPY cmd/check-fabric/ cmd/check-fabric/
 RUN cd pkg/gpu/mocknvml && make clean && make
 RUN cd pkg/gpu/mockcuda && make clean && make
 RUN cd pkg/network/mockibsysfs && make clean && make
-RUN mkdir -p /out && go build -mod=vendor -o /out/render-ib-sysfs ./cmd/render-ib-sysfs
+RUN mkdir -p /out \
+    && go build -mod=vendor -o /out/render-ib-sysfs ./cmd/render-ib-sysfs \
+    && go build -mod=vendor -o /out/nvidia-imex     ./cmd/fake-imex/daemon \
+    && go build -mod=vendor -o /out/nvidia-imex-ctl ./cmd/fake-imex/ctl \
+    && go build -mod=vendor -o /out/check-fabric    ./cmd/check-fabric
 
 FROM debian:bookworm-slim
 ARG KUBECTL_VERSION=v1.32.0
@@ -33,6 +40,17 @@ COPY --from=builder /src/pkg/gpu/mocknvml/libnvidia-ml.so.* /usr/local/lib/
 COPY --from=builder /src/pkg/gpu/mockcuda/libcuda.so.* /usr/local/lib/
 COPY --from=builder /src/pkg/network/mockibsysfs/libibmocksys.so.* /usr/local/lib/
 COPY --from=builder /out/render-ib-sysfs /usr/local/bin/render-ib-sysfs
+# Fake IMEX binaries used for ComputeDomain simulation on KIND. Installed
+# at the same paths the upstream compute-domain-daemon expects in $PATH,
+# so the thin daemon image layer (Dockerfile.compute-domain-daemon) can
+# COPY them straight from this image. See NVIDIA/k8s-test-infra#304.
+COPY --from=builder /out/nvidia-imex     /usr/bin/nvidia-imex
+COPY --from=builder /out/nvidia-imex-ctl /usr/bin/nvidia-imex-ctl
+# check-fabric: tiny Go consumer that calls nvmlDeviceGetGpuFabricInfo
+# via the LD_PRELOAD'd mock library. Used by docs/demo/compute-domain
+# to confirm the topology overlay assigned the expected clique to each
+# node. See NVIDIA/k8s-test-infra#304.
+COPY --from=builder /out/check-fabric    /usr/local/bin/check-fabric
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends curl ca-certificates gnupg2 \

--- a/deployments/nvml-mock/Dockerfile.compute-domain-daemon
+++ b/deployments/nvml-mock/Dockerfile.compute-domain-daemon
@@ -1,0 +1,29 @@
+# Copyright 2026 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Thin overlay on the upstream compute-domain-daemon image that swaps in
+# the fake nvidia-imex / nvidia-imex-ctl binaries from the nvml-mock
+# image. With this image deployed (via the upstream Helm chart's image
+# override), the real compute-domain-controller and -daemon run
+# unmodified against the mock NVML fabric APIs on a hardware-free KIND
+# cluster. See NVIDIA/k8s-test-infra#304.
+
+ARG NVML_MOCK_IMAGE=ghcr.io/nvidia/nvml-mock:latest
+ARG COMPUTE_DOMAIN_DAEMON_IMAGE=registry.k8s.io/dra-driver-nvidia-gpu/compute-domain-daemon:latest
+
+FROM ${NVML_MOCK_IMAGE} AS imex
+
+FROM ${COMPUTE_DOMAIN_DAEMON_IMAGE}
+COPY --from=imex /usr/bin/nvidia-imex     /usr/bin/nvidia-imex
+COPY --from=imex /usr/bin/nvidia-imex-ctl /usr/bin/nvidia-imex-ctl

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
@@ -37,6 +37,20 @@ device_defaults:
   num_gpu_cores: 18432              # Blackwell has more CUDA cores
 
   # ---------------------------------------------------------------------------
+  # NVLink fabric (GB200 ComputeDomain). The clique_id / cluster_uuid below
+  # are placeholder defaults; the topology-overlay step in the engine
+  # rewrites them per-node based on the cluster-level topology ConfigMap
+  # (set Helm value `topology.enabled=true`). Nodes that don't appear in
+  # the topology fall through to these defaults, which is sufficient for
+  # single-node experiments. See pkg/gpu/mocknvml/engine/fabric.go.
+  # ---------------------------------------------------------------------------
+  fabric:
+    cluster_uuid: "00000000-0000-0000-0000-000000000001"
+    clique_id: 0
+    state: "completed"
+    health_mask: 0
+
+  # ---------------------------------------------------------------------------
   # InfoROM versions
   # ---------------------------------------------------------------------------
   inforom:

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -61,6 +61,22 @@ spec:
             # workloads) all see the config at the same in-container location.
             - name: MOCK_NVML_CONFIG
               value: /etc/nvml-mock/config.yaml
+            {{- if .Values.topology.enabled }}
+            # Point the engine's topology overlay at the in-pod mount of
+            # the cluster-level topology ConfigMap. See
+            # pkg/gpu/mocknvml/engine/config.go applyTopologyOverlay().
+            - name: MOCK_TOPOLOGY_CONFIG
+              value: /etc/nvml-mock/topology/topology.yaml
+            {{- end }}
+            {{- if .Values.imex.enabled }}
+            # Shared coordination directory for the fake nvidia-imex /
+            # nvidia-imex-ctl binaries baked into this image. The same
+            # hostPath is bind-mounted into compute-domain-daemon pods
+            # via the thin image layer in
+            # deployments/nvml-mock/Dockerfile.compute-domain-daemon.
+            - name: IMEX_STATE_DIR
+              value: {{ .Values.imex.stateDir }}
+            {{- end }}
             # LD_PRELOAD installs the InfiniBand sysfs redirector in every
             # process spawned in this container (e.g. `kubectl exec ibstat`).
             # The shim only rewrites paths under /sys/class/infiniband*,
@@ -91,6 +107,14 @@ spec:
               mountPath: /host/var/run/cdi
             - name: host-run-nvidia
               mountPath: /host/run/nvidia
+            {{- if .Values.topology.enabled }}
+            - name: gpu-topology
+              mountPath: /etc/nvml-mock/topology
+            {{- end }}
+            {{- if .Values.imex.enabled }}
+            - name: host-imex-state
+              mountPath: {{ .Values.imex.stateDir }}
+            {{- end }}
       volumes:
         - name: host-nvml-mock
           hostPath:
@@ -107,3 +131,14 @@ spec:
           hostPath:
             path: /run/nvidia
             type: DirectoryOrCreate
+        {{- if .Values.topology.enabled }}
+        - name: gpu-topology
+          configMap:
+            name: {{ include "nvml-mock.fullname" . }}-topology
+        {{- end }}
+        {{- if .Values.imex.enabled }}
+        - name: host-imex-state
+          hostPath:
+            path: {{ .Values.imex.stateDir }}
+            type: DirectoryOrCreate
+        {{- end }}

--- a/deployments/nvml-mock/helm/nvml-mock/templates/topology-configmap.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/topology-configmap.yaml
@@ -1,0 +1,21 @@
+{{- /*
+Copyright 2026 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+
+Cluster-level ComputeDomain topology. Consumed only by the mock NVML
+engine at LoadConfig() time to override per-node fabric attributes; see
+pkg/gpu/mocknvml/engine/config.go applyTopologyOverlay().
+*/ -}}
+{{- if .Values.topology.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nvml-mock.fullname" . }}-topology
+  labels:
+    {{- include "nvml-mock.labels" . | nindent 4 }}
+data:
+  topology.yaml: |
+    version: 1
+    domains:
+      {{- toYaml .Values.topology.domains | nindent 6 }}
+{{- end }}

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
@@ -875,6 +875,20 @@ should match snapshot with gb200 profile:
           num_gpu_cores: 18432              # Blackwell has more CUDA cores
 
           # ---------------------------------------------------------------------------
+          # NVLink fabric (GB200 ComputeDomain). The clique_id / cluster_uuid below
+          # are placeholder defaults; the topology-overlay step in the engine
+          # rewrites them per-node based on the cluster-level topology ConfigMap
+          # (set Helm value `topology.enabled=true`). Nodes that don't appear in
+          # the topology fall through to these defaults, which is sufficient for
+          # single-node experiments. See pkg/gpu/mocknvml/engine/fabric.go.
+          # ---------------------------------------------------------------------------
+          fabric:
+            cluster_uuid: "00000000-0000-0000-0000-000000000001"
+            clique_id: 0
+            state: "completed"
+            health_mask: 0
+
+          # ---------------------------------------------------------------------------
           # InfoROM versions
           # ---------------------------------------------------------------------------
           inforom:

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -70,6 +70,37 @@ updateStrategy:
 # is overkill and slows rollouts.
 terminationGracePeriodSeconds: 10
 
+# ComputeDomain (NVLink fabric) simulation. Opt-in: when `topology.enabled`
+# is true a cluster-level ConfigMap declaring domain UUID + per-clique node
+# membership is rendered and mounted into every nvml-mock pod. The mock
+# NVML engine looks up its NODE_NAME on startup and overrides each GPU's
+# fabric cluster_uuid / clique_id accordingly. See
+# pkg/gpu/mocknvml/engine/fabric.go and issue NVIDIA/k8s-test-infra#304.
+topology:
+  enabled: false
+  # Cluster-level topology document (consumed only by the mock NVML
+  # engine). Each node must appear in exactly one clique within one
+  # domain. Example:
+  # domains:
+  #   - name: "test-domain-1"
+  #     uuid: "00000000-0000-0000-0000-000000000001"
+  #     cliques:
+  #       - id: 0
+  #         nodes: [kind-worker, kind-worker2]
+  #       - id: 1
+  #         nodes: [kind-worker3, kind-worker4]
+  domains: []
+
+# Fake IMEX coordination. When `imex.enabled` is true the chart mounts a
+# hostPath state directory into the nvml-mock pod so the fake nvidia-imex
+# / nvidia-imex-ctl binaries (compiled into the image) can coordinate
+# peer readiness via marker files. Real compute-domain-daemon pods reuse
+# the same hostPath via a thin image layer (see
+# deployments/nvml-mock/Dockerfile.compute-domain-daemon).
+imex:
+  enabled: false
+  stateDir: /var/lib/nvml-mock/imex-state
+
 # Integration with external projects
 integrations:
   fakeGpuOperator:

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -43,3 +43,22 @@ cd failure-injection && ./run.sh
 
 See [failure-injection/README.md](failure-injection/README.md) for the
 walkthrough.
+
+### ComputeDomain (NVLink fabric)
+
+Dedicated cluster (`nvml-mock-compute-domain`) with 4 workers sharing a
+hostPath state directory. Exercises the mock NVML fabric APIs
+(`nvmlDeviceGetGpuFabricInfo` / `…InfoV`) driven by a cluster-level
+topology ConfigMap, plus the fake `nvidia-imex` /
+`nvidia-imex-ctl` binaries coordinating peer readiness through marker
+files on the shared volume. Concludes with a `helm upgrade` that
+rebinds every node into a new clique without rebuilding the image.
+
+**Requirements:** Docker, Kind, Helm
+
+```bash
+cd compute-domain && ./run.sh
+```
+
+See [compute-domain/README.md](compute-domain/README.md) for the
+walkthrough.

--- a/docs/demo/compute-domain/README.md
+++ b/docs/demo/compute-domain/README.md
@@ -1,0 +1,145 @@
+# nvml-mock ComputeDomain Demo
+
+End-to-end walkthrough of the ComputeDomain (NVLink fabric) simulation
+on a dedicated Kind cluster. This demo exercises every component
+introduced by [NVIDIA/k8s-test-infra#304](https://github.com/NVIDIA/k8s-test-infra/issues/304):
+
+* **Mock NVML fabric APIs** — `nvmlDeviceGetGpuFabricInfo` and
+  `nvmlDeviceGetGpuFabricInfoV` return the cluster UUID, clique ID, and
+  registration state that the cluster-level topology ConfigMap assigned
+  to the current node (via `NODE_NAME`).
+* **Cluster-level topology ConfigMap** — declares the GB200 NVLink
+  domains and which Kubernetes nodes belong to which clique. The mock
+  NVML library overlays it on top of the per-profile YAML at
+  `LoadConfig()` time.
+* **Fake `nvidia-imex` / `nvidia-imex-ctl`** — file-based readiness
+  protocol over a shared hostPath. `nvidia-imex-ctl` exits 0 + prints
+  `READY` only when every peer in `nodes.cfg` has dropped a marker
+  file; SIGTERM-ing a daemon removes its marker and trips the probe.
+
+The demo lives in its own cluster (`nvml-mock-compute-domain`) and its
+own 4-worker Kind topology
+([`tests/e2e/kind-compute-domain-config.yaml`](../../../tests/e2e/kind-compute-domain-config.yaml))
+that mounts `/tmp/nvml-mock-imex-state` from the host into every worker
+node container — the cross-node shared volume the real
+compute-domain-daemon would normally get from a CSI driver.
+
+## What the script does
+
+1. (Re)creates the dedicated Kind cluster (idempotent: an existing
+   `nvml-mock-compute-domain` cluster is reused) and clears
+   `/tmp/nvml-mock-imex-state` so the IMEX assertions start from a
+   clean slate.
+2. Builds and loads the `nvml-mock:compute-domain` image, which
+   bundles three new binaries on top of the standard nvml-mock image:
+   `/usr/bin/nvidia-imex`, `/usr/bin/nvidia-imex-ctl`, and
+   `/usr/local/bin/check-fabric`.
+3. Installs the chart with:
+
+   ```text
+   gpu.profile=gb200
+   topology.enabled=true
+   topology.domains=<demo topology>
+   imex.enabled=true
+   ```
+
+   This renders both ConfigMaps (`nvml-mock-config` and
+   `nvml-mock-topology`) and mounts the shared hostPath state
+   directory into every pod.
+
+   The script intentionally does **not** pass `--set gpu.count=...`.
+   That flag only sizes the host-side CDI spec produced by
+   `scripts/setup.sh`; the in-pod ConfigMap at
+   `/etc/nvml-mock/config.yaml` — which is what `check-fabric` loads
+   — always reflects the chosen profile's full device list (8 GPUs
+   for `gb200`). For ComputeDomain verification this is actually
+   *stronger* evidence: every one of the 8 GPUs on each node must
+   report the same `cliqueId` / `clusterUuid`, exercising the
+   topology overlay over the full device list rather than a subset.
+4. **Scenario 1 — per-node fabric identity**. Runs `check-fabric`
+   inside one pod per worker and asserts:
+   * `nvml-mock-compute-domain-worker` / `-worker2` report **clique 0**,
+   * `-worker3` / `-worker4` report **clique 1**,
+   * every node reports the demo cluster UUID
+     `00000000-0000-0000-0000-0000000000ab` and `state=completed`.
+5. **Scenario 2 — fake IMEX coordination**. Hand-writes a `nodes.cfg`
+   listing both clique-0 pod IPs and walks the readiness probe
+   through three transitions:
+   * 1 of 2 markers present → `nvidia-imex-ctl` exits 1,
+   * 2 of 2 markers present → `nvidia-imex-ctl` prints `READY`,
+   * peer SIGTERMed → marker removed → `nvidia-imex-ctl` exits 1.
+
+   The script reads the markers directly off the host filesystem
+   (`/tmp/nvml-mock-imex-state/<pod-ip>`) to prove the coordination
+   actually traverses the shared volume.
+6. **Scenario 3 — topology rebinding (no image rebuild)**. A
+   `helm upgrade --reuse-values` swaps the topology document so every
+   node is now a member of clique 99 in a brand-new domain UUID. After
+   a forced DaemonSet recycle, `check-fabric` reflects the new
+   identity on every worker. This is the gear the real
+   compute-domain-controller would shift between integration tests.
+
+## Quick start
+
+```bash
+./run.sh
+```
+
+The script is idempotent — rerun it as often as you like; the
+existing cluster is reused and `helm upgrade --install` covers both
+first-time install and follow-up upgrades.
+
+## How the fakes fit alongside the real compute-domain-daemon
+
+The upstream daemon spawns `nvidia-imex` as a subprocess and runs
+`nvidia-imex-ctl -c /imexd/imexd.cfg -q` from its readiness probe. With
+this demo's image installed, both binaries are already in `$PATH` at
+the canonical locations. To run the real daemon against this cluster
+without modifying it, point its container image at
+[`deployments/nvml-mock/Dockerfile.compute-domain-daemon`](../../../deployments/nvml-mock/Dockerfile.compute-domain-daemon),
+which is a 2-line `FROM upstream-daemon` overlay that copies in the
+fakes from the nvml-mock image.
+
+> **Heads up — patching the upstream chart.** The nvml-mock chart wires
+> `NODE_NAME` (downward API), `MOCK_TOPOLOGY_CONFIG`, and the topology
+> ConfigMap mount onto its own DaemonSet, which is why `check-fabric`
+> running inside the mock pod sees the per-node fabric identity for
+> free. The upstream `compute-domain-daemon` pod gets *none* of that
+> from its own chart, so if you swap its image for the
+> `Dockerfile.compute-domain-daemon` overlay above you also have to
+> patch the upstream values to:
+>
+> 1. inject `NODE_NAME` via the downward API
+>    (`fieldRef: spec.nodeName`),
+> 2. set `MOCK_TOPOLOGY_CONFIG=/config/topology.yaml` (or mount the
+>    topology ConfigMap at whatever path you prefer and point this env
+>    var at it),
+> 3. mount the `nvml-mock-topology` ConfigMap at that path.
+>
+> Without those three additions the linked `libnvidia-ml.so` cannot
+> look up the node in the topology and falls back to the per-profile
+> defaults — the daemon will think every node is in the same clique.
+
+## Topology / clique layout used by the demo
+
+```text
+domain "demo-domain"           uuid 00000000-0000-0000-0000-0000000000ab
+  clique 0:
+    - nvml-mock-compute-domain-worker
+    - nvml-mock-compute-domain-worker2
+  clique 1:
+    - nvml-mock-compute-domain-worker3
+    - nvml-mock-compute-domain-worker4
+```
+
+The full values fragment lives at [`topology.yaml`](./topology.yaml)
+and is passed to Helm with `-f topology.yaml` (not `--set-file`, which
+would inline the file as a string literal rather than as a parsed
+list).
+
+## Clean up
+
+```bash
+kind delete cluster --name nvml-mock-compute-domain
+rm -rf /tmp/nvml-mock-imex-state
+```

--- a/docs/demo/compute-domain/run.sh
+++ b/docs/demo/compute-domain/run.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+# Copyright 2026 NVIDIA CORPORATION
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# End-to-end demo of nvml-mock ComputeDomain simulation
+# (NVIDIA/k8s-test-infra#304).
+#
+# Spins up a dedicated 4-worker Kind cluster wired with extraMounts
+# that share a hostPath (/tmp/nvml-mock-imex-state) across every
+# worker, installs nvml-mock with the gb200 profile + topology overlay
+# + fake IMEX coordination, and walks through four assertions:
+#
+#   1. Mock NVML fabric API
+#      Each pod's nvmlDeviceGetGpuFabricInfo (via the bundled
+#      `check-fabric` consumer) returns the cluster UUID, clique ID,
+#      and `state=completed` assigned to its node by the cluster-level
+#      topology ConfigMap.
+#
+#   2. Per-node clique assignment
+#      kind-compute-domain-worker / -worker2 report clique 0;
+#      -worker3 / -worker4 report clique 1.
+#
+#   3. Fake IMEX peer coordination
+#      With a hand-written nodes.cfg listing every pod IP in a clique,
+#      nvidia-imex-ctl prints `READY` once the fake nvidia-imex daemon
+#      has dropped a marker file for every peer; it exits 1 as soon as
+#      one peer's marker is removed.
+#
+#   4. Topology rebinding without rebuilding the image
+#      `helm upgrade --reuse-values` with a different topology document
+#      promotes every node to clique 99 of a new domain UUID, and
+#      check-fabric reflects the new identity after a DaemonSet
+#      rollout.
+
+set -euo pipefail
+
+###############################################################################
+# Configuration
+###############################################################################
+CLUSTER_NAME="nvml-mock-compute-domain"
+IMAGE_NAME="nvml-mock:compute-domain"
+RELEASE_NAME="nvml-mock"
+CHART_PATH="deployments/nvml-mock/helm/nvml-mock"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+KIND_CONFIG="${REPO_ROOT}/tests/e2e/kind-compute-domain-config.yaml"
+TOPOLOGY_FILE="${REPO_ROOT}/docs/demo/compute-domain/topology.yaml"
+HOST_STATE_DIR="/tmp/nvml-mock-imex-state"
+EXPECTED_DOMAIN_UUID="00000000-0000-0000-0000-0000000000ab"
+# Kind names worker nodes "<cluster>-worker[N]". Keep these in sync
+# with the node lists in topology.yaml and tests/e2e/kind-compute-domain-config.yaml.
+WORKER1="${CLUSTER_NAME}-worker"
+WORKER2="${CLUSTER_NAME}-worker2"
+WORKER3="${CLUSTER_NAME}-worker3"
+WORKER4="${CLUSTER_NAME}-worker4"
+
+###############################################################################
+# Helpers
+###############################################################################
+info() { printf '\n==> %s\n' "$*" >&2; }
+sub()  { printf '    %s\n' "$*" >&2; }
+ok()   { printf '    \xE2\x9C\x93 %s\n' "$*" >&2; }
+fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+# pod_on_node: echo the name of the running nvml-mock pod scheduled on
+# the given Kubernetes node. Used both to query fabric info per node
+# and to drive the IMEX coordination test.
+pod_on_node() {
+  local node=$1
+  # Poll briefly: the rollout settles before the API server's pod list
+  # always reflects the new generation, so a tight loop is more
+  # reliable than a single shot.
+  for _ in $(seq 1 30); do
+    local name
+    name=$(kubectl get pods -l "app.kubernetes.io/name=${RELEASE_NAME}" \
+      --field-selector="spec.nodeName=${node},status.phase=Running" \
+      -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+    if [[ -n "${name}" ]]; then
+      printf '%s\n' "${name}"
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+# wait_for_rollout: block until every nvml-mock pod is Running, then
+# confirm at least one pod exists per worker (the topology overlay is
+# pulled on Init() per pod, so we can't verify clique assignment
+# before the pods are up).
+wait_for_rollout() {
+  kubectl rollout status "daemonset/${RELEASE_NAME}" --timeout=180s >/dev/null
+}
+
+# assert_clique: assert the check-fabric output from `node` reports
+# `expected_clique`. check-fabric prints one block per visible GPU; we
+# just spot-check GPU 0 since every GPU on a node shares the same
+# fabric identity by design.
+assert_clique() {
+  local node=$1 expected_clique=$2 expected_uuid=$3
+  local pod
+  pod=$(pod_on_node "${node}")
+  if [[ -z "${pod}" ]]; then
+    fail "no running pod found on node ${node}"
+  fi
+  sub "${node} (pod=${pod}) — running check-fabric"
+  local out
+  out=$(kubectl exec "${pod}" -- check-fabric 2>&1 || true)
+  printf '%s\n' "${out}" | sed 's/^/      /' >&2
+  if ! printf '%s\n' "${out}" | grep -q "cliqueId    : ${expected_clique}"; then
+    fail "${node}: expected cliqueId ${expected_clique} in check-fabric output"
+  fi
+  if ! printf '%s\n' "${out}" | grep -qi "clusterUuid : ${expected_uuid}"; then
+    fail "${node}: expected clusterUuid ${expected_uuid} in check-fabric output"
+  fi
+  if ! printf '%s\n' "${out}" | grep -q 'state       : completed'; then
+    fail "${node}: expected state=completed in check-fabric output"
+  fi
+  ok "${node}: clique=${expected_clique} uuid=${expected_uuid} state=completed"
+}
+
+# expect_ctl_not_ready: run nvidia-imex-ctl inside `pod` and assert it
+# exits 1 (the "peer not ready" path). Stdout/stderr are captured and
+# replayed as a single indented status line so the demo log stays
+# legible — without this helper kubectl spills both
+# `fake-imex-ctl: peer X not ready` and `command terminated with exit
+# code 1` onto separate lines, which is technically correct but reads
+# like an error from the demo itself.
+expect_ctl_not_ready() {
+  local pod=$1 reason=$2
+  local out rc
+  set +e
+  out=$(kubectl exec "${pod}" -- env "IMEX_NODES_CONFIG=${NODES_CFG}" \
+    nvidia-imex-ctl -c /dev/null -q 2>&1)
+  rc=$?
+  set -e
+  if [[ "${rc}" -ne 1 ]]; then
+    printf '%s\n' "${out}" | sed 's/^/      /' >&2
+    fail "nvidia-imex-ctl ${reason}: rc=${rc} (want 1), out=${out}"
+  fi
+  # Surface only the informative line from fake-imex-ctl's stderr
+  # (drops the trailing "command terminated with exit code 1" that
+  # kubectl injects after the container exits non-zero).
+  local detail
+  detail=$(printf '%s\n' "${out}" | grep -E '^fake-imex-ctl:' | head -1)
+  ok "nvidia-imex-ctl ${reason} (rc=1) — ${detail:-peer not ready}"
+}
+
+###############################################################################
+# Step 1 — Kind cluster (with shared hostPath for IMEX state)
+###############################################################################
+info "Preparing shared hostPath: ${HOST_STATE_DIR}"
+mkdir -p "${HOST_STATE_DIR}"
+# Wipe stale markers from a previous run so the IMEX assertions below
+# can rely on a clean baseline.
+rm -f "${HOST_STATE_DIR}"/* 2>/dev/null || true
+
+info "Creating Kind cluster: ${CLUSTER_NAME}"
+if kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
+  sub "Cluster already exists, reusing it"
+else
+  kind create cluster --name "${CLUSTER_NAME}" --config="${KIND_CONFIG}"
+fi
+
+###############################################################################
+# Step 2 — Build + load the image
+###############################################################################
+info "Building image: ${IMAGE_NAME}"
+docker build -t "${IMAGE_NAME}" \
+  -f "${REPO_ROOT}/deployments/nvml-mock/Dockerfile" "${REPO_ROOT}"
+
+info "Loading image into Kind"
+kind load docker-image "${IMAGE_NAME}" --name "${CLUSTER_NAME}"
+
+###############################################################################
+# Step 3 — Install nvml-mock with gb200 + topology + IMEX
+###############################################################################
+# NOTE: `--set-file topology.domains=...` cannot be used here. That
+# flag stuffs the raw file bytes in as a string literal, which would
+# make `toYaml` in templates/topology-configmap.yaml render the list
+# as an indented block scalar instead of the structured array the
+# engine expects. Using `-f <values-file>` lets helm parse the file
+# normally and deep-merge it with the defaults.
+info "Installing chart (gb200 + topology + IMEX)"
+# NOTE: `--set gpu.count=...` is intentionally NOT passed. The flag
+# only controls the host-side CDI spec / /dev/nvidia* device nodes
+# emitted by setup.sh; the in-pod ConfigMap mounted at
+# /etc/nvml-mock/config.yaml — which is what check-fabric below
+# loads — always reflects the profile's full device list (8 for
+# gb200). For this demo the GPU count is irrelevant: what matters is
+# that every GPU on a node reports the cliqueId / clusterUuid the
+# topology overlay assigned to that node, which is stronger evidence
+# the deeper the per-node device list goes.
+helm upgrade --install "${RELEASE_NAME}" "${REPO_ROOT}/${CHART_PATH}" \
+  -f "${TOPOLOGY_FILE}" \
+  --set image.repository=nvml-mock \
+  --set image.tag=compute-domain \
+  --set gpu.profile=gb200 \
+  --set imex.enabled=true \
+  --set-string updateStrategy.rollingUpdate.maxUnavailable=100% \
+  --set terminationGracePeriodSeconds=1 \
+  --wait --timeout 180s >/dev/null
+
+wait_for_rollout
+
+###############################################################################
+# Step 4 — Verify the rendered topology ConfigMap
+###############################################################################
+info "Rendered topology ConfigMap"
+kubectl get "configmap/${RELEASE_NAME}-topology" \
+  -o jsonpath='{.data.topology\.yaml}' | sed 's/^/    /'
+echo
+
+###############################################################################
+# Scenario 1 — Per-node clique assignment via mock NVML fabric API
+###############################################################################
+info "Scenario 1: per-node fabric identity (cluster ${EXPECTED_DOMAIN_UUID})"
+assert_clique "${WORKER1}" 0 "${EXPECTED_DOMAIN_UUID}"
+assert_clique "${WORKER2}" 0 "${EXPECTED_DOMAIN_UUID}"
+assert_clique "${WORKER3}" 1 "${EXPECTED_DOMAIN_UUID}"
+assert_clique "${WORKER4}" 1 "${EXPECTED_DOMAIN_UUID}"
+
+###############################################################################
+# Scenario 2 — Fake IMEX peer coordination (shared hostPath markers)
+###############################################################################
+# Each nvml-mock pod's entrypoint does NOT start nvidia-imex
+# automatically — the real compute-domain-daemon would. To exercise
+# the coordination protocol without deploying upstream, we run the
+# fake daemon ad-hoc inside one pod per clique-0 worker and verify
+# nvidia-imex-ctl from a peer.
+info "Scenario 2: fake IMEX peer coordination"
+
+POD_A=$(pod_on_node "${WORKER1}")
+POD_B=$(pod_on_node "${WORKER2}")
+sub "clique 0 pods: ${POD_A}, ${POD_B}"
+
+# Read both pod IPs so we can write a synthetic nodes.cfg.
+IP_A=$(kubectl get pod "${POD_A}" -o jsonpath='{.status.podIP}')
+IP_B=$(kubectl get pod "${POD_B}" -o jsonpath='{.status.podIP}')
+sub "pod IPs: ${POD_A}=${IP_A}  ${POD_B}=${IP_B}"
+
+# Write nodes.cfg into both pods. The chart already mounts the shared
+# state dir at /var/lib/nvml-mock/imex-state; the fakes read
+# IMEX_NODES_CONFIG with default /imexd/nodes.cfg, so we override
+# with a writable path inside /tmp.
+NODES_CFG=/tmp/nodes.cfg
+for pod in "${POD_A}" "${POD_B}"; do
+  kubectl exec "${pod}" -- sh -c "printf '%s\n%s\n' '${IP_A}' '${IP_B}' > ${NODES_CFG}"
+done
+
+# Start the fake daemon in pod A and check from pod B. We background
+# the daemon and capture its PID so we can SIGTERM it later.
+sub "starting fake nvidia-imex in ${POD_A}"
+kubectl exec "${POD_A}" -- sh -c \
+  "POD_IP=${IP_A} IMEX_NODES_CONFIG=${NODES_CFG} \
+   nvidia-imex -c /dev/null >/tmp/imex.log 2>&1 &
+   echo \$! > /tmp/imex.pid"
+
+# Poll up to 5s for the marker to appear under the shared hostPath.
+sub "waiting for marker ${IP_A} under ${HOST_STATE_DIR}"
+for _ in $(seq 1 25); do
+  if [[ -f "${HOST_STATE_DIR}/${IP_A}" ]]; then break; fi
+  sleep 0.2
+done
+[[ -f "${HOST_STATE_DIR}/${IP_A}" ]] || fail "marker ${IP_A} never appeared"
+ok "marker for ${IP_A} present on host"
+
+# 1 of 2 markers → ctl exits 1.
+expect_ctl_not_ready "${POD_B}" "with 1/2 markers"
+
+# Bring up pod B's daemon → 2/2 markers → ctl prints READY.
+sub "starting fake nvidia-imex in ${POD_B}"
+kubectl exec "${POD_B}" -- sh -c \
+  "POD_IP=${IP_B} IMEX_NODES_CONFIG=${NODES_CFG} \
+   nvidia-imex -c /dev/null >/tmp/imex.log 2>&1 &
+   echo \$! > /tmp/imex.pid"
+
+for _ in $(seq 1 25); do
+  if [[ -f "${HOST_STATE_DIR}/${IP_B}" ]]; then break; fi
+  sleep 0.2
+done
+[[ -f "${HOST_STATE_DIR}/${IP_B}" ]] || fail "marker ${IP_B} never appeared"
+
+CTL_OUT=$(kubectl exec "${POD_B}" -- env "IMEX_NODES_CONFIG=${NODES_CFG}" \
+  nvidia-imex-ctl -c /dev/null -q 2>/dev/null)
+if [[ "${CTL_OUT}" == "READY" ]]; then
+  ok "nvidia-imex-ctl prints READY with 2/2 markers"
+else
+  fail "nvidia-imex-ctl with 2/2 markers printed '${CTL_OUT}' (want READY)"
+fi
+
+# SIGTERM the daemon in pod A → marker removed → ctl exits 1 again.
+sub "killing nvidia-imex in ${POD_A}"
+kubectl exec "${POD_A}" -- sh -c \
+  'kill -TERM "$(cat /tmp/imex.pid)"; sleep 1' || true
+
+for _ in $(seq 1 25); do
+  if [[ ! -f "${HOST_STATE_DIR}/${IP_A}" ]]; then break; fi
+  sleep 0.2
+done
+[[ ! -f "${HOST_STATE_DIR}/${IP_A}" ]] || fail "marker ${IP_A} did not get cleaned up"
+ok "marker for ${IP_A} removed by SIGTERM"
+
+expect_ctl_not_ready "${POD_B}" "after peer SIGTERM"
+
+# Tidy up the surviving daemon so the rollout in Scenario 3 doesn't
+# inherit stale state.
+kubectl exec "${POD_B}" -- sh -c \
+  'kill -TERM "$(cat /tmp/imex.pid)" 2>/dev/null || true' || true
+rm -f "${HOST_STATE_DIR}"/* 2>/dev/null || true
+
+###############################################################################
+# Scenario 3 — Topology rebinding (helm upgrade, no image rebuild)
+###############################################################################
+info "Scenario 3: rebind every node into clique 99 of a new domain"
+NEW_TOPO=$(mktemp)
+NEW_UUID="00000000-0000-0000-0000-0000000000ff"
+# Full values fragment (not just the list under `domains`) — `-f`
+# merges it on top of the existing release values without disturbing
+# anything else.
+cat >"${NEW_TOPO}" <<EOF
+topology:
+  enabled: true
+  domains:
+    - name: rebinder
+      uuid: "${NEW_UUID}"
+      cliques:
+        - id: 99
+          nodes:
+            - ${WORKER1}
+            - ${WORKER2}
+            - ${WORKER3}
+            - ${WORKER4}
+EOF
+helm upgrade "${RELEASE_NAME}" "${REPO_ROOT}/${CHART_PATH}" \
+  --reuse-values \
+  -f "${NEW_TOPO}" \
+  --wait --timeout 180s >/dev/null
+
+# The engine reads MOCK_TOPOLOGY_CONFIG once at process start, so we
+# need to recycle every pod for the new clique to take effect.
+sub "evicting pods to re-read topology"
+kubectl delete pods -l "app.kubernetes.io/name=${RELEASE_NAME}" \
+  --ignore-not-found >/dev/null
+wait_for_rollout
+
+assert_clique "${WORKER1}" 99 "${NEW_UUID}"
+assert_clique "${WORKER2}" 99 "${NEW_UUID}"
+assert_clique "${WORKER3}" 99 "${NEW_UUID}"
+assert_clique "${WORKER4}" 99 "${NEW_UUID}"
+rm -f "${NEW_TOPO}"
+
+###############################################################################
+# Summary
+###############################################################################
+cat <<EOF
+
+==> All three ComputeDomain scenarios verified.
+
+   Scenario 1  fabric API     : every node reports its assigned clique
+                                (workers 1-2 -> clique 0, workers 3-4 -> clique 1)
+                                via nvmlDeviceGetGpuFabricInfo.
+   Scenario 2  fake IMEX      : nvidia-imex-ctl transitions
+                                NOT-READY -> READY -> NOT-READY in lockstep
+                                with marker files on the shared hostPath.
+   Scenario 3  rebind         : helm upgrade + DaemonSet rollout promoted
+                                every node to clique 99 with a new cluster
+                                UUID — no image rebuild required.
+
+==> The upstream compute-domain-controller and compute-domain-daemon
+    can now run unmodified against this cluster: their NVML calls land
+    on the mock library, and their fork of nvidia-imex / nvidia-imex-ctl
+    is shadowed by the fakes shipped in the nvml-mock image (see
+    deployments/nvml-mock/Dockerfile.compute-domain-daemon for the
+    thin overlay image).
+
+==> Tear down
+    kind delete cluster --name ${CLUSTER_NAME}
+    rm -rf ${HOST_STATE_DIR}
+EOF

--- a/docs/demo/compute-domain/topology.yaml
+++ b/docs/demo/compute-domain/topology.yaml
@@ -1,0 +1,31 @@
+# Helm values fragment for the ComputeDomain demo
+# (docs/demo/compute-domain/run.sh). Passed to `helm upgrade --install`
+# via `-f <this file>` so the chart merges it on top of its defaults.
+#
+# `--set-file` is NOT used here: that flag stuffs the raw file bytes
+# into the target key as a string literal, which would defeat the
+# structured list helm expects under `topology.domains`.
+#
+# Node names follow Kind's `<cluster-name>-worker[N]` convention. The
+# cluster is created from tests/e2e/kind-compute-domain-config.yaml as
+# `nvml-mock-compute-domain`, so worker0 .. worker3 land at
+# `nvml-mock-compute-domain-worker`, `-worker2`, `-worker3`, `-worker4`.
+#
+# Layout:
+#   domain "demo-domain"
+#     clique 0: -worker, -worker2
+#     clique 1: -worker3, -worker4
+topology:
+  enabled: true
+  domains:
+    - name: demo-domain
+      uuid: "00000000-0000-0000-0000-0000000000ab"
+      cliques:
+        - id: 0
+          nodes:
+            - nvml-mock-compute-domain-worker
+            - nvml-mock-compute-domain-worker2
+        - id: 1
+          nodes:
+            - nvml-mock-compute-domain-worker3
+            - nvml-mock-compute-domain-worker4

--- a/pkg/gpu/mocknvml/bridge/fabric.go
+++ b/pkg/gpu/mocknvml/bridge/fabric.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main provides NVML GPU fabric (NVLink ComputeDomain) functions.
+// This file contains hand-written implementations for:
+//   - nvmlDeviceGetGpuFabricInfo (v1 struct, no version field)
+//   - nvmlDeviceGetGpuFabricInfoV (versioned, dispatches on version field)
+//
+// These power ComputeDomain simulation on KIND clusters: the real
+// dra-driver-nvidia-gpu controller and daemon read these APIs to learn
+// the NVLink domain UUID and clique each GPU belongs to. See issue
+// NVIDIA/k8s-test-infra#304 for the full design.
+
+package main
+
+/*
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "nvml_types.h"
+*/
+import "C"
+import (
+	"unsafe"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
+)
+
+// nvmlGpuFabricInfo_v2 / _v3 version identifiers — match the upstream
+// NVML_STRUCT_VERSION(GpuFabricInfo, N) encoding (size | (version << 24))
+// computed at runtime so we are robust to struct padding differences.
+func fabricStructVersion(size uintptr, version uint32) uint32 {
+	return uint32(size) | (version << 24)
+}
+
+//export nvmlDeviceGetGpuFabricInfo
+func nvmlDeviceGetGpuFabricInfo(device C.nvmlDevice_t, gpuFabricInfo *C.nvmlGpuFabricInfo_t) C.nvmlReturn_t {
+	if gpuFabricInfo == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(device.handle))
+	dev, ok := engine.GetEngine().LookupDevice(handle).(*engine.ConfigurableDevice)
+	if !ok {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	info, ret := dev.GetMockFabricInfo()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	for i := 0; i < len(info.ClusterUUID); i++ {
+		gpuFabricInfo.clusterUuid[i] = C.uchar(info.ClusterUUID[i])
+	}
+	gpuFabricInfo.status = C.nvmlReturn_t(info.Status)
+	gpuFabricInfo.cliqueId = C.uint(info.CliqueID)
+	gpuFabricInfo.state = C.nvmlGpuFabricState_t(info.State)
+	return C.NVML_SUCCESS
+}
+
+//export nvmlDeviceGetGpuFabricInfoV
+func nvmlDeviceGetGpuFabricInfoV(device C.nvmlDevice_t, gpuFabricInfo *C.nvmlGpuFabricInfoV_t) C.nvmlReturn_t {
+	if gpuFabricInfo == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := uintptr(unsafe.Pointer(device.handle))
+	dev, ok := engine.GetEngine().LookupDevice(handle).(*engine.ConfigurableDevice)
+	if !ok {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	info, ret := dev.GetMockFabricInfoV()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+
+	// The caller selects the struct version by writing into the
+	// `version` field before calling. We recognise the v2 and v3
+	// encodings; anything else (including zero) defaults to v3 since
+	// nvmlGpuFabricInfoV_t is the v3 alias in this header.
+	requested := uint32(gpuFabricInfo.version)
+	v2 := fabricStructVersion(unsafe.Sizeof(C.nvmlGpuFabricInfo_v2_t{}), 2)
+	v3 := fabricStructVersion(unsafe.Sizeof(C.nvmlGpuFabricInfo_v3_t{}), 3)
+
+	switch requested {
+	case v2:
+		// Reinterpret as v2 layout. The two structs share their
+		// leading fields up through healthMask; v3 just adds
+		// healthSummary at the tail, which v2 callers must not touch.
+		v2info := (*C.nvmlGpuFabricInfo_v2_t)(unsafe.Pointer(gpuFabricInfo))
+		v2info.version = C.uint(v2)
+		for i := 0; i < len(info.ClusterUUID); i++ {
+			v2info.clusterUuid[i] = C.uchar(info.ClusterUUID[i])
+		}
+		v2info.status = C.nvmlReturn_t(info.Status)
+		v2info.cliqueId = C.uint(info.CliqueID)
+		v2info.state = C.nvmlGpuFabricState_t(info.State)
+		v2info.healthMask = C.uint(info.HealthMask)
+		return C.NVML_SUCCESS
+	default:
+		// Treat unknown / zero version as the latest (v3). This keeps
+		// callers that forgot to set `version` working while still
+		// flagging strict mismatches via ARGUMENT_VERSION_MISMATCH
+		// when we *can* detect them below.
+		if requested != 0 && requested != v3 {
+			return C.NVML_ERROR_ARGUMENT_VERSION_MISMATCH
+		}
+		gpuFabricInfo.version = C.uint(v3)
+		for i := 0; i < len(info.ClusterUUID); i++ {
+			gpuFabricInfo.clusterUuid[i] = C.uchar(info.ClusterUUID[i])
+		}
+		gpuFabricInfo.status = C.nvmlReturn_t(info.Status)
+		gpuFabricInfo.cliqueId = C.uint(info.CliqueID)
+		gpuFabricInfo.state = C.nvmlGpuFabricState_t(info.State)
+		gpuFabricInfo.healthMask = C.uint(info.HealthMask)
+		gpuFabricInfo.healthSummary = C.uchar(info.HealthSummary)
+		return C.NVML_SUCCESS
+	}
+}

--- a/pkg/gpu/mocknvml/bridge/nvml_types.h
+++ b/pkg/gpu/mocknvml/bridge/nvml_types.h
@@ -294,8 +294,47 @@ typedef struct nvmlGpmSupport_st {
     unsigned int isSupportedDevice;
 } nvmlGpmSupport_t;
 typedef struct nvmlGpuDynamicPstatesInfo_st                 nvmlGpuDynamicPstatesInfo_t;
-typedef struct nvmlGpuFabricInfoV_st                        nvmlGpuFabricInfoV_t;
-typedef struct nvmlGpuFabricInfo_st                         nvmlGpuFabricInfo_t;
+
+/* GPU Fabric information — full definitions needed by the bridge so
+ * nvmlDeviceGetGpuFabricInfo / nvmlDeviceGetGpuFabricInfoV can populate
+ * the caller's struct. Layout matches the upstream NVML public header
+ * (versions v1 / v2 / v3); see vendor/github.com/NVIDIA/go-nvml/pkg/nvml/nvml.h. */
+#define NVML_GPU_FABRIC_UUID_LEN 16
+
+#define NVML_GPU_FABRIC_STATE_NOT_SUPPORTED 0
+#define NVML_GPU_FABRIC_STATE_NOT_STARTED   1
+#define NVML_GPU_FABRIC_STATE_IN_PROGRESS   2
+#define NVML_GPU_FABRIC_STATE_COMPLETED     3
+
+typedef unsigned char nvmlGpuFabricState_t;
+
+typedef struct nvmlGpuFabricInfo_st {
+    unsigned char        clusterUuid[NVML_GPU_FABRIC_UUID_LEN];
+    nvmlReturn_t         status;
+    unsigned int         cliqueId;
+    nvmlGpuFabricState_t state;
+} nvmlGpuFabricInfo_t;
+
+typedef struct nvmlGpuFabricInfo_v2_st {
+    unsigned int         version;
+    unsigned char        clusterUuid[NVML_GPU_FABRIC_UUID_LEN];
+    nvmlReturn_t         status;
+    unsigned int         cliqueId;
+    nvmlGpuFabricState_t state;
+    unsigned int         healthMask;
+} nvmlGpuFabricInfo_v2_t;
+
+typedef struct nvmlGpuFabricInfo_v3_st {
+    unsigned int         version;
+    unsigned char        clusterUuid[NVML_GPU_FABRIC_UUID_LEN];
+    nvmlReturn_t         status;
+    unsigned int         cliqueId;
+    nvmlGpuFabricState_t state;
+    unsigned int         healthMask;
+    unsigned char        healthSummary;
+} nvmlGpuFabricInfo_v3_t;
+
+typedef nvmlGpuFabricInfo_v3_t nvmlGpuFabricInfoV_t;
 typedef struct nvmlGpuInstanceInfo_st                       nvmlGpuInstanceInfo_t;
 typedef struct nvmlGpuInstancePlacement_st                  nvmlGpuInstancePlacement_t;
 typedef struct nvmlGpuInstanceProfileInfo_st                nvmlGpuInstanceProfileInfo_t;

--- a/pkg/gpu/mocknvml/bridge/stubs_generated.go
+++ b/pkg/gpu/mocknvml/bridge/stubs_generated.go
@@ -21,7 +21,7 @@ package main
 */
 import "C"
 
-// 302 stub functions for unimplemented NVML functions.
+// 300 stub functions for unimplemented NVML functions.
 // These return NVML_ERROR_NOT_SUPPORTED (3).
 
 //export nvmlComputeInstanceDestroy
@@ -295,16 +295,6 @@ func nvmlDeviceGetGpcClkMinMaxVfOffset(device C.nvmlDevice_t, minOffset *C.int, 
 //export nvmlDeviceGetGpcClkVfOffset
 func nvmlDeviceGetGpcClkVfOffset(device C.nvmlDevice_t, offset *C.int) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetGpcClkVfOffset")
-}
-
-//export nvmlDeviceGetGpuFabricInfo
-func nvmlDeviceGetGpuFabricInfo(device C.nvmlDevice_t, gpuFabricInfo *C.nvmlGpuFabricInfo_t) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetGpuFabricInfo")
-}
-
-//export nvmlDeviceGetGpuFabricInfoV
-func nvmlDeviceGetGpuFabricInfoV(device C.nvmlDevice_t, gpuFabricInfo *C.nvmlGpuFabricInfoV_t) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetGpuFabricInfoV")
 }
 
 //export nvmlDeviceGetGpuInstanceById

--- a/pkg/gpu/mocknvml/engine/config.go
+++ b/pkg/gpu/mocknvml/engine/config.go
@@ -102,6 +102,16 @@ func LoadConfig() *Config {
 			if yamlConfig.System.NumDevices > 0 {
 				config.NumDevices = yamlConfig.System.NumDevices
 			}
+
+			// Topology overlay: when a cluster-level topology ConfigMap is
+			// mounted into the pod we look up the current Kubernetes node
+			// (NODE_NAME) and override the fabric cluster UUID / clique ID
+			// on the YAML defaults so every device on this node reports
+			// the correct ComputeDomain identity. Nodes not present in the
+			// topology fall through to the YAML-default fabric config (or
+			// to NOT_SUPPORTED when none is set, matching non-GB200 GPUs).
+			applyTopologyOverlay(yamlConfig)
+
 			debugLog("[CONFIG] Loaded YAML config: %d devices, driver %s\n", config.NumDevices, config.DriverVersion)
 
 			// Cache the config
@@ -352,7 +362,94 @@ func mergeDeviceOverride(base *DeviceConfig, override *DeviceOverride) {
 	if override.Failure != nil {
 		base.Failure = override.Failure
 	}
+	if override.Fabric != nil {
+		base.Fabric = override.Fabric
+	}
 	// Add more fields as needed
+}
+
+// applyTopologyOverlay rewrites yamlConfig.DeviceDefaults.Fabric (and any
+// per-device override that already carries a Fabric block) based on a
+// cluster-level topology document. The lookup key is the Kubernetes node
+// name supplied through the NODE_NAME environment variable (set via the
+// downward API in the DaemonSet). When either the topology file or the
+// NODE_NAME is unset, this is a no-op.
+//
+// Resolution order for the topology path:
+//  1. MOCK_TOPOLOGY_CONFIG env var (explicit path)
+//  2. /config/topology.yaml (canonical helm mount)
+func applyTopologyOverlay(yamlConfig *YAMLConfig) {
+	nodeName := os.Getenv("NODE_NAME")
+	if nodeName == "" {
+		return
+	}
+	topoPath := os.Getenv("MOCK_TOPOLOGY_CONFIG")
+	if topoPath == "" {
+		topoPath = "/config/topology.yaml"
+	}
+	if _, err := os.Stat(topoPath); err != nil {
+		// No topology mounted — leave fabric config untouched.
+		return
+	}
+	data, err := os.ReadFile(topoPath)
+	if err != nil {
+		warnLog("Failed to read topology %s: %v\n", topoPath, err)
+		return
+	}
+	var topo TopologyDocument
+	if err := yaml.Unmarshal(data, &topo); err != nil {
+		warnLog("Failed to parse topology %s: %v\n", topoPath, err)
+		return
+	}
+	// The profile is the gate: if the loaded YAML has no fabric block on
+	// its DeviceDefaults, the GPU type modelled by this profile is not
+	// fabric-attached (e.g. A100). Synthesising a FabricConfig here would
+	// silently start reporting GB200-style fabric info on every device,
+	// which is exactly what real NVML does *not* do on those GPUs.
+	if yamlConfig.DeviceDefaults.Fabric == nil {
+		debugLog("[CONFIG] Topology overlay: profile has no fabric defaults, skipping overlay for node=%s\n", nodeName)
+		return
+	}
+	for _, domain := range topo.Domains {
+		for _, clique := range domain.Cliques {
+			for _, n := range clique.Nodes {
+				if n != nodeName {
+					continue
+				}
+				overrideFabric(yamlConfig, domain.UUID, clique.ID)
+				debugLog("[CONFIG] Topology overlay: node=%s domain=%s clique=%d\n",
+					nodeName, domain.UUID, clique.ID)
+				return
+			}
+		}
+	}
+	debugLog("[CONFIG] Topology overlay: node=%s not in topology, leaving fabric defaults\n", nodeName)
+}
+
+// overrideFabric pins the supplied cluster UUID / clique ID onto the
+// already-present DeviceDefaults.Fabric (the caller guarantees it is
+// non-nil — see applyTopologyOverlay). Per-device overrides that carry
+// their own Fabric block get the same treatment so the entire node
+// reports a consistent fabric identity.
+func overrideFabric(yamlConfig *YAMLConfig, clusterUUID string, cliqueID uint32) {
+	yamlConfig.DeviceDefaults.Fabric.ClusterUUID = clusterUUID
+	yamlConfig.DeviceDefaults.Fabric.CliqueID = cliqueID
+	if yamlConfig.DeviceDefaults.Fabric.State == "" {
+		yamlConfig.DeviceDefaults.Fabric.State = "completed"
+	}
+	// forward-compat: no profile currently ships per-device fabric blocks,
+	// but if one does in the future we keep the whole node coherent by
+	// rewriting those too rather than silently letting them diverge.
+	for i := range yamlConfig.Devices {
+		if yamlConfig.Devices[i].Fabric == nil {
+			continue
+		}
+		yamlConfig.Devices[i].Fabric.ClusterUUID = clusterUUID
+		yamlConfig.Devices[i].Fabric.CliqueID = cliqueID
+		if yamlConfig.Devices[i].Fabric.State == "" {
+			yamlConfig.Devices[i].Fabric.State = "completed"
+		}
+	}
 }
 
 // Note: debugLog is defined in utils.go to avoid duplication

--- a/pkg/gpu/mocknvml/engine/config_types.go
+++ b/pkg/gpu/mocknvml/engine/config_types.go
@@ -138,6 +138,11 @@ type DeviceConfig struct {
 	// uncorrectable ECC, Xid). When nil (default) the device behaves as
 	// healthy hardware.
 	Failure *FailureInjectionConfig `json:"failure,omitempty"`
+
+	// Fabric enables the GB200/GB300 NVLink fabric API surface. When nil
+	// (default) GetGpuFabricInfo / GetGpuFabricInfoV report
+	// ERROR_NOT_SUPPORTED — matching every non-fabric-attached GPU.
+	Fabric *FabricConfig `json:"fabric,omitempty"`
 }
 
 // DeviceOverride contains per-device settings that override defaults
@@ -531,6 +536,61 @@ type FailureInjectionConfig struct {
 // fallen off the bus", 64 = "ECC double-bit error").
 type XidErrorConfig struct {
 	Code uint64 `json:"code,omitempty"`
+}
+
+// FabricConfig models the per-GPU NVLink fabric attributes that
+// nvmlDeviceGetGpuFabricInfo / nvmlDeviceGetGpuFabricInfoV expose for
+// fabric-attached GPUs (Hopper+ / GB200 / GB300). All GPUs on the same
+// physical node share the same fabric config — the NVLink domain is a
+// node-level property.
+//
+// State strings map to the NVML_GPU_FABRIC_STATE_* enum:
+//   - "not_started" -> 0
+//   - "in_progress" -> 1
+//   - "completed"   -> 2
+//
+// ClusterUUID is parsed as RFC-4122-style hex; non-hex characters are
+// dropped and the buffer is zero-padded to 16 bytes so the YAML can
+// carry either bare hex or dashed UUID form.
+type FabricConfig struct {
+	// ClusterUUID identifies the NVLink fabric (16-byte UUID). Accepts
+	// dashed form ("00000000-0000-0000-0000-000000000001") or bare hex.
+	ClusterUUID string `json:"cluster_uuid,omitempty"`
+	// CliqueID is the clique within the cluster this GPU belongs to.
+	CliqueID uint32 `json:"clique_id,omitempty"`
+	// State is the GPU registration state with the fabric manager.
+	// Defaults to "completed" (the healthy steady-state value).
+	State string `json:"state,omitempty"`
+	// HealthMask is the v2 health bitmask. Defaults to 0 (healthy).
+	HealthMask uint32 `json:"health_mask,omitempty"`
+}
+
+// TopologyDocument is the cluster-level ConfigMap that maps individual
+// nodes (by Kubernetes node name) to fabric clusters and cliques. It is
+// the single source of truth for ComputeDomain topology in the mock.
+//
+// At LoadConfig() time the engine looks up the current node (via
+// NODE_NAME) and, if found in the topology, overrides the per-device
+// FabricConfig.ClusterUUID / CliqueID. Nodes absent from the topology
+// keep their default fabric config (or report NOT_SUPPORTED when no
+// FabricConfig is present).
+type TopologyDocument struct {
+	Version int              `json:"version"`
+	Domains []TopologyDomain `json:"domains"`
+}
+
+// TopologyDomain represents one NVLink fabric domain (cluster UUID).
+type TopologyDomain struct {
+	Name    string            `json:"name,omitempty"`
+	UUID    string            `json:"uuid"`
+	Cliques []TopologyClique  `json:"cliques"`
+}
+
+// TopologyClique groups the Kubernetes node names that share a clique
+// inside a fabric domain.
+type TopologyClique struct {
+	ID    uint32   `json:"id"`
+	Nodes []string `json:"nodes"`
 }
 
 // NVLinkConfig defines NVLink topology

--- a/pkg/gpu/mocknvml/engine/fabric.go
+++ b/pkg/gpu/mocknvml/engine/fabric.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"encoding/hex"
+	"strings"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+// FabricState* values mirror NVML_GPU_FABRIC_STATE_* from the public NVML
+// header. We re-declare them here so the engine layer never has to pull
+// in CGo and so that callers (and tests) can compare against named
+// constants instead of magic numbers.
+const (
+	FabricStateNotSupported uint8 = 0
+	FabricStateNotStarted   uint8 = 1
+	FabricStateInProgress   uint8 = 2
+	FabricStateCompleted    uint8 = 3
+)
+
+// FabricInfo is the engine-internal shape of a GPU's fabric attributes
+// (the union of v1, v2, v3 NVML structs). The CGo bridge converts this
+// to the appropriate C struct version selected by the caller.
+//
+// No PartitionID: nvml_types.h does not carry a partition_id field on
+// any of v1/v2/v3, so plumbing one through the engine would only be
+// dead weight. Reintroduce when there is a real NVML struct version
+// that exposes it.
+type FabricInfo struct {
+	ClusterUUID   [16]byte
+	Status        uint32 // NVML return code embedded inside the struct (SUCCESS by default)
+	CliqueID      uint32
+	State         uint8
+	HealthMask    uint32
+	HealthSummary uint8
+}
+
+// GetMockFabricInfo returns the v1 fabric information for this device.
+// Returns ERROR_NOT_SUPPORTED when no FabricConfig is attached, matching
+// real NVML behaviour on non-fabric-attached GPUs.
+//
+// Named to avoid shadowing the embedded dgxa100.Device's interface method
+// `GetGpuFabricInfo() (nvml.GpuFabricInfo, nvml.Return)` while still
+// giving the bridge a single typed entry point.
+func (d *ConfigurableDevice) GetMockFabricInfo() (FabricInfo, nvml.Return) {
+	if ret := d.handleLookupReturn(); ret != nvml.SUCCESS {
+		return FabricInfo{}, ret
+	}
+	if d.config == nil || d.config.Fabric == nil {
+		return FabricInfo{}, nvml.ERROR_NOT_SUPPORTED
+	}
+	info := buildFabricInfo(d.config.Fabric)
+	debugLog("[NVML] nvmlDeviceGetGpuFabricInfo -> clique=%d state=%d\n", info.CliqueID, info.State)
+	return info, nvml.SUCCESS
+}
+
+// GetMockFabricInfoV returns the versioned (v2/v3) fabric information
+// for this device. The struct version selection happens in the bridge —
+// the engine returns every field and lets the bridge zero out what the
+// caller's selected version cannot represent.
+//
+// Named to avoid shadowing the embedded dgxa100.Device's interface
+// method `GetGpuFabricInfoV() GpuFabricInfoHandler`.
+func (d *ConfigurableDevice) GetMockFabricInfoV() (FabricInfo, nvml.Return) {
+	if ret := d.handleLookupReturn(); ret != nvml.SUCCESS {
+		return FabricInfo{}, ret
+	}
+	if d.config == nil || d.config.Fabric == nil {
+		return FabricInfo{}, nvml.ERROR_NOT_SUPPORTED
+	}
+	info := buildFabricInfo(d.config.Fabric)
+	debugLog("[NVML] nvmlDeviceGetGpuFabricInfoV -> clique=%d state=%d healthMask=0x%x\n",
+		info.CliqueID, info.State, info.HealthMask)
+	return info, nvml.SUCCESS
+}
+
+func buildFabricInfo(cfg *FabricConfig) FabricInfo {
+	info := FabricInfo{
+		CliqueID:   cfg.CliqueID,
+		HealthMask: cfg.HealthMask,
+		State:      parseFabricState(cfg.State),
+	}
+	info.ClusterUUID = parseClusterUUID(cfg.ClusterUUID)
+	return info
+}
+
+func parseFabricState(s string) uint8 {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "completed":
+		// Empty defaults to "completed" — the most useful steady state
+		// for the happy-path tests this mock exists to enable.
+		return FabricStateCompleted
+	case "not_started", "notstarted":
+		return FabricStateNotStarted
+	case "in_progress", "inprogress":
+		return FabricStateInProgress
+	case "not_supported", "notsupported":
+		return FabricStateNotSupported
+	default:
+		return FabricStateCompleted
+	}
+}
+
+// parseClusterUUID accepts either a bare 32-hex string or an RFC-4122
+// style dashed UUID and packs it into a 16-byte buffer. Non-hex
+// characters are silently dropped; short input is right-padded with
+// zeros so misconfiguration does not block startup.
+func parseClusterUUID(s string) [16]byte {
+	var out [16]byte
+	cleaned := strings.Map(func(r rune) rune {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'f', r >= 'A' && r <= 'F':
+			return r
+		default:
+			return -1
+		}
+	}, s)
+	if len(cleaned) > 32 {
+		cleaned = cleaned[:32]
+	}
+	for len(cleaned) < 32 {
+		cleaned += "0"
+	}
+	b, err := hex.DecodeString(cleaned)
+	if err != nil {
+		return out
+	}
+	copy(out[:], b)
+	return out
+}

--- a/pkg/gpu/mocknvml/engine/fabric_test.go
+++ b/pkg/gpu/mocknvml/engine/fabric_test.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/go-nvml/pkg/nvml/mock/dgxa100"
+)
+
+func makeFabricDevice(t *testing.T, fabric *FabricConfig) *ConfigurableDevice {
+	t.Helper()
+	base := dgxa100.New()
+	bd, _ := base.Devices[0].(*dgxa100.Device)
+	return NewConfigurableDevice(0, bd, &DeviceConfig{Fabric: fabric},
+		"GPU-00000000-0000-0000-0000-000000000000", "00000000:01:00.0", 0, nil)
+}
+
+func TestGetMockFabricInfo_NotSupportedWhenNil(t *testing.T) {
+	dev := makeFabricDevice(t, nil)
+	_, ret := dev.GetMockFabricInfo()
+	if ret != nvml.ERROR_NOT_SUPPORTED {
+		t.Fatalf("nil fabric: want ERROR_NOT_SUPPORTED, got %v", ret)
+	}
+	_, ret = dev.GetMockFabricInfoV()
+	if ret != nvml.ERROR_NOT_SUPPORTED {
+		t.Fatalf("nil fabric V: want ERROR_NOT_SUPPORTED, got %v", ret)
+	}
+}
+
+func TestGetMockFabricInfo_PopulatesFields(t *testing.T) {
+	dev := makeFabricDevice(t, &FabricConfig{
+		ClusterUUID: "00000000-0000-0000-0000-0000000000ab",
+		CliqueID:    7,
+		State:       "completed",
+		HealthMask:  0x42,
+	})
+	info, ret := dev.GetMockFabricInfo()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("v1: %v", ret)
+	}
+	if info.CliqueID != 7 {
+		t.Errorf("CliqueID: want 7, got %d", info.CliqueID)
+	}
+	if info.State != FabricStateCompleted {
+		t.Errorf("State: want completed (%d), got %d", FabricStateCompleted, info.State)
+	}
+	if info.ClusterUUID[15] != 0xab {
+		t.Errorf("ClusterUUID last byte: want 0xab, got 0x%x", info.ClusterUUID[15])
+	}
+
+	v, ret := dev.GetMockFabricInfoV()
+	if ret != nvml.SUCCESS {
+		t.Fatalf("V: %v", ret)
+	}
+	if v.HealthMask != 0x42 {
+		t.Errorf("V: healthMask=%d", v.HealthMask)
+	}
+}
+
+func TestParseFabricState(t *testing.T) {
+	cases := map[string]uint8{
+		"":             FabricStateCompleted,
+		"completed":    FabricStateCompleted,
+		"not_started":  FabricStateNotStarted,
+		"in_progress":  FabricStateInProgress,
+		"InProgress":   FabricStateInProgress,
+		"NotSupported": FabricStateNotSupported,
+		"garbage":      FabricStateCompleted,
+	}
+	for in, want := range cases {
+		if got := parseFabricState(in); got != want {
+			t.Errorf("parseFabricState(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestParseClusterUUID(t *testing.T) {
+	out := parseClusterUUID("00000000-0000-0000-0000-000000000001")
+	if out[15] != 0x01 {
+		t.Errorf("last byte: want 0x01, got 0x%x", out[15])
+	}
+	// short input is zero-padded
+	short := parseClusterUUID("ff")
+	if short[0] != 0xff || short[15] != 0x00 {
+		t.Errorf("short: want [ff..00], got %x", short)
+	}
+}
+
+func TestTopologyOverlay(t *testing.T) {
+	dir := t.TempDir()
+	topoPath := filepath.Join(dir, "topology.yaml")
+	if err := os.WriteFile(topoPath, []byte(`
+version: 1
+domains:
+  - name: dom1
+    uuid: "00000000-0000-0000-0000-0000000000ab"
+    cliques:
+      - id: 5
+        nodes: [nodeA, nodeB]
+      - id: 9
+        nodes: [nodeC]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("NODE_NAME", "nodeB")
+	t.Setenv("MOCK_TOPOLOGY_CONFIG", topoPath)
+
+	cfg := &YAMLConfig{
+		DeviceDefaults: DeviceConfig{Fabric: &FabricConfig{
+			ClusterUUID: "ZERO",
+			CliqueID:    0,
+		}},
+	}
+	applyTopologyOverlay(cfg)
+	if cfg.DeviceDefaults.Fabric.CliqueID != 5 {
+		t.Errorf("CliqueID: want 5, got %d", cfg.DeviceDefaults.Fabric.CliqueID)
+	}
+	if cfg.DeviceDefaults.Fabric.ClusterUUID != "00000000-0000-0000-0000-0000000000ab" {
+		t.Errorf("ClusterUUID: got %q", cfg.DeviceDefaults.Fabric.ClusterUUID)
+	}
+}
+
+func TestTopologyOverlay_NoFabricDefaults_NoOp(t *testing.T) {
+	// Regression: with topology.enabled=true but a non-fabric profile
+	// (e.g. a100) DeviceDefaults.Fabric stays nil so the overlay must
+	// not synthesise a FabricConfig — otherwise every A100 would start
+	// reporting GB200-style fabric info.
+	dir := t.TempDir()
+	topoPath := filepath.Join(dir, "topology.yaml")
+	_ = os.WriteFile(topoPath, []byte(`
+version: 1
+domains:
+  - uuid: "00000000-0000-0000-0000-0000000000ab"
+    cliques:
+      - id: 5
+        nodes: [nodeA]
+`), 0o644)
+	t.Setenv("NODE_NAME", "nodeA")
+	t.Setenv("MOCK_TOPOLOGY_CONFIG", topoPath)
+
+	cfg := &YAMLConfig{DeviceDefaults: DeviceConfig{}}
+	applyTopologyOverlay(cfg)
+	if cfg.DeviceDefaults.Fabric != nil {
+		t.Errorf("non-fabric profile: want Fabric=nil after overlay, got %+v", cfg.DeviceDefaults.Fabric)
+	}
+}
+
+func TestTopologyOverlay_NodeNotPresent_NoChange(t *testing.T) {
+	dir := t.TempDir()
+	topoPath := filepath.Join(dir, "topology.yaml")
+	_ = os.WriteFile(topoPath, []byte(`
+version: 1
+domains:
+  - uuid: aaaa
+    cliques:
+      - id: 0
+        nodes: [otherNode]
+`), 0o644)
+	t.Setenv("NODE_NAME", "missingNode")
+	t.Setenv("MOCK_TOPOLOGY_CONFIG", topoPath)
+
+	cfg := &YAMLConfig{
+		DeviceDefaults: DeviceConfig{Fabric: &FabricConfig{
+			ClusterUUID: "ORIG",
+			CliqueID:    77,
+		}},
+	}
+	applyTopologyOverlay(cfg)
+	if cfg.DeviceDefaults.Fabric.CliqueID != 77 || cfg.DeviceDefaults.Fabric.ClusterUUID != "ORIG" {
+		t.Errorf("unexpected mutation: %+v", cfg.DeviceDefaults.Fabric)
+	}
+}

--- a/pkg/imexcoord/coord.go
+++ b/pkg/imexcoord/coord.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package imexcoord implements the shared-volume coordination protocol
+// used by the fake IMEX binaries (cmd/fake-imex/{daemon,ctl}) to
+// simulate ComputeDomain peer discovery on KIND clusters without real
+// GB200 hardware. See NVIDIA/k8s-test-infra#304 for the full design.
+//
+// Protocol (single-clique view; the real compute-domain-daemon writes a
+// per-clique nodes.cfg so the fake never has to know cliques itself):
+//
+//  1. The fake nvidia-imex daemon writes an empty marker file at
+//     <stateDir>/<pod-ip> on startup and removes it on SIGTERM/SIGINT.
+//  2. The fake nvidia-imex-ctl readiness probe reads the same
+//     nodes.cfg the real daemon writes, looks up each peer IP under
+//     <stateDir>, and reports READY iff every peer's marker exists.
+//
+// Pod IPs are globally unique in Kubernetes, so no clique
+// subdirectories are required — the daemon's own filtering already
+// scopes the nodes.cfg to the correct clique.
+package imexcoord
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DefaultStateDir is the canonical hostPath shared between KIND
+// workers. KIND mounts /tmp/nvml-mock-imex-state on the host to this
+// path inside each node container via extraMounts.
+const DefaultStateDir = "/var/lib/nvml-mock/imex-state"
+
+// DefaultNodesConfig matches the path the upstream compute-domain-daemon
+// uses when it writes its peer list (see writeDaemonsConfig() in
+// kubernetes-sigs/dra-driver-nvidia-gpu).
+const DefaultNodesConfig = "/imexd/nodes.cfg"
+
+// EnvStateDir and EnvNodesConfig override DefaultStateDir and
+// DefaultNodesConfig respectively. Both fakes honour the same env vars
+// so tests can run them against a temp directory without root.
+const (
+	EnvStateDir    = "IMEX_STATE_DIR"
+	EnvNodesConfig = "IMEX_NODES_CONFIG"
+	EnvPodIP       = "POD_IP"
+)
+
+// StateDir returns the effective state directory, falling back to
+// DefaultStateDir if EnvStateDir is empty.
+func StateDir() string {
+	if v := os.Getenv(EnvStateDir); v != "" {
+		return v
+	}
+	return DefaultStateDir
+}
+
+// NodesConfigPath returns the effective nodes.cfg path.
+func NodesConfigPath() string {
+	if v := os.Getenv(EnvNodesConfig); v != "" {
+		return v
+	}
+	return DefaultNodesConfig
+}
+
+// MarkerPath returns the marker filename for the given peer IP.
+func MarkerPath(stateDir, ip string) string {
+	return filepath.Join(stateDir, ip)
+}
+
+// WriteMarker creates an empty marker file at <stateDir>/<ip>. It is
+// idempotent — re-running it on an existing marker is fine.
+func WriteMarker(stateDir, ip string) error {
+	if ip == "" {
+		return fmt.Errorf("imexcoord: empty pod IP, cannot write marker")
+	}
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return fmt.Errorf("imexcoord: mkdir %s: %w", stateDir, err)
+	}
+	path := MarkerPath(stateDir, ip)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("imexcoord: write marker %s: %w", path, err)
+	}
+	return f.Close()
+}
+
+// RemoveMarker removes a marker file. Missing files are not an error so
+// shutdown paths can call this unconditionally.
+func RemoveMarker(stateDir, ip string) error {
+	if ip == "" {
+		return nil
+	}
+	err := os.Remove(MarkerPath(stateDir, ip))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// ReadPeers parses nodes.cfg and returns the list of peer IPs in the
+// order they appear. Blank lines and lines starting with '#' are
+// ignored, matching the upstream daemon's writer.
+func ReadPeers(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	var peers []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// nodes.cfg may contain `ip` or `ip port`; keep only the IP.
+		if idx := strings.IndexAny(line, " \t"); idx >= 0 {
+			line = line[:idx]
+		}
+		peers = append(peers, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return peers, nil
+}
+
+// AllPeersReady returns true iff every peer in `peers` has a marker
+// file under stateDir. An empty peer list is treated as "ready"
+// (single-node clique — there is nothing to wait for).
+func AllPeersReady(stateDir string, peers []string) (bool, string) {
+	for _, p := range peers {
+		if _, err := os.Stat(MarkerPath(stateDir, p)); err != nil {
+			return false, p
+		}
+	}
+	return true, ""
+}

--- a/pkg/imexcoord/coord_test.go
+++ b/pkg/imexcoord/coord_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package imexcoord
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAllPeersReady_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	for _, ip := range []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"} {
+		if err := WriteMarker(dir, ip); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ok, missing := AllPeersReady(dir, []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"})
+	if !ok {
+		t.Fatalf("expected ready, got missing=%s", missing)
+	}
+}
+
+func TestAllPeersReady_MissingPeer(t *testing.T) {
+	dir := t.TempDir()
+	_ = WriteMarker(dir, "10.0.0.1")
+	ok, missing := AllPeersReady(dir, []string{"10.0.0.1", "10.0.0.99"})
+	if ok || missing != "10.0.0.99" {
+		t.Fatalf("expected missing=10.0.0.99 not-ready, got ok=%v missing=%q", ok, missing)
+	}
+}
+
+func TestAllPeersReady_EmptyPeersTreatedAsReady(t *testing.T) {
+	if ok, _ := AllPeersReady(t.TempDir(), nil); !ok {
+		t.Fatal("empty peers should be ready")
+	}
+}
+
+func TestRemoveMarker_IsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	if err := RemoveMarker(dir, "10.0.0.1"); err != nil {
+		t.Fatalf("remove missing: %v", err)
+	}
+	_ = WriteMarker(dir, "10.0.0.1")
+	if err := RemoveMarker(dir, "10.0.0.1"); err != nil {
+		t.Fatalf("remove existing: %v", err)
+	}
+}
+
+func TestReadPeers_SkipsCommentsBlanksAndPort(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nodes.cfg")
+	_ = os.WriteFile(path, []byte("# header\n\n10.0.0.1\n10.0.0.2 50051\n  \n"), 0o644)
+	peers, err := ReadPeers(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(peers) != 2 || peers[0] != "10.0.0.1" || peers[1] != "10.0.0.2" {
+		t.Fatalf("unexpected peers: %v", peers)
+	}
+}

--- a/tests/e2e/kind-compute-domain-config.yaml
+++ b/tests/e2e/kind-compute-domain-config.yaml
@@ -1,0 +1,56 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Kind cluster config for ComputeDomain (NVLink fabric) simulation.
+#
+# Each worker mounts the same hostPath into /var/lib/nvml-mock/imex-state
+# so the fake nvidia-imex daemons on every node coordinate readiness via
+# shared marker files. The mock NVML library reads the topology overlay
+# (Helm value topology.enabled=true) to learn its clique / cluster UUID.
+#
+# Pair with the gb200 profile and topology enabled:
+#   helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+#     --set gpu.profile=gb200 \
+#     --set gpu.count=4 \
+#     --set topology.enabled=true \
+#     --set imex.enabled=true \
+#     --set-file topology.domains=tests/e2e/compute-domain-topology.yaml
+#
+# Usage:
+#   mkdir -p /tmp/nvml-mock-imex-state
+#   kind create cluster --name compute-domain \
+#       --config tests/e2e/kind-compute-domain-config.yaml
+#
+# See NVIDIA/k8s-test-infra#304 for the full design.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri"]
+      enable_cdi = true
+nodes:
+  - role: control-plane
+  - role: worker
+    labels:
+      nvml-mock/clique: "0"
+    extraMounts:
+      - hostPath: /tmp/nvml-mock-imex-state
+        containerPath: /var/lib/nvml-mock/imex-state
+  - role: worker
+    labels:
+      nvml-mock/clique: "0"
+    extraMounts:
+      - hostPath: /tmp/nvml-mock-imex-state
+        containerPath: /var/lib/nvml-mock/imex-state
+  - role: worker
+    labels:
+      nvml-mock/clique: "1"
+    extraMounts:
+      - hostPath: /tmp/nvml-mock-imex-state
+        containerPath: /var/lib/nvml-mock/imex-state
+  - role: worker
+    labels:
+      nvml-mock/clique: "1"
+    extraMounts:
+      - hostPath: /tmp/nvml-mock-imex-state
+        containerPath: /var/lib/nvml-mock/imex-state


### PR DESCRIPTION
## Summary

Closes #304. Adds end-to-end simulation support for the NVIDIA GPU
Operator's ComputeDomain lifecycle on KIND clusters by mocking the
NVML fabric APIs and providing a file-based replacement for
\`nvidia-imex\` / \`nvidia-imex-ctl\`.

- **Mock NVML fabric APIs**: new \`FabricConfig\` type, per-device
  \`GetMockFabricInfo\` / \`GetMockFabricInfoV\` methods and a
  cluster-level topology overlay applied per \`NODE_NAME\` at
  \`LoadConfig\` time. CGo bridge exposes
  \`nvmlDeviceGetGpuFabricInfo[V]\` with ABI-compatible C structs.
- **Fake IMEX**: \`cmd/fake-imex/{daemon,ctl}\` plus a shared
  \`pkg/imexcoord\` package coordinate peers through marker files on
  a shared hostPath volume — suitable as a drop-in for
  \`nvidia-imex\` / \`nvidia-imex-ctl\` in tests.
- **Helm**: new topology ConfigMap template, \`imex\` / \`topology\`
  values, default \`fabric\` block in the \`gb200\` profile and
  daemonset wiring for the new volumes and env vars.
- **Demo**: \`docs/demo/compute-domain/\` with \`run.sh\`, README,
  \`topology.yaml\` and a dedicated KIND config exercising 4 workers
  across 2 cliques (verifies in-clique peer readiness, cross-clique
  isolation and a topology rebind).
- **Tests**: unit tests for fabric overlay + \`imexcoord\`, plus a
  fake-imex integration test.

## Test plan

- [x] \`go test ./pkg/gpu/mocknvml/engine/... ./pkg/imexcoord/... ./cmd/fake-imex/...\`
- [x] \`docs/demo/compute-domain/run.sh\` on a local KIND cluster
  (4 workers, gb200 profile, 2 cliques): per-clique readiness +
  cross-clique \`fake-imex-ctl\` failures + topology rebind all pass
- [ ] Reviewer: rebuild the chart image and re-run the demo