### PR TITLE
feat(dashboard): wire DRA driver images to registry.k8s.io

### DIFF
--- a/artifact_fetcher.go
+++ b/artifact_fetcher.go
@@ -81,20 +81,24 @@ var defaultRepos = []string{
 	"nvidia/holodeck",
 }
 
-// imageRepo pairs a GitHub repository path with its GitHub Packages container
-// name. The repo field is the full owner/repo used for constructing HTML URLs,
-// while pkgName is the container package name used by the Packages API.
+// imageRepo pairs a GitHub repository path with its container-registry
+// coordinates. The repo field is the full owner/repo for source/release link
+// construction. pkgName is the image path within its registry. imageRegistry
+// discriminates the fetch path: "" or "ghcr.io" = GitHub Packages (default);
+// "registry.k8s.io" = OCI registry served by the kubernetes-sigs project
+// release pipeline. Per docs/plans/2026-05-11-dra-registry-k8s-io-design.md.
 type imageRepo struct {
-	repo    string // GitHub repo path, e.g. "nvidia/nvidia-container-toolkit"
-	pkgName string // GitHub Packages name, e.g. "container-toolkit"
+	repo          string // GitHub repo path, e.g. "nvidia/nvidia-container-toolkit"
+	pkgName       string // image path within the registry, e.g. "container-toolkit"
+	imageRegistry string // "" / "ghcr.io" = GHCR (default); "registry.k8s.io" for OCI
 }
 
 var defaultImages = []imageRepo{
-	{"nvidia/k8s-device-plugin", "k8s-device-plugin"},
-	{"kubernetes-sigs/dra-driver-nvidia-gpu", "dra-driver-nvidia-gpu"}, // donated 2026-04-30; pkgName best-effort (kubernetes-sigs GHCR not yet listable without read:packages)
-	{"nvidia/nvidia-container-toolkit", "container-toolkit"},
-	{"nvidia/gpu-operator", "gpu-operator"},
-	{"nvidia/gpu-driver-container", "driver"},
+	{"nvidia/k8s-device-plugin", "k8s-device-plugin", ""},
+	{"kubernetes-sigs/dra-driver-nvidia-gpu", "dra-driver-nvidia/dra-driver-nvidia-gpu", "registry.k8s.io"}, // images live at registry.k8s.io after Prow promotion; see docs/plans/2026-05-11-dra-registry-k8s-io-design.md
+	{"nvidia/nvidia-container-toolkit", "container-toolkit", ""},
+	{"nvidia/gpu-operator", "gpu-operator", ""},
+	{"nvidia/gpu-driver-container", "driver", ""},
 }
 
 var allRepos = []string{
@@ -1613,7 +1617,21 @@ func buildCommitURL(repo, tag string) string {
 	return ""
 }
 
+// fetchLatestImageTag dispatches to the right registry-specific fetcher based
+// on ir.imageRegistry. The empty string defaults to GHCR (the historical
+// behavior). Per docs/plans/2026-05-11-dra-registry-k8s-io-design.md.
 func fetchLatestImageTag(ctx context.Context, client *github.Client, ir imageRepo) (ImageInfo, error) {
+	switch ir.imageRegistry {
+	case "", "ghcr.io":
+		return fetchLatestGHCRTag(ctx, client, ir)
+	case "registry.k8s.io":
+		return fetchLatestRegistryK8sTag(ctx, client, ir)
+	default:
+		return ImageInfo{}, fmt.Errorf("unknown imageRegistry %q for %s", ir.imageRegistry, ir.repo)
+	}
+}
+
+func fetchLatestGHCRTag(ctx context.Context, client *github.Client, ir imageRepo) (ImageInfo, error) {
 	parts := strings.Split(ir.repo, "/")
 	if len(parts) != 2 {
 		return ImageInfo{}, fmt.Errorf("invalid repo: %s", ir.repo)
@@ -1645,6 +1663,48 @@ func fetchLatestImageTag(ctx context.Context, client *github.Client, ir imageRep
 		Tag:       tag,
 		Pushed:    latest.GetCreatedAt().Format(time.RFC3339),
 		HTMLURL:   htmlURL,
+		ImageType: classifyImageTag(tag),
+		CommitURL: buildCommitURL(ir.repo, tag),
+	}, nil
+}
+
+// fetchLatestRegistryK8sTag handles imageRepo entries whose images live at
+// registry.k8s.io (or other OCI registries with no Packages API). Instead of
+// listing OCI tags — which would not give us push timestamps — we list the
+// source repo's GitHub releases and treat the newest release as authoritative
+// for the latest image tag and push date. This matches the release process:
+// the GitHub release publish triggers the Prow image-push job.
+//
+// Spec: docs/plans/2026-05-11-dra-registry-k8s-io-design.md.
+func fetchLatestRegistryK8sTag(ctx context.Context, client *github.Client, ir imageRepo) (ImageInfo, error) {
+	parts := strings.Split(ir.repo, "/")
+	if len(parts) != 2 {
+		return ImageInfo{}, fmt.Errorf("invalid repo: %s", ir.repo)
+	}
+	owner, name := parts[0], parts[1]
+
+	rels, _, err := client.Repositories.ListReleases(ctx, owner, name, &github.ListOptions{PerPage: 5})
+	if err != nil {
+		return ImageInfo{}, fmt.Errorf("list releases %s: %w", ir.repo, err)
+	}
+	if len(rels) == 0 {
+		return ImageInfo{}, fmt.Errorf("no releases found for %s", ir.repo)
+	}
+
+	// GitHub returns releases newest-first.
+	latest := rels[0]
+	tag := latest.GetTagName()
+
+	// No GHCR page exists for registry.k8s.io-hosted images; both the Tag-cell
+	// link (HTMLURL) and the Source-cell link (CommitURL) point at the GitHub
+	// release page. buildCommitURL already returns this for SemVer tags.
+	releaseURL := fmt.Sprintf("https://github.com/%s/releases/tag/%s", ir.repo, tag)
+
+	return ImageInfo{
+		Repo:      ir.repo,
+		Tag:       tag,
+		Pushed:    latest.GetPublishedAt().Format(time.RFC3339),
+		HTMLURL:   releaseURL,
 		ImageType: classifyImageTag(tag),
 		CommitURL: buildCommitURL(ir.repo, tag),
 	}, nil

--- a/artifact_fetcher_registry_test.go
+++ b/artifact_fetcher_registry_test.go
@@ -1,0 +1,194 @@
+// Tests for the registry.k8s.io image-tag fetcher (and its dispatcher
+// integration). The fetcher reads the latest GitHub release for the source
+// repo and uses its tag_name/published_at as the image-tag/push-date pair,
+// on the assumption that the kubernetes-sigs release process pushes the
+// image when the release publishes.
+//
+// Spec: docs/plans/2026-05-11-dra-registry-k8s-io-design.md.
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v55/github"
+)
+
+// newReleasesStub returns an httptest server that serves the given JSON
+// payload at /repos/{owner}/{name}/releases and 404s anything else. The
+// returned *github.Client is rebased onto that server's URL so the fetcher
+// hits the stub instead of api.github.com.
+func newReleasesStub(t *testing.T, owner, name, body string) *github.Client {
+	t.Helper()
+	wantPath := "/repos/" + owner + "/" + name + "/releases"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, wantPath) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := github.NewClient(nil)
+	client.BaseURL = mustParseURL(t, srv.URL+"/")
+	return client
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	return u
+}
+
+func TestFetchLatestRegistryK8sTag_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	// GitHub returns releases newest-first. The fetcher must take index 0.
+	body := `[
+		{"tag_name": "v25.12.0", "published_at": "2026-02-12T14:55:44Z"},
+		{"tag_name": "v25.8.1",  "published_at": "2025-12-17T17:06:25Z"},
+		{"tag_name": "v25.8.0",  "published_at": "2025-10-20T20:11:17Z"}
+	]`
+	client := newReleasesStub(t, "kubernetes-sigs", "dra-driver-nvidia-gpu", body)
+
+	ir := imageRepo{
+		repo:          "kubernetes-sigs/dra-driver-nvidia-gpu",
+		pkgName:       "dra-driver-nvidia/dra-driver-nvidia-gpu",
+		imageRegistry: "registry.k8s.io",
+	}
+	var got ImageInfo
+	got, err := fetchLatestRegistryK8sTag(context.Background(), client, ir)
+	if err != nil {
+		t.Fatalf("fetchLatestRegistryK8sTag: %v", err)
+	}
+	if got.Tag != "v25.12.0" {
+		t.Errorf("Tag = %q; want %q", got.Tag, "v25.12.0")
+	}
+	if got.Pushed != "2026-02-12T14:55:44Z" {
+		t.Errorf("Pushed = %q; want %q", got.Pushed, "2026-02-12T14:55:44Z")
+	}
+	if got.ImageType != "release" {
+		t.Errorf("ImageType = %q; want %q (SemVer tag must classify as release)", got.ImageType, "release")
+	}
+	wantHTMLURL := "https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/releases/tag/v25.12.0"
+	if got.HTMLURL != wantHTMLURL {
+		t.Errorf("HTMLURL = %q; want %q", got.HTMLURL, wantHTMLURL)
+	}
+	// CommitURL for a SemVer tag should be the release URL (delegated to buildCommitURL).
+	if got.CommitURL != wantHTMLURL {
+		t.Errorf("CommitURL = %q; want %q (release URL for SemVer)", got.CommitURL, wantHTMLURL)
+	}
+}
+
+// TestFetchLatestImageTag_Dispatch asserts the dispatcher routes by
+// imageRegistry. We stub /repos/.../releases (registry.k8s.io path) and
+// /orgs/.../packages/... (GHCR path) on the same server and watch which one
+// is hit per imageRegistry value.
+func TestFetchLatestImageTag_Dispatch(t *testing.T) {
+	t.Parallel()
+
+	var (
+		ghcrHit     bool
+		releasesHit bool
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/orgs/") && strings.Contains(r.URL.Path, "/packages/"):
+			ghcrHit = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[{"id":1,"created_at":"2026-05-01T00:00:00Z","metadata":{"container":{"tags":["v1.0.0"]}}}]`)
+		case strings.HasPrefix(r.URL.Path, "/repos/") && strings.HasSuffix(r.URL.Path, "/releases"):
+			releasesHit = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[{"tag_name":"v25.12.0","published_at":"2026-02-12T14:55:44Z"}]`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := github.NewClient(nil)
+	client.BaseURL = mustParseURL(t, srv.URL+"/")
+
+	cases := []struct {
+		name          string
+		ir            imageRepo
+		wantGHCR      bool
+		wantReleases  bool
+		wantErrSubstr string
+	}{
+		{
+			name:         "empty registry routes to GHCR",
+			ir:           imageRepo{repo: "nvidia/k8s-device-plugin", pkgName: "k8s-device-plugin", imageRegistry: ""},
+			wantGHCR:     true,
+			wantReleases: false,
+		},
+		{
+			name:         "ghcr.io explicitly routes to GHCR",
+			ir:           imageRepo{repo: "nvidia/k8s-device-plugin", pkgName: "k8s-device-plugin", imageRegistry: "ghcr.io"},
+			wantGHCR:     true,
+			wantReleases: false,
+		},
+		{
+			name:         "registry.k8s.io routes to releases",
+			ir:           imageRepo{repo: "kubernetes-sigs/dra-driver-nvidia-gpu", pkgName: "dra-driver-nvidia/dra-driver-nvidia-gpu", imageRegistry: "registry.k8s.io"},
+			wantGHCR:     false,
+			wantReleases: true,
+		},
+		{
+			name:          "unknown registry returns error",
+			ir:            imageRepo{repo: "nvidia/foo", pkgName: "foo", imageRegistry: "quay.io"},
+			wantGHCR:      false,
+			wantReleases:  false,
+			wantErrSubstr: "unknown imageRegistry",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ghcrHit, releasesHit = false, false
+			_, err := fetchLatestImageTag(context.Background(), client, tc.ir)
+
+			if tc.wantErrSubstr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrSubstr) {
+					t.Fatalf("err = %v; want non-nil containing %q", err, tc.wantErrSubstr)
+				}
+				return
+			}
+			if ghcrHit != tc.wantGHCR {
+				t.Errorf("ghcrHit = %v; want %v", ghcrHit, tc.wantGHCR)
+			}
+			if releasesHit != tc.wantReleases {
+				t.Errorf("releasesHit = %v; want %v", releasesHit, tc.wantReleases)
+			}
+		})
+	}
+}
+
+func TestFetchLatestRegistryK8sTag_NoReleases(t *testing.T) {
+	t.Parallel()
+
+	client := newReleasesStub(t, "kubernetes-sigs", "dra-driver-nvidia-gpu", `[]`)
+
+	ir := imageRepo{
+		repo:          "kubernetes-sigs/dra-driver-nvidia-gpu",
+		pkgName:       "dra-driver-nvidia/dra-driver-nvidia-gpu",
+		imageRegistry: "registry.k8s.io",
+	}
+	_, err := fetchLatestRegistryK8sTag(context.Background(), client, ir)
+	if err == nil {
+		t.Fatalf("err = nil; want non-nil for empty releases response")
+	}
+	if !strings.Contains(err.Error(), "no releases found") {
+		t.Fatalf("err = %v; want it to contain 'no releases found'", err)
+	}
+}

