### PR TITLE
feat(dashboard): wire DRA driver images to registry.k8s.io

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,6 +34,12 @@ jobs:
         with:
           go-version: "1.24"
 
+      - name: Go vet
+        run: go vet ./...
+
+      - name: Go tests
+        run: go test -race -count=1 ./...
+
       - name: Restore previous history data
         run: |
           mkdir -p ./public/data
@@ -62,6 +68,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: JS tests
+        run: npm test
 
       - name: Build
         run: npm run build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,10 +37,16 @@ jobs:
       - name: Restore previous history data
         run: |
           mkdir -p ./public/data
+          # history.json (existing)
           curl -sSf -o /tmp/history.json \
             "https://nvidia.github.io/k8s-test-infra/data/history.json" \
             && mv /tmp/history.json ./public/data/history.json \
             || echo '{}' > ./public/data/history.json
+          # issues_prs.json (new — feeds runIssuesPRsPhase cache fallback)
+          curl -sSf -o /tmp/issues_prs.json \
+            "https://nvidia.github.io/k8s-test-infra/data/issues_prs.json" \
+            && mv /tmp/issues_prs.json ./public/data/issues_prs.json \
+            || echo '{"repos":{}}' > ./public/data/issues_prs.json
 
       - name: Update artifacts
         env:

--- a/.github/workflows/lint-deploy-schedule.yaml
+++ b/.github/workflows/lint-deploy-schedule.yaml
@@ -1,0 +1,21 @@
+name: Lint deploy.yaml schedule
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/deploy.yaml
+      - hack/lint_deploy_schedule.sh
+      - .github/workflows/lint-deploy-schedule.yaml
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: schedule guardrail
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Lint
+        run: ./hack/lint_deploy_schedule.sh .github/workflows/deploy.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,41 @@
+name: Go Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - feat/dashboard-enhancements
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Verify modules
+        run: |
+          go mod tidy
+          if ! git diff --quiet -- go.mod go.sum; then
+            echo "::error::go.mod or go.sum out of sync; run 'go mod tidy' locally and commit"
+            git diff -- go.mod go.sum
+            exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -race -count=1 ./...

--- a/artifact_fetcher.go
+++ b/artifact_fetcher.go
@@ -1330,7 +1330,6 @@ func writeJSON(path string, v any) error {
 	return enc.Encode(v)
 }
 
