### PR TITLE
feat(fetcher): support registry.k8s.io for DRA driver images

### DIFF
--- a/artifact_fetcher.go
+++ b/artifact_fetcher.go
@@ -1621,8 +1621,14 @@ func buildCommitURL(repo, tag string) string {
 // on ir.imageRegistry. The empty string defaults to GHCR (the historical
 // behavior). Per docs/plans/2026-05-11-dra-registry-k8s-io-design.md.
 func fetchLatestImageTag(ctx context.Context, client *github.Client, ir imageRepo) (ImageInfo, error) {
-	// No dispatch yet — the imageRegistry field lands in Task 2.
-	return fetchLatestGHCRTag(ctx, client, ir)
+	switch ir.imageRegistry {
+	case "", "ghcr.io":
+		return fetchLatestGHCRTag(ctx, client, ir)
+	case "registry.k8s.io":
+		return fetchLatestRegistryK8sTag(ctx, client, ir)
+	default:
+		return ImageInfo{}, fmt.Errorf("unknown imageRegistry %q for %s", ir.imageRegistry, ir.repo)
+	}
 }
 
 func fetchLatestGHCRTag(ctx context.Context, client *github.Client, ir imageRepo) (ImageInfo, error) {

--- a/artifact_fetcher.go
+++ b/artifact_fetcher.go
@@ -81,20 +81,24 @@ var defaultRepos = []string{
 	"nvidia/holodeck",
 }
 
-// imageRepo pairs a GitHub repository path with its GitHub Packages container
-// name. The repo field is the full owner/repo used for constructing HTML URLs,
-// while pkgName is the container package name used by the Packages API.
+// imageRepo pairs a GitHub repository path with its container-registry
+// coordinates. The repo field is the full owner/repo for source/release link
+// construction. pkgName is the image path within its registry. imageRegistry
+// discriminates the fetch path: "" or "ghcr.io" = GitHub Packages (default);
+// "registry.k8s.io" = OCI registry served by the kubernetes-sigs project
+// release pipeline. Per docs/plans/2026-05-11-dra-registry-k8s-io-design.md.
 type imageRepo struct {
-	repo    string // GitHub repo path, e.g. "nvidia/nvidia-container-toolkit"
-	pkgName string // GitHub Packages name, e.g. "container-toolkit"
+	repo          string // GitHub repo path, e.g. "nvidia/nvidia-container-toolkit"
+	pkgName       string // image path within the registry, e.g. "container-toolkit"
+	imageRegistry string // "" / "ghcr.io" = GHCR (default); "registry.k8s.io" for OCI
 }
 
 var defaultImages = []imageRepo{
-	{"nvidia/k8s-device-plugin", "k8s-device-plugin"},
-	{"kubernetes-sigs/dra-driver-nvidia-gpu", "dra-driver-nvidia-gpu"}, // donated 2026-04-30; pkgName best-effort (kubernetes-sigs GHCR not yet listable without read:packages)
-	{"nvidia/nvidia-container-toolkit", "container-toolkit"},
-	{"nvidia/gpu-operator", "gpu-operator"},
-	{"nvidia/gpu-driver-container", "driver"},
+	{"nvidia/k8s-device-plugin", "k8s-device-plugin", ""},
+	{"kubernetes-sigs/dra-driver-nvidia-gpu", "dra-driver-nvidia-gpu", ""}, // rewired to registry.k8s.io in a follow-up commit
+	{"nvidia/nvidia-container-toolkit", "container-toolkit", ""},
+	{"nvidia/gpu-operator", "gpu-operator", ""},
+	{"nvidia/gpu-driver-container", "driver", ""},
 }
 
 var allRepos = []string{
@@ -1613,7 +1617,15 @@ func buildCommitURL(repo, tag string) string {
 	return ""
 }
 
+// fetchLatestImageTag dispatches to the right registry-specific fetcher based
+// on ir.imageRegistry. The empty string defaults to GHCR (the historical
+// behavior). Per docs/plans/2026-05-11-dra-registry-k8s-io-design.md.
 func fetchLatestImageTag(ctx context.Context, client *github.Client, ir imageRepo) (ImageInfo, error) {
+	// No dispatch yet — the imageRegistry field lands in Task 2.
+	return fetchLatestGHCRTag(ctx, client, ir)
+}
+
+func fetchLatestGHCRTag(ctx context.Context, client *github.Client, ir imageRepo) (ImageInfo, error) {
 	parts := strings.Split(ir.repo, "/")
 	if len(parts) != 2 {
 		return ImageInfo{}, fmt.Errorf("invalid repo: %s", ir.repo)
@@ -1645,6 +1657,48 @@ func fetchLatestImageTag(ctx context.Context, client *github.Client, ir imageRep
 		Tag:       tag,
 		Pushed:    latest.GetCreatedAt().Format(time.RFC3339),
 		HTMLURL:   htmlURL,
+		ImageType: classifyImageTag(tag),
+		CommitURL: buildCommitURL(ir.repo, tag),
+	}, nil
+}
+
+// fetchLatestRegistryK8sTag handles imageRepo entries whose images live at
+// registry.k8s.io (or other OCI registries with no Packages API). Instead of
+// listing OCI tags — which would not give us push timestamps — we list the
+// source repo's GitHub releases and treat the newest release as authoritative
+// for the latest image tag and push date. This matches the release process:
+// the GitHub release publish triggers the Prow image-push job.
+//
+// Spec: docs/plans/2026-05-11-dra-registry-k8s-io-design.md.
+func fetchLatestRegistryK8sTag(ctx context.Context, client *github.Client, ir imageRepo) (ImageInfo, error) {
+	parts := strings.Split(ir.repo, "/")
+	if len(parts) != 2 {
+		return ImageInfo{}, fmt.Errorf("invalid repo: %s", ir.repo)
+	}
+	owner, name := parts[0], parts[1]
+
+	rels, _, err := client.Repositories.ListReleases(ctx, owner, name, &github.ListOptions{PerPage: 5})
+	if err != nil {
+		return ImageInfo{}, fmt.Errorf("list releases %s: %w", ir.repo, err)
+	}
+	if len(rels) == 0 {
+		return ImageInfo{}, fmt.Errorf("no releases found for %s", ir.repo)
+	}
+
+	// GitHub returns releases newest-first.
+	latest := rels[0]
+	tag := latest.GetTagName()
+
+	// No GHCR page exists for registry.k8s.io-hosted images; both the Tag-cell
+	// link (HTMLURL) and the Source-cell link (CommitURL) point at the GitHub
+	// release page. buildCommitURL already returns this for SemVer tags.
+	releaseURL := fmt.Sprintf("https://github.com/%s/releases/tag/%s", ir.repo, tag)
+
+	return ImageInfo{
+		Repo:      ir.repo,
+		Tag:       tag,
+		Pushed:    latest.GetPublishedAt().Format(time.RFC3339),
+		HTMLURL:   releaseURL,
 		ImageType: classifyImageTag(tag),
 		CommitURL: buildCommitURL(ir.repo, tag),
 	}, nil

--- a/artifact_fetcher.go
+++ b/artifact_fetcher.go
@@ -95,7 +95,7 @@ type imageRepo struct {
 
 var defaultImages = []imageRepo{
 	{"nvidia/k8s-device-plugin", "k8s-device-plugin", ""},
-	{"kubernetes-sigs/dra-driver-nvidia-gpu", "dra-driver-nvidia-gpu", ""}, // rewired to registry.k8s.io in a follow-up commit
+	{"kubernetes-sigs/dra-driver-nvidia-gpu", "dra-driver-nvidia/dra-driver-nvidia-gpu", "registry.k8s.io"}, // images live at registry.k8s.io after Prow promotion; see docs/plans/2026-05-11-dra-registry-k8s-io-design.md
 	{"nvidia/nvidia-container-toolkit", "container-toolkit", ""},
 	{"nvidia/gpu-operator", "gpu-operator", ""},
 	{"nvidia/gpu-driver-container", "driver", ""},

--- a/artifact_fetcher_registry_test.go
+++ b/artifact_fetcher_registry_test.go
@@ -89,3 +89,22 @@ func TestFetchLatestRegistryK8sTag_HappyPath(t *testing.T) {
 		t.Errorf("CommitURL = %q; want %q (release URL for SemVer)", got.CommitURL, wantHTMLURL)
 	}
 }
+
+func TestFetchLatestRegistryK8sTag_NoReleases(t *testing.T) {
+	t.Parallel()
+
+	client := newReleasesStub(t, "kubernetes-sigs", "dra-driver-nvidia-gpu", `[]`)
+
+	ir := imageRepo{
+		repo:          "kubernetes-sigs/dra-driver-nvidia-gpu",
+		pkgName:       "dra-driver-nvidia/dra-driver-nvidia-gpu",
+		imageRegistry: "registry.k8s.io",
+	}
+	_, err := fetchLatestRegistryK8sTag(context.Background(), client, ir)
+	if err == nil {
+		t.Fatalf("err = nil; want non-nil for empty releases response")
+	}
+	if !strings.Contains(err.Error(), "no releases found") {
+		t.Fatalf("err = %v; want it to contain 'no releases found'", err)
+	}
+}

--- a/artifact_fetcher_registry_test.go
+++ b/artifact_fetcher_registry_test.go
@@ -90,6 +90,90 @@ func TestFetchLatestRegistryK8sTag_HappyPath(t *testing.T) {
 	}
 }
 
+// TestFetchLatestImageTag_Dispatch asserts the dispatcher routes by
+// imageRegistry. We stub /repos/.../releases (registry.k8s.io path) and
+// /orgs/.../packages/... (GHCR path) on the same server and watch which one
+// is hit per imageRegistry value.
+func TestFetchLatestImageTag_Dispatch(t *testing.T) {
+	t.Parallel()
+
+	var (
+		ghcrHit     bool
+		releasesHit bool
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/orgs/") && strings.Contains(r.URL.Path, "/packages/"):
+			ghcrHit = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[{"id":1,"created_at":"2026-05-01T00:00:00Z","metadata":{"container":{"tags":["v1.0.0"]}}}]`)
+		case strings.HasPrefix(r.URL.Path, "/repos/") && strings.HasSuffix(r.URL.Path, "/releases"):
+			releasesHit = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[{"tag_name":"v25.12.0","published_at":"2026-02-12T14:55:44Z"}]`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := github.NewClient(nil)
+	client.BaseURL = mustParseURL(t, srv.URL+"/")
+
+	cases := []struct {
+		name          string
+		ir            imageRepo
+		wantGHCR      bool
+		wantReleases  bool
+		wantErrSubstr string
+	}{
+		{
+			name:         "empty registry routes to GHCR",
+			ir:           imageRepo{repo: "nvidia/k8s-device-plugin", pkgName: "k8s-device-plugin", imageRegistry: ""},
+			wantGHCR:     true,
+			wantReleases: false,
+		},
+		{
+			name:         "ghcr.io explicitly routes to GHCR",
+			ir:           imageRepo{repo: "nvidia/k8s-device-plugin", pkgName: "k8s-device-plugin", imageRegistry: "ghcr.io"},
+			wantGHCR:     true,
+			wantReleases: false,
+		},
+		{
+			name:         "registry.k8s.io routes to releases",
+			ir:           imageRepo{repo: "kubernetes-sigs/dra-driver-nvidia-gpu", pkgName: "dra-driver-nvidia/dra-driver-nvidia-gpu", imageRegistry: "registry.k8s.io"},
+			wantGHCR:     false,
+			wantReleases: true,
+		},
+		{
+			name:          "unknown registry returns error",
+			ir:            imageRepo{repo: "nvidia/foo", pkgName: "foo", imageRegistry: "quay.io"},
+			wantGHCR:      false,
+			wantReleases:  false,
+			wantErrSubstr: "unknown imageRegistry",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ghcrHit, releasesHit = false, false
+			_, err := fetchLatestImageTag(context.Background(), client, tc.ir)
+
+			if tc.wantErrSubstr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrSubstr) {
+					t.Fatalf("err = %v; want non-nil containing %q", err, tc.wantErrSubstr)
+				}
+				return
+			}
+			if ghcrHit != tc.wantGHCR {
+				t.Errorf("ghcrHit = %v; want %v", ghcrHit, tc.wantGHCR)
+			}
+			if releasesHit != tc.wantReleases {
+				t.Errorf("releasesHit = %v; want %v", releasesHit, tc.wantReleases)
+			}
+		})
+	}
+}
+
 func TestFetchLatestRegistryK8sTag_NoReleases(t *testing.T) {
 	t.Parallel()
 

--- a/artifact_fetcher_registry_test.go
+++ b/artifact_fetcher_registry_test.go
@@ -1,0 +1,91 @@
+// Tests for the registry.k8s.io image-tag fetcher (and its dispatcher
+// integration). The fetcher reads the latest GitHub release for the source
+// repo and uses its tag_name/published_at as the image-tag/push-date pair,
+// on the assumption that the kubernetes-sigs release process pushes the
+// image when the release publishes.
+//
+// Spec: docs/plans/2026-05-11-dra-registry-k8s-io-design.md.
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v55/github"
+)
+
+// newReleasesStub returns an httptest server that serves the given JSON
+// payload at /repos/{owner}/{name}/releases and 404s anything else. The
+// returned *github.Client is rebased onto that server's URL so the fetcher
+// hits the stub instead of api.github.com.
+func newReleasesStub(t *testing.T, owner, name, body string) *github.Client {
+	t.Helper()
+	wantPath := "/repos/" + owner + "/" + name + "/releases"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, wantPath) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := github.NewClient(nil)
+	client.BaseURL = mustParseURL(t, srv.URL+"/")
+	return client
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	return u
+}
+
+func TestFetchLatestRegistryK8sTag_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	// GitHub returns releases newest-first. The fetcher must take index 0.
+	body := `[
+		{"tag_name": "v25.12.0", "published_at": "2026-02-12T14:55:44Z"},
+		{"tag_name": "v25.8.1",  "published_at": "2025-12-17T17:06:25Z"},
+		{"tag_name": "v25.8.0",  "published_at": "2025-10-20T20:11:17Z"}
+	]`
+	client := newReleasesStub(t, "kubernetes-sigs", "dra-driver-nvidia-gpu", body)
+
+	ir := imageRepo{
+		repo:          "kubernetes-sigs/dra-driver-nvidia-gpu",
+		pkgName:       "dra-driver-nvidia/dra-driver-nvidia-gpu",
+		imageRegistry: "registry.k8s.io",
+	}
+	var got ImageInfo
+	got, err := fetchLatestRegistryK8sTag(context.Background(), client, ir)
+	if err != nil {
+		t.Fatalf("fetchLatestRegistryK8sTag: %v", err)
+	}
+	if got.Tag != "v25.12.0" {
+		t.Errorf("Tag = %q; want %q", got.Tag, "v25.12.0")
+	}
+	if got.Pushed != "2026-02-12T14:55:44Z" {
+		t.Errorf("Pushed = %q; want %q", got.Pushed, "2026-02-12T14:55:44Z")
+	}
+	if got.ImageType != "release" {
+		t.Errorf("ImageType = %q; want %q (SemVer tag must classify as release)", got.ImageType, "release")
+	}
+	wantHTMLURL := "https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/releases/tag/v25.12.0"
+	if got.HTMLURL != wantHTMLURL {
+		t.Errorf("HTMLURL = %q; want %q", got.HTMLURL, wantHTMLURL)
+	}
+	// CommitURL for a SemVer tag should be the release URL (delegated to buildCommitURL).
+	if got.CommitURL != wantHTMLURL {
+		t.Errorf("CommitURL = %q; want %q (release URL for SemVer)", got.CommitURL, wantHTMLURL)
+	}
+}

--- a/artifact_fetcher_repos_test.go
+++ b/artifact_fetcher_repos_test.go
@@ -93,6 +93,33 @@ func TestDRAMigrationLiteralsAligned(t *testing.T) {
 			t.Errorf("defaultImages missing entry with repo=%q", newRepo)
 		}
 	})