--- a/artifact_fetcher_repos_test.go
+++ b/artifact_fetcher_repos_test.go
@@ -93,6 +93,33 @@ func TestDRAMigrationLiteralsAligned(t *testing.T) {
 			t.Errorf("defaultImages missing entry with repo=%q", newRepo)
 		}
 	})
+	t.Run("defaultImages.registryCoords", func(t *testing.T) {
+		t.Parallel()
+		// Post-CNCF-donation: DRA driver images live at
+		// registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu, promoted
+		// from a k8s-staging registry by the Prow release job.
+		// See docs/plans/2026-05-11-dra-registry-k8s-io-design.md.
+		const (
+			wantPkgName  = "dra-driver-nvidia/dra-driver-nvidia-gpu"
+			wantRegistry = "registry.k8s.io"
+		)
+		var found bool
+		for _, ir := range defaultImages {
+			if ir.repo != newRepo {
+				continue
+			}
+			found = true
+			if ir.imageRegistry != wantRegistry {
+				t.Errorf("defaultImages DRA entry imageRegistry = %q; want %q", ir.imageRegistry, wantRegistry)
+			}
+			if ir.pkgName != wantPkgName {
+				t.Errorf("defaultImages DRA entry pkgName = %q; want %q (full registry.k8s.io image path)", ir.pkgName, wantPkgName)
+			}
+		}
+		if !found {
+			t.Errorf("defaultImages missing entry with repo=%q", newRepo)
+		}
+	})
 	t.Run("projects.ts", func(t *testing.T) {
 		t.Parallel()
 		// Read the TS file as a string and grep for the canonical literal.


### PR DESCRIPTION
## Summary

Promote `feat/dashboard-enhancements` to `gh-pages` — picks up PR #338 (DRA driver image fetch from `registry.k8s.io`).

After NVIDIA donated the DRA driver to kubernetes-sigs (2026-04-30), the dashboard's image row for that project went silent because the new home publishes container images to `registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu`, not GHCR. PR #338 adds an `imageRegistry` discriminator on `imageRepo` and a release-based fetcher for OCI registries with no Packages API.

## Post-deploy expectation

The `kubernetes-sigs/dra-driver-nvidia-gpu` row appears in the dashboard's image table again, with the latest GitHub release tag (e.g. `v25.12.0`), a Release badge, the release `published_at` as the push date, and Tag + Source links both pointing to the GitHub release page.

## Deploy

Merge triggers `deploy.yaml` (push on `gh-pages` → rebuild + publish to GitHub Pages). The deploy now runs `go vet`, `go test`, and `npm test` before `npm run build` per the gate landed in PR #336.

## Test plan

- All component PR tests already CI-green on `feat/dashboard-enhancements`:
  - `TestFetchLatestRegistryK8sTag_HappyPath` (3-release fixture, mutation against `rels[1]`)
  - `TestFetchLatestRegistryK8sTag_NoReleases` (mutation against removed `len(rels)==0` guard)
  - `TestFetchLatestImageTag_Dispatch` (table-driven; routes for `""`, `"ghcr.io"`, `"registry.k8s.io"`, unknown)
  - `TestDRAMigrationLiteralsAligned` extended with `defaultImages.registryCoords` sub-test
- Post-deploy visual check: the DRA project shows an image row with a SemVer tag.