-
 var (
 	semverRe = regexp.MustCompile(`^v?\d+\.\d+\.\d+`)
 	commitRe = regexp.MustCompile(`^([0-9a-f]{7,40})`)

--- a/artifact_fetcher.go
+++ b/artifact_fetcher.go
@@ -48,23 +48,14 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// githubBypassKeyType is the type used for the rate-limit bypass context key.
-// Defining a unique type avoids collisions with other package's context keys.
-type githubBypassKeyType struct{}
-
-// githubBypass is the context value go-github checks to skip its built-in
-// rate-limit pre-check. The middleware in this package owns this concern;
-// passing it through the context bypasses go-github's own logic.
-//
-// Note: go-github v55 keeps its bypassRateLimitCheck constant unexported,
-// so we cannot reference it directly. We define our own typed key with the
-// same intent; in v55 the underlying go-github pre-check is not actually
-// suppressed, but the rate-limit middleware still owns the retry logic so
-// 429/secondary-limit responses are handled before go-github's pre-check
-// becomes relevant. A future bump to v75+ (which exports
-// github.BypassRateLimitCheck) lets us swap this var to point at the
-// upstream symbol without changing call sites or tests.
-var githubBypass any = githubBypassKeyType{}
+// TODO(v75+): when go-github exports github.BypassRateLimitCheck, declare
+// `var githubBypass any = github.BypassRateLimitCheck` and stamp it into the
+// outgoing context inside buildClient so go-github's built-in pre-check is
+// suppressed (the middleware owns retry semantics). Until then, a typed
+// private key would not be honored by v55 and stamping one would only
+// pollute the caller's context.Value() lookups, so we omit it. The
+// middleware still handles 429/secondary-limit responses correctly because
+// it sits below go-github's pre-check.
 
 // secondarySleepCap is the maximum duration the rate-limit middleware will
 // sleep on a single secondary-rate-limit response. Exceeding it triggers the
@@ -131,13 +122,8 @@ var allRepos = []string{
 //     lands, primary-limit exhaustion blanks the failing repo's row in
 //     this run's output.
 //
-// The returned context carries our githubBypass marker. In go-github v55
-// the equivalent symbol is unexported, so this is currently a no-op;
-// see the githubBypass var declaration for the rationale and the v75+
-// migration path. The middleware still handles 429 responses correctly
-// because it sits below go-github's check.
-//
 // Spec: docs/plans/2026-04-30-dashboard-duration-options-design.md (Q5).
+// See the TODO above for the v75+ bypass-marker migration.
 func buildClient(ctx context.Context, token string, logger *slog.Logger) (*github.Client, context.Context) {
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	oauthClient := oauth2.NewClient(ctx, ts)
@@ -165,7 +151,6 @@ func buildClient(ctx context.Context, token string, logger *slog.Logger) (*githu
 	)
 
 	client := github.NewClient(rateLimited)
-	ctx = context.WithValue(ctx, githubBypass, true)
 	return client, ctx
 }
 

--- a/artifact_fetcher.go
+++ b/artifact_fetcher.go
@@ -25,23 +25,50 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
+	"maps"
 	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"maps"
 	"sort"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
 
+	"github.com/gofri/go-github-ratelimit/v2/github_ratelimit"
+	"github.com/gofri/go-github-ratelimit/v2/github_ratelimit/github_primary_ratelimit"
+	"github.com/gofri/go-github-ratelimit/v2/github_ratelimit/github_secondary_ratelimit"
 	"github.com/google/go-github/v55/github"
 	types "github.com/onsi/ginkgo/v2/types"
 	"golang.org/x/oauth2"
 )
+
+// githubBypassKeyType is the type used for the rate-limit bypass context key.
+// Defining a unique type avoids collisions with other package's context keys.
+type githubBypassKeyType struct{}
+
+// githubBypass is the context value go-github checks to skip its built-in
+// rate-limit pre-check. The middleware in this package owns this concern;
+// passing it through the context bypasses go-github's own logic.
+//
+// Note: go-github v55 keeps its bypassRateLimitCheck constant unexported,
+// so we cannot reference it directly. We define our own typed key with the
+// same intent; in v55 the underlying go-github pre-check is not actually
+// suppressed, but the rate-limit middleware still owns the retry logic so
+// 429/secondary-limit responses are handled before go-github's pre-check
+// becomes relevant. A future bump to v75+ (which exports
+// github.BypassRateLimitCheck) lets us swap this var to point at the
+// upstream symbol without changing call sites or tests.
+var githubBypass any = githubBypassKeyType{}
+
+// secondarySleepCap is the maximum duration the rate-limit middleware will
+// sleep on a single secondary-rate-limit response. Exceeding it triggers the
+// abort callback. Tests may override this via the package-level variable.
+var secondarySleepCap = 5 * time.Minute
 
 // -----------------------------------------------------------------------------
 // CLI flags
@@ -88,6 +115,57 @@ var allRepos = []string{
 	"nvidia/mig-parted",
 	"nvidia/gpu-driver-container",
 	"nvidia/k8s-nim-operator",
+}
+
+// buildClient constructs a *github.Client whose HTTP transport is wrapped
+// with the gofri/go-github-ratelimit/v2 middleware. The middleware handles
+// GitHub's primary and secondary rate limits transparently:
+//   - Secondary rate limits (429 / 403 + secondary-body) → middleware sleeps
+//     until Retry-After and retries, capped per-call at 5 minutes.
+//   - Primary rate limits (5000/hr exhausted) → middleware returns a typed
+//     error to the caller. In PR-A the caller's existing error path takes
+//     over (push to errCh, the run continues with whatever was successfully
+//     fetched). PR-B introduces a per-repo cache fallback that, when
+//     present, will be preferred over the bare error path; until PR-B
+//     lands, primary-limit exhaustion blanks the failing repo's row in
+//     this run's output.
+//
+// The returned context carries our githubBypass marker. In go-github v55
+// the equivalent symbol is unexported, so this is currently a no-op;
+// see the githubBypass var declaration for the rationale and the v75+
+// migration path. The middleware still handles 429 responses correctly
+// because it sits below go-github's check.
+//
+// Spec: docs/plans/2026-04-30-dashboard-duration-options-design.md (Q5).
+func buildClient(ctx context.Context, token string, logger *slog.Logger) (*github.Client, context.Context) {
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	oauthClient := oauth2.NewClient(ctx, ts)
+
+	rateLimited := github_ratelimit.NewClient(oauthClient.Transport,
+		github_primary_ratelimit.WithLimitDetectedCallback(func(c *github_primary_ratelimit.CallbackContext) {
+			logger.Warn("github primary rate limit detected",
+				"category", c.Category,
+				"reset", c.ResetTime)
+		}),
+		github_primary_ratelimit.WithRequestPreventedCallback(func(c *github_primary_ratelimit.CallbackContext) {
+			logger.Warn("github request prevented by active rate limit",
+				"category", c.Category)
+		}),
+		github_secondary_ratelimit.WithLimitDetectedCallback(func(c *github_secondary_ratelimit.CallbackContext) {
+			logger.Warn("github secondary rate limit detected",
+				"reset", c.ResetTime,
+				"total_sleep", c.TotalSleepTime)
+		}),
+		github_secondary_ratelimit.WithSingleSleepLimit(secondarySleepCap, func(c *github_secondary_ratelimit.CallbackContext) {
+			logger.Error("secondary rate limit sleep would exceed cap; aborting",
+				"reset", c.ResetTime,
+				"cap", secondarySleepCap)
+		}),
+	)
+
+	client := github.NewClient(rateLimited)
+	ctx = context.WithValue(ctx, githubBypass, true)
+	return client, ctx
 }
 
 type RepoInfo struct {
@@ -162,8 +240,8 @@ type RepoStatsEntry struct {
 }
 
 type HistoryFile struct {
-	Snapshots []HistorySnapshot          `json:"snapshots"`
-	Traffic   map[string]RepoTraffic     `json:"traffic"`
+	Snapshots []HistorySnapshot           `json:"snapshots"`
+	Traffic   map[string]RepoTraffic      `json:"traffic"`
 	RepoStats map[string][]RepoStatsEntry `json:"repoStats"`
 }
 
@@ -355,9 +433,8 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-	tc := oauth2.NewClient(ctx, ts)
-	client := github.NewClient(tc)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	client, ctx := buildClient(ctx, token, logger)
 
 	resCh := make(chan TestResult, len(repos))
 	errCh := make(chan error, len(repos))
@@ -641,7 +718,7 @@ func processRepo(parent context.Context, client *github.Client, repo, token, art
 	}
 
 	tmpZip := filepath.Join(os.TempDir(), fmt.Sprintf("%s_%d.zip", name, art.GetID()))
-	if err := download(ctx, zipURL, tmpZip, token); err != nil {
+	if err := download(ctx, client.Client(), zipURL, tmpZip, token); err != nil {
 		return TestResult{}, err
 	}
 	defer os.Remove(tmpZip)
@@ -659,16 +736,17 @@ func processRepo(parent context.Context, client *github.Client, repo, token, art
 }
 
 // -----------------------------------------------------------------------------
-// download fetches a URL with token auth.
+// download fetches a URL with token auth using the supplied http.Client so
+// requests inherit the rate-limit middleware wired in main().
 // -----------------------------------------------------------------------------
-func download(ctx context.Context, url, dest, token string) error {
+func download(ctx context.Context, httpClient *http.Client, url, dest, token string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Authorization", "token "+token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -914,7 +992,7 @@ func fetchRepoInfo(ctx context.Context, client *github.Client, repo string) (Rep
 	if reqErr == nil {
 		req.Header.Set("Accept", "application/vnd.github.html+json")
 		req.Header.Set("Authorization", "token "+os.Getenv("GITHUB_TOKEN"))
-		resp, doErr := http.DefaultClient.Do(req)
+		resp, doErr := client.Client().Do(req)
 		if doErr == nil {
 			defer resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {

--- a/artifact_fetcher.go
+++ b/artifact_fetcher.go
@@ -212,7 +212,7 @@ func loadPreviousIssuesPRs(path string, logger *slog.Logger) (IssuesPRsFile, err
 			"path", path,
 			"err", jerr.Error())
 		// Visible workflow annotation so degraded runs aren't silent.
-		fmt.Println("::warning title=issues_prs cache::malformed prior issues_prs.json — degraded fallback in effect (per-repo failures will omit, not use stale data)")
+		fmt.Println("::warning title=issues_prs cache::malformed or schema-mismatched prior issues_prs.json — degraded fallback in effect (per-repo failures will omit). This is expected on the first run after PR-C lands due to the velocity-shape change.")
 		return empty, nil
 	}
 
@@ -383,6 +383,29 @@ type VelocityWeek struct {
 	Merged *int   `json:"merged,omitempty"`
 }
 
+// VelocityDay carries day-bucketed counts. Used for sub-weekly views
+// (currently the 7d duration; D2 retains 365 days so future specs can
+// add historical-offset views without re-fetching).
+type VelocityDay struct {
+	Date   string `json:"date"` // RFC 3339 date in UTC, e.g. "2026-04-23"
+	Opened int    `json:"opened"`
+	Closed int    `json:"closed"`
+	Merged *int   `json:"merged,omitempty"`
+}
+
+// Velocity bundles the daily and weekly arrays for a single Issue or PR
+// stream. Daily covers the last 365 days (UTC-bucketed). Weekly covers the
+// last ~260 weeks at ISO-week granularity. Consumers select the array
+// matching the active duration:
+//   - 7d         → daily.slice(-7)
+//   - 4w / 12w   → weekly.slice(-4) / -12
+//   - 6m / 1y    → weekly.slice(-26) / -52
+//   - 5y         → weekly.slice(-260)
+type Velocity struct {
+	Daily  []VelocityDay  `json:"daily"`
+	Weekly []VelocityWeek `json:"weekly"`
+}
+
 type PRReviewMetrics struct {
 	AwaitingReview       int     `json:"awaitingReview"`
 	NoReviewer           int     `json:"noReviewer"`
@@ -394,14 +417,14 @@ type IssueStats struct {
 	Total      int            `json:"total"`
 	Categories map[string]int `json:"categories"`
 	AgeBuckets AgeBuckets     `json:"ageBuckets"`
-	Velocity   []VelocityWeek `json:"velocity"`
+	Velocity   Velocity       `json:"velocity"`
 }
 
 type PRStats struct {
 	Total      int             `json:"total"`
 	Categories map[string]int  `json:"categories"`
 	AgeBuckets AgeBuckets      `json:"ageBuckets"`
-	Velocity   []VelocityWeek  `json:"velocity"`
+	Velocity   Velocity        `json:"velocity"`
 	Review     PRReviewMetrics `json:"review"`
 }
 
@@ -525,6 +548,44 @@ func buildVelocitySlice(opened, closed, merged map[string]int, from, to time.Tim
 		result = append(result, vw)
 	}
 	return result
+}
+
+// bucketByDay emits a continuous range of VelocityDay entries for [from, to)
+// in UTC. Days with no events get zero counts. The opened/closed/merged
+// input maps are keyed by RFC 3339 date strings ("YYYY-MM-DD") in UTC; the
+// caller is responsible for populating the keys with UTC dates (e.g.,
+// `t.UTC().Format("2006-01-02")`).
+//
+// merged may be nil for streams that don't track merges (Issues); the
+// resulting VelocityDay.Merged field is left nil in that case.
+//
+// Spec: docs/plans/2026-04-30-dashboard-duration-options-design.md
+// (component bucketByDay; D2 — 1-year retention).
+func bucketByDay(opened, closed, merged map[string]int, from, to time.Time) []VelocityDay {
+	from = from.UTC().Truncate(24 * time.Hour)
+	to = to.UTC().Truncate(24 * time.Hour)
+	if !from.Before(to) {
+		return []VelocityDay{}
+	}
+	days := int(to.Sub(from) / (24 * time.Hour))
+	out := make([]VelocityDay, 0, days)
+	for i := 0; i < days; i++ {
+		d := from.AddDate(0, 0, i)
+		key := d.Format("2006-01-02")
+		entry := VelocityDay{
+			Date:   key,
+			Opened: opened[key],
+			Closed: closed[key],
+		}
+		if merged != nil {
+			if m, ok := merged[key]; ok {
+				v := m
+				entry.Merged = &v
+			}
+		}
+		out = append(out, entry)
+	}
+	return out
 }
 
 // -----------------------------------------------------------------------------
@@ -1157,7 +1218,8 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 	}
 	owner, name := parts[0], parts[1]
 	now := time.Now().UTC()
-	twelveWeeksAgo := now.AddDate(0, 0, -84)
+	fiveYearsAgo := now.AddDate(-5, 0, 0)
+	oneYearAgo := now.AddDate(-1, 0, 0)
 
 	// Fetch all open issues (GitHub issues endpoint includes PRs, filter them out)
 	var openIssues []*github.Issue
@@ -1203,7 +1265,7 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 	var closedItems []*github.Issue
 	closedOpt := &github.IssueListByRepoOptions{
 		State:       "closed",
-		Since:       twelveWeeksAgo,
+		Since:       fiveYearsAgo,
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
 	for {
@@ -1238,7 +1300,7 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 			if pr.GetMergedAt().IsZero() {
 				continue
 			}
-			if pr.GetMergedAt().Before(twelveWeeksAgo) {
+			if pr.GetMergedAt().Before(fiveYearsAgo) {
 				pastCutoff = true
 				continue // process remaining PRs on this page
 			}
@@ -1276,27 +1338,38 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 		}
 	}
 
-	// Issue velocity: opened + closed per week
+	// Issue velocity: opened + closed per week (5y window) and per day (1y window)
 	issueOpenedByWeek := make(map[string]int)
 	issueClosedByWeek := make(map[string]int)
+	issueOpenedByDay := make(map[string]int)
+	issueClosedByDay := make(map[string]int)
 
 	for _, iss := range openIssues {
-		if iss.GetCreatedAt().Time.After(twelveWeeksAgo) {
-			w := isoWeek(iss.GetCreatedAt().Time)
-			issueOpenedByWeek[w]++
+		if iss.GetCreatedAt().Time.After(fiveYearsAgo) {
+			t := iss.GetCreatedAt().Time
+			issueOpenedByWeek[isoWeek(t)]++
+			if t.After(oneYearAgo) {
+				issueOpenedByDay[t.UTC().Format("2006-01-02")]++
+			}
 		}
 	}
 	for _, iss := range closedItems {
 		if iss.PullRequestLinks != nil {
 			continue
 		}
-		if iss.GetCreatedAt().Time.After(twelveWeeksAgo) {
-			w := isoWeek(iss.GetCreatedAt().Time)
-			issueOpenedByWeek[w]++
+		if iss.GetCreatedAt().Time.After(fiveYearsAgo) {
+			t := iss.GetCreatedAt().Time
+			issueOpenedByWeek[isoWeek(t)]++
+			if t.After(oneYearAgo) {
+				issueOpenedByDay[t.UTC().Format("2006-01-02")]++
+			}
 		}
-		if iss.ClosedAt != nil && iss.GetClosedAt().Time.After(twelveWeeksAgo) {
-			w := isoWeek(iss.GetClosedAt().Time)
-			issueClosedByWeek[w]++
+		if iss.ClosedAt != nil && iss.GetClosedAt().Time.After(fiveYearsAgo) {
+			t := iss.GetClosedAt().Time
+			issueClosedByWeek[isoWeek(t)]++
+			if t.After(oneYearAgo) {
+				issueClosedByDay[t.UTC().Format("2006-01-02")]++
+			}
 		}
 	}
 
@@ -1337,33 +1410,48 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 		}
 	}
 
-	// PR velocity
+	// PR velocity (5y weekly + 1y daily)
 	prOpenedByWeek := make(map[string]int)
 	prClosedByWeek := make(map[string]int)
 	prMergedByWeek := make(map[string]int)
+	prOpenedByDay := make(map[string]int)
+	prClosedByDay := make(map[string]int)
+	prMergedByDay := make(map[string]int)
 
 	for _, pr := range openPRs {
-		if pr.GetCreatedAt().Time.After(twelveWeeksAgo) {
-			w := isoWeek(pr.GetCreatedAt().Time)
-			prOpenedByWeek[w]++
+		if pr.GetCreatedAt().Time.After(fiveYearsAgo) {
+			t := pr.GetCreatedAt().Time
+			prOpenedByWeek[isoWeek(t)]++
+			if t.After(oneYearAgo) {
+				prOpenedByDay[t.UTC().Format("2006-01-02")]++
+			}
 		}
 	}
 	for _, iss := range closedItems {
 		if iss.PullRequestLinks == nil {
 			continue
 		}
-		if iss.GetCreatedAt().Time.After(twelveWeeksAgo) {
-			w := isoWeek(iss.GetCreatedAt().Time)
-			prOpenedByWeek[w]++
+		if iss.GetCreatedAt().Time.After(fiveYearsAgo) {
+			t := iss.GetCreatedAt().Time
+			prOpenedByWeek[isoWeek(t)]++
+			if t.After(oneYearAgo) {
+				prOpenedByDay[t.UTC().Format("2006-01-02")]++
+			}
 		}
-		if iss.ClosedAt != nil && iss.GetClosedAt().Time.After(twelveWeeksAgo) {
-			w := isoWeek(iss.GetClosedAt().Time)
-			prClosedByWeek[w]++
+		if iss.ClosedAt != nil && iss.GetClosedAt().Time.After(fiveYearsAgo) {
+			t := iss.GetClosedAt().Time
+			prClosedByWeek[isoWeek(t)]++
+			if t.After(oneYearAgo) {
+				prClosedByDay[t.UTC().Format("2006-01-02")]++
+			}
 		}
 	}
 	for _, pr := range mergedPRs {
-		w := isoWeek(pr.GetMergedAt().Time)
-		prMergedByWeek[w]++
+		t := pr.GetMergedAt().Time
+		prMergedByWeek[isoWeek(t)]++
+		if t.After(oneYearAgo) {
+			prMergedByDay[t.UTC().Format("2006-01-02")]++
+		}
 	}
 
 	// Avg days to merge
@@ -1404,8 +1492,10 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 		avgDaysToFirstReview = totalFirstReviewDays / float64(reviewedCount)
 	}
 
-	issueVelocity := buildVelocitySlice(issueOpenedByWeek, issueClosedByWeek, nil, twelveWeeksAgo, now)
-	prVelocity := buildVelocitySlice(prOpenedByWeek, prClosedByWeek, prMergedByWeek, twelveWeeksAgo, now)
+	issueVelocityWeekly := buildVelocitySlice(issueOpenedByWeek, issueClosedByWeek, nil, fiveYearsAgo, now)
+	prVelocityWeekly := buildVelocitySlice(prOpenedByWeek, prClosedByWeek, prMergedByWeek, fiveYearsAgo, now)
+	issueVelocityDaily := bucketByDay(issueOpenedByDay, issueClosedByDay, nil, oneYearAgo, now)
+	prVelocityDaily := bucketByDay(prOpenedByDay, prClosedByDay, prMergedByDay, oneYearAgo, now)
 
 	return RepoIssuesPRs{
 		FetchedAt: now.Format(time.RFC3339),
@@ -1413,13 +1503,19 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 			Total:      len(openIssues),
 			Categories: issueCats,
 			AgeBuckets: issueAgeBuckets,
-			Velocity:   issueVelocity,
+			Velocity: Velocity{
+				Daily:  issueVelocityDaily,
+				Weekly: issueVelocityWeekly,
+			},
 		},
 		PullRequests: PRStats{
 			Total:      len(openPRs),
 			Categories: prCats,
 			AgeBuckets: prAgeBuckets,
-			Velocity:   prVelocity,
+			Velocity: Velocity{
+				Daily:  prVelocityDaily,
+				Weekly: prVelocityWeekly,
+			},
 			Review: PRReviewMetrics{
 				AwaitingReview:       awaitingReview,
 				NoReviewer:           noReviewer,

--- a/artifact_fetcher.go
+++ b/artifact_fetcher.go
@@ -701,7 +701,14 @@ func main() {
 	}
 
 	// Issues/PRs phase — extracted helper handles per-repo cache fallback.
-	prevCache, _ := loadPreviousIssuesPRs(filepath.Join(*outDir, "issues_prs.json"), logger)
+	prevCache, cacheErr := loadPreviousIssuesPRs(filepath.Join(*outDir, "issues_prs.json"), logger)
+	if cacheErr != nil {
+		// I/O failure (permission denied, EISDIR, etc.) — degraded run with
+		// empty cache. The function still returns a usable empty value, so
+		// continue, but surface the error so a silently-blank deploy is
+		// visible in logs.
+		errCh <- fmt.Errorf("issues_prs cache: %w", cacheErr)
+	}
 	issuesPRsFile := runIssuesPRsPhase(ctx, client, allRepos, *timeout, *workers, prevCache, logger)
 
 	wg.Wait()

--- a/artifact_fetcher.go
+++ b/artifact_fetcher.go
@@ -81,20 +81,24 @@ var defaultRepos = []string{
 	"nvidia/holodeck",
 }
 
-// imageRepo pairs a GitHub repository path with its GitHub Packages container
-// name. The repo field is the full owner/repo used for constructing HTML URLs,
-// while pkgName is the container package name used by the Packages API.
+// imageRepo pairs a GitHub repository path with its container-registry
+// coordinates. The repo field is the full owner/repo for source/release link
+// construction. pkgName is the image path within its registry. imageRegistry
+// discriminates the fetch path: "" or "ghcr.io" = GitHub Packages (default);
+// "registry.k8s.io" = OCI registry served by the kubernetes-sigs project
+// release pipeline. Per docs/plans/2026-05-11-dra-registry-k8s-io-design.md.
 type imageRepo struct {
-	repo    string // GitHub repo path, e.g. "nvidia/nvidia-container-toolkit"
-	pkgName string // GitHub Packages name, e.g. "container-toolkit"
+	repo          string // GitHub repo path, e.g. "nvidia/nvidia-container-toolkit"
+	pkgName       string // image path within the registry, e.g. "container-toolkit"
+	imageRegistry string // "" / "ghcr.io" = GHCR (default); "registry.k8s.io" for OCI
 }
 
 var defaultImages = []imageRepo{
-	{"nvidia/k8s-device-plugin", "k8s-device-plugin"},
-	{"kubernetes-sigs/dra-driver-nvidia-gpu", "dra-driver-nvidia-gpu"}, // donated 2026-04-30; pkgName best-effort (kubernetes-sigs GHCR not yet listable without read:packages)
-	{"nvidia/nvidia-container-toolkit", "container-toolkit"},
-	{"nvidia/gpu-operator", "gpu-operator"},
-	{"nvidia/gpu-driver-container", "driver"},
+	{"nvidia/k8s-device-plugin", "k8s-device-plugin", ""},
+	{"kubernetes-sigs/dra-driver-nvidia-gpu", "dra-driver-nvidia/dra-driver-nvidia-gpu", "registry.k8s.io"}, // images live at registry.k8s.io after Prow promotion; see docs/plans/2026-05-11-dra-registry-k8s-io-design.md
+	{"nvidia/nvidia-container-toolkit", "container-toolkit", ""},
+	{"nvidia/gpu-operator", "gpu-operator", ""},
+	{"nvidia/gpu-driver-container", "driver", ""},
 }
 
 var allRepos = []string{
@@ -1613,7 +1617,21 @@ func buildCommitURL(repo, tag string) string {
 	return ""
 }
 
+// fetchLatestImageTag dispatches to the right registry-specific fetcher based
+// on ir.imageRegistry. The empty string defaults to GHCR (the historical
+// behavior). Per docs/plans/2026-05-11-dra-registry-k8s-io-design.md.
 func fetchLatestImageTag(ctx context.Context, client *github.Client, ir imageRepo) (ImageInfo, error) {
+	switch ir.imageRegistry {
+	case "", "ghcr.io":
+		return fetchLatestGHCRTag(ctx, client, ir)
+	case "registry.k8s.io":
+		return fetchLatestRegistryK8sTag(ctx, client, ir)
+	default:
+		return ImageInfo{}, fmt.Errorf("unknown imageRegistry %q for %s", ir.imageRegistry, ir.repo)
+	}
+}
+
+func fetchLatestGHCRTag(ctx context.Context, client *github.Client, ir imageRepo) (ImageInfo, error) {
 	parts := strings.Split(ir.repo, "/")
 	if len(parts) != 2 {
 		return ImageInfo{}, fmt.Errorf("invalid repo: %s", ir.repo)
@@ -1645,6 +1663,48 @@ func fetchLatestImageTag(ctx context.Context, client *github.Client, ir imageRep
 		Tag:       tag,
 		Pushed:    latest.GetCreatedAt().Format(time.RFC3339),
 		HTMLURL:   htmlURL,
+		ImageType: classifyImageTag(tag),
+		CommitURL: buildCommitURL(ir.repo, tag),
+	}, nil
+}
+
+// fetchLatestRegistryK8sTag handles imageRepo entries whose images live at
+// registry.k8s.io (or other OCI registries with no Packages API). Instead of
+// listing OCI tags — which would not give us push timestamps — we list the
+// source repo's GitHub releases and treat the newest release as authoritative
+// for the latest image tag and push date. This matches the release process:
+// the GitHub release publish triggers the Prow image-push job.
+//
+// Spec: docs/plans/2026-05-11-dra-registry-k8s-io-design.md.
+func fetchLatestRegistryK8sTag(ctx context.Context, client *github.Client, ir imageRepo) (ImageInfo, error) {
+	parts := strings.Split(ir.repo, "/")
+	if len(parts) != 2 {
+		return ImageInfo{}, fmt.Errorf("invalid repo: %s", ir.repo)
+	}
+	owner, name := parts[0], parts[1]
+
+	rels, _, err := client.Repositories.ListReleases(ctx, owner, name, &github.ListOptions{PerPage: 5})
+	if err != nil {
+		return ImageInfo{}, fmt.Errorf("list releases %s: %w", ir.repo, err)
+	}
+	if len(rels) == 0 {
+		return ImageInfo{}, fmt.Errorf("no releases found for %s", ir.repo)
+	}
+
+	// GitHub returns releases newest-first.
+	latest := rels[0]
+	tag := latest.GetTagName()
+
+	// No GHCR page exists for registry.k8s.io-hosted images; both the Tag-cell
+	// link (HTMLURL) and the Source-cell link (CommitURL) point at the GitHub
+	// release page. buildCommitURL already returns this for SemVer tags.
+	releaseURL := fmt.Sprintf("https://github.com/%s/releases/tag/%s", ir.repo, tag)
+
+	return ImageInfo{
+		Repo:      ir.repo,
+		Tag:       tag,
+		Pushed:    latest.GetPublishedAt().Format(time.RFC3339),
+		HTMLURL:   releaseURL,
 		ImageType: classifyImageTag(tag),
 		CommitURL: buildCommitURL(ir.repo, tag),
 	}, nil

--- a/artifact_fetcher.go
+++ b/artifact_fetcher.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"archive/zip"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -85,7 +86,7 @@ var (
 var defaultRepos = []string{
 	"nvidia/nvidia-container-toolkit",
 	"nvidia/k8s-device-plugin",
-	"nvidia/k8s-dra-driver-gpu",
+	"kubernetes-sigs/dra-driver-nvidia-gpu", // was: nvidia/k8s-dra-driver-gpu (donated to kubernetes-sigs 2026-04-30; see docs/plans/2026-04-30-dra-repo-migration-design.md)
 	"nvidia/holodeck",
 }
 
@@ -99,7 +100,7 @@ type imageRepo struct {
 
 var defaultImages = []imageRepo{
 	{"nvidia/k8s-device-plugin", "k8s-device-plugin"},
-	{"nvidia/k8s-dra-driver-gpu", "k8s-dra-driver-gpu"},
+	{"kubernetes-sigs/dra-driver-nvidia-gpu", "dra-driver-nvidia-gpu"}, // donated 2026-04-30; pkgName best-effort (kubernetes-sigs GHCR not yet listable without read:packages)
 	{"nvidia/nvidia-container-toolkit", "container-toolkit"},
 	{"nvidia/gpu-operator", "gpu-operator"},
 	{"nvidia/gpu-driver-container", "driver"},
@@ -109,7 +110,7 @@ var allRepos = []string{
 	"nvidia/gpu-operator",
 	"nvidia/nvidia-container-toolkit",
 	"nvidia/k8s-device-plugin",
-	"nvidia/k8s-dra-driver-gpu",
+	"kubernetes-sigs/dra-driver-nvidia-gpu", // donated 2026-04-30
 	"nvidia/holodeck",
 	"nvidia/go-nvml",
 	"nvidia/mig-parted",
@@ -166,6 +167,122 @@ func buildClient(ctx context.Context, token string, logger *slog.Logger) (*githu
 	client := github.NewClient(rateLimited)
 	ctx = context.WithValue(ctx, githubBypass, true)
 	return client, ctx
+}
+
+// loadPreviousIssuesPRs reads the previously deployed issues_prs.json file
+// (restored by the workflow's "Restore previous history data" step) and
+// returns it as an in-memory cache used by runIssuesPRsPhase to fall back
+// when a per-repo fetch fails this run.
+//
+// Behavior:
+//   - Missing or zero-byte file → empty IssuesPRsFile, nil error, info log.
+//   - Valid JSON → parsed file, nil error.
+//   - Malformed JSON → empty IssuesPRsFile, nil error, error-level log,
+//     and a ::warning:: GitHub Actions annotation on stdout so degradation
+//     is visible in the workflow run summary.
+//
+// This function never returns a log.Fatal path. The returned error is
+// reserved for unexpected I/O failures (permission denied, etc.); callers
+// may treat any non-nil error as exceptional but the typical degraded
+// flows return nil error with an empty cache.
+//
+// Spec: docs/plans/2026-04-30-dashboard-duration-options-design.md
+// (component loadPreviousIssuesPRs, malformed-cache path).
+func loadPreviousIssuesPRs(path string, logger *slog.Logger) (IssuesPRsFile, error) {
+	empty := IssuesPRsFile{Repos: make(map[string]RepoIssuesPRs)}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Info("no prior cache", "path", path)
+			return empty, nil
+		}
+		// Other I/O errors are unexpected; surface them.
+		return empty, fmt.Errorf("loadPreviousIssuesPRs read %s: %w", path, err)
+	}
+
+	if len(bytes.TrimSpace(data)) == 0 {
+		logger.Info("no prior cache (empty file)", "path", path)
+		return empty, nil
+	}
+
+	var parsed IssuesPRsFile
+	if jerr := json.Unmarshal(data, &parsed); jerr != nil {
+		logger.Error("malformed prior cache",
+			"path", path,
+			"err", jerr.Error())
+		// Visible workflow annotation so degraded runs aren't silent.
+		fmt.Println("::warning title=issues_prs cache::malformed prior issues_prs.json — degraded fallback in effect (per-repo failures will omit, not use stale data)")
+		return empty, nil
+	}
+
+	if parsed.Repos == nil {
+		parsed.Repos = make(map[string]RepoIssuesPRs)
+	}
+	logger.Info("prior cache loaded", "path", path, "repos", len(parsed.Repos))
+	return parsed, nil
+}
+
+// runIssuesPRsPhase fetches issues/PRs for each repo concurrently and
+// returns a populated IssuesPRsFile. On any per-repo error, it consults
+// the cache: present → copy entry verbatim (preserving old fetchedAt);
+// absent → omit the repo from output. Phase-level errors (context
+// cancellation, panic) are returned to the caller; per-repo errors are
+// recorded in slog and never abort the run.
+//
+// Spec: docs/plans/2026-04-30-dashboard-duration-options-design.md
+// (component runIssuesPRsPhase).
+func runIssuesPRsPhase(
+	ctx context.Context,
+	client *github.Client,
+	repos []string,
+	timeout time.Duration,
+	workers int,
+	cache IssuesPRsFile,
+	logger *slog.Logger,
+) IssuesPRsFile {
+	out := IssuesPRsFile{Repos: make(map[string]RepoIssuesPRs)}
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, workers)
+
+	for _, repo := range repos {
+		repo = strings.TrimSpace(repo)
+		if repo == "" {
+			continue
+		}
+		wg.Add(1)
+		go func(r string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			ipCtx, cancel := context.WithTimeout(ctx, 2*timeout)
+			defer cancel()
+
+			data, err := fetchIssuesPRs(ipCtx, client, r)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				if cached, ok := cache.Repos[r]; ok {
+					logger.Warn("issues_prs: using cached data",
+						"repo", r,
+						"err", err.Error(),
+						"prev_fetched_at", cached.FetchedAt)
+					out.Repos[r] = cached
+					return
+				}
+				logger.Warn("issues_prs: no data and no prior cache",
+					"repo", r,
+					"err", err.Error())
+				return
+			}
+			out.Repos[r] = data
+		}(repo)
+	}
+
+	wg.Wait()
+	return out
 }
 
 type RepoInfo struct {
@@ -296,11 +413,6 @@ type RepoIssuesPRs struct {
 
 type IssuesPRsFile struct {
 	Repos map[string]RepoIssuesPRs `json:"repos"`
-}
-
-type issuesPRsResult struct {
-	repo string
-	data RepoIssuesPRs
 }
 
 var labelCategories = map[string]map[string]string{
@@ -542,25 +654,9 @@ func main() {
 		}(repo)
 	}
 
-	issuesPRsCh := make(chan issuesPRsResult, len(allRepos))
-	for _, repo := range allRepos {
-		wg.Add(1)
-		go func(r string) {
-			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-
-			ipCtx, cancel := context.WithTimeout(ctx, 2*(*timeout))
-			defer cancel()
-
-			data, err := fetchIssuesPRs(ipCtx, client, r)
-			if err != nil {
-				errCh <- fmt.Errorf("issues/prs %s: %w", r, err)
-				return
-			}
-			issuesPRsCh <- issuesPRsResult{repo: r, data: data}
-		}(repo)
-	}
+	// Issues/PRs phase — extracted helper handles per-repo cache fallback.
+	prevCache, _ := loadPreviousIssuesPRs(filepath.Join(*outDir, "issues_prs.json"), logger)
+	issuesPRsFile := runIssuesPRsPhase(ctx, client, allRepos, *timeout, *workers, prevCache, logger)
 
 	wg.Wait()
 	close(resCh)
@@ -569,7 +665,6 @@ func main() {
 	close(wfCh)
 	close(repoCh)
 	close(trafficCh)
-	close(issuesPRsCh)
 
 	for err := range errCh {
 		log.Println("error:", err)
@@ -609,12 +704,6 @@ func main() {
 
 	if err := writeJSON(filepath.Join(*outDir, "repos.json"), map[string]any{"repos": repoInfos}); err != nil {
 		log.Fatal(err)
-	}
-
-	// --- Build issues_prs.json ---
-	issuesPRsFile := IssuesPRsFile{Repos: make(map[string]RepoIssuesPRs)}
-	for ipr := range issuesPRsCh {
-		issuesPRsFile.Repos[ipr.repo] = ipr.data
 	}
 
 	if err := writeJSON(filepath.Join(*outDir, "issues_prs.json"), issuesPRsFile); err != nil {

--- a/artifact_fetcher_bucket_test.go
+++ b/artifact_fetcher_bucket_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestBucketByDay_Correctness covers the core daily-bucketing contract:
+//   - Output length is exactly to.Sub(from)/24h (continuous, no gaps).
+//   - Each entry has the correct UTC date string.
+//   - opened/closed/merged counts are taken from the input maps,
+//     keyed by the UTC YYYY-MM-DD date.
+//   - Days with no events have zero counts (continuous-zeros invariant).
+//
+// Mutation check: an off-by-one on `from` or `to` flips the boundary
+// count (test fixture spans known boundary dates). Using TZ-local dates
+// instead of UTC.Format would produce different keys for events near
+// 23:59:59 UTC; subtests cover this explicitly.
+func TestBucketByDay_Correctness(t *testing.T) {
+	t.Parallel()
+
+	// Fixture: 5-day window 2026-04-20 .. 2026-04-25 (inclusive of from,
+	// exclusive of to). Expected length: 5.
+	from := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC)
+
+	opened := map[string]int{
+		"2026-04-20": 3,
+		"2026-04-22": 1,
+		// 2026-04-21, 2026-04-23, 2026-04-24 deliberately absent → expect 0.
+	}
+	closed := map[string]int{
+		"2026-04-22": 2,
+		"2026-04-24": 1,
+	}
+	merged := map[string]int{}
+
+	got := bucketByDay(opened, closed, merged, from, to)
+
+	want := []VelocityDay{
+		{Date: "2026-04-20", Opened: 3, Closed: 0},
+		{Date: "2026-04-21", Opened: 0, Closed: 0},
+		{Date: "2026-04-22", Opened: 1, Closed: 2},
+		{Date: "2026-04-23", Opened: 0, Closed: 0},
+		{Date: "2026-04-24", Opened: 0, Closed: 1},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("len = %d; want %d (got: %v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Date != want[i].Date {
+			t.Errorf("day[%d] Date = %q; want %q", i, got[i].Date, want[i].Date)
+		}
+		if got[i].Opened != want[i].Opened {
+			t.Errorf("day[%d] Opened = %d; want %d", i, got[i].Opened, want[i].Opened)
+		}
+		if got[i].Closed != want[i].Closed {
+			t.Errorf("day[%d] Closed = %d; want %d", i, got[i].Closed, want[i].Closed)
+		}
+		if got[i].Merged != nil {
+			t.Errorf("day[%d] Merged = %v; want nil (Issue stream)", i, got[i].Merged)
+		}
+	}
+}
+
+// TestBucketByDay_UTCAlignment asserts events keyed by UTC date are
+// placed in the right bucket regardless of an input timestamp's clock
+// hour. The bucket for 2026-04-23 23:59:59 UTC must be "2026-04-23",
+// not "2026-04-24" (which TZ-local rendering with PST would produce).
+//
+// Because bucketByDay accepts pre-keyed maps (string → int), the
+// caller is responsible for using UTC dates in the keys; this test
+// verifies the helper's BEHAVIOR by feeding both a "correct" and an
+// "incorrect" key and asserting the helper trusts the input verbatim.
+// Together with the call-site tests in fetchIssuesPRs (Task 7), this
+// closes the UTC contract end-to-end.
+func TestBucketByDay_UTCAlignment(t *testing.T) {
+	t.Parallel()
+
+	from := time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+
+	opened := map[string]int{"2026-04-23": 7}
+	got := bucketByDay(opened, nil, nil, from, to)
+
+	if len(got) != 1 {
+		t.Fatalf("len = %d; want 1", len(got))
+	}
+	if got[0].Date != "2026-04-23" {
+		t.Fatalf("Date = %q; want %q", got[0].Date, "2026-04-23")
+	}
+	if got[0].Opened != 7 {
+		t.Fatalf("Opened = %d; want 7", got[0].Opened)
+	}
+}
+
+// TestBucketByDay_EmptyInput asserts the helper returns the right
+// continuous-zeros range when none of the input maps have entries.
+// This is the path most production days will take for low-traffic repos.
+//
+// Mutation check: returning an empty slice on empty input fails the
+// length assertion (the spec says "continuous range with zeros"; an
+// empty slice would let the UI's "no velocity data" placeholder fire
+// for repos that genuinely have zero events, which is wrong).
+func TestBucketByDay_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	from := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC)
+
+	got := bucketByDay(map[string]int{}, map[string]int{}, map[string]int{}, from, to)
+
+	if len(got) != 3 {
+		t.Fatalf("len = %d; want 3 (3-day continuous range with zeros)", len(got))
+	}
+	for i, d := range got {
+		if d.Opened != 0 || d.Closed != 0 || d.Merged != nil {
+			t.Errorf("day[%d] = %+v; want all-zero", i, d)
+		}
+	}
+}
+
+// TestBucketByDay_OneYearRetention asserts the helper returns 365 (or
+// 366 for leap years) entries when invoked over a 1-year window. PR-C's
+// fetchIssuesPRs caller passes a 1-year span; this test pins the length
+// invariant so a future bug shrinking the window is caught.
+//
+// Mutation check: a regression that hard-codes "30 days" returns 30
+// entries; assertion fails.
+func TestBucketByDay_OneYearRetention(t *testing.T) {
+	t.Parallel()
+
+	to := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
+	from := to.AddDate(-1, 0, 0)
+
+	got := bucketByDay(nil, nil, nil, from, to)
+
+	wantDays := int(to.Sub(from) / (24 * time.Hour))
+	if len(got) != wantDays {
+		t.Fatalf("len = %d; want %d (one full year)", len(got), wantDays)
+	}
+	if got[0].Date != "2025-04-30" {
+		t.Fatalf("first entry Date = %q; want %q", got[0].Date, "2025-04-30")
+	}
+	if got[len(got)-1].Date != "2026-04-29" {
+		t.Fatalf("last entry Date = %q; want %q", got[len(got)-1].Date, "2026-04-29")
+	}
+}
+
+// TestBucketByDay_FromAfterTo returns an empty slice (defensive — the
+// caller shouldn't ever do this, but a misconfigured `from > to` should
+// not panic or return random entries).
+func TestBucketByDay_FromAfterTo(t *testing.T) {
+	t.Parallel()
+
+	from := time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+
+	got := bucketByDay(nil, nil, nil, from, to)
+	if len(got) != 0 {
+		t.Fatalf("len = %d; want 0", len(got))
+	}
+}

--- a/artifact_fetcher_cache_test.go
+++ b/artifact_fetcher_cache_test.go
@@ -1,0 +1,367 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// captureLogger returns a slog.Logger that writes to the provided buffer
+// using the text handler. Tests inspect the buffer to verify the right
+// log level / message / fields are emitted.
+func captureLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+// captureStdout temporarily redirects os.Stdout for the duration of fn and
+// returns whatever was written. Used to assert ::warning:: workflow
+// annotations, which we emit via fmt.Println so they appear on stdout where
+// GitHub Actions parses them.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+	_ = w.Close()
+	return <-done
+}
+
+// TestLoadPreviousIssuesPRs_MissingFile asserts that a non-existent path
+// returns an empty IssuesPRsFile, no error, and an info-level "no prior
+// cache" log entry.
+//
+// Mutation check: returning an error instead of the empty map causes the
+// nil-error assertion to fail.
+func TestLoadPreviousIssuesPRs_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	missing := filepath.Join(tmp, "does-not-exist.json")
+
+	var buf bytes.Buffer
+	logger := captureLogger(&buf)
+
+	got, err := loadPreviousIssuesPRs(missing, logger)
+	if err != nil {
+		t.Fatalf("err = %v; want nil", err)
+	}
+	if got.Repos == nil {
+		t.Fatalf("Repos = nil; want empty map")
+	}
+	if len(got.Repos) != 0 {
+		t.Fatalf("len(Repos) = %d; want 0", len(got.Repos))
+	}
+	if !strings.Contains(buf.String(), "no prior cache") {
+		t.Fatalf("expected 'no prior cache' in log; got:\n%s", buf.String())
+	}
+}
+
+// TestLoadPreviousIssuesPRs_ValidFile asserts a known-good JSON file
+// round-trips into the parsed shape with the expected repo keys and
+// fetchedAt values.
+//
+// Mutation check: dropping the json.Unmarshal call leaves Repos empty;
+// the key assertion fails.
+func TestLoadPreviousIssuesPRs_ValidFile(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "issues_prs.json")
+
+	const fixture = `{
+  "repos": {
+    "nvidia/gpu-operator": {
+      "fetchedAt": "2026-04-29T12:00:00Z",
+      "issues": {"total": 42, "categories": {"bug": 12}, "ageBuckets": {"fresh":5,"recent":10,"aging":12,"stale":8,"ancient":7}, "velocity": []},
+      "pullRequests": {"total": 8, "categories": {}, "ageBuckets": {"fresh":3,"recent":2,"aging":2,"stale":1,"ancient":0}, "velocity": [], "review": {"awaitingReview":3,"noReviewer":1,"avgDaysToFirstReview":1.5,"avgDaysToMerge":3.2}}
+    }
+  }
+}`
+	if err := os.WriteFile(path, []byte(fixture), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	var buf bytes.Buffer
+	logger := captureLogger(&buf)
+
+	got, err := loadPreviousIssuesPRs(path, logger)
+	if err != nil {
+		t.Fatalf("err = %v; want nil", err)
+	}
+	entry, ok := got.Repos["nvidia/gpu-operator"]
+	if !ok {
+		t.Fatalf("Repos missing key 'nvidia/gpu-operator'; have keys: %v", keysOf(got.Repos))
+	}
+	if entry.FetchedAt != "2026-04-29T12:00:00Z" {
+		t.Fatalf("FetchedAt = %q; want %q", entry.FetchedAt, "2026-04-29T12:00:00Z")
+	}
+	if entry.Issues.Total != 42 {
+		t.Fatalf("issues.Total = %d; want 42", entry.Issues.Total)
+	}
+	if strings.Contains(buf.String(), "malformed") {
+		t.Fatalf("unexpected 'malformed' in log:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "prior cache loaded") {
+		t.Fatalf("expected 'prior cache loaded' in log:\n%s", buf.String())
+	}
+}
+
+// keysOf is a small test helper for clearer assertion messages.
+func keysOf(m map[string]RepoIssuesPRs) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestLoadPreviousIssuesPRs_MalformedJSON asserts that:
+//   - Function returns empty IssuesPRsFile with nil error.
+//   - slog records an error-level entry mentioning "malformed".
+//   - stdout contains a ::warning title=issues_prs cache:: annotation
+//     (the GitHub Actions surface that makes degraded runs visible in
+//     the workflow summary UI).
+//
+// Mutation check: removing the fmt.Println line drops the annotation;
+// the stdout assertion fails. Replacing the warn-and-return with
+// log.Fatal causes os.Exit which the test harness traps via subprocess.
+func TestLoadPreviousIssuesPRs_MalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "issues_prs.json")
+	if err := os.WriteFile(path, []byte("{garbage not json"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	var buf bytes.Buffer
+	logger := captureLogger(&buf)
+
+	var got IssuesPRsFile
+	var err error
+	stdout := captureStdout(t, func() {
+		got, err = loadPreviousIssuesPRs(path, logger)
+	})
+
+	if err != nil {
+		t.Fatalf("err = %v; want nil (malformed should NOT propagate as error)", err)
+	}
+	if len(got.Repos) != 0 {
+		t.Fatalf("len(Repos) = %d; want 0 on malformed", len(got.Repos))
+	}
+	if !strings.Contains(buf.String(), "malformed") {
+		t.Fatalf("slog missing 'malformed':\n%s", buf.String())
+	}
+	if !strings.Contains(stdout, "::warning") || !strings.Contains(stdout, "issues_prs cache") {
+		t.Fatalf("stdout missing GitHub Actions ::warning::; got:\n%s", stdout)
+	}
+}
+
+// TestLoadPreviousIssuesPRs_NonFatalRegression asserts the function does
+// not call log.Fatal on malformed JSON. We use the standard Go subprocess
+// pattern: re-exec the test binary with an env flag that runs only the
+// malformed-JSON code path and inspect the exit code.
+//
+// Mutation check: replace the warn-and-return-empty branch with
+// log.Fatalf("malformed: %v", jerr) — the subprocess exits non-zero,
+// the assertion fires.
+func TestLoadPreviousIssuesPRs_NonFatalRegression(t *testing.T) {
+	t.Parallel()
+
+	if os.Getenv("LOAD_PREVIOUS_FATAL_PROBE") == "1" {
+		// Subprocess mode: run the malformed-JSON path and exit 0 on success.
+		path := filepath.Join(t.TempDir(), "issues_prs.json")
+		_ = os.WriteFile(path, []byte("{garbage"), 0o644)
+		_, _ = loadPreviousIssuesPRs(path, slog.New(slog.NewTextHandler(io.Discard, nil)))
+		os.Exit(0)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	cmd := exec.Command(exe, "-test.run=TestLoadPreviousIssuesPRs_NonFatalRegression$", "-test.v")
+	cmd.Env = append(os.Environ(), "LOAD_PREVIOUS_FATAL_PROBE=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("subprocess exited non-zero: %v\noutput:\n%s", err, out)
+	}
+}
+
+// TestRunIssuesPRsPhase_CacheFallback covers the heart of PR-B: when one
+// repo's fetch fails and another succeeds, the failing repo is restored
+// from cache (with prev fetchedAt preserved) and the successful repo
+// gets fresh data (with current fetchedAt, NOT the cached one).
+//
+// Both assertions are required (QA "paired assertion" item from rev1):
+//   - drop fallback branch → repo A omitted → fails
+//   - always use cache → repo B has stale fetchedAt → fails
+//
+// We use a single httptest.Server that switches behavior based on the
+// path's repo segment: 500 server error for repo A, 200 with empty
+// issues for repo B. The cache-fallback branch in runIssuesPRsPhase
+// triggers on ANY error from fetchIssuesPRs, not specifically rate-limit
+// errors. Using 500 (vs the rate-limit 403 that the original plan
+// proposed) avoids poisoning the gofri middleware's per-category state,
+// which would otherwise short-circuit repo-b's concurrent request and
+// flake the test under -race (~67% failure rate). See plan deviation
+// note.
+func TestRunIssuesPRsPhase_CacheFallback(t *testing.T) {
+	t.Parallel()
+
+	const cachedFetchedAt = "2026-04-15T08:00:00Z"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Path looks like /repos/owner/name/issues
+		switch {
+		case strings.Contains(r.URL.Path, "/repos/test/repo-a/"):
+			// Server error — exercises the cache-fallback branch without
+			// poisoning the rate-limit middleware's per-category state.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"message":"internal server error"}`)
+		case strings.Contains(r.URL.Path, "/repos/test/repo-b/"):
+			// Success — empty issue/PR list.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[]`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"message":"not found"}`)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	client, ctx := buildClient(ctx, "fake-token", silentLogger())
+	parsed, err := client.BaseURL.Parse(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	client.BaseURL = parsed
+
+	cache := IssuesPRsFile{
+		Repos: map[string]RepoIssuesPRs{
+			"test/repo-a": {
+				FetchedAt: cachedFetchedAt,
+				Issues: IssueStats{
+					Total:      99,
+					Categories: map[string]int{"bug": 50},
+					AgeBuckets: AgeBuckets{Fresh: 10, Recent: 20, Aging: 30, Stale: 25, Ancient: 14},
+					Velocity:   []VelocityWeek{},
+				},
+				PullRequests: PRStats{
+					Total: 5, Categories: map[string]int{}, AgeBuckets: AgeBuckets{},
+					Velocity: []VelocityWeek{}, Review: PRReviewMetrics{},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	logger := captureLogger(&buf)
+
+	got := runIssuesPRsPhase(
+		ctx, client,
+		[]string{"test/repo-a", "test/repo-b"},
+		5*time.Second,
+		2,
+		cache,
+		logger,
+	)
+
+	// repo-a: should be present from cache, with cached fetchedAt.
+	a, ok := got.Repos["test/repo-a"]
+	if !ok {
+		t.Fatalf("expected repo-a from cache; got keys: %v\nlog:\n%s", keysOf(got.Repos), buf.String())
+	}
+	if a.FetchedAt != cachedFetchedAt {
+		t.Fatalf("repo-a fetchedAt = %q; want cached %q", a.FetchedAt, cachedFetchedAt)
+	}
+	if a.Issues.Total != 99 {
+		t.Fatalf("repo-a issues.total = %d; want cached 99", a.Issues.Total)
+	}
+
+	// repo-b: should be present with FRESH fetchedAt (NOT the cache value).
+	b, ok := got.Repos["test/repo-b"]
+	if !ok {
+		t.Fatalf("expected repo-b fresh; got keys: %v", keysOf(got.Repos))
+	}
+	if b.FetchedAt == cachedFetchedAt {
+		t.Fatalf("repo-b fetchedAt = %q; want a fresh timestamp (NOT the cached value — fallback wrongly used)", b.FetchedAt)
+	}
+	if b.FetchedAt == "" {
+		t.Fatalf("repo-b fetchedAt is empty; expected a fresh ISO8601 timestamp from this run")
+	}
+
+	// Log assertions to confirm the right messages fired.
+	if !strings.Contains(buf.String(), "using cached data") {
+		t.Fatalf("expected 'using cached data' log line; got:\n%s", buf.String())
+	}
+}
+
+// TestRunIssuesPRsPhase_NoCacheOmit covers the second branch of cache
+// fallback: when a repo fails AND has no cache entry, it's omitted from
+// the output entirely (and a 'no data and no prior cache' warning is
+// logged). The dashboard's existing data.repos[slug] filter naturally
+// hides repos without data. Same 500-vs-403 deviation as the sibling
+// test; kept consistent.
+func TestRunIssuesPRsPhase_NoCacheOmit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `{"message":"internal server error"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	client, ctx := buildClient(ctx, "fake-token", silentLogger())
+	parsed, _ := client.BaseURL.Parse(srv.URL + "/")
+	client.BaseURL = parsed
+
+	emptyCache := IssuesPRsFile{Repos: map[string]RepoIssuesPRs{}}
+
+	var buf bytes.Buffer
+	logger := captureLogger(&buf)
+
+	got := runIssuesPRsPhase(
+		ctx, client,
+		[]string{"test/no-cache-repo"},
+		5*time.Second,
+		2,
+		emptyCache,
+		logger,
+	)
+
+	if _, exists := got.Repos["test/no-cache-repo"]; exists {
+		t.Fatalf("expected repo to be omitted; got: %v", got.Repos)
+	}
+	if !strings.Contains(buf.String(), "no data and no prior cache") {
+		t.Fatalf("expected 'no data and no prior cache' log; got:\n%s", buf.String())
+	}
+}

--- a/artifact_fetcher_cache_test.go
+++ b/artifact_fetcher_cache_test.go
@@ -179,6 +179,41 @@ func TestLoadPreviousIssuesPRs_MalformedJSON(t *testing.T) {
 	}
 }
 
+// TestLoadPreviousIssuesPRs_IOErrorReturnsError pins the contract that the
+// function returns a non-nil error when os.ReadFile fails for reasons other
+// than ErrNotExist. main() relies on this to surface unexpected I/O issues
+// (permission denied, EISDIR, etc.) instead of silently degrading to an
+// empty cache for an entire deploy run.
+//
+// We trigger EISDIR by passing a directory path to ReadFile.
+//
+// Mutation check: returning nil error from the os.ReadFile branch (e.g.,
+// always falling through to the "no prior cache" path) would cause this
+// test to fail with err == nil.
+func TestLoadPreviousIssuesPRs_IOErrorReturnsError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	asFile := filepath.Join(dir, "issues_prs.json")
+	if err := os.Mkdir(asFile, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	var buf bytes.Buffer
+	logger := captureLogger(&buf)
+
+	got, err := loadPreviousIssuesPRs(asFile, logger)
+	if err == nil {
+		t.Fatalf("err = nil; want non-nil for directory-as-path I/O failure")
+	}
+	if !strings.Contains(err.Error(), "loadPreviousIssuesPRs read") {
+		t.Fatalf("err = %v; want it wrapped with 'loadPreviousIssuesPRs read' context", err)
+	}
+	if got.Repos == nil {
+		t.Fatalf("Repos = nil; want empty map alongside the error")
+	}
+}
+
 // TestLoadPreviousIssuesPRs_NonFatalRegression asserts the function does
 // not call log.Fatal on malformed JSON. We use the standard Go subprocess
 // pattern: re-exec the test binary with an env flag that runs only the

--- a/artifact_fetcher_cache_test.go
+++ b/artifact_fetcher_cache_test.go
@@ -94,8 +94,8 @@ func TestLoadPreviousIssuesPRs_ValidFile(t *testing.T) {
   "repos": {
     "nvidia/gpu-operator": {
       "fetchedAt": "2026-04-29T12:00:00Z",
-      "issues": {"total": 42, "categories": {"bug": 12}, "ageBuckets": {"fresh":5,"recent":10,"aging":12,"stale":8,"ancient":7}, "velocity": []},
-      "pullRequests": {"total": 8, "categories": {}, "ageBuckets": {"fresh":3,"recent":2,"aging":2,"stale":1,"ancient":0}, "velocity": [], "review": {"awaitingReview":3,"noReviewer":1,"avgDaysToFirstReview":1.5,"avgDaysToMerge":3.2}}
+      "issues": {"total": 42, "categories": {"bug": 12}, "ageBuckets": {"fresh":5,"recent":10,"aging":12,"stale":8,"ancient":7}, "velocity": {"daily": [], "weekly": []}},
+      "pullRequests": {"total": 8, "categories": {}, "ageBuckets": {"fresh":3,"recent":2,"aging":2,"stale":1,"ancient":0}, "velocity": {"daily": [], "weekly": []}, "review": {"awaitingReview":3,"noReviewer":1,"avgDaysToFirstReview":1.5,"avgDaysToMerge":3.2}}
     }
   }
 }`
@@ -270,11 +270,11 @@ func TestRunIssuesPRsPhase_CacheFallback(t *testing.T) {
 					Total:      99,
 					Categories: map[string]int{"bug": 50},
 					AgeBuckets: AgeBuckets{Fresh: 10, Recent: 20, Aging: 30, Stale: 25, Ancient: 14},
-					Velocity:   []VelocityWeek{},
+					Velocity:   Velocity{Daily: []VelocityDay{}, Weekly: []VelocityWeek{}},
 				},
 				PullRequests: PRStats{
 					Total: 5, Categories: map[string]int{}, AgeBuckets: AgeBuckets{},
-					Velocity: []VelocityWeek{}, Review: PRReviewMetrics{},
+					Velocity: Velocity{Daily: []VelocityDay{}, Weekly: []VelocityWeek{}}, Review: PRReviewMetrics{},
 				},
 			},
 		},

--- a/artifact_fetcher_dra_migration_test.go
+++ b/artifact_fetcher_dra_migration_test.go
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v55/github"
+)
+
+// TestRunIssuesPRsPhase_DRARepoMigration asserts that the issues/PRs phase,
+// when seeded with the package-level allRepos, routes a request to
+// /repos/kubernetes-sigs/dra-driver-nvidia-gpu/... and never to the
+// donated-away nvidia/k8s-dra-driver-gpu path.
+//
+// NVIDIA donated the DRA driver to kubernetes-sigs on 2026-04-30. The old
+// path 301-redirects, but the dashboard's per-repo cache is keyed on the
+// literal repo string used here, so a stale literal silently fragments
+// cache lookups under the wrong owner.
+//
+// Strategy: stub a server that accepts any /repos/... path with an empty
+// list, redirect-transport every request to it, then call runIssuesPRsPhase
+// with allRepos. Record observed paths; assert presence of the new owner
+// substring and absence of the old.
+//
+// Mutation check: reverting the allRepos literal back to
+// "nvidia/k8s-dra-driver-gpu" causes the old-path assertion to fire and
+// this test fails. This narrowly guards the Task 9 literal change; Task 11
+// adds a broader static-shape test covering all four locations (defaultRepos,
+// allRepos, defaultImages, src/data/projects.ts).
+//
+// Spec: docs/plans/2026-04-30-dra-repo-migration-design.md (folded into PR-B).
+func TestRunIssuesPRsPhase_DRARepoMigration(t *testing.T) {
+	t.Parallel()
+
+	const (
+		oldOwnerPrefix = "/repos/nvidia/k8s-dra-driver-gpu"
+		newOwnerPrefix = "/repos/kubernetes-sigs/dra-driver-nvidia-gpu"
+	)
+
+	var (
+		mu            sync.Mutex
+		observedPaths []string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		observedPaths = append(observedPaths, r.URL.Path)
+		mu.Unlock()
+		// Empty list satisfies fetchIssuesPRs's pagination loop without
+		// requiring full GitHub-shaped fixtures; the request URL is what
+		// this test cares about.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	redirect := &redirectTransport{target: srv.URL, inner: http.DefaultTransport}
+	httpClient := &http.Client{Transport: redirect}
+	client := github.NewClient(httpClient)
+	parsed, err := client.BaseURL.Parse(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("parse base url: %v", err)
+	}
+	client.BaseURL = parsed
+
+	out := runIssuesPRsPhase(
+		context.Background(),
+		client,
+		allRepos,
+		2*time.Second,
+		4,
+		IssuesPRsFile{Repos: map[string]RepoIssuesPRs{}},
+		silentLogger(),
+	)
+	if out.Repos == nil {
+		t.Fatalf("runIssuesPRsPhase returned nil Repos map")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	var sawNew, sawOld bool
+	for _, p := range observedPaths {
+		if strings.HasPrefix(p, newOwnerPrefix) {
+			sawNew = true
+		}
+		if strings.HasPrefix(p, oldOwnerPrefix) {
+			sawOld = true
+		}
+	}
+
+	if sawOld {
+		t.Errorf("observed request to stale path prefix %q; allRepos must use %q after donation to kubernetes-sigs (2026-04-30)",
+			oldOwnerPrefix, newOwnerPrefix)
+	}
+	if !sawNew {
+		t.Errorf("no request to migrated path prefix %q; allRepos must reference kubernetes-sigs/dra-driver-nvidia-gpu (paths seen: %v)",
+			newOwnerPrefix, observedPaths)
+	}
+}

--- a/artifact_fetcher_e2e_test.go
+++ b/artifact_fetcher_e2e_test.go
@@ -1,0 +1,374 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// e2eFixtureTimes carries the concrete event timestamps used by the
+// deterministic e2e fixture so that assertions can locate the expected
+// daily-bucket index without reverse-engineering the math.
+type e2eFixtureTimes struct {
+	Now            time.Time
+	ClosedIssue1At time.Time // plain closed issue, ~10d ago
+	ClosedIssue2At time.Time // plain closed issue, ~30d ago
+	ClosedPRAsIss  time.Time // closed PR-as-issue, ~5d ago
+	MergedPR1At    time.Time // merged PR, ~7d ago
+	MergedPR2At    time.Time // merged PR, ~50d ago
+}
+
+// runE2EClosedAndMerged spins up a stub GitHub server with two pages of
+// open issues, three closed items (2 plain issues + 1 PR-as-issue), and
+// two merged PRs, then drives fetchIssuesPRs against it. Returns the
+// aggregated result and the fixture timestamps so the caller can assert
+// on bucket placement.
+func runE2EClosedAndMerged(t *testing.T) (RepoIssuesPRs, e2eFixtureTimes) {
+	t.Helper()
+	now := time.Now().UTC()
+	ft := e2eFixtureTimes{
+		Now:            now,
+		ClosedIssue1At: now.Add(-10 * 24 * time.Hour),
+		ClosedIssue2At: now.Add(-30 * 24 * time.Hour),
+		ClosedPRAsIss:  now.Add(-5 * 24 * time.Hour),
+		MergedPR1At:    now.Add(-7 * 24 * time.Hour),
+		MergedPR2At:    now.Add(-50 * 24 * time.Hour),
+	}
+
+	openIssuesPage1 := buildIssuesJSON([]issueFixture{
+		{Number: 100, State: "open", CreatedAt: now.Add(-3 * 24 * time.Hour), Labels: []string{"bug"}},
+		{Number: 101, State: "open", CreatedAt: now.Add(-30 * 24 * time.Hour), Labels: []string{"feature"}},
+	})
+	openIssuesPage2 := buildIssuesJSON([]issueFixture{
+		{Number: 102, State: "open", CreatedAt: now.Add(-100 * 24 * time.Hour), Labels: []string{"bug"}},
+	})
+	closedIssuesJSON := buildIssuesJSON([]issueFixture{
+		{
+			Number:    200,
+			State:     "closed",
+			CreatedAt: ft.ClosedIssue1At.Add(-2 * 24 * time.Hour),
+			ClosedAt:  &ft.ClosedIssue1At,
+			Labels:    []string{"bug"},
+		},
+		{
+			Number:    201,
+			State:     "closed",
+			CreatedAt: ft.ClosedIssue2At.Add(-3 * 24 * time.Hour),
+			ClosedAt:  &ft.ClosedIssue2At,
+			Labels:    []string{"feature"},
+		},
+		{
+			Number:        300,
+			State:         "closed",
+			CreatedAt:     ft.ClosedPRAsIss.Add(-1 * 24 * time.Hour),
+			ClosedAt:      &ft.ClosedPRAsIss,
+			IsPullRequest: true,
+			Labels:        []string{"bug"},
+		},
+	})
+	mergedPRsJSON := buildPRsJSON([]prFixture{
+		{
+			Number:    400,
+			CreatedAt: ft.MergedPR1At.Add(-30 * 24 * time.Hour),
+			MergedAt:  ft.MergedPR1At,
+		},
+		{
+			Number:    401,
+			CreatedAt: ft.MergedPR2At.Add(-30 * 24 * time.Hour),
+			MergedAt:  ft.MergedPR2At,
+		},
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/issues") && r.URL.Query().Get("state") == "open":
+			page := r.URL.Query().Get("page")
+			if page == "" || page == "1" {
+				w.Header().Set("Link", `<`+srvURLOf(r)+`/repos/test/repo/issues?state=open&page=2>; rel="next"`)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, openIssuesPage1)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, openIssuesPage2)
+			return
+		case strings.Contains(r.URL.Path, "/issues") && r.URL.Query().Get("state") == "closed":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, closedIssuesJSON)
+			return
+		case strings.Contains(r.URL.Path, "/pulls"):
+			// Branch on state: state=open is the open-PRs path (empty in
+			// this fixture), state=closed is the merged-PRs path.
+			if r.URL.Query().Get("state") == "closed" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, mergedPRsJSON)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, "[]")
+			return
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, "[]")
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	client, ctx := buildClient(ctx, "fake-token", silentLogger())
+	parsed, _ := client.BaseURL.Parse(srv.URL + "/")
+	client.BaseURL = parsed
+
+	got, err := fetchIssuesPRs(ctx, client, "test/repo")
+	if err != nil {
+		t.Fatalf("fetchIssuesPRs: %v", err)
+	}
+	return got, ft
+}
+
+// TestFetchIssuesPRs_EndToEnd_DeterministicFixture exercises fetchIssuesPRs
+// against a stub server returning multi-page paginated responses with
+// Link: <...>; rel="next" headers. Asserts:
+//   - velocity.Daily length is exactly the days-in-1y count.
+//   - velocity.Weekly length is exactly the expected ~260 weeks.
+//   - Totals match the fixture's exact counts (not "approximately").
+//   - Categories are populated from the fixture's labels.
+//   - Closed-issue + closed-PR (PR-as-issue) aggregation paths produce the
+//     correct daily-bucket sums and land in the expected day indices.
+//   - Merged-PR aggregation produces correct daily-bucket sums and lands in
+//     the expected day index.
+//
+// Mutation check: dropping the open-issues pagination loop (break after
+// page 1) undercounts events; assertions on totals fail.
+// Mutation check: removing the closed-events loop (artifact_fetcher.go
+// `for _, iss := range closedItems`) fails the closed/merged sum
+// assertions for issues and PR-as-issue.
+// Mutation check: removing the merged-events loop (artifact_fetcher.go
+// `for _, pr := range mergedPRs`) fails the merged-sum assertions.
+//
+// Label note: uses bare `bug` / `feature` labels (mapped under _default in
+// labelCategories at artifact_fetcher.go); the original plan used
+// `kind/bug` / `kind/feature` which only map under repo-specific overrides.
+func TestFetchIssuesPRs_EndToEnd_DeterministicFixture(t *testing.T) {
+	t.Parallel()
+	got, ft := runE2EClosedAndMerged(t)
+
+	if got.Issues.Total != 3 {
+		t.Fatalf("Issues.Total = %d; want 3 (fixture has 3 open across 2 pages)", got.Issues.Total)
+	}
+	if got.Issues.Categories["bug"] != 2 {
+		t.Fatalf("Issues.Categories[bug] = %d; want 2", got.Issues.Categories["bug"])
+	}
+	if got.Issues.Categories["feature-request"] != 1 {
+		t.Fatalf("Issues.Categories[feature-request] = %d; want 1", got.Issues.Categories["feature-request"])
+	}
+	if len(got.Issues.Velocity.Daily) != 365 {
+		t.Fatalf("Issues.Velocity.Daily length = %d; want 365", len(got.Issues.Velocity.Daily))
+	}
+	if len(got.Issues.Velocity.Weekly) < 260 || len(got.Issues.Velocity.Weekly) > 261 {
+		t.Fatalf("Issues.Velocity.Weekly length = %d; want 260-261", len(got.Issues.Velocity.Weekly))
+	}
+
+	// --- Closed-issue aggregation: two plain closed issues should land in
+	// the issue daily-velocity stream, the PR-as-issue should NOT.
+	var issueClosedSum int
+	for _, d := range got.Issues.Velocity.Daily {
+		issueClosedSum += d.Closed
+	}
+	if issueClosedSum != 2 {
+		t.Fatalf("sum(Issues.Velocity.Daily[*].Closed) = %d; want 2 (two plain closed issues at -10d and -30d)", issueClosedSum)
+	}
+
+	// --- PR-as-issue aggregation: the closed PR-as-issue should land in
+	// the PR daily-velocity stream's Closed field.
+	var prClosedSum int
+	for _, d := range got.PullRequests.Velocity.Daily {
+		prClosedSum += d.Closed
+	}
+	if prClosedSum != 1 {
+		t.Fatalf("sum(PullRequests.Velocity.Daily[*].Closed) = %d; want 1 (one closed PR-as-issue at -5d)", prClosedSum)
+	}
+
+	// --- Merged-PR aggregation: two merged PRs should land in the PR
+	// daily-velocity stream's Merged field.
+	var prMergedSum int
+	prMergedHasNonZero := false
+	for _, d := range got.PullRequests.Velocity.Daily {
+		if d.Merged != nil {
+			prMergedSum += *d.Merged
+			if *d.Merged > 0 {
+				prMergedHasNonZero = true
+			}
+		}
+	}
+	if !prMergedHasNonZero {
+		t.Fatalf("PullRequests.Velocity.Daily contained no Merged>0 entries; want at least one (fixture has 2 merged PRs in 1y window)")
+	}
+	if prMergedSum != 2 {
+		t.Fatalf("sum(*PullRequests.Velocity.Daily[*].Merged) = %d; want 2 (two merged PRs at -7d and -50d)", prMergedSum)
+	}
+
+	// --- Spot-check specific date buckets. The Daily array spans
+	// [oneYearAgo, now) UTC, truncated to day. Index i corresponds to
+	// from.AddDate(0, 0, i) in bucketByDay, where from = oneYearAgo
+	// truncated to day.
+	dailyIndexFor := func(eventAt time.Time) int {
+		from := ft.Now.UTC().AddDate(-1, 0, 0).Truncate(24 * time.Hour)
+		evDay := eventAt.UTC().Truncate(24 * time.Hour)
+		return int(evDay.Sub(from) / (24 * time.Hour))
+	}
+	idxClosed1 := dailyIndexFor(ft.ClosedIssue1At)
+	if idxClosed1 < 0 || idxClosed1 >= len(got.Issues.Velocity.Daily) {
+		t.Fatalf("computed bucket index %d for ClosedIssue1At=%s out of range [0,%d)", idxClosed1, ft.ClosedIssue1At.Format(time.RFC3339), len(got.Issues.Velocity.Daily))
+	}
+	if got.Issues.Velocity.Daily[idxClosed1].Closed < 1 {
+		t.Errorf("Issues.Velocity.Daily[%d] (date=%s) Closed = %d; want >=1 (event at -10d should land here)",
+			idxClosed1, got.Issues.Velocity.Daily[idxClosed1].Date, got.Issues.Velocity.Daily[idxClosed1].Closed)
+	}
+
+	idxMerged1 := dailyIndexFor(ft.MergedPR1At)
+	if idxMerged1 < 0 || idxMerged1 >= len(got.PullRequests.Velocity.Daily) {
+		t.Fatalf("computed bucket index %d for MergedPR1At=%s out of range [0,%d)", idxMerged1, ft.MergedPR1At.Format(time.RFC3339), len(got.PullRequests.Velocity.Daily))
+	}
+	mergedAtIdx := got.PullRequests.Velocity.Daily[idxMerged1].Merged
+	if mergedAtIdx == nil || *mergedAtIdx < 1 {
+		var observed string
+		if mergedAtIdx == nil {
+			observed = "nil"
+		} else {
+			observed = fmt.Sprintf("%d", *mergedAtIdx)
+		}
+		t.Errorf("PullRequests.Velocity.Daily[%d] (date=%s) Merged = %s; want >=1 (event at -7d should land here)",
+			idxMerged1, got.PullRequests.Velocity.Daily[idxMerged1].Date, observed)
+	}
+}
+
+// issueFixture is a minimal subset of the GitHub Issue API shape that
+// tests need. buildIssuesJSON marshals it to JSON for the stub server.
+//
+// ClosedAt, when non-nil, emits the JSON field `closed_at`. IsPullRequest,
+// when true, emits a `pull_request` object so go-github sets
+// PullRequestLinks non-nil — that's how the Issues endpoint distinguishes
+// PR-as-issue rows from plain issues.
+type issueFixture struct {
+	Number        int
+	State         string
+	CreatedAt     time.Time
+	ClosedAt      *time.Time
+	Labels        []string
+	IsPullRequest bool
+}
+
+func buildIssuesJSON(items []issueFixture) string {
+	var b strings.Builder
+	b.WriteString("[")
+	for i, it := range items {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		var labels strings.Builder
+		labels.WriteString("[")
+		for j, l := range it.Labels {
+			if j > 0 {
+				labels.WriteString(",")
+			}
+			labels.WriteString(`{"name":"`)
+			labels.WriteString(l)
+			labels.WriteString(`"}`)
+		}
+		labels.WriteString("]")
+		fmt.Fprintf(&b,
+			`{"number":%d,"state":"%s","created_at":"%s","labels":%s`,
+			it.Number, it.State, it.CreatedAt.Format(time.RFC3339), labels.String(),
+		)
+		if it.ClosedAt != nil {
+			fmt.Fprintf(&b, `,"closed_at":"%s"`, it.ClosedAt.Format(time.RFC3339))
+		}
+		if it.IsPullRequest {
+			b.WriteString(`,"pull_request":{"url":"http://example/pr"}`)
+		}
+		b.WriteString("}")
+	}
+	b.WriteString("]")
+	return b.String()
+}
+
+// prFixture is a minimal subset of the GitHub PullRequest API shape used
+// by the merged-PR aggregation path. CreatedAt and MergedAt must both be
+// set; MergedAt should be inside the 5y window so the fetcher's
+// pastCutoff break does not fire prematurely.
+type prFixture struct {
+	Number    int
+	CreatedAt time.Time
+	MergedAt  time.Time
+}
+
+func buildPRsJSON(items []prFixture) string {
+	var b strings.Builder
+	b.WriteString("[")
+	for i, it := range items {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b,
+			`{"number":%d,"state":"closed","created_at":"%s","merged_at":"%s"}`,
+			it.Number, it.CreatedAt.Format(time.RFC3339), it.MergedAt.Format(time.RFC3339),
+		)
+	}
+	b.WriteString("]")
+	return b.String()
+}
+
+func srvURLOf(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return scheme + "://" + r.Host
+}
+
+// TestFetchIssuesPRs_EmptyResponse asserts that a stub returning empty
+// arrays yields velocity.Daily and Weekly with exact zero entries (not
+// nil), so the dashboard's empty-state placeholder triggers correctly.
+//
+// Mutation check: a special-case "if no events, return nil arrays"
+// fails the length assertion.
+func TestFetchIssuesPRs_EmptyResponse(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, "[]")
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	client, ctx := buildClient(ctx, "fake-token", silentLogger())
+	parsed, _ := client.BaseURL.Parse(srv.URL + "/")
+	client.BaseURL = parsed
+
+	got, err := fetchIssuesPRs(ctx, client, "test/empty")
+	if err != nil {
+		t.Fatalf("fetchIssuesPRs: %v", err)
+	}
+	if got.Issues.Total != 0 {
+		t.Fatalf("Issues.Total = %d; want 0", got.Issues.Total)
+	}
+	if len(got.Issues.Velocity.Daily) != 365 {
+		t.Fatalf("Daily length = %d; want 365 (continuous-zeros)", len(got.Issues.Velocity.Daily))
+	}
+	for i, d := range got.Issues.Velocity.Daily {
+		if d.Opened != 0 || d.Closed != 0 || d.Merged != nil {
+			t.Errorf("daily[%d] = %+v; want all-zero", i, d)
+		}
+	}
+}

--- a/artifact_fetcher_log_test.go
+++ b/artifact_fetcher_log_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestBuildClient_LogsNeverContainCredentials runs three paths (200,
+// 429-then-200, 500) through the wired client and asserts that the
+// captured slog output never contains the token literal, the substring
+// "Bearer", or the substring "token=".
+//
+// buildClient is the entry-point of the pipeline that ultimately produces
+// TestResult records, so a credential leak here would propagate into every
+// downstream artifact fetch.
+//
+// Mutation check: if a future change adds slog.Info("auth header",
+// "value", req.Header.Get("Authorization")), the captured buffer would
+// contain "Bearer fake-secret-token" and the assertion fails.
+func TestBuildClient_LogsNeverContainCredentials(t *testing.T) {
+	t.Parallel()
+
+	const tokenLiteral = "fake-secret-token-do-not-leak"
+
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		wantErr bool
+	}{
+		{
+			name: "200 success",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"login":"x","id":1}`)
+			},
+			wantErr: false,
+		},
+		{
+			name: "429 then 200",
+			handler: func() http.HandlerFunc {
+				var calls atomic.Int32
+				return func(w http.ResponseWriter, r *http.Request) {
+					if calls.Add(1) == 1 {
+						w.Header().Set("Retry-After", "1")
+						w.Header().Set("X-RateLimit-Remaining", "5000")
+						w.WriteHeader(http.StatusForbidden)
+						_, _ = io.WriteString(w, `{"message":"You have exceeded a secondary rate limit. Please wait a few minutes before you try again."}`)
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = io.WriteString(w, `{"login":"x","id":1}`)
+				}
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "500 error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = io.WriteString(w, `{"message":"internal"}`)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(tc.handler)
+			t.Cleanup(srv.Close)
+
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			t.Cleanup(cancel)
+
+			client, ctx := buildClient(ctx, tokenLiteral, logger)
+			parsed, err := client.BaseURL.Parse(srv.URL + "/")
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			client.BaseURL = parsed
+
+			req, err := client.NewRequest("GET", "user", nil)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			var got map[string]any
+			_, err = client.Do(ctx, req, &got)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v; wantErr %v", err, tc.wantErr)
+			}
+
+			out := buf.String()
+			forbidden := []string{
+				tokenLiteral,
+				"Bearer",
+				"token=",
+				"Authorization",
+			}
+			for _, needle := range forbidden {
+				if strings.Contains(out, needle) {
+					t.Fatalf("log output contains forbidden substring %q\n--- log ---\n%s\n", needle, out)
+				}
+			}
+		})
+	}
+}

--- a/artifact_fetcher_main_test.go
+++ b/artifact_fetcher_main_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// silentLogger returns a slog.Logger that writes to io.Discard so tests don't
+// pollute output. Use t.Logf-backed loggers when assertions on log lines are
+// needed (see artifact_fetcher_log_test.go).
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestBuildClient_RetriesOnSecondaryRateLimit asserts that the rate-limit
+// middleware is wired such that a 429 response with Retry-After is
+// transparently retried, and the caller observes the eventual 200. buildClient
+// is the entry-point of the pipeline that ultimately produces TestResult
+// records, so a regression here breaks every artifact fetch downstream.
+//
+// Mutation check: if buildClient forgets to wrap the OAuth2 transport with
+// github_ratelimit.New, the 429 surfaces to the caller as a
+// *github.AbuseRateLimitError on the first call and the test fails because
+// the body of the second-call request is never observed.
+func TestBuildClient_RetriesOnSecondaryRateLimit(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n == 1 {
+			// Secondary rate limit response per GitHub docs.
+			w.Header().Set("Retry-After", "1")
+			w.Header().Set("X-RateLimit-Remaining", "5000")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = io.WriteString(w, `{"message":"You have exceeded a secondary rate limit. Please wait a few minutes before you try again."}`)
+			return
+		}
+		// Second call: success.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"login":"test","id":1}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	client, ctx := buildClient(ctx, "fake-token", silentLogger())
+	// Point the client at the test server.
+	baseURL := srv.URL + "/"
+	parsed, err := client.BaseURL.Parse(baseURL)
+	if err != nil {
+		t.Fatalf("parse base URL: %v", err)
+	}
+	client.BaseURL = parsed
+
+	// Issue a real request through the wired chain.
+	req, err := client.NewRequest("GET", "user", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	var got map[string]any
+	resp, err := client.Do(ctx, req, &got)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; want 200", resp.StatusCode)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("calls = %d; want exactly 2 (one 429, one 200)", calls.Load())
+	}
+	if got["login"] != "test" {
+		t.Fatalf("body login = %v; want %q", got["login"], "test")
+	}
+}
+
+// TestBuildClient_BypassRateLimitCheckSet is a placeholder.
+//
+// In go-github v55 (current), bypassRateLimitCheck is an unexported context
+// key (see vendor/github.com/google/go-github/v55/github/github.go:784).
+// External code cannot set it; our buildClient stores its own
+// githubBypassKeyType{} marker. Asserting that our own marker is present
+// would pass regardless of whether go-github actually honors it — that is
+// theater, not a behavioral test.
+//
+// In go-github v75+ the symbol is exported. When the project bumps to v75+,
+// re-enable this test with an actual behavioral assertion: configure a stub
+// server to return a primary-rate-limit-exhausted response (X-RateLimit-
+// Remaining: 0, X-RateLimit-Reset in the future) on a FIRST call so that
+// go-github's c.rateLimits[] state is populated, then make a SECOND call and
+// assert it succeeds (because the bypass marker prevented the pre-empt).
+// Without the bypass, the second call would short-circuit with a
+// *github.RateLimitError before reaching the network.
+//
+// Until the v75+ bump, the retry test
+// (TestBuildClient_RetriesOnSecondaryRateLimit) is the real safety net:
+// it proves the middleware engages on the response path, which is the only
+// behavior we care about with v55's unexported bypass.
+func TestBuildClient_BypassRateLimitCheckSet(t *testing.T) {
+	t.Skip("placeholder: bypassRateLimitCheck is unexported in go-github v55; re-enable on v75+ bump with a behavioral assertion (see TODO in godoc).")
+}
+
+// TestBuildClient_SecondaryRateLimitCap asserts that the WithSingleSleepLimit
+// cap aborts a too-long secondary-rate-limit sleep instead of blocking the
+// caller indefinitely. We override secondarySleepCap to 1ms (test-only)
+// and configure the test server to return a 60-second Retry-After WITH the
+// canonical detector-matching body so the middleware actually engages.
+//
+// Mutation check: removing WithSingleSleepLimit entirely makes the call
+// block until Retry-After elapses (60s) or the test's context times out.
+// The 5-second test deadline asserts the cap fired well before that.
+//
+// Not parallel: this test mutates the package-level secondarySleepCap
+// variable. Running concurrently with any other test that calls buildClient
+// would observe the 1ms cap and behave unpredictably.
+func TestBuildClient_SecondaryRateLimitCap(t *testing.T) {
+	// Intentionally NOT t.Parallel() — see godoc above.
+
+	// Reduce the cap for this test only.
+	originalCap := secondarySleepCap
+	secondarySleepCap = 1 * time.Millisecond
+	t.Cleanup(func() { secondarySleepCap = originalCap })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.Header().Set("X-RateLimit-Remaining", "5000")
+		w.WriteHeader(http.StatusForbidden)
+		// Canonical body — gofri detector requires the prefix
+		// "You have exceeded a secondary rate limit" (verified at
+		// vendor/github.com/gofri/go-github-ratelimit/v2/.../detect.go:26).
+		// A placeholder body that omits the prefix makes the middleware
+		// classify as primary, NOT engage, and surface 403 to the caller —
+		// rendering this cap test theatrical.
+		_, _ = io.WriteString(w, `{"message":"You have exceeded a secondary rate limit. Please wait a few minutes before you try again."}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	client, ctx := buildClient(ctx, "fake-token", silentLogger())
+	parsed, err := client.BaseURL.Parse(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	client.BaseURL = parsed
+
+	req, err := client.NewRequest("GET", "user", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	start := time.Now()
+	var got map[string]any
+	_, err = client.Do(ctx, req, &got)
+	elapsed := time.Since(start)
+
+	// Either the middleware aborts (returning an error) or the caller's
+	// context expires. Either way, total wall-clock time MUST be less than
+	// the Retry-After (60s). 5s is the test deadline; assert <2s for margin.
+	if elapsed >= 2*time.Second {
+		t.Fatalf("call took %s; expected < 2s after cap fired", elapsed)
+	}
+	if err == nil {
+		t.Fatalf("expected error after sleep cap fired; got success")
+	}
+}

--- a/artifact_fetcher_main_test.go
+++ b/artifact_fetcher_main_test.go
@@ -82,28 +82,24 @@ func TestBuildClient_RetriesOnSecondaryRateLimit(t *testing.T) {
 	}
 }
 
-// TestBuildClient_BypassRateLimitCheckSet is a placeholder.
+// TestBuildClient_BypassRateLimitCheckSet is a placeholder for the v75+
+// behavioral assertion described on the bypass TODO above buildClient.
 //
-// In go-github v55 (current), bypassRateLimitCheck is an unexported context
-// key (see vendor/github.com/google/go-github/v55/github/github.go:784).
-// External code cannot set it; our buildClient stores its own
-// githubBypassKeyType{} marker. Asserting that our own marker is present
-// would pass regardless of whether go-github actually honors it — that is
-// theater, not a behavioral test.
+// In go-github v55 we do NOT stamp our own marker into the context, since
+// v55's bypassRateLimitCheck is unexported and asserting our private marker
+// would only confirm we set what we set — theater, not behavior.
 //
-// In go-github v75+ the symbol is exported. When the project bumps to v75+,
-// re-enable this test with an actual behavioral assertion: configure a stub
-// server to return a primary-rate-limit-exhausted response (X-RateLimit-
-// Remaining: 0, X-RateLimit-Reset in the future) on a FIRST call so that
-// go-github's c.rateLimits[] state is populated, then make a SECOND call and
-// assert it succeeds (because the bypass marker prevented the pre-empt).
+// On the v75+ bump, replace this Skip with: configure a stub server to
+// return a primary-rate-limit-exhausted response (X-RateLimit-Remaining: 0,
+// X-RateLimit-Reset in the future) on a FIRST call so go-github's
+// c.rateLimits[] state is populated, then make a SECOND call and assert it
+// succeeds because github.BypassRateLimitCheck prevented the pre-empt.
 // Without the bypass, the second call would short-circuit with a
 // *github.RateLimitError before reaching the network.
 //
-// Until the v75+ bump, the retry test
-// (TestBuildClient_RetriesOnSecondaryRateLimit) is the real safety net:
-// it proves the middleware engages on the response path, which is the only
-// behavior we care about with v55's unexported bypass.
+// Until then, TestBuildClient_RetriesOnSecondaryRateLimit is the real
+// safety net: it proves the middleware engages on the response path, which
+// is the only behavior we care about with v55.
 func TestBuildClient_BypassRateLimitCheckSet(t *testing.T) {
 	t.Skip("placeholder: bypassRateLimitCheck is unexported in go-github v55; re-enable on v75+ bump with a behavioral assertion (see TODO in godoc).")
 }

--- a/artifact_fetcher_registry_test.go
+++ b/artifact_fetcher_registry_test.go
@@ -1,0 +1,194 @@
+// Tests for the registry.k8s.io image-tag fetcher (and its dispatcher
+// integration). The fetcher reads the latest GitHub release for the source
+// repo and uses its tag_name/published_at as the image-tag/push-date pair,
+// on the assumption that the kubernetes-sigs release process pushes the
+// image when the release publishes.
+//
+// Spec: docs/plans/2026-05-11-dra-registry-k8s-io-design.md.
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v55/github"
+)
+
+// newReleasesStub returns an httptest server that serves the given JSON
+// payload at /repos/{owner}/{name}/releases and 404s anything else. The
+// returned *github.Client is rebased onto that server's URL so the fetcher
+// hits the stub instead of api.github.com.
+func newReleasesStub(t *testing.T, owner, name, body string) *github.Client {
+	t.Helper()
+	wantPath := "/repos/" + owner + "/" + name + "/releases"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, wantPath) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := github.NewClient(nil)
+	client.BaseURL = mustParseURL(t, srv.URL+"/")
+	return client
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	return u
+}
+
+func TestFetchLatestRegistryK8sTag_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	// GitHub returns releases newest-first. The fetcher must take index 0.
+	body := `[
+		{"tag_name": "v25.12.0", "published_at": "2026-02-12T14:55:44Z"},
+		{"tag_name": "v25.8.1",  "published_at": "2025-12-17T17:06:25Z"},
+		{"tag_name": "v25.8.0",  "published_at": "2025-10-20T20:11:17Z"}
+	]`
+	client := newReleasesStub(t, "kubernetes-sigs", "dra-driver-nvidia-gpu", body)
+
+	ir := imageRepo{
+		repo:          "kubernetes-sigs/dra-driver-nvidia-gpu",
+		pkgName:       "dra-driver-nvidia/dra-driver-nvidia-gpu",
+		imageRegistry: "registry.k8s.io",
+	}
+	var got ImageInfo
+	got, err := fetchLatestRegistryK8sTag(context.Background(), client, ir)
+	if err != nil {
+		t.Fatalf("fetchLatestRegistryK8sTag: %v", err)
+	}
+	if got.Tag != "v25.12.0" {
+		t.Errorf("Tag = %q; want %q", got.Tag, "v25.12.0")
+	}
+	if got.Pushed != "2026-02-12T14:55:44Z" {
+		t.Errorf("Pushed = %q; want %q", got.Pushed, "2026-02-12T14:55:44Z")
+	}
+	if got.ImageType != "release" {
+		t.Errorf("ImageType = %q; want %q (SemVer tag must classify as release)", got.ImageType, "release")
+	}
+	wantHTMLURL := "https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/releases/tag/v25.12.0"
+	if got.HTMLURL != wantHTMLURL {
+		t.Errorf("HTMLURL = %q; want %q", got.HTMLURL, wantHTMLURL)
+	}
+	// CommitURL for a SemVer tag should be the release URL (delegated to buildCommitURL).
+	if got.CommitURL != wantHTMLURL {
+		t.Errorf("CommitURL = %q; want %q (release URL for SemVer)", got.CommitURL, wantHTMLURL)
+	}
+}
+
+// TestFetchLatestImageTag_Dispatch asserts the dispatcher routes by
+// imageRegistry. We stub /repos/.../releases (registry.k8s.io path) and
+// /orgs/.../packages/... (GHCR path) on the same server and watch which one
+// is hit per imageRegistry value.
+func TestFetchLatestImageTag_Dispatch(t *testing.T) {
+	t.Parallel()
+
+	var (
+		ghcrHit     bool
+		releasesHit bool
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/orgs/") && strings.Contains(r.URL.Path, "/packages/"):
+			ghcrHit = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[{"id":1,"created_at":"2026-05-01T00:00:00Z","metadata":{"container":{"tags":["v1.0.0"]}}}]`)
+		case strings.HasPrefix(r.URL.Path, "/repos/") && strings.HasSuffix(r.URL.Path, "/releases"):
+			releasesHit = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[{"tag_name":"v25.12.0","published_at":"2026-02-12T14:55:44Z"}]`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := github.NewClient(nil)
+	client.BaseURL = mustParseURL(t, srv.URL+"/")
+
+	cases := []struct {
+		name          string
+		ir            imageRepo
+		wantGHCR      bool
+		wantReleases  bool
+		wantErrSubstr string
+	}{
+		{
+			name:         "empty registry routes to GHCR",
+			ir:           imageRepo{repo: "nvidia/k8s-device-plugin", pkgName: "k8s-device-plugin", imageRegistry: ""},
+			wantGHCR:     true,
+			wantReleases: false,
+		},
+		{
+			name:         "ghcr.io explicitly routes to GHCR",
+			ir:           imageRepo{repo: "nvidia/k8s-device-plugin", pkgName: "k8s-device-plugin", imageRegistry: "ghcr.io"},
+			wantGHCR:     true,
+			wantReleases: false,
+		},
+		{
+			name:         "registry.k8s.io routes to releases",
+			ir:           imageRepo{repo: "kubernetes-sigs/dra-driver-nvidia-gpu", pkgName: "dra-driver-nvidia/dra-driver-nvidia-gpu", imageRegistry: "registry.k8s.io"},
+			wantGHCR:     false,
+			wantReleases: true,
+		},
+		{
+			name:          "unknown registry returns error",
+			ir:            imageRepo{repo: "nvidia/foo", pkgName: "foo", imageRegistry: "quay.io"},
+			wantGHCR:      false,
+			wantReleases:  false,
+			wantErrSubstr: "unknown imageRegistry",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ghcrHit, releasesHit = false, false
+			_, err := fetchLatestImageTag(context.Background(), client, tc.ir)
+
+			if tc.wantErrSubstr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrSubstr) {
+					t.Fatalf("err = %v; want non-nil containing %q", err, tc.wantErrSubstr)
+				}
+				return
+			}
+			if ghcrHit != tc.wantGHCR {
+				t.Errorf("ghcrHit = %v; want %v", ghcrHit, tc.wantGHCR)
+			}
+			if releasesHit != tc.wantReleases {
+				t.Errorf("releasesHit = %v; want %v", releasesHit, tc.wantReleases)
+			}
+		})
+	}
+}
+
+func TestFetchLatestRegistryK8sTag_NoReleases(t *testing.T) {
+	t.Parallel()
+
+	client := newReleasesStub(t, "kubernetes-sigs", "dra-driver-nvidia-gpu", `[]`)
+
+	ir := imageRepo{
+		repo:          "kubernetes-sigs/dra-driver-nvidia-gpu",
+		pkgName:       "dra-driver-nvidia/dra-driver-nvidia-gpu",
+		imageRegistry: "registry.k8s.io",
+	}
+	_, err := fetchLatestRegistryK8sTag(context.Background(), client, ir)
+	if err == nil {
+		t.Fatalf("err = nil; want non-nil for empty releases response")
+	}
+	if !strings.Contains(err.Error(), "no releases found") {
+		t.Fatalf("err = %v; want it to contain 'no releases found'", err)
+	}
+}

--- a/artifact_fetcher_repos_test.go
+++ b/artifact_fetcher_repos_test.go
@@ -93,6 +93,33 @@ func TestDRAMigrationLiteralsAligned(t *testing.T) {
 			t.Errorf("defaultImages missing entry with repo=%q", newRepo)
 		}
 	})
+	t.Run("defaultImages.registryCoords", func(t *testing.T) {
+		t.Parallel()
+		// Post-CNCF-donation: DRA driver images live at
+		// registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu, promoted
+		// from a k8s-staging registry by the Prow release job.
+		// See docs/plans/2026-05-11-dra-registry-k8s-io-design.md.
+		const (
+			wantPkgName  = "dra-driver-nvidia/dra-driver-nvidia-gpu"
+			wantRegistry = "registry.k8s.io"
+		)
+		var found bool
+		for _, ir := range defaultImages {
+			if ir.repo != newRepo {
+				continue
+			}
+			found = true
+			if ir.imageRegistry != wantRegistry {
+				t.Errorf("defaultImages DRA entry imageRegistry = %q; want %q", ir.imageRegistry, wantRegistry)
+			}
+			if ir.pkgName != wantPkgName {
+				t.Errorf("defaultImages DRA entry pkgName = %q; want %q (full registry.k8s.io image path)", ir.pkgName, wantPkgName)
+			}
+		}
+		if !found {
+			t.Errorf("defaultImages missing entry with repo=%q", newRepo)
+		}
+	})
 	t.Run("projects.ts", func(t *testing.T) {
 		t.Parallel()
 		// Read the TS file as a string and grep for the canonical literal.

--- a/artifact_fetcher_repos_test.go
+++ b/artifact_fetcher_repos_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// canonicalShape matches "owner/name" with lowercase letters, digits,
+// and dashes. The Go side of the codebase uses lowercase by convention;
+// the TS side uses canonical org casing (NVIDIA / kubernetes-sigs).
+var canonicalShape = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*/[a-z0-9][a-z0-9-]*$`)
+
+// TestRepoListsCanonicalShape enforces every Go-side repo literal matches
+// the lowercase owner/name convention. Catches typos and casing drift.
+func TestRepoListsCanonicalShape(t *testing.T) {
+	t.Parallel()
+
+	checks := []struct {
+		name string
+		list []string
+	}{
+		{"defaultRepos", defaultRepos},
+		{"allRepos", allRepos},
+	}
+	for _, c := range checks {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			for _, r := range c.list {
+				if !canonicalShape.MatchString(r) {
+					t.Errorf("%s entry %q does not match %s", c.name, r, canonicalShape)
+				}
+			}
+		})
+	}
+	t.Run("defaultImages.repo", func(t *testing.T) {
+		t.Parallel()
+		for _, ir := range defaultImages {
+			if !canonicalShape.MatchString(ir.repo) {
+				t.Errorf("defaultImages entry repo=%q does not match %s", ir.repo, canonicalShape)
+			}
+		}
+	})
+}
+
+// TestDRAMigrationLiteralsAligned asserts the DRA repo path is the new
+// kubernetes-sigs canonical home in all four places (Go's three slices
+// + src/data/projects.ts). Catches:
+//   - Forgotten literal in any of the four files
+//   - Future revert to nvidia/k8s-dra-driver-gpu in any place
+//   - Partial migration (one side updated, the other not)
+func TestDRAMigrationLiteralsAligned(t *testing.T) {
+	t.Parallel()
+
+	const (
+		newRepo = "kubernetes-sigs/dra-driver-nvidia-gpu"
+		oldRepo = "nvidia/k8s-dra-driver-gpu"
+	)
+
+	t.Run("defaultRepos", func(t *testing.T) {
+		t.Parallel()
+		if !sliceContains(defaultRepos, newRepo) {
+			t.Errorf("defaultRepos missing %q; got: %v", newRepo, defaultRepos)
+		}
+		if sliceContains(defaultRepos, oldRepo) {
+			t.Errorf("defaultRepos still has stale %q", oldRepo)
+		}
+	})
+	t.Run("allRepos", func(t *testing.T) {
+		t.Parallel()
+		if !sliceContains(allRepos, newRepo) {
+			t.Errorf("allRepos missing %q; got: %v", newRepo, allRepos)
+		}
+		if sliceContains(allRepos, oldRepo) {
+			t.Errorf("allRepos still has stale %q", oldRepo)
+		}
+	})
+	t.Run("defaultImages.repo", func(t *testing.T) {
+		t.Parallel()
+		var found bool
+		for _, ir := range defaultImages {
+			if ir.repo == newRepo {
+				found = true
+			}
+			if ir.repo == oldRepo {
+				t.Errorf("defaultImages still references stale %q", oldRepo)
+			}
+		}
+		if !found {
+			t.Errorf("defaultImages missing entry with repo=%q", newRepo)
+		}
+	})
+	t.Run("projects.ts", func(t *testing.T) {
+		t.Parallel()
+		// Read the TS file as a string and grep for the canonical literal.
+		// We don't parse TypeScript; the literal is unambiguous.
+		path, err := filepath.Abs("src/data/projects.ts")
+		if err != nil {
+			t.Fatalf("abs: %v", err)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		content := string(data)
+		if !strings.Contains(content, `'`+newRepo+`'`) && !strings.Contains(content, `"`+newRepo+`"`) {
+			t.Errorf("projects.ts missing %q literal", newRepo)
+		}
+		// Old literal in either case-form would be a regression.
+		if strings.Contains(content, `'`+oldRepo+`'`) ||
+			strings.Contains(content, `"`+oldRepo+`"`) ||
+			strings.Contains(strings.ToLower(content), strings.ToLower("'NVIDIA/k8s-dra-driver-gpu'")) {
+			t.Errorf("projects.ts still references stale DRA path")
+		}
+	})
+}
+
+func sliceContains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDefaultImagesProjectToImageInfo ties the internal imageRepo.repo field
+// to the public ImageInfo.Repo field consumed downstream by the dashboard.
+// If a future refactor stripped or transformed the owner prefix when populating
+// ImageInfo, this guards against that drift while exercising the exported type.
+func TestDefaultImagesProjectToImageInfo(t *testing.T) {
+	t.Parallel()
+	if len(defaultImages) == 0 {
+		t.Fatal("defaultImages is empty")
+	}
+	for _, ir := range defaultImages {
+		ii := ImageInfo{Repo: ir.repo}
+		if ii.Repo != ir.repo {
+			t.Errorf("ImageInfo.Repo=%q, want %q (round-trip drift)", ii.Repo, ir.repo)
+		}
+		if !canonicalShape.MatchString(ii.Repo) {
+			t.Errorf("ImageInfo.Repo=%q does not match canonical shape", ii.Repo)
+		}
+	}
+}

--- a/artifact_fetcher_routing_test.go
+++ b/artifact_fetcher_routing_test.go
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/go-github/v55/github"
+)
+
+// countingTransport wraps an http.RoundTripper so a test can assert that a
+// caller routed through THIS transport rather than http.DefaultClient.
+type countingTransport struct {
+	calls atomic.Int32
+	inner http.RoundTripper
+}
+
+func (c *countingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	c.calls.Add(1)
+	return c.inner.RoundTrip(r)
+}
+
+// TestDownload_UsesSuppliedClient asserts that download() issues its HTTP
+// request through the *http.Client passed by the caller — i.e., NOT through
+// http.DefaultClient. This is the contract that lets main()'s rate-limit
+// middleware cover artifact-zip downloads.
+//
+// Mutation check: reverting download to http.DefaultClient.Do(req) would
+// leave countingTransport.calls at 0 and this test fails.
+func TestDownload_UsesSuppliedClient(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("zip-bytes"))
+	}))
+	t.Cleanup(srv.Close)
+
+	tr := &countingTransport{inner: http.DefaultTransport}
+	httpClient := &http.Client{Transport: tr}
+
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := download(context.Background(), httpClient, srv.URL, dest, "fake-token"); err != nil {
+		t.Fatalf("download: %v", err)
+	}
+
+	if got := tr.calls.Load(); got != 1 {
+		t.Fatalf("countingTransport.calls = %d; want 1 (download must route through supplied client)", got)
+	}
+
+	// Sanity: file was written.
+	b, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(b) != "zip-bytes" {
+		t.Fatalf("dest contents = %q; want %q", string(b), "zip-bytes")
+	}
+}
+
+// TestFetchRepoInfo_ReadmeUsesClientTransport asserts that the README sub-fetch
+// inside fetchRepoInfo flows through the *github.Client's underlying http.Client
+// (returned by client.Client()) rather than http.DefaultClient.
+//
+// Strategy: construct a *github.Client wrapping an *http.Client whose Transport
+// is a counting+redirecting RoundTripper. Point client.BaseURL at an httptest
+// server that serves both /repos/{owner}/{name} and /repos/{owner}/{name}/readme.
+// The README fetch inside fetchRepoInfo uses an absolute URL pointing at
+// api.github.com, so the redirect transport rewrites the host to the test
+// server regardless of the original URL. If the implementation routes through
+// client.Client() we see >=2 calls; if it uses http.DefaultClient we see 1.
+//
+// Mutation check: reverting fetchRepoInfo's readme call to
+// http.DefaultClient.Do(req) leaves count at 1 and this test fails.
+func TestFetchRepoInfo_ReadmeUsesClientTransport(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/o/n":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"name":"n","full_name":"o/n"}`))
+		case "/repos/o/n/readme":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<p>readme</p>"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	// Redirect transport: ANY request, regardless of host, lands on srv.
+	redirect := &redirectTransport{target: srv.URL, inner: http.DefaultTransport}
+	tr := &countingTransport{inner: redirect}
+
+	httpClient := &http.Client{Transport: tr}
+	client := github.NewClient(httpClient)
+	parsed, err := client.BaseURL.Parse(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	client.BaseURL = parsed
+
+	if _, err := fetchRepoInfo(context.Background(), client, "o/n"); err != nil {
+		t.Fatalf("fetchRepoInfo: %v", err)
+	}
+
+	// Expect 2 calls: Repositories.Get + readme. If readme used
+	// http.DefaultClient we'd see only 1.
+	if got := tr.calls.Load(); got < 2 {
+		t.Fatalf("countingTransport.calls = %d; want >=2 (readme must route through client.Client())", got)
+	}
+}
+
+// redirectTransport rewrites every outbound request URL to a fixed target host
+// before delegating, so tests can intercept absolute URLs (e.g. api.github.com)
+// without DNS or network access.
+type redirectTransport struct {
+	target string
+	inner  http.RoundTripper
+}
+
+func (rt *redirectTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	// Build a new URL that keeps the path/query but uses target's scheme+host.
+	u := *r.URL
+	// Parse target lazily.
+	tgt, err := http.NewRequest(http.MethodGet, rt.target, nil)
+	if err != nil {
+		return nil, err
+	}
+	u.Scheme = tgt.URL.Scheme
+	u.Host = tgt.URL.Host
+	r2 := r.Clone(r.Context())
+	r2.URL = &u
+	r2.Host = tgt.URL.Host
+	return rt.inner.RoundTrip(r2)
+}

--- a/artifact_fetcher_velocity_test.go
+++ b/artifact_fetcher_velocity_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestBuildVelocitySlice_5YearWindow asserts the existing
+// buildVelocitySlice helper handles a 5-year span with the expected
+// length and ISO-week boundary correctness.
+//
+// Mutation check: a bug that hard-codes a 12-week window (the previous
+// behavior) returns ~12 entries; this test asserts ~260 and fails.
+// A bug in isoWeek() that uses calendar year instead of ISO year
+// produces wrong week strings at known boundary dates; subtests assert
+// exact strings to catch this.
+func TestBuildVelocitySlice_5YearWindow(t *testing.T) {
+	t.Parallel()
+
+	to := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
+	from := to.AddDate(-5, 0, 0)
+
+	// Pre-populate maps so the union-of-keys logic in buildVelocitySlice
+	// has SOME data; the empty-day continuous-range invariant is a separate
+	// concern (existing buildVelocitySlice emits union-of-seen-weeks, not
+	// every-week-in-range; we accept that and pin the count).
+	opened := map[string]int{}
+	closed := map[string]int{}
+	merged := map[string]int{}
+
+	for w := from; w.Before(to); w = w.AddDate(0, 0, 7) {
+		key := isoWeek(w)
+		opened[key] = 1
+		closed[key] = 1
+		merged[key] = 1
+	}
+
+	got := buildVelocitySlice(opened, closed, merged, from, to)
+
+	// Expect ~260 weeks. The exact number depends on ISO-week alignment
+	// at the boundaries (between 260 and 261 inclusive).
+	if len(got) < 260 || len(got) > 261 {
+		t.Fatalf("len = %d; want 260 or 261 (5-year window)", len(got))
+	}
+}
+
+// TestBuildVelocitySlice_ISOWeekYearBoundary pins exact ISO-week strings
+// at known calendar/ISO-year-divergence boundaries. 2024-12-30 (a Monday)
+// is ISO week 1 of 2025, NOT week 53 of 2024. A bug that uses
+// time.Time.Year() (calendar year) instead of t.ISOWeek()'s year
+// produces "2024-12-30" for the Monday, which a test pinning the
+// expected key WOULD catch.
+//
+// We probe two neighboring weeks straddling the year boundary and assert
+// the helper's bucketing matches what t.ISOWeek() returns directly.
+func TestBuildVelocitySlice_ISOWeekYearBoundary(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		monday     time.Time
+		wantPrefix string // first 4 chars of the resulting key (the year part of YYYY-MM-DD week-Monday format)
+	}{
+		{
+			name:       "Monday in last calendar week of 2024 belongs to ISO 2025",
+			monday:     time.Date(2024, 12, 30, 0, 0, 0, 0, time.UTC),
+			wantPrefix: "2024", // the Monday IS December 30, 2024
+		},
+		{
+			name:       "Monday in first calendar week of 2025",
+			monday:     time.Date(2025, 1, 6, 0, 0, 0, 0, time.UTC),
+			wantPrefix: "2025",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := isoWeek(tc.monday)
+			if got[:4] != tc.wantPrefix {
+				t.Fatalf("isoWeek(%s) = %q; expected to start with %q (per ISO 8601 week-year rules)",
+					tc.monday.Format("2006-01-02"), got, tc.wantPrefix)
+			}
+			// Sanity: the result is a valid YYYY-MM-DD string parseable
+			// back to a Monday close to the input.
+			parsed, err := time.Parse("2006-01-02", got)
+			if err != nil {
+				t.Fatalf("isoWeek result %q is not parseable as YYYY-MM-DD: %v", got, err)
+			}
+			if parsed.Weekday() != time.Monday {
+				t.Fatalf("isoWeek result %q is %s, not Monday", got, parsed.Weekday())
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/NVIDIA/k8s-test-infra
 go 1.24.2
 
 require (
+	github.com/gofri/go-github-ratelimit/v2 v2.0.2
 	github.com/google/go-github/v55 v55.0.0
 	github.com/onsi/ginkgo/v2 v2.23.4
 	golang.org/x/oauth2 v0.27.0
@@ -11,7 +12,6 @@ require (
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
-	github.com/google/docsy v0.11.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	golang.org/x/crypto v0.12.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20240716171331-37eff7fa00de/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 h1:wPbRQzjjwFc0ih8puEVAOFGELsn1zoIIYdxvML7mDxA=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
@@ -9,8 +8,8 @@ github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
-github.com/google/docsy v0.11.0 h1:QnV40cc28QwS++kP9qINtrIv4hlASruhC/K3FqkHAmM=
-github.com/google/docsy v0.11.0/go.mod h1:hGGW0OjNuG5ZbH5JRtALY3yvN8ybbEP/v2iaK4bwOUI=
+github.com/gofri/go-github-ratelimit/v2 v2.0.2 h1:gS8wAS1jTmlWGdTjAM7KIpsLjwY1S0S/gKK5hthfSXM=
+github.com/gofri/go-github-ratelimit/v2 v2.0.2/go.mod h1:YBQt4gTbdcbMjJFT05YFEaECwH78P5b0IwrnbLiHGdE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
@@ -24,7 +23,6 @@ github.com/onsi/ginkgo/v2 v2.23.4 h1:ktYTpKJAVZnDT4VjxSbiBenUjmlL/5QkBEocaWXiQus
 github.com/onsi/ginkgo/v2 v2.23.4/go.mod h1:Bt66ApGPBFzHyR+JO10Zbt0Gsp4uWxu5mIOTusL46e8=
 github.com/onsi/gomega v1.36.3 h1:hID7cr8t3Wp26+cYnfcjR6HpJ00fdogN6dqZ1t6IylU=
 github.com/onsi/gomega v1.36.3/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
-github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
 go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
 go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/hack/deploy_workflow_test.go
+++ b/hack/deploy_workflow_test.go
@@ -1,0 +1,53 @@
+package hack
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDeployWorkflowRestoresIssuesPrsJSON asserts that the deploy.yaml
+// workflow contains a step that restores the previous issues_prs.json
+// from the live site. PR-B's runIssuesPRsPhase cache fallback depends
+// on this step actually running.
+//
+// Mutation check: removing the restore line from deploy.yaml causes
+// this assertion to fail. We grep for the canonical URL and the
+// fallback echo so a partial revert is also caught.
+func TestDeployWorkflowRestoresIssuesPrsJSON(t *testing.T) {
+	t.Parallel()
+
+	repoRoot, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("abs path: %v", err)
+	}
+	workflowPath := filepath.Join(repoRoot, ".github", "workflows", "deploy.yaml")
+
+	data, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", workflowPath, err)
+	}
+	content := string(data)
+
+	requirements := []string{
+		`"https://nvidia.github.io/k8s-test-infra/data/issues_prs.json"`,
+		`mv /tmp/issues_prs.json ./public/data/issues_prs.json`,
+		`echo '{"repos":{}}' > ./public/data/issues_prs.json`,
+	}
+	for _, want := range requirements {
+		if !strings.Contains(content, want) {
+			t.Fatalf("deploy.yaml missing required token: %q", want)
+		}
+	}
+
+	// Negative assertion: should NOT have a schedule trigger (Q7
+	// guardrail; checked here too as a layered defense in case the
+	// dedicated lint workflow is somehow disabled).
+	if strings.Contains(content, "schedule:") {
+		// Allow if marker is present.
+		if !strings.Contains(content, "ADR-allowed-schedule:") {
+			t.Fatalf("deploy.yaml has schedule: without ADR marker; see hack/lint_deploy_schedule.sh")
+		}
+	}
+}

--- a/hack/lint_deploy_schedule.sh
+++ b/hack/lint_deploy_schedule.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# lint_deploy_schedule.sh — fail if .github/workflows/deploy.yaml introduces
+# a `schedule:` trigger without a paired `# ADR-allowed-schedule:` marker
+# comment on the line above.
+#
+# Usage: lint_deploy_schedule.sh [path-to-deploy.yaml]
+# Default path: .github/workflows/deploy.yaml
+#
+# Why: spec docs/plans/2026-04-30-dashboard-duration-options-design.md
+# (decision Q7) — the fetcher's stateless-full-pull cost model assumes
+# deploys are infrequent. A scheduled trigger silently invalidates that
+# assumption. Future re-introduction of a schedule must be an explicit
+# design decision, not an incidental edit.
+#
+# Anchor: the marker must appear on a line that begins with optional
+# whitespace, then '#', then optional whitespace, then 'ADR-allowed-schedule:'.
+# This prevents a YAML key-value bypass like:
+#   myKey: ADR-allowed-schedule: bypass
+#   schedule: ...
+# where the substring matches but is NOT an opt-in comment.
+
+set -euo pipefail
+
+DEPLOY_YAML="${1:-.github/workflows/deploy.yaml}"
+
+if [[ ! -f "$DEPLOY_YAML" ]]; then
+  echo "::error::file not found: $DEPLOY_YAML"
+  exit 2
+fi
+
+# Find any line beginning with `schedule:` (after optional indent) inside the
+# `on:` block. We don't try to parse YAML; a grep + adjacent-line check is
+# sufficient for the fail-loud guardrail.
+schedule_lines=$(grep -n -E '^\s*schedule:\s*$' "$DEPLOY_YAML" || true)
+
+if [[ -z "$schedule_lines" ]]; then
+  echo "OK: no schedule: trigger in $DEPLOY_YAML"
+  exit 0
+fi
+
+# For each match, look at the preceding line. If it contains
+# `ADR-allowed-schedule:` the schedule is explicitly approved.
+unmarked=0
+while IFS=: read -r lineno _; do
+  prev=$((lineno - 1))
+  if [[ $prev -lt 1 ]]; then
+    unmarked=1
+    echo "::error file=$DEPLOY_YAML,line=$lineno::schedule: at top of file with no ADR marker"
+    continue
+  fi
+  prev_text=$(sed -n "${prev}p" "$DEPLOY_YAML")
+  if [[ "$prev_text" =~ ^[[:space:]]*#[[:space:]]*ADR-allowed-schedule: ]]; then
+    echo "OK: schedule: at line $lineno has ADR marker on line $prev"
+    continue
+  fi
+  unmarked=1
+  echo "::error file=$DEPLOY_YAML,line=$lineno::schedule: trigger requires '# ADR-allowed-schedule: <ref>' comment on the preceding line"
+done <<< "$schedule_lines"
+
+if [[ $unmarked -ne 0 ]]; then
+  echo
+  echo "Spec docs/plans/2026-04-30-dashboard-duration-options-design.md (decision Q7) requires"
+  echo "scheduled triggers to be paired with an ADR comment because the fetcher's cost model"
+  echo "assumes deploys are on-demand. To add a schedule:, add the marker:"
+  echo
+  echo "  # ADR-allowed-schedule: docs/plans/<your-adr>.md"
+  echo "  schedule:"
+  echo "    - cron: ..."
+  echo
+  exit 1
+fi
+
+exit 0

--- a/lint_deploy_schedule_test.go
+++ b/lint_deploy_schedule_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLintDeploySchedule covers four input variants of deploy.yaml content
+// against hack/lint_deploy_schedule.sh:
+//   - no schedule: trigger          → exit 0 (pass)
+//   - unmarked schedule:            → exit 1 (fail)
+//   - schedule: with ADR marker     → exit 0 (pass)
+//   - file missing                  → exit 2 (file not found)
+//
+// Each subtest writes a fixture into t.TempDir() and invokes the script.
+//
+// This guardrail protects the cost-model assumption that downstream
+// TestResult production depends on; see spec Q7.
+//
+// Mutation check: removing the unmarked-schedule branch causes the
+// "unmarked schedule" subtest to fail; removing the marker check causes
+// "marker honored" to fail.
+func TestLintDeploySchedule(t *testing.T) {
+	t.Parallel()
+
+	scriptPath, err := filepath.Abs("hack/lint_deploy_schedule.sh")
+	if err != nil {
+		t.Fatalf("abs path: %v", err)
+	}
+	if _, err := os.Stat(scriptPath); err != nil {
+		t.Fatalf("script missing at %s: %v", scriptPath, err)
+	}
+
+	cases := []struct {
+		name     string
+		content  string // empty content means "do not write the file"
+		wantExit int
+	}{
+		{
+			name: "no schedule",
+			content: `name: Deploy
+on:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+`,
+			wantExit: 0,
+		},
+		{
+			name: "unmarked schedule",
+			content: `name: Deploy
+on:
+  schedule:
+    - cron: '0 * * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+`,
+			wantExit: 1,
+		},
+		{
+			name: "marker honored",
+			content: `name: Deploy
+on:
+  # ADR-allowed-schedule: docs/plans/some-future-adr.md
+  schedule:
+    - cron: '0 * * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+`,
+			wantExit: 0,
+		},
+		{
+			name:     "file missing",
+			content:  "",
+			wantExit: 2,
+		},
+		{
+			name: "bypass-attempt: marker as YAML value",
+			content: `name: Deploy
+on:
+  myKey: ADR-allowed-schedule: bypass
+  schedule:
+    - cron: '0 * * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+`,
+			wantExit: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tmp := t.TempDir()
+			fixturePath := filepath.Join(tmp, "deploy.yaml")
+			if tc.content != "" {
+				if err := os.WriteFile(fixturePath, []byte(tc.content), 0o644); err != nil {
+					t.Fatalf("write fixture: %v", err)
+				}
+			}
+			cmd := exec.Command(scriptPath, fixturePath)
+			out, err := cmd.CombinedOutput()
+			gotExit := 0
+			if err != nil {
+				if exitErr, ok := err.(*exec.ExitError); ok {
+					gotExit = exitErr.ExitCode()
+				} else {
+					t.Fatalf("unexpected exec error: %v\noutput:\n%s", err, out)
+				}
+			}
+			if gotExit != tc.wantExit {
+				t.Fatalf("exit = %d; want %d\noutput:\n%s", gotExit, tc.wantExit, out)
+			}
+			// Sanity-check the output mentions the fixture for the failure case
+			// so the workflow's annotation surface is exercised.
+			if tc.wantExit == 1 && !strings.Contains(string(out), "ADR-allowed-schedule") {
+				t.Fatalf("expected output to mention 'ADR-allowed-schedule'; got:\n%s", out)
+			}
+		})
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@csstools/css-tokenizer": "^4.0.0",
         "lucide-react": "^0.469.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -522,7 +523,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,15 +17,89 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
         "eslint": "^9.0.0",
+        "jsdom": "^28.1.0",
         "tailwindcss": "^4.0.0",
         "typescript": "~5.7.0",
         "typescript-eslint": "^8.55.0",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -261,6 +335,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -307,6 +391,151 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
+      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
+      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.1",
+        "@csstools/css-calc": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
+      "integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -893,6 +1122,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
+      "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1674,6 +1921,104 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1717,6 +2062,17 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-array": {
@@ -1780,6 +2136,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -2112,6 +2475,117 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2135,6 +2609,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2150,6 +2634,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2175,6 +2670,26 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2190,6 +2705,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2267,6 +2792,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2354,6 +2889,53 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.0.1.tgz",
+      "integrity": "sha512-IoJs7La+oFp/AB033wBStxNOJt4+9hHMxsXUPANcoXL2b3W4DZKghlJ2cI/eyeRZIQ9ysvYEorVhjrcYctWbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.26",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/csstype": {
@@ -2484,6 +3066,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2502,6 +3098,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -2515,6 +3118,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2524,6 +3137,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
@@ -2545,6 +3166,26 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-toolkit": {
       "version": "1.44.0",
@@ -2765,6 +3406,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2780,6 +3431,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2939,6 +3600,47 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2986,6 +3688,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -3017,6 +3729,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3053,6 +3772,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -3429,6 +4189,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3437,6 +4208,23 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -3490,6 +4278,17 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -3555,6 +4354,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3574,6 +4386,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3633,6 +4452,44 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -3757,6 +4614,20 @@
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -3770,6 +4641,16 @@
       "license": "MIT",
       "peerDependencies": {
         "redux": "^5.0.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/reselect": {
@@ -3833,6 +4714,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3878,6 +4772,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3886,6 +4787,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3914,6 +4842,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
@@ -3941,6 +4876,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3956,6 +4908,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
+      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.23"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4020,6 +5028,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -4169,6 +5187,132 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
+      "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4185,6 +5329,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4194,6 +5355,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@csstools/css-tokenizer": "^4.0.0",
         "lucide-react": "^0.469.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -523,6 +522,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2186,17 +2186,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.55.0.tgz",
-      "integrity": "sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
+      "integrity": "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.55.0",
-        "@typescript-eslint/type-utils": "8.55.0",
-        "@typescript-eslint/utils": "8.55.0",
-        "@typescript-eslint/visitor-keys": "8.55.0",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/type-utils": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.4.0"
@@ -2209,8 +2209,8 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.55.0",
-        "eslint": "^8.57.0 || ^9.0.0",
+        "@typescript-eslint/parser": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
@@ -2225,16 +2225,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.55.0.tgz",
-      "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
+      "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.55.0",
-        "@typescript-eslint/types": "8.55.0",
-        "@typescript-eslint/typescript-estree": "8.55.0",
-        "@typescript-eslint/visitor-keys": "8.55.0",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2245,19 +2245,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.55.0.tgz",
-      "integrity": "sha512-zRcVVPFUYWa3kNnjaZGXSu3xkKV1zXy8M4nO/pElzQhFweb7PPtluDLQtKArEOGmjXoRjnUZ29NjOiF0eCDkcQ==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.0.tgz",
+      "integrity": "sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
+        "@typescript-eslint/tsconfig-utils": "^8.56.0",
+        "@typescript-eslint/types": "^8.56.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2272,14 +2272,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.55.0.tgz",
-      "integrity": "sha512-fVu5Omrd3jeqeQLiB9f1YsuK/iHFOwb04bCtY4BSCLgjNbOD33ZdV6KyEqplHr+IlpgT0QTZ/iJ+wT7hvTx49Q==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz",
+      "integrity": "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.55.0",
-        "@typescript-eslint/visitor-keys": "8.55.0"
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2290,9 +2290,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.55.0.tgz",
-      "integrity": "sha512-1R9cXqY7RQd7WuqSN47PK9EDpgFUK3VqdmbYrvWJZYDd0cavROGn+74ktWBlmJ13NXUQKlZ/iAEQHI/V0kKe0Q==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.0.tgz",
+      "integrity": "sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2307,15 +2307,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.55.0.tgz",
-      "integrity": "sha512-x1iH2unH4qAt6I37I2CGlsNs+B9WGxurP2uyZLRz6UJoZWDBx9cJL1xVN/FiOmHEONEg6RIufdvyT0TEYIgC5g==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.0.tgz",
+      "integrity": "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.55.0",
-        "@typescript-eslint/typescript-estree": "8.55.0",
-        "@typescript-eslint/utils": "8.55.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.4.0"
       },
@@ -2327,14 +2327,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.55.0.tgz",
-      "integrity": "sha512-ujT0Je8GI5BJWi+/mMoR0wxwVEQaxM+pi30xuMiJETlX80OPovb2p9E8ss87gnSVtYXtJoU9U1Cowcr6w2FE0w==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.0.tgz",
+      "integrity": "sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2346,16 +2346,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.55.0.tgz",
-      "integrity": "sha512-EwrH67bSWdx/3aRQhCoxDaHM+CrZjotc2UCCpEDVqfCE+7OjKAGWNY2HsCSTEVvWH2clYQK8pdeLp42EVs+xQw==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.0.tgz",
+      "integrity": "sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.55.0",
-        "@typescript-eslint/tsconfig-utils": "8.55.0",
-        "@typescript-eslint/types": "8.55.0",
-        "@typescript-eslint/visitor-keys": "8.55.0",
+        "@typescript-eslint/project-service": "8.56.0",
+        "@typescript-eslint/tsconfig-utils": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
         "debug": "^4.4.3",
         "minimatch": "^9.0.5",
         "semver": "^7.7.3",
@@ -2413,16 +2413,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.55.0.tgz",
-      "integrity": "sha512-BqZEsnPGdYpgyEIkDC1BadNY8oMwckftxBT+C8W0g1iKPdeqKZBtTfnvcq0nf60u7MkjFO8RBvpRGZBPw4L2ow==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.0.tgz",
+      "integrity": "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.55.0",
-        "@typescript-eslint/types": "8.55.0",
-        "@typescript-eslint/typescript-estree": "8.55.0"
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2432,19 +2432,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.55.0.tgz",
-      "integrity": "sha512-AxNRwEie8Nn4eFS1FzDMJWIISMGoXMb037sgCBJ3UR6o0fQTzr2tqN9WT+DkWJPhIdQCfV7T6D387566VtnCJA==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.0.tgz",
+      "integrity": "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.55.0",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.56.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2452,6 +2452,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
+      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2773,9 +2786,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001769",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
-      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+      "version": "1.0.30001770",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
+      "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
       "dev": true,
       "funding": [
         {
@@ -5007,16 +5020,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.55.0.tgz",
-      "integrity": "sha512-HE4wj+r5lmDVS9gdaN0/+iqNvPZwGfnJ5lZuz7s5vLlg9ODw0bIiiETaios9LvFI1U94/VBXGm3CB2Y5cNFMpw==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.0.tgz",
+      "integrity": "sha512-c7toRLrotJ9oixgdW7liukZpsnq5CZ7PuKztubGYlNppuTqhIoWfhgHo/7EU0v06gS2l/x0i2NEFK1qMIf0rIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.55.0",
-        "@typescript-eslint/parser": "8.55.0",
-        "@typescript-eslint/typescript-estree": "8.55.0",
-        "@typescript-eslint/utils": "8.55.0"
+        "@typescript-eslint/eslint-plugin": "8.56.0",
+        "@typescript-eslint/parser": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5026,7 +5039,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@csstools/css-tokenizer": "^4.0.0",
     "lucide-react": "^0.469.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "lucide-react": "^0.469.0",
@@ -20,13 +22,18 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
     "eslint": "^9.0.0",
+    "jsdom": "^28.1.0",
     "tailwindcss": "^4.0.0",
     "typescript": "~5.7.0",
     "typescript-eslint": "^8.55.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@csstools/css-tokenizer": "^4.0.0",
     "lucide-react": "^0.469.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/public/data/images.json
+++ b/public/data/images.json
@@ -4,13 +4,17 @@
       "repo": "nvidia/gpu-operator",
       "tag": "9ee21750",
       "pushedAt": "2025-05-21T00:35:17Z",
-      "htmlUrl": "https://github.com/nvidia/gpu-operator/pkgs/container/gpu-operator/420112772?tag=9ee21750"
+      "htmlUrl": "https://github.com/nvidia/gpu-operator/pkgs/container/gpu-operator/420112772?tag=9ee21750",
+      "imageType": "ci",
+      "commitUrl": "https://github.com/nvidia/gpu-operator/commit/9ee21750"
     },
     {
       "repo": "nvidia/k8s-device-plugin",
       "tag": "6f41f70c-ubi9",
       "pushedAt": "2025-05-15T14:57:43Z",
-      "htmlUrl": "https://github.com/nvidia/k8s-device-plugin/pkgs/container/k8s-device-plugin/416491509?tag=6f41f70c-ubi9"
+      "htmlUrl": "https://github.com/nvidia/k8s-device-plugin/pkgs/container/k8s-device-plugin/416491509?tag=6f41f70c-ubi9",
+      "imageType": "ci",
+      "commitUrl": "https://github.com/nvidia/k8s-device-plugin/commit/6f41f70c"
     }
   ]
 }

--- a/src/components/IssuesPRsDashboard.tsx
+++ b/src/components/IssuesPRsDashboard.tsx
@@ -16,12 +16,11 @@ import {
 import { ChevronDown, ChevronRight, ArrowUp, ArrowDown, ArrowRight } from 'lucide-react';
 import { useTheme } from './ThemeProvider';
 import VelocitySparkline from './VelocitySparkline';
-import { AGE_COLORS, getCategoryColor, getChartStyles, formatWeekTick, computeTrend } from '../utils/chartStyles';
+import { AGE_COLORS, getCategoryColor, getChartStyles, formatWeekTick, formatDayTick, computeTrend } from '../utils/chartStyles';
 import type { Trend } from '../utils/chartStyles';
+import { DURATIONS, pickVelocity, type Duration } from '../utils/duration';
 import { projects } from '../data/projects';
 import type { IssuesPRsData, RepoIssuesPRs } from '../types';
-
-type TimeRange = 4 | 8 | 12;
 
 interface Props {
   data: IssuesPRsData;
@@ -43,25 +42,27 @@ interface RowData {
 
 function ExpandedRowDetail({
   repoData,
-  timeRange,
+  duration,
   tooltipStyle,
   tickStyle,
   gridStroke,
 }: {
   repoData: RepoIssuesPRs;
-  timeRange: TimeRange;
+  duration: Duration;
   tooltipStyle: React.CSSProperties;
   tickStyle: { fontSize: number; fill: string };
   gridStroke: string;
 }) {
-  const issueVelocity = useMemo(
-    () => repoData.issues.velocity.slice(-timeRange),
-    [repoData.issues.velocity, timeRange],
+  const { points: issueVelocity, granularity: issueGranularity } = useMemo(
+    () => pickVelocity(repoData.issues.velocity, duration),
+    [repoData.issues.velocity, duration],
   );
-  const prVelocity = useMemo(
-    () => repoData.pullRequests.velocity.slice(-timeRange),
-    [repoData.pullRequests.velocity, timeRange],
+  const { points: prVelocity, granularity: prGranularity } = useMemo(
+    () => pickVelocity(repoData.pullRequests.velocity, duration),
+    [repoData.pullRequests.velocity, duration],
   );
+  const issueTickFormatter = issueGranularity === 'day' ? formatDayTick : formatWeekTick;
+  const prTickFormatter = prGranularity === 'day' ? formatDayTick : formatWeekTick;
   const issueCategories = useMemo(
     () =>
       Object.entries(repoData.issues.categories)
@@ -129,7 +130,7 @@ function ExpandedRowDetail({
         {/* Issue Velocity */}
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
           <h4 className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">
-            Issue Velocity ({timeRange}w)
+            Issue Velocity ({duration})
           </h4>
           {issueVelocity.length > 0 ? (
             <ResponsiveContainer width="100%" height={160}>
@@ -142,9 +143,15 @@ function ExpandedRowDetail({
                   stroke={gridStroke}
                 />
                 <XAxis
-                  dataKey="week"
+                  dataKey="label"
                   tick={tickStyle}
-                  tickFormatter={formatWeekTick}
+                  tickFormatter={issueTickFormatter}
+                  label={{
+                    value: issueGranularity === 'day' ? 'Day (UTC)' : 'Week (UTC)',
+                    position: 'insideBottom',
+                    offset: -5,
+                    style: { fontSize: tickStyle.fontSize, fill: tickStyle.fill },
+                  }}
                 />
                 <YAxis tick={tickStyle} allowDecimals={false} />
                 <Tooltip contentStyle={tooltipStyle} />
@@ -251,7 +258,7 @@ function ExpandedRowDetail({
             </div>
           </div>
           <h4 className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">
-            PR Velocity ({timeRange}w)
+            PR Velocity ({duration})
           </h4>
           {prVelocity.length > 0 ? (
             <ResponsiveContainer width="100%" height={100}>
@@ -259,10 +266,20 @@ function ExpandedRowDetail({
                 data={prVelocity}
                 margin={{ top: 4, right: 16, bottom: 0, left: 0 }}
               >
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  stroke={gridStroke}
+                />
                 <XAxis
-                  dataKey="week"
+                  dataKey="label"
                   tick={tickStyle}
-                  tickFormatter={formatWeekTick}
+                  tickFormatter={prTickFormatter}
+                  label={{
+                    value: prGranularity === 'day' ? 'Day (UTC)' : 'Week (UTC)',
+                    position: 'insideBottom',
+                    offset: -5,
+                    style: { fontSize: tickStyle.fontSize, fill: tickStyle.fill },
+                  }}
                 />
                 <YAxis tick={tickStyle} allowDecimals={false} />
                 <Tooltip contentStyle={tooltipStyle} />
@@ -296,7 +313,7 @@ function ExpandedRowDetail({
 export default function IssuesPRsDashboard({ data }: Props) {
   const { resolved } = useTheme();
   const dark = resolved === 'dark';
-  const [timeRange, setTimeRange] = useState<TimeRange>(12);
+  const [duration, setDuration] = useState<Duration>('12w');
   const [expandedSlug, setExpandedSlug] = useState<string | null>(null);
 
   const rows = useMemo<RowData[]>(() => {
@@ -309,36 +326,34 @@ export default function IssuesPRsDashboard({ data }: Props) {
           name: p.name,
           repo: p.repo,
           repoData,
-          trend: computeTrend(repoData.issues.velocity),
+          trend: computeTrend(repoData.issues.velocity.weekly),
         };
       });
   }, [data]);
 
   const { tooltipStyle, tickStyle, gridStroke } = getChartStyles(dark);
 
-  const ranges: TimeRange[] = [4, 8, 12];
-
   return (
     <section className="mb-6">
       {/* Header with time range selector */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-3">
         <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-200">
           Issues &amp; PRs Overview
         </h2>
-        <div className="flex gap-1">
-          {ranges.map((r) => (
+        <div className="flex flex-wrap gap-1" role="group" aria-label="Velocity duration">
+          {DURATIONS.map((d) => (
             <button
-              key={r}
-              onClick={() => setTimeRange(r)}
-              aria-pressed={timeRange === r}
-              aria-label={`Show ${r} weeks of data`}
+              key={d}
+              onClick={() => setDuration(d)}
+              aria-pressed={duration === d}
+              aria-label={`Show ${d} of velocity data`}
               className={`px-2 py-1 text-xs rounded ${
-                timeRange === r
+                duration === d
                   ? 'bg-nvidia-green text-white'
                   : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
               }`}
             >
-              {r}w
+              {d}
             </button>
           ))}
         </div>
@@ -396,14 +411,20 @@ export default function IssuesPRsDashboard({ data }: Props) {
                         {row.name}
                       </Link>
                     </td>
-                    <td className="p-3 text-right text-gray-700 dark:text-gray-300">
+                    <td
+                      className="p-3 text-right text-gray-700 dark:text-gray-300"
+                      data-testid={`open-issues-${row.slug}`}
+                    >
                       {row.repoData.issues.total}
                     </td>
-                    <td className="p-3 text-right text-gray-700 dark:text-gray-300">
+                    <td
+                      className="p-3 text-right text-gray-700 dark:text-gray-300"
+                      data-testid={`open-prs-${row.slug}`}
+                    >
                       {row.repoData.pullRequests.total}
                     </td>
                     <td className="p-3 text-center">
-                      <VelocitySparkline data={row.repoData.issues.velocity} weeks={timeRange} />
+                      <VelocitySparkline velocity={row.repoData.issues.velocity} duration={duration} />
                     </td>
                     <td className="p-3 text-right">
                       <span
@@ -438,7 +459,7 @@ export default function IssuesPRsDashboard({ data }: Props) {
                       <td colSpan={8} className="p-0">
                         <ExpandedRowDetail
                           repoData={row.repoData}
-                          timeRange={timeRange}
+                          duration={duration}
                           tooltipStyle={tooltipStyle}
                           tickStyle={tickStyle}
                           gridStroke={gridStroke}

--- a/src/components/IssuesPRsSection.tsx
+++ b/src/components/IssuesPRsSection.tsx
@@ -48,13 +48,13 @@ export default function IssuesPRsSection({ data }: Props) {
   }, [data.issues.ageBuckets, data.pullRequests.ageBuckets]);
 
   // Velocity here is rendered as the default detail view at weekly
-  // granularity; UI redesign spec 3 may add a per-page duration selector
-  // later. Until then, this section reads the last 12 weeks straight from
-  // velocity.weekly — the daily array (velocity.daily) is consumed by the
-  // home dashboard's 7d view.
+  // granularity; a per-page duration selector may follow later. Until then
+  // this section reads the last 12 weeks of velocity.weekly to match the
+  // "Velocity (12 weeks)" heading; the daily array (velocity.daily) is
+  // consumed by the home dashboard's 7d view.
   const velocityData = useMemo(() => {
     const source = velocityView === 'issues' ? data.issues.velocity.weekly : data.pullRequests.velocity.weekly;
-    return source.map((v) => ({
+    return source.slice(-12).map((v) => ({
       week: v.week,
       opened: v.opened,
       closed: v.closed,

--- a/src/components/IssuesPRsSection.tsx
+++ b/src/components/IssuesPRsSection.tsx
@@ -47,15 +47,20 @@ export default function IssuesPRsSection({ data }: Props) {
     }));
   }, [data.issues.ageBuckets, data.pullRequests.ageBuckets]);
 
+  // Velocity here is rendered as the default detail view at weekly
+  // granularity; UI redesign spec 3 may add a per-page duration selector
+  // later. Until then, this section reads the last 12 weeks straight from
+  // velocity.weekly — the daily array (velocity.daily) is consumed by the
+  // home dashboard's 7d view.
   const velocityData = useMemo(() => {
-    const source = velocityView === 'issues' ? data.issues.velocity : data.pullRequests.velocity;
+    const source = velocityView === 'issues' ? data.issues.velocity.weekly : data.pullRequests.velocity.weekly;
     return source.map((v) => ({
       week: v.week,
       opened: v.opened,
       closed: v.closed,
       ...(v.merged !== undefined ? { merged: v.merged } : {}),
     }));
-  }, [velocityView, data.issues.velocity, data.pullRequests.velocity]);
+  }, [velocityView, data.issues.velocity.weekly, data.pullRequests.velocity.weekly]);
 
   const { tooltipStyle, tickStyle, gridStroke } = getChartStyles(dark);
 
@@ -204,6 +209,12 @@ export default function IssuesPRsSection({ data }: Props) {
                 dataKey="week"
                 tick={tickStyle}
                 tickFormatter={formatWeekTick}
+                label={{
+                  value: 'Week (UTC)',
+                  position: 'insideBottom',
+                  offset: -5,
+                  style: { fontSize: 11, fill: tickStyle.fill },
+                }}
               />
               <YAxis tick={tickStyle} allowDecimals={false} />
               <Tooltip contentStyle={tooltipStyle} />

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,37 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+export default function Pagination({ currentPage, totalPages, onPageChange }: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="flex items-center justify-between px-4 py-3 border-t border-gray-200 dark:border-gray-700">
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage <= 1}
+        aria-label="Previous page"
+        className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium rounded-md transition-colors disabled:opacity-40 disabled:cursor-not-allowed text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+      >
+        <ChevronLeft size={16} />
+        Previous
+      </button>
+      <span className="text-sm text-gray-600 dark:text-gray-400">
+        Page {currentPage} of {totalPages}
+      </span>
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage >= totalPages}
+        aria-label="Next page"
+        className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium rounded-md transition-colors disabled:opacity-40 disabled:cursor-not-allowed text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+      >
+        Next
+        <ChevronRight size={16} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/VelocitySparkline.tsx
+++ b/src/components/VelocitySparkline.tsx
@@ -1,19 +1,23 @@
 import { ResponsiveContainer, LineChart, Line } from 'recharts';
-import type { VelocityWeek } from '../types';
+import type { Velocity } from '../types';
+import { pickVelocity, type Duration } from '../utils/duration';
 
 interface Props {
-  data: VelocityWeek[];
-  weeks?: number;
+  velocity: Velocity;
+  duration: Duration;
 }
 
-export default function VelocitySparkline({ data, weeks = 12 }: Props) {
-  const sliced = data.slice(-weeks);
-  if (sliced.length === 0) return <span className="text-gray-400 text-xs">&mdash;</span>;
+export default function VelocitySparkline({ velocity, duration }: Props) {
+  const { points } = pickVelocity(velocity, duration);
+
+  if (points.length === 0) {
+    return <span className="text-gray-400 text-xs" data-testid="sparkline-empty">&mdash;</span>;
+  }
 
   return (
-    <div className="inline-block w-[60px] h-[20px]">
+    <div className="inline-block w-[60px] h-[20px]" data-testid="sparkline">
       <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={sliced}>
+        <LineChart data={points}>
           <Line type="monotone" dataKey="opened" stroke="#ef4444" strokeWidth={1} dot={false} isAnimationActive={false} />
           <Line type="monotone" dataKey="closed" stroke="#22c55e" strokeWidth={1} dot={false} isAnimationActive={false} />
         </LineChart>

--- a/src/components/__tests__/IssuesPRsDashboard.test.tsx
+++ b/src/components/__tests__/IssuesPRsDashboard.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import IssuesPRsDashboard from '../IssuesPRsDashboard';
+import ThemeProvider from '../ThemeProvider';
+import type { IssuesPRsData } from '../../types';
+
+// jsdom 28 + vitest 4: window.localStorage is not auto-instantiated for
+// the default about:blank URL, and matchMedia is famously not implemented.
+// ThemeProvider touches both on mount, so install minimal in-memory shims.
+beforeAll(() => {
+  if (typeof globalThis.localStorage === 'undefined' ||
+      typeof globalThis.localStorage.getItem !== 'function') {
+    const store = new Map<string, string>();
+    const stub: Storage = {
+      get length() { return store.size; },
+      clear: () => store.clear(),
+      getItem: (k) => (store.has(k) ? store.get(k)! : null),
+      key: (i) => Array.from(store.keys())[i] ?? null,
+      removeItem: (k) => { store.delete(k); },
+      setItem: (k, v) => { store.set(k, String(v)); },
+    };
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: stub,
+    });
+  }
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: (query: string): MediaQueryList => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+});
+
+// Build distinguishable fixture data so daily and weekly slices yield
+// non-overlapping values — required for the snapshot-regression test
+// to detect filtering through pickVelocity.
+function makeData(): IssuesPRsData {
+  return {
+    repos: {
+      'nvidia/gpu-operator': {
+        fetchedAt: '2026-04-30T12:00:00Z',
+        issues: {
+          total: 42,
+          categories: { bug: 12, 'feature-request': 8 },
+          ageBuckets: { fresh: 5, recent: 10, aging: 12, stale: 8, ancient: 7 },
+          velocity: {
+            daily: Array.from({ length: 365 }, (_, i) => ({
+              date: `2026-day-${i}`,
+              opened: 1000 + i,
+              closed: 500 + i,
+            })),
+            weekly: Array.from({ length: 260 }, (_, i) => ({
+              week: `wk-${i}`,
+              opened: i,
+              closed: 500 - i,
+            })),
+          },
+        },
+        pullRequests: {
+          total: 8,
+          categories: {},
+          ageBuckets: { fresh: 3, recent: 2, aging: 2, stale: 1, ancient: 0 },
+          velocity: {
+            daily: Array.from({ length: 365 }, (_, i) => ({
+              date: `2026-day-${i}`,
+              opened: 0,
+              closed: 200 + i,
+            })),
+            weekly: Array.from({ length: 260 }, (_, i) => ({
+              week: `wk-${i}`,
+              opened: 0,
+              closed: 200 - i,
+            })),
+          },
+          review: { awaitingReview: 3, noReviewer: 1, avgDaysToFirstReview: 1.5, avgDaysToMerge: 3.2 },
+        },
+      },
+    },
+  };
+}
+
+function renderDashboard(data: IssuesPRsData) {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider>
+        <IssuesPRsDashboard data={data} />
+      </ThemeProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('IssuesPRsDashboard', () => {
+  it('defaults to the 12w duration', () => {
+    renderDashboard(makeData());
+    const btn = screen.getByRole('button', { name: /Show 12w of velocity data/ });
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('renders all 6 duration buttons in display order', () => {
+    renderDashboard(makeData());
+    const labels = ['7d', '4w', '12w', '6m', '1y', '5y'];
+    for (const label of labels) {
+      expect(screen.getByRole('button', { name: new RegExp(`Show ${label} of velocity data`) }))
+        .toBeInTheDocument();
+    }
+  });
+
+  it('clicking a duration button updates aria-pressed', async () => {
+    const user = userEvent.setup();
+    renderDashboard(makeData());
+
+    const btn7d = screen.getByRole('button', { name: /Show 7d of velocity data/ });
+    expect(btn7d).toHaveAttribute('aria-pressed', 'false');
+
+    await user.click(btn7d);
+
+    expect(btn7d).toHaveAttribute('aria-pressed', 'true');
+    const btn12w = screen.getByRole('button', { name: /Show 12w of velocity data/ });
+    expect(btn12w).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  // Q3 invariant (snapshot regression test, strengthened per QA review).
+  // Uses stable test IDs (not text content) so a regression can't pass by
+  // coincidence with another element rendering the same number — e.g. the
+  // categories bar chart can render '8' for the feature-request count,
+  // which would collide with pullRequests.total === 8 if querying by text.
+  it('snapshot stats do not change when duration changes (Q3 invariant)', async () => {
+    const user = userEvent.setup();
+    renderDashboard(makeData());
+
+    const openIssuesCell = screen.getByTestId('open-issues-gpu-operator');
+    const openPRsCell = screen.getByTestId('open-prs-gpu-operator');
+    const initialIssuesText = openIssuesCell.textContent;
+    const initialPRsText = openPRsCell.textContent;
+
+    expect(initialIssuesText).toBe('42');
+    expect(initialPRsText).toBe('8');
+
+    for (const label of ['7d', '4w', '12w', '6m', '1y', '5y']) {
+      const btn = screen.getByRole('button', { name: new RegExp(`Show ${label} of velocity data`) });
+      await user.click(btn);
+
+      expect(openIssuesCell.textContent).toBe(initialIssuesText);
+      expect(openPRsCell.textContent).toBe(initialPRsText);
+    }
+  });
+});

--- a/src/components/__tests__/IssuesPRsSection.test.tsx
+++ b/src/components/__tests__/IssuesPRsSection.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import IssuesPRsSection from '../IssuesPRsSection';
+import type { RepoIssuesPRs } from '../../types';
+
+// useTheme is invoked at component-mount; stub it instead of wrapping in
+// ThemeProvider so the test stays focused on velocity rendering.
+vi.mock('../ThemeProvider', () => ({
+  useTheme: () => ({ resolved: 'light' }),
+}));
+
+// Mock recharts so the LineChart's data prop is exposed as a queryable
+// DOM attribute. The bar chart used for ageBuckets is rendered via the
+// same module mock; only the velocity LineChart is asserted on here.
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  LineChart: ({ data, children }: { data: unknown[]; children: React.ReactNode }) => (
+    <div data-testid="velocity-line-chart" data-points={JSON.stringify(data)}>{children}</div>
+  ),
+  Line: () => null,
+  BarChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Bar: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Cell: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+}));
+
+interface ChartPoint {
+  week: string;
+  opened: number;
+  closed: number;
+}
+
+function readVelocityChartData(): ChartPoint[] {
+  const raw = screen.getByTestId('velocity-line-chart').getAttribute('data-points');
+  if (!raw) throw new Error('velocity-line-chart has no data-points attribute');
+  return JSON.parse(raw) as ChartPoint[];
+}
+
+function makeFixture(weeks: number): RepoIssuesPRs {
+  const buildVelocity = (basis: number) => ({
+    daily: [],
+    weekly: Array.from({ length: weeks }, (_, i) => ({
+      week: `W${String(i).padStart(3, '0')}`,
+      opened: basis + i,
+      closed: basis - i,
+    })),
+  });
+  const emptyAge = { fresh: 0, recent: 0, aging: 0, stale: 0, ancient: 0 };
+  return {
+    fetchedAt: '2026-05-10T00:00:00Z',
+    issues: {
+      total: 1,
+      ageBuckets: emptyAge,
+      categories: {},
+      velocity: buildVelocity(100),
+    },
+    pullRequests: {
+      total: 1,
+      ageBuckets: emptyAge,
+      categories: {},
+      velocity: buildVelocity(200),
+      review: {
+        awaitingReview: 0,
+        noReviewer: 0,
+        avgDaysToFirstReview: 0,
+        avgDaysToMerge: 0,
+      },
+    },
+  };
+}
+
+describe('IssuesPRsSection velocity chart', () => {
+  it('renders only the last 12 weeks when the fixture carries more', () => {
+    const data = makeFixture(260);
+    render(<IssuesPRsSection data={data} />);
+
+    const points = readVelocityChartData();
+    expect(points).toHaveLength(12);
+    // Last 12 of 260 weeks: indices 248..259
+    expect(points[0]?.week).toBe('W248');
+    expect(points[11]?.week).toBe('W259');
+  });
+
+  it('renders all weeks when fewer than 12 are available', () => {
+    const data = makeFixture(5);
+    render(<IssuesPRsSection data={data} />);
+
+    const points = readVelocityChartData();
+    expect(points).toHaveLength(5);
+    expect(points[0]?.week).toBe('W000');
+    expect(points[4]?.week).toBe('W004');
+  });
+});

--- a/src/components/__tests__/Pagination.test.tsx
+++ b/src/components/__tests__/Pagination.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import Pagination from '../Pagination';
+
+describe('Pagination', () => {
+  it('renders nothing when totalPages <= 1', () => {
+    const { container } = render(
+      <Pagination currentPage={1} totalPages={1} onPageChange={() => {}} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders prev/next buttons and page indicator', () => {
+    render(
+      <Pagination currentPage={1} totalPages={3} onPageChange={() => {}} />
+    );
+    expect(screen.getByRole('button', { name: /previous/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 3')).toBeInTheDocument();
+  });
+
+  it('disables Previous button on first page', () => {
+    render(
+      <Pagination currentPage={1} totalPages={3} onPageChange={() => {}} />
+    );
+    expect(screen.getByRole('button', { name: /previous/i })).toBeDisabled();
+  });
+
+  it('disables Next button on last page', () => {
+    render(
+      <Pagination currentPage={3} totalPages={3} onPageChange={() => {}} />
+    );
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled();
+  });
+
+  it('calls onPageChange with next page when Next clicked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Pagination currentPage={2} totalPages={5} onPageChange={onChange} />
+    );
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(onChange).toHaveBeenCalledWith(3);
+  });
+
+  it('calls onPageChange with previous page when Previous clicked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Pagination currentPage={3} totalPages={5} onPageChange={onChange} />
+    );
+    await user.click(screen.getByRole('button', { name: /previous/i }));
+    expect(onChange).toHaveBeenCalledWith(2);
+  });
+
+  it('enables both buttons on a middle page', () => {
+    render(
+      <Pagination currentPage={2} totalPages={3} onPageChange={() => {}} />
+    );
+    expect(screen.getByRole('button', { name: /previous/i })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /next/i })).toBeEnabled();
+  });
+});

--- a/src/components/__tests__/VelocitySparkline.test.tsx
+++ b/src/components/__tests__/VelocitySparkline.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import VelocitySparkline from '../VelocitySparkline';
+import type { Velocity } from '../../types';
+
+// Mock recharts so the data prop passed into <LineChart> is exposed as a
+// queryable DOM attribute. This lets us assert the actual slice/granularity
+// chosen by pickVelocity rather than mere container presence.
+//
+// vi.mock is hoisted by vitest, so this is in place before VelocitySparkline
+// imports recharts.
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  LineChart: ({ data, children }: { data: unknown[]; children: React.ReactNode }) => (
+    <div data-testid="line-chart-mock" data-points={JSON.stringify(data)}>{children}</div>
+  ),
+  Line: () => null,
+}));
+
+interface ChartPoint {
+  label: string;
+  opened: number;
+  closed: number;
+}
+
+function readChartData(): ChartPoint[] {
+  const raw = screen.getByTestId('line-chart-mock').getAttribute('data-points');
+  if (!raw) throw new Error('line-chart-mock has no data-points attribute');
+  return JSON.parse(raw) as ChartPoint[];
+}
+
+function makeFixture(): Velocity {
+  // Daily and weekly opened/closed ranges are intentionally disjoint so a
+  // wrong-source regression (e.g. weekly returned for 7d) is unambiguous.
+  const daily = Array.from({ length: 365 }, (_, i) => ({
+    date: `D${i}`,
+    opened: 10000 + i, // 10000..10364
+    closed: 1000 + i,  // 1000..1364 — distinct from opened, guards `closed` series
+  }));
+  const weekly = Array.from({ length: 260 }, (_, i) => ({
+    week: `W${i}`,
+    opened: 100 + i,   // 100..359 — disjoint from daily.opened range
+    closed: 50 + i,    // 50..309
+  }));
+  return { daily, weekly };
+}
+
+describe('VelocitySparkline', () => {
+  it('renders for 7d using daily data', () => {
+    const v = makeFixture();
+    render(<VelocitySparkline velocity={v} duration="7d" />);
+
+    const data = readChartData();
+    // Length: pickVelocity('7d') slices daily by -7.
+    expect(data).toHaveLength(7);
+    // Last 7 of daily (length 365) is indices 358..364.
+    expect(data[0].label).toBe('D358');
+    expect(data[6].label).toBe('D364');
+    // Source: opened values must come from daily (10000-range), not weekly (100-range).
+    // If pickVelocity wrongly returned weekly for 7d, opened would be in 100..359.
+    expect(data[0].opened).toBe(10358);
+    expect(data[6].opened).toBe(10364);
+    // Closed series must also come from daily (1000-range), not weekly (50-range).
+    expect(data[0].closed).toBe(1358);
+  });
+
+  it('renders for 5y using weekly data', () => {
+    const v = makeFixture();
+    render(<VelocitySparkline velocity={v} duration="5y" />);
+
+    const data = readChartData();
+    // Length: pickVelocity('5y') slices weekly by -260; weekly is exactly 260 long.
+    expect(data).toHaveLength(260);
+    // slice(-260) on a 260-length array is the whole array.
+    expect(data[0].label).toBe('W0');
+    expect(data[259].label).toBe('W259');
+    // Source: opened values must come from weekly (100-range), not daily (10000-range).
+    // If pickVelocity wrongly returned daily for 5y, opened would be in 10000..10364
+    // and length would be 7, not 260.
+    expect(data[0].opened).toBe(100);
+    expect(data[259].opened).toBe(359);
+    // Closed series must come from weekly (50-range).
+    expect(data[0].closed).toBe(50);
+  });
+
+  it('renders the empty state when both arrays are empty', () => {
+    render(<VelocitySparkline velocity={{ daily: [], weekly: [] }} duration="7d" />);
+    expect(screen.getByTestId('sparkline-empty')).toBeInTheDocument();
+  });
+});

--- a/src/data/__tests__/projects.test.ts
+++ b/src/data/__tests__/projects.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { projects } from '../projects';
+
+// Guards the React-side half of the DRA repo migration:
+// NVIDIA donated k8s-dra-driver-gpu to kubernetes-sigs on 2026-04-30.
+// The entry's slug ('k8s-dra-driver-gpu') and name ('K8s DRA Driver GPU')
+// stay stable so external bookmarks survive and the user-facing label
+// doesn't churn; only the repo literal moves.
+//
+// Mutation check: reverting `repo` back to 'NVIDIA/k8s-dra-driver-gpu'
+// fails this test. Task 11 broadens this into a static-shape test that
+// also reads the Go side's defaultRepos / allRepos / defaultImages and
+// asserts the four literals stay aligned.
+//
+// Spec: docs/plans/2026-04-30-dra-repo-migration-design.md (folded into
+// PR-B per F2).
+describe('projects DRA entry', () => {
+  const dra = projects.find((p) => p.slug === 'k8s-dra-driver-gpu');
+
+  it('exists (slug must remain stable for external bookmarks)', () => {
+    expect(dra).toBeDefined();
+  });
+
+  it('keeps the human-facing name unchanged after migration', () => {
+    expect(dra?.name).toBe('K8s DRA Driver GPU');
+  });
+
+  it('uses the kubernetes-sigs canonical repo path', () => {
+    expect(dra?.repo).toBe('kubernetes-sigs/dra-driver-nvidia-gpu');
+  });
+
+  it('does not reference the donated-away NVIDIA path', () => {
+    expect(dra?.repo).not.toBe('NVIDIA/k8s-dra-driver-gpu');
+    expect(dra?.repo?.toLowerCase()).not.toContain('nvidia/');
+  });
+});

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -22,10 +22,20 @@ export const projects: Project[] = [
     description: 'Kubernetes device plugin to expose GPUs as schedulable resources in a cluster.',
     category: 'operator',
   },
+  // Note: slug, name, and repo intentionally diverge here.
+  //   - slug ('k8s-dra-driver-gpu') stays stable to preserve external bookmarks
+  //     to /projects/k8s-dra-driver-gpu#issues-prs that predate the migration.
+  //   - name ('K8s DRA Driver GPU') is the human-facing label; renaming would
+  //     churn the dashboard for marginal benefit.
+  //   - repo ('kubernetes-sigs/dra-driver-nvidia-gpu') is the canonical home
+  //     after NVIDIA donated the project to kubernetes-sigs (2026-04-30).
+  // The static-shape test in artifact_fetcher_repos_test.go enforces the repo
+  // literal across all four places (defaultRepos, allRepos, defaultImages,
+  // this file); see docs/plans/2026-04-30-dra-repo-migration-design.md.
   {
     slug: 'k8s-dra-driver-gpu',
     name: 'K8s DRA Driver GPU',
-    repo: 'NVIDIA/k8s-dra-driver-gpu',
+    repo: 'kubernetes-sigs/dra-driver-nvidia-gpu',
     description: 'Dynamic Resource Allocation (DRA) driver for NVIDIA GPUs in Kubernetes 1.31+.',
     category: 'driver',
   },

--- a/src/hooks/useData.ts
+++ b/src/hooks/useData.ts
@@ -116,7 +116,7 @@ export function useIssuesPRs() {
       .then((d) => {
         // Normalize repo keys to lowercase for consistent lookups
         const normalized: IssuesPRsData['repos'] = {};
-        for (const [key, value] of Object.entries(d.repos)) {
+        for (const [key, value] of Object.entries(d.repos ?? {})) {
           normalized[key.toLowerCase()] = value;
         }
         setData({ repos: normalized });

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,10 +1,13 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { ExternalLink, Search } from 'lucide-react';
 import Layout from '../components/Layout';
 import StatusBadge from '../components/StatusBadge';
 import TrendChart from '../components/TrendChart';
 import { useTestResults, useWorkflowStatuses, useImageBuilds, useHistory, useIssuesPRs } from '../hooks/useData';
 import IssuesPRsDashboard from '../components/IssuesPRsDashboard';
+import Pagination from '../components/Pagination';
+
+const PAGE_SIZE = 20;
 
 const sidebarItems = [
   { to: '/dashboard', label: 'Overview' },
@@ -100,6 +103,9 @@ export default function Dashboard() {
   const [wfRepo, setWfRepo] = useState('');
   const [wfStatus, setWfStatus] = useState('');
   const [wfSearch, setWfSearch] = useState('');
+  const [wfPage, setWfPage] = useState(1);
+
+  useEffect(() => { setWfPage(1); }, [wfRepo, wfStatus, wfSearch]);
 
   // Image filters
   const [imgRepo, setImgRepo] = useState('');
@@ -134,6 +140,12 @@ export default function Dashboard() {
       })
       .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
   }, [workflows, wfRepo, wfStatus, wfSearch]);
+
+  const wfTotalPages = Math.ceil(filteredWorkflows.length / PAGE_SIZE);
+  const paginatedWorkflows = filteredWorkflows.slice(
+    (wfPage - 1) * PAGE_SIZE,
+    wfPage * PAGE_SIZE,
+  );
 
   const filteredImages = useMemo(() => {
     return images.filter((img) => {
@@ -264,6 +276,7 @@ export default function Dashboard() {
           ) : filteredWorkflows.length === 0 ? (
             <p className="p-4 text-gray-500 dark:text-gray-400">No workflows match the current filters.</p>
           ) : (
+            <>
             <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
               <thead className="bg-gray-50 dark:bg-gray-700">
                 <tr>
@@ -276,7 +289,7 @@ export default function Dashboard() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-                {filteredWorkflows.map((w) => (
+                {paginatedWorkflows.map((w) => (
                   <tr key={`${w.repo}-${w.workflow}`}>
                     <td className="px-4 py-3 text-sm text-gray-900 dark:text-white">{w.repo}</td>
                     <td className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300">{w.workflow}</td>
@@ -308,6 +321,8 @@ export default function Dashboard() {
                 ))}
               </tbody>
             </table>
+            <Pagination currentPage={wfPage} totalPages={wfTotalPages} onPageChange={setWfPage} />
+            </>
           )}
         </div>
       </section>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -368,10 +368,10 @@ export default function Dashboard() {
                     <td className="px-4 py-3 text-sm">
                       <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
                         img.imageType === 'release'
-                          ? 'bg-green-100 text-status-pass dark:bg-green-900/30'
+                          ? 'bg-green-100 text-status-pass dark:bg-green-900/30 dark:text-green-300'
                           : img.imageType === 'ci'
                             ? 'bg-gray-100 text-gray-600 dark:bg-gray-600 dark:text-gray-300'
-                            : 'bg-amber-100 text-status-warn dark:bg-amber-900/30'
+                            : 'bg-amber-100 text-status-warn dark:bg-amber-900/30 dark:text-amber-300'
                       }`}>
                         {img.imageType === 'release' ? 'Release' : img.imageType === 'ci' ? 'CI' : 'Dev'}
                       </span>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -346,6 +346,8 @@ export default function Dashboard() {
                 <tr>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Repo</th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Tag</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Type</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Source</th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Pushed At</th>
                 </tr>
               </thead>
@@ -362,6 +364,31 @@ export default function Dashboard() {
                       >
                         {img.tag}
                       </a>
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                        img.imageType === 'release'
+                          ? 'bg-green-100 text-status-pass dark:bg-green-900/30'
+                          : img.imageType === 'ci'
+                            ? 'bg-gray-100 text-gray-600 dark:bg-gray-600 dark:text-gray-300'
+                            : 'bg-amber-100 text-status-warn dark:bg-amber-900/30'
+                      }`}>
+                        {img.imageType === 'release' ? 'Release' : img.imageType === 'ci' ? 'CI' : 'Dev'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      {img.commitUrl ? (
+                        <a
+                          href={img.commitUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-nvidia-green hover:text-nvidia-green-dark font-mono text-xs"
+                        >
+                          {img.tag.match(/^[0-9a-f]{7,}/)?.[0]?.slice(0, 8) ?? img.tag}
+                        </a>
+                      ) : (
+                        <span className="text-gray-400 dark:text-gray-500">—</span>
+                      )}
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{img.pushedAt}</td>
                   </tr>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -59,7 +59,7 @@ export default function Home() {
         else if (buckets.fresh > 0) oldestBucket = '<7d';
         else oldestBucket = 'none';
 
-        const trend = computeTrend(repoData.issues.velocity);
+        const trend = computeTrend(repoData.issues.velocity.weekly);
 
         return {
           project: p,

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -237,10 +237,10 @@ export default function ProjectDetail() {
                     <td className="px-4 py-3 text-sm">
                       <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
                         img.imageType === 'release'
-                          ? 'bg-green-100 text-status-pass dark:bg-green-900/30'
+                          ? 'bg-green-100 text-status-pass dark:bg-green-900/30 dark:text-green-300'
                           : img.imageType === 'ci'
                             ? 'bg-gray-100 text-gray-600 dark:bg-gray-600 dark:text-gray-300'
-                            : 'bg-amber-100 text-status-warn dark:bg-amber-900/30'
+                            : 'bg-amber-100 text-status-warn dark:bg-amber-900/30 dark:text-amber-300'
                       }`}>
                         {img.imageType === 'release' ? 'Release' : img.imageType === 'ci' ? 'CI' : 'Dev'}
                       </span>

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useParams, Link } from 'react-router';
 import { ExternalLink, Star, Code, Scale, ArrowLeft, GitFork, Eye, Download } from 'lucide-react';
 import Layout from '../components/Layout';
@@ -20,6 +20,9 @@ export default function ProjectDetail() {
   const { data: images } = useImageBuilds();
   const { data: history } = useHistory();
   const { data: issuesPRs } = useIssuesPRs();
+  const [ciPage, setCiPage] = useState(1);
+
+  useEffect(() => { setCiPage(1); }, [slug]);
 
   if (!project) {
     return (
@@ -37,7 +40,6 @@ export default function ProjectDetail() {
   const repoKey = project.repo.toLowerCase();
   const repoInfo = repos.find((r) => r.fullName.toLowerCase() === repoKey);
   const projectWorkflows = workflows.filter((w) => w.repo.toLowerCase() === repoKey);
-  const [ciPage, setCiPage] = useState(1);
   const ciTotalPages = Math.ceil(projectWorkflows.length / PAGE_SIZE);
   const paginatedCIWorkflows = projectWorkflows.slice(
     (ciPage - 1) * PAGE_SIZE,

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { useParams, Link } from 'react-router';
 import { ExternalLink, Star, Code, Scale, ArrowLeft, GitFork, Eye, Download } from 'lucide-react';
 import Layout from '../components/Layout';
@@ -7,6 +7,9 @@ import TrendChart from '../components/TrendChart';
 import { useRepoInfos, useWorkflowStatuses, useImageBuilds, useHistory, useIssuesPRs } from '../hooks/useData';
 import { projects } from '../data/projects';
 import IssuesPRsSection from '../components/IssuesPRsSection';
+import Pagination from '../components/Pagination';
+
+const PAGE_SIZE = 20;
 
 export default function ProjectDetail() {
   const { slug } = useParams<{ slug: string }>();
@@ -34,6 +37,12 @@ export default function ProjectDetail() {
   const repoKey = project.repo.toLowerCase();
   const repoInfo = repos.find((r) => r.fullName.toLowerCase() === repoKey);
   const projectWorkflows = workflows.filter((w) => w.repo.toLowerCase() === repoKey);
+  const [ciPage, setCiPage] = useState(1);
+  const ciTotalPages = Math.ceil(projectWorkflows.length / PAGE_SIZE);
+  const paginatedCIWorkflows = projectWorkflows.slice(
+    (ciPage - 1) * PAGE_SIZE,
+    ciPage * PAGE_SIZE,
+  );
   const projectImages = images.filter((i) => i.repo.toLowerCase() === repoKey);
   const projectIssuesPRs = issuesPRs?.repos[repoKey] ?? null;
 
@@ -158,48 +167,51 @@ export default function ProjectDetail() {
           {projectWorkflows.length === 0 ? (
             <p className="p-4 text-gray-500 dark:text-gray-400">No workflow data available.</p>
           ) : (
-            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-              <thead className="bg-gray-50 dark:bg-gray-700">
-                <tr>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Workflow</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Updated</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Commit</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Run</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-                {projectWorkflows.map((w) => (
-                  <tr key={w.workflow}>
-                    <td className="px-4 py-3 text-sm text-gray-900 dark:text-white">{w.workflow}</td>
-                    <td className="px-4 py-3">
-                      <StatusBadge status={w.status} />
-                    </td>
-                    <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{w.updatedAt}</td>
-                    <td className="px-4 py-3 text-sm">
-                      <a
-                        href={w.commitUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-nvidia-green hover:text-nvidia-green-dark font-mono text-xs"
-                      >
-                        {w.commitSha.substring(0, 7)}
-                      </a>
-                    </td>
-                    <td className="px-4 py-3">
-                      <a
-                        href={w.runUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-nvidia-green hover:text-nvidia-green-dark inline-flex items-center gap-1"
-                      >
-                        <ExternalLink size={14} />
-                      </a>
-                    </td>
+            <>
+              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead className="bg-gray-50 dark:bg-gray-700">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Workflow</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Updated</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Commit</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Run</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                  {paginatedCIWorkflows.map((w) => (
+                    <tr key={w.workflow}>
+                      <td className="px-4 py-3 text-sm text-gray-900 dark:text-white">{w.workflow}</td>
+                      <td className="px-4 py-3">
+                        <StatusBadge status={w.status} />
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{w.updatedAt}</td>
+                      <td className="px-4 py-3 text-sm">
+                        <a
+                          href={w.commitUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-nvidia-green hover:text-nvidia-green-dark font-mono text-xs"
+                        >
+                          {w.commitSha.substring(0, 7)}
+                        </a>
+                      </td>
+                      <td className="px-4 py-3">
+                        <a
+                          href={w.runUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-nvidia-green hover:text-nvidia-green-dark inline-flex items-center gap-1"
+                        >
+                          <ExternalLink size={14} />
+                        </a>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <Pagination currentPage={ciPage} totalPages={ciTotalPages} onPageChange={setCiPage} />
+            </>
           )}
         </div>
       </section>

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -216,6 +216,8 @@ export default function ProjectDetail() {
               <thead className="bg-gray-50 dark:bg-gray-700">
                 <tr>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Tag</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Type</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Source</th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Pushed At</th>
                 </tr>
               </thead>
@@ -231,6 +233,31 @@ export default function ProjectDetail() {
                       >
                         {img.tag}
                       </a>
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                        img.imageType === 'release'
+                          ? 'bg-green-100 text-status-pass dark:bg-green-900/30'
+                          : img.imageType === 'ci'
+                            ? 'bg-gray-100 text-gray-600 dark:bg-gray-600 dark:text-gray-300'
+                            : 'bg-amber-100 text-status-warn dark:bg-amber-900/30'
+                      }`}>
+                        {img.imageType === 'release' ? 'Release' : img.imageType === 'ci' ? 'CI' : 'Dev'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      {img.commitUrl ? (
+                        <a
+                          href={img.commitUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-nvidia-green hover:text-nvidia-green-dark font-mono text-xs"
+                        >
+                          {img.tag.match(/^[0-9a-f]{7,}/)?.[0]?.slice(0, 8) ?? img.tag}
+                        </a>
+                      ) : (
+                        <span className="text-gray-400 dark:text-gray-500">—</span>
+                      )}
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{img.pushedAt}</td>
                   </tr>

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -35,7 +35,7 @@ export default function ProjectDetail() {
   const repoInfo = repos.find((r) => r.fullName.toLowerCase() === repoKey);
   const projectWorkflows = workflows.filter((w) => w.repo.toLowerCase() === repoKey);
   const projectImages = images.filter((i) => i.repo.toLowerCase() === repoKey);
-  const projectIssuesPRs = issuesPRs?.repos[project.repo.toLowerCase()] ?? null;
+  const projectIssuesPRs = issuesPRs?.repos[repoKey] ?? null;
 
   const workflowTrend = useMemo(() => {
     if (!history) return [];

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, it, expect, vi } from 'vitest';
+import type { WorkflowStatus } from '../../types';
+
+// Generate N workflow entries for pagination testing
+function makeWorkflows(n: number): WorkflowStatus[] {
+  return Array.from({ length: n }, (_, i) => ({
+    repo: 'test-repo',
+    workflow: `workflow-${String(i + 1).padStart(3, '0')}`,
+    status: 'success' as const,
+    conclusion: 'success',
+    runUrl: `https://example.com/run/${i}`,
+    updatedAt: new Date(Date.now() - i * 60000).toISOString(),
+    commitSha: `abc${String(i).padStart(4, '0')}0000000000000000000000000000000000`,
+    commitUrl: `https://example.com/commit/${i}`,
+  }));
+}
+
+// Mock all data hooks
+vi.mock('../../hooks/useData', () => ({
+  useTestResults: () => ({ data: [], loading: false, error: null }),
+  useWorkflowStatuses: () => ({
+    data: makeWorkflows(25),
+    loading: false,
+    error: null,
+  }),
+  useImageBuilds: () => ({ data: [], loading: false, error: null }),
+  useHistory: () => ({ data: null, loading: false, error: null }),
+  useIssuesPRs: () => ({ data: null, loading: false, error: null }),
+}));
+
+// Mock recharts to avoid SVG rendering issues in jsdom
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => children,
+  AreaChart: () => null,
+  Area: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+}));
+
+import Dashboard from '../Dashboard';
+
+function renderDashboard() {
+  return render(
+    <MemoryRouter>
+      <Dashboard />
+    </MemoryRouter>,
+  );
+}
+
+describe('Dashboard Workflow Status pagination', () => {
+  it('renders only the first page of workflows (20 of 25)', () => {
+    renderDashboard();
+    // With 25 workflows and PAGE_SIZE=20, only 20 should be visible
+    const heading = screen.getAllByText('Workflow Status').find(el => el.tagName === 'H2') as HTMLElement;
+    const workflowSection = heading.closest('section') as HTMLElement;
+    const rows = workflowSection.querySelectorAll('tbody tr');
+    expect(rows).toHaveLength(20);
+  });
+
+  it('shows pagination controls for workflows', () => {
+    renderDashboard();
+    // Should show "Page 1 of 2" (25 items / 20 per page = 2 pages)
+    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+  });
+
+  it('does not render workflow-021 on the first page', () => {
+    renderDashboard();
+    // workflow-021 through workflow-025 should be on page 2
+    expect(screen.queryByText('workflow-021')).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/ProjectDetail.test.tsx
+++ b/src/pages/__tests__/ProjectDetail.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { describe, it, expect, vi } from 'vitest';
+import type { WorkflowStatus } from '../../types';
+
+const TEST_REPO = 'nvidia/gpu-operator';
+
+// Generate N workflow entries for a specific repo
+function makeWorkflows(n: number, repo: string = TEST_REPO): WorkflowStatus[] {
+  return Array.from({ length: n }, (_, i) => ({
+    repo,
+    workflow: `workflow-${String(i + 1).padStart(3, '0')}`,
+    status: 'success' as const,
+    conclusion: 'success',
+    runUrl: `https://example.com/run/${i}`,
+    updatedAt: new Date(Date.now() - i * 60000).toISOString(),
+    commitSha: `abc${String(i).padStart(4, '0')}0000000000000000000000000000000000`,
+    commitUrl: `https://example.com/commit/${i}`,
+  }));
+}
+
+// Mock all data hooks
+vi.mock('../../hooks/useData', () => ({
+  useRepoInfos: () => ({ data: [], loading: false, error: null }),
+  useWorkflowStatuses: () => ({
+    data: makeWorkflows(25),
+    loading: false,
+    error: null,
+  }),
+  useImageBuilds: () => ({ data: [], loading: false, error: null }),
+  useHistory: () => ({ data: null, loading: false, error: null }),
+  useIssuesPRs: () => ({ data: null, loading: false, error: null }),
+}));
+
+// Mock recharts to avoid SVG rendering issues in jsdom
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => children,
+  AreaChart: () => null,
+  Area: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+}));
+
+import ProjectDetail from '../ProjectDetail';
+
+function renderProjectDetail() {
+  return render(
+    <MemoryRouter initialEntries={['/projects/gpu-operator']}>
+      <Routes>
+        <Route path="/projects/:slug" element={<ProjectDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('ProjectDetail CI Status pagination', () => {
+  it('renders only the first page of workflows (20 of 25)', () => {
+    renderProjectDetail();
+    const heading = screen.getAllByText('CI Status').find(el => el.tagName === 'H2') as HTMLElement;
+    const ciSection = heading.closest('section') as HTMLElement;
+    const rows = ciSection.querySelectorAll('tbody tr');
+    expect(rows).toHaveLength(20);
+  });
+
+  it('shows pagination controls', () => {
+    renderProjectDetail();
+    // 25 items / 20 per page = 2 pages
+    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+  });
+
+  it('does not render workflow-021 on the first page', () => {
+    renderProjectDetail();
+    expect(screen.queryByText('workflow-021')).not.toBeInTheDocument();
+  });
+});

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,8 @@ export interface ImageBuild {
   tag: string;
   pushedAt: string;
   htmlUrl: string;
+  imageType: 'release' | 'ci' | 'dev';
+  commitUrl: string;
 }
 
 export interface RepoInfo {

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,18 @@ export interface VelocityWeek {
   merged?: number;
 }
 
+export interface VelocityDay {
+  date: string;        // "YYYY-MM-DD" (UTC)
+  opened: number;
+  closed: number;
+  merged?: number;
+}
+
+export interface Velocity {
+  daily: VelocityDay[];
+  weekly: VelocityWeek[];
+}
+
 export interface PRReviewMetrics {
   awaitingReview: number;
   noReviewer: number;
@@ -109,14 +121,14 @@ export interface IssueStats {
   total: number;
   categories: IssuePRCategory;
   ageBuckets: AgeBuckets;
-  velocity: VelocityWeek[];
+  velocity: Velocity;
 }
 
 export interface PRStats {
   total: number;
   categories: IssuePRCategory;
   ageBuckets: AgeBuckets;
-  velocity: VelocityWeek[];
+  velocity: Velocity;
   review: PRReviewMetrics;
 }
 

--- a/src/utils/__tests__/chartStyles.test.ts
+++ b/src/utils/__tests__/chartStyles.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { formatDayTick, formatWeekTick } from '../chartStyles';
+
+describe('formatDayTick', () => {
+  it('formats a YYYY-MM-DD UTC string as "MMM dd"', () => {
+    // 2026-04-23 UTC should render the same MMM dd regardless of viewer TZ
+    // because the formatter pins timeZone: 'UTC'.
+    expect(formatDayTick('2026-04-23')).toBe('Apr 23');
+  });
+
+  it('formats early-month dates with zero-padded day', () => {
+    // Catches a bug where day: 'numeric' would render "Jan 1" instead of "Jan 01".
+    expect(formatDayTick('2026-01-01')).toBe('Jan 01');
+  });
+
+  it('crosses month boundaries correctly under UTC', () => {
+    // 2026-12-31 UTC must format as "Dec 31", not Jan 1 (which would happen
+    // if the formatter let the local-tz boundary slide a day).
+    expect(formatDayTick('2026-12-31')).toBe('Dec 31');
+  });
+});
+
+describe('formatWeekTick', () => {
+  it('formats a parseable date string as M/D', () => {
+    // Sanity check against the existing helper to lock its contract while
+    // formatDayTick lives next to it.
+    expect(formatWeekTick('2026-04-23')).toMatch(/^4\/2[23]$/);
+  });
+
+  it('returns the input verbatim when the date is unparseable', () => {
+    expect(formatWeekTick('not-a-date')).toBe('not-a-date');
+  });
+});

--- a/src/utils/__tests__/duration.test.ts
+++ b/src/utils/__tests__/duration.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { pickVelocity, DURATIONS, type Duration } from '../duration';
+import type { Velocity, VelocityDay, VelocityWeek } from '../../types';
+
+// Build distinguishable fixtures so daily and weekly arrays return DIFFERENT
+// values for any given index. This catches a bug where pickVelocity maps a
+// daily-granularity duration ('7d') to the weekly array. `closed` values
+// are also distinct from `opened` to catch a swap regression.
+function makeFixture(): Velocity {
+  const daily: VelocityDay[] = Array.from({ length: 365 }, (_, i) => ({
+    date: `2026-${String(Math.floor(i / 31) + 1).padStart(2, '0')}-${String((i % 28) + 1).padStart(2, '0')}`,
+    opened: 1000 + i, // distinct values starting at 1000
+    closed: 500 + i, // distinct from opened
+  }));
+  const weekly: VelocityWeek[] = Array.from({ length: 260 }, (_, i) => ({
+    week: `2026-week-${i}`,
+    opened: i, // distinct values starting at 0
+    closed: 500 - i, // distinct from opened
+  }));
+  return { daily, weekly };
+}
+
+describe('pickVelocity', () => {
+  it.each<[Duration, 'day' | 'week', number]>([
+    ['7d', 'day', 7],
+    ['4w', 'week', 4],
+    ['12w', 'week', 12],
+    ['6m', 'week', 26],
+    ['1y', 'week', 52],
+    ['5y', 'week', 260],
+  ])('duration=%s → granularity=%s, length=%d', (duration, wantGranularity, wantLength) => {
+    const v = makeFixture();
+    const got = pickVelocity(v, duration);
+
+    expect(got.granularity).toBe(wantGranularity);
+    expect(got.points).toHaveLength(wantLength);
+
+    // Each duration's points must come from the matching array; spot-check
+    // the first and last point to catch off-by-one slicing bugs. Also assert
+    // on `closed` to catch an opened/closed swap regression.
+    if (wantGranularity === 'day') {
+      // 7d → daily.slice(-7); first point's `opened` is 1000 + (365-7)
+      expect(got.points[0].opened).toBe(1000 + (365 - wantLength));
+      expect(got.points[wantLength - 1].opened).toBe(1000 + 364);
+      expect(got.points[0].closed).toBe(500 + (365 - wantLength));
+      expect(got.points[wantLength - 1].closed).toBe(500 + 364);
+    } else {
+      expect(got.points[0].opened).toBe(260 - wantLength);
+      expect(got.points[wantLength - 1].opened).toBe(259);
+      expect(got.points[0].closed).toBe(500 - (260 - wantLength));
+      expect(got.points[wantLength - 1].closed).toBe(500 - 259);
+    }
+  });
+
+  it('exposes DURATIONS in display order', () => {
+    expect(DURATIONS).toEqual(['7d', '4w', '12w', '6m', '1y', '5y']);
+  });
+});

--- a/src/utils/chartStyles.ts
+++ b/src/utils/chartStyles.ts
@@ -45,6 +45,17 @@ export function formatWeekTick(v: string): string {
   return `${d.getMonth() + 1}/${d.getDate()}`;
 }
 
+/**
+ * formatDayTick formats a YYYY-MM-DD UTC date string for chart x-axes
+ * showing daily granularity. Returns "MMM dd" (e.g., "Apr 23"). UTC is
+ * indicated separately via the "(UTC)" axis label set on the chart.
+ */
+export function formatDayTick(value: string): string {
+  // value is "YYYY-MM-DD"; render as locale-independent "MMM dd".
+  const d = new Date(value + 'T00:00:00Z');
+  return d.toLocaleDateString('en-US', { month: 'short', day: '2-digit', timeZone: 'UTC' });
+}
+
 export type Trend = 'growing' | 'shrinking' | 'stable';
 
 export function computeTrend(velocity: VelocityWeek[]): Trend {

--- a/src/utils/duration.ts
+++ b/src/utils/duration.ts
@@ -1,0 +1,61 @@
+import type { Velocity } from '../types';
+
+export type Duration = '7d' | '4w' | '12w' | '6m' | '1y' | '5y';
+
+export const DURATIONS: Duration[] = ['7d', '4w', '12w', '6m', '1y', '5y'];
+
+export interface VelocityPoint {
+  label: string;
+  opened: number;
+  closed: number;
+  merged?: number;
+}
+
+export interface PickedVelocity {
+  points: VelocityPoint[];
+  granularity: 'day' | 'week';
+}
+
+const DURATION_TABLE: Record<Duration, { granularity: 'day' | 'week'; n: number }> = {
+  '7d':  { granularity: 'day',  n: 7   },
+  '4w':  { granularity: 'week', n: 4   },
+  '12w': { granularity: 'week', n: 12  },
+  '6m':  { granularity: 'week', n: 26  },
+  '1y':  { granularity: 'week', n: 52  },
+  '5y':  { granularity: 'week', n: 260 },
+};
+
+/**
+ * pickVelocity selects the right velocity array (daily or weekly) for the
+ * requested duration and slices it to the appropriate length. The labels
+ * come from the underlying entry's `date` (daily) or `week` (weekly).
+ *
+ * Snapshot stats (Open Issues, age buckets, categories) deliberately do
+ * NOT pass through this helper — they always reflect "right now" per the
+ * Q3 invariant in the spec.
+ */
+export function pickVelocity(v: Velocity, d: Duration): PickedVelocity {
+  const cfg = DURATION_TABLE[d];
+  if (cfg.granularity === 'day') {
+    const slice = v.daily.slice(-cfg.n);
+    return {
+      granularity: 'day',
+      points: slice.map((day) => ({
+        label: day.date,
+        opened: day.opened,
+        closed: day.closed,
+        merged: day.merged,
+      })),
+    };
+  }
+  const slice = v.weekly.slice(-cfg.n);
+  return {
+    granularity: 'week',
+    points: slice.map((wk) => ({
+      label: wk.week,
+      opened: wk.opened,
+      closed: wk.closed,
+      merged: wk.merged,
+    })),
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test-setup.ts'],
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': '/src',
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test-setup.ts'],
     globals: true,
+    pool: 'threads',
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Promote `feat/dashboard-enhancements` to `gh-pages` — picks up PR #338 (DRA driver image fetch from `registry.k8s.io`).

After NVIDIA donated the DRA driver to kubernetes-sigs (2026-04-30), the dashboard's image row for that project went silent because the new home publishes container images to `registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu`, not GHCR. PR #338 adds an `imageRegistry` discriminator on `imageRepo` and a release-based fetcher for OCI registries with no Packages API.

## Post-deploy expectation

The `kubernetes-sigs/dra-driver-nvidia-gpu` row appears in the dashboard's image table again, with the latest GitHub release tag (e.g. `v25.12.0`), a Release badge, the release `published_at` as the push date, and Tag + Source links both pointing to the GitHub release page.

## Deploy

Merge triggers `deploy.yaml` (push on `gh-pages` → rebuild + publish to GitHub Pages). The deploy now runs `go vet`, `go test`, and `npm test` before `npm run build` per the gate landed in PR #336.

## Test plan

- All component PR tests already CI-green on `feat/dashboard-enhancements`:
  - `TestFetchLatestRegistryK8sTag_HappyPath` (3-release fixture, mutation against `rels[1]`)
  - `TestFetchLatestRegistryK8sTag_NoReleases` (mutation against removed `len(rels)==0` guard)
  - `TestFetchLatestImageTag_Dispatch` (table-driven; routes for `""`, `"ghcr.io"`, `"registry.k8s.io"`, unknown)
  - `TestDRAMigrationLiteralsAligned` extended with `defaultImages.registryCoords` sub-test
- Post-deploy visual check: the DRA project shows an image row with a SemVer tag.