+	t.Run("defaultImages.registryCoords", func(t *testing.T) {
+		t.Parallel()
+		// Post-CNCF-donation: DRA driver images live at
+		// registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu, promoted
+		// from a k8s-staging registry by the Prow release job.
+		// See docs/plans/2026-05-11-dra-registry-k8s-io-design.md.
+		const (
+			wantPkgName  = "dra-driver-nvidia/dra-driver-nvidia-gpu"
+			wantRegistry = "registry.k8s.io"
+		)
+		var found bool
+		for _, ir := range defaultImages {
+			if ir.repo != newRepo {
+				continue
+			}
+			found = true
+			if ir.imageRegistry != wantRegistry {
+				t.Errorf("defaultImages DRA entry imageRegistry = %q; want %q", ir.imageRegistry, wantRegistry)
+			}
+			if ir.pkgName != wantPkgName {
+				t.Errorf("defaultImages DRA entry pkgName = %q; want %q (full registry.k8s.io image path)", ir.pkgName, wantPkgName)
+			}
+		}
+		if !found {
+			t.Errorf("defaultImages missing entry with repo=%q", newRepo)
+		}
+	})
 	t.Run("projects.ts", func(t *testing.T) {
 		t.Parallel()
 		// Read the TS file as a string and grep for the canonical literal.


### PR DESCRIPTION
## Summary

After PR #318 migrated the DRA driver repo path `NVIDIA/k8s-dra-driver-gpu` → `kubernetes-sigs/dra-driver-nvidia-gpu`, the dashboard's image table for that project went silent. Reason: the new kubernetes-sigs project publishes images to `registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu`, not GHCR. The fetcher's call to `client.Organizations.PackageGetAllVersions(ctx, "kubernetes-sigs", "container", "dra-driver-nvidia-gpu", ...)` returns 401 / not-found — verified 2026-05-11.

This PR adds:

- An `imageRegistry` discriminator on `imageRepo`. `""` / `"ghcr.io"` → current GHCR path; `"registry.k8s.io"` → new path. Four NVIDIA-owned entries default to `""` and need no churn.
- `fetchLatestRegistryK8sTag`: reads GitHub releases newest-first; the latest release's `tag_name` + `published_at` become the image's `Tag` + `Pushed`. Both Tag-column link and Source-column link point at the GitHub release page (`registry.k8s.io` has no UI). No OCI manifest probing.
- Dispatcher in `fetchLatestImageTag` keyed off `imageRegistry`.
- Wire DRA entry: `{repo: "kubernetes-sigs/dra-driver-nvidia-gpu", pkgName: "dra-driver-nvidia/dra-driver-nvidia-gpu", imageRegistry: "registry.k8s.io"}`.

No frontend changes. No new module dependencies.

## Test plan

- `TestFetchLatestRegistryK8sTag_HappyPath` — three-release `httptest` fixture; asserts `Tag` / `Pushed` / `HTMLURL` / `CommitURL` / `ImageType` against the newest release.
- `TestFetchLatestRegistryK8sTag_NoReleases` — `httptest` returns `[]`; asserts wrapped `"no releases found"` error. Mutation: removing the `len(rels) == 0` guard panics — confirmed pre-commit.
- `TestFetchLatestImageTag_Dispatch` — table-driven; one shared stub server handles both `/orgs/.../packages/...` and `/repos/.../releases`; asserts which endpoint is hit per `imageRegistry` value (`""`, `"ghcr.io"`, `"registry.k8s.io"`, unknown).
- `TestDRAMigrationLiteralsAligned` (existing) gains a `defaultImages.registryCoords` sub-test pinning `imageRegistry == "registry.k8s.io"` and the full multi-segment `pkgName`.

`go vet ./... && go test -race -count=1 ./...` clean locally; `npm test` clean (no JS changes).

## Design

Spec: `docs/plans/2026-05-11-dra-registry-k8s-io-design.md`.
