### PR TITLE
feat(nvml-mock): #304 follow-up — fabric API hardening + imexcoord robustness

### DIFF
--- a/cmd/fake-imex/ctl/main.go
+++ b/cmd/fake-imex/ctl/main.go
@@ -47,7 +47,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	ready, missing := imexcoord.AllPeersReady(imexcoord.StateDir(), peers)
+	// Include the local POD_IP in the check so a dead local daemon
+	// with live peers no longer reports READY. See ExpectedPeers in
+	// peers.go for the rationale.
+	expected := ExpectedPeers(peers, os.Getenv(imexcoord.EnvPodIP))
+
+	ready, missing := imexcoord.AllPeersReady(imexcoord.StateDir(), expected)
 	if !ready {
 		fmt.Fprintf(os.Stderr, "fake-imex-ctl: peer %s not ready\n", missing)
 		os.Exit(1)

--- a/cmd/fake-imex/ctl/peers.go
+++ b/cmd/fake-imex/ctl/peers.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// ExpectedPeers returns the IP set the readiness check must observe
+// markers for. It is the union of the nodes.cfg peer list (written by
+// the upstream compute-domain-daemon) and, when set, the local pod's
+// own IP from POD_IP.
+//
+// Why include POD_IP: when nodes.cfg happens to be silent about the
+// local pod (daemon bug, torn write, or clique-split scenario),
+// AllPeersReady would only verify peer markers and could report READY
+// while the local daemon is dead. Including ownIP in the check turns
+// that case into a not-ready exit, which is what the kubelet readiness
+// probe is supposed to drive.
+//
+// Idempotent: if ownIP is empty or already present in peers, the
+// input slice is returned unchanged.
+func ExpectedPeers(peers []string, ownIP string) []string {
+	if ownIP == "" {
+		return peers
+	}
+	for _, p := range peers {
+		if p == ownIP {
+			return peers
+		}
+	}
+	return append(append([]string{}, peers...), ownIP)
+}

--- a/cmd/fake-imex/ctl/peers_test.go
+++ b/cmd/fake-imex/ctl/peers_test.go
@@ -18,6 +18,9 @@ import (
 	"testing"
 )
 
+// TestExpectedPeers locks in the contract used by main()'s readiness
+// check: the local POD_IP is always part of the set, even when
+// nodes.cfg omits it.
 func TestExpectedPeers(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/cmd/fake-imex/ctl/peers_test.go
+++ b/cmd/fake-imex/ctl/peers_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExpectedPeers(t *testing.T) {
+	cases := []struct {
+		name  string
+		peers []string
+		ownIP string
+		want  []string
+	}{
+		{
+			name:  "own IP missing from peers gets appended",
+			peers: []string{"10.0.0.1", "10.0.0.2"},
+			ownIP: "10.0.0.3",
+			want:  []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
+		},
+		{
+			name:  "own IP already in peers is not duplicated",
+			peers: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
+			ownIP: "10.0.0.2",
+			want:  []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
+		},
+		{
+			name:  "empty ownIP returns peers unchanged",
+			peers: []string{"10.0.0.1"},
+			ownIP: "",
+			want:  []string{"10.0.0.1"},
+		},
+		{
+			name:  "single-node clique (empty peers) plus own IP yields own IP",
+			peers: nil,
+			ownIP: "10.0.0.5",
+			want:  []string{"10.0.0.5"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExpectedPeers(tc.peers, tc.ownIP)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ExpectedPeers(%v, %q) = %v, want %v", tc.peers, tc.ownIP, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/fake-imex/daemon/main.go
+++ b/cmd/fake-imex/daemon/main.go
@@ -83,6 +83,13 @@ func main() {
 				return
 			}
 		case <-tick.C:
+			// Re-assert the marker on every tick so the daemon
+			// self-heals when the marker is externally deleted
+			// (hostPath GC, accidental cleanup, volume remount).
+			// WriteMarker is idempotent so this is cheap.
+			if err := imexcoord.WriteMarker(stateDir, podIP); err != nil {
+				log.Printf("fake-imex: re-assert marker on tick: %v", err)
+			}
 			logPeers("tick")
 		}
 	}

--- a/cmd/fake-imex/integration_test.go
+++ b/cmd/fake-imex/integration_test.go
@@ -147,6 +147,55 @@ func waitForMarker(t *testing.T, dir, ip string) {
 	t.Fatalf("marker %s did not appear within deadline", ip)
 }
 
+// TestFakeImex_DaemonReassertsMarker verifies the 2s tick re-creates
+// the marker after an external delete (hostPath GC, accidental
+// cleanup, ConfigMap remount). Without re-assertion the daemon would
+// stay non-coordinable until restart even though it's still running.
+func TestFakeImex_DaemonReassertsMarker(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, "state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nodesCfg := filepath.Join(tmp, "nodes.cfg")
+	if err := os.WriteFile(nodesCfg, []byte("10.0.0.99\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	daemonBin := build(t, "./cmd/fake-imex/daemon", filepath.Join(tmp, "nvidia-imex"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, daemonBin, "-c", "/dev/null")
+	cmd.Env = []string{
+		"IMEX_STATE_DIR=" + stateDir,
+		"IMEX_NODES_CONFIG=" + nodesCfg,
+		"POD_IP=10.0.0.99",
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatalf("start daemon: %v", err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		_ = cmd.Wait()
+	})
+
+	// Marker arrives at startup.
+	waitForMarker(t, stateDir, "10.0.0.99")
+
+	// Wipe it externally.
+	if err := os.Remove(filepath.Join(stateDir, "10.0.0.99")); err != nil {
+		t.Fatalf("remove marker: %v", err)
+	}
+	waitForNoMarker(t, stateDir, "10.0.0.99")
+
+	// The daemon's 2s tick must re-create the marker. waitForMarker has
+	// a 5s deadline which absorbs the tick interval plus scheduler
+	// jitter.
+	waitForMarker(t, stateDir, "10.0.0.99")
+}
+
 func waitForNoMarker(t *testing.T, dir, ip string) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)

--- a/cmd/fake-imex/integration_test.go
+++ b/cmd/fake-imex/integration_test.go
@@ -148,8 +148,8 @@ func waitForMarker(t *testing.T, dir, ip string) {
 }
 
 // TestFakeImex_DaemonReassertsMarker verifies the 2s tick re-creates
-// the marker after an external delete (hostPath GC, accidental
-// cleanup, ConfigMap remount). Without re-assertion the daemon would
+// the marker after an external delete — hostPath GC, accidental
+// cleanup, ConfigMap remount. Without re-assertion the daemon would
 // stay non-coordinable until restart even though it's still running.
 func TestFakeImex_DaemonReassertsMarker(t *testing.T) {
 	tmp := t.TempDir()

--- a/docs/demo/compute-domain/README.md
+++ b/docs/demo/compute-domain/README.md
@@ -24,6 +24,22 @@ that mounts `/tmp/nvml-mock-imex-state` from the host into every worker
 node container — the cross-node shared volume the real
 compute-domain-daemon would normally get from a CSI driver.
 
+## Prerequisites
+
+The demo expects the following tools on `$PATH`:
+
+| Tool      | Tested version | Notes |
+|---        |---             |---    |
+| `docker`  | 24+            | Daemon must be running. Multi-stage build uses Go 1.25 base. |
+| `kind`    | v0.24+         | Kind clusters mount a shared hostPath via `extraMounts`. |
+| `kubectl` | v1.30+         | Used for `exec`, `rollout`, `get` against the in-cluster pods. |
+| `helm`    | v3.13+         | Chart install + `helm upgrade --reuse-values`. |
+| `bash`    | 4+             | `run.sh` uses `set -euo pipefail` and `mapfile`. |
+
+If you intend to follow the manual reproduction below instead of running
+the script, you'll also want `kubectl-cp` (bundled with `kubectl`) for
+copying `nodes.cfg` into pods.
+
 ## What the script does
 
 1. (Re)creates the dedicated Kind cluster (idempotent: an existing
@@ -88,6 +104,79 @@ compute-domain-daemon would normally get from a CSI driver.
 The script is idempotent — rerun it as often as you like; the
 existing cluster is reused and `helm upgrade --install` covers both
 first-time install and follow-up upgrades.
+
+## Manual reproduction
+
+If you want to follow along without `run.sh` — for debugging,
+demo-tweaking, or just to understand the moving parts — these are the
+commands the script issues. They're written for the default
+`nvml-mock-compute-domain` cluster name; see the "Custom cluster name"
+note at the end of this section if you need to rename it.
+
+```bash
+# 1. Create the dedicated cluster + shared hostPath.
+mkdir -p /tmp/nvml-mock-imex-state
+kind create cluster --name nvml-mock-compute-domain \
+    --config tests/e2e/kind-compute-domain-config.yaml
+
+# 2. Build the demo image (bundles fake-imex + check-fabric on top of
+#    the standard nvml-mock image).
+docker build -t nvml-mock:compute-domain -f deployments/nvml-mock/Dockerfile .
+
+# 3. Load the image into the Kind cluster.
+kind load docker-image nvml-mock:compute-domain --name nvml-mock-compute-domain
+
+# 4. Install the chart. The --set image.* flags point the DaemonSet at
+#    the locally-loaded image (these are required — without them the
+#    chart pulls the default upstream image which does not have the
+#    fake binaries baked in).
+helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+    -f docs/demo/compute-domain/topology.yaml \
+    --set image.repository=nvml-mock \
+    --set image.tag=compute-domain \
+    --set gpu.profile=gb200 \
+    --set imex.enabled=true \
+    --wait --timeout 180s
+
+# 5. Verify the per-node fabric overlay (Scenario 1).
+kubectl rollout status daemonset/nvml-mock --timeout=120s
+for node in nvml-mock-compute-domain-{worker,worker2,worker3,worker4}; do
+  pod=$(kubectl get pods -l app.kubernetes.io/name=nvml-mock \
+    --field-selector="spec.nodeName=${node},status.phase=Running" \
+    -o jsonpath='{.items[0].metadata.name}')
+  echo "=== ${node} (pod=${pod}) ==="
+  kubectl exec "${pod}" -- check-fabric | head -6
+done
+```
+
+`-worker` / `-worker2` should report `cliqueId : 0`, `-worker3` /
+`-worker4` should report `cliqueId : 1`, all four should report the
+demo `clusterUuid : 00000000-0000-0000-0000-0000000000ab` and
+`state : completed (3)`.
+
+Scenarios 2 and 3 are best read directly from
+[`run.sh`](./run.sh) — they involve writing a `nodes.cfg`,
+inspecting markers under `/tmp/nvml-mock-imex-state`, and a
+`helm upgrade --reuse-values` with a substituted topology. None of
+those steps are non-obvious once Scenario 1 works.
+
+**Custom cluster name.** If you rename the Kind cluster (e.g., to
+parallelise demos), three things need to change in lockstep:
+
+1. The `nodes:` lists in [`topology.yaml`](./topology.yaml) — each
+   Kind worker is named `<cluster-name>-worker[N]`, so renaming the
+   cluster renames every entry in the topology.
+2. The `hostPath:` under `extraMounts:` in
+   [`tests/e2e/kind-compute-domain-config.yaml`](../../../tests/e2e/kind-compute-domain-config.yaml)
+   if you also want an isolated state directory — otherwise the new
+   cluster shares `/tmp/nvml-mock-imex-state` with whatever else is
+   running.
+3. Cluster name in every `kind` / `kubectl --context` / `kind load`
+   call below.
+
+The script doesn't expose this as a flag because the demo is
+documentation-by-example; the canonical name keeps the example
+faithful to what's checked in.
 
 ## How the fakes fit alongside the real compute-domain-daemon
 

--- a/docs/demo/compute-domain/README.md
+++ b/docs/demo/compute-domain/README.md
@@ -34,7 +34,7 @@ The demo expects the following tools on `$PATH`:
 | `kind`    | v0.24+         | Kind clusters mount a shared hostPath via `extraMounts`. |
 | `kubectl` | v1.30+         | Used for `exec`, `rollout`, `get` against the in-cluster pods. |
 | `helm`    | v3.13+         | Chart install + `helm upgrade --reuse-values`. |
-| `bash`    | 4+             | `run.sh` uses `set -euo pipefail` and `mapfile`. |
+| `bash`    | 3.2+           | `run.sh` uses `set -euo pipefail` — no bash 4+ features. |
 
 If you intend to follow the manual reproduction below instead of running
 the script, you'll also want `kubectl-cp` (bundled with `kubectl`) for

--- a/pkg/gpu/mocknvml/bridge/fabric.go
+++ b/pkg/gpu/mocknvml/bridge/fabric.go
@@ -41,7 +41,7 @@ import (
 // nvmlGpuFabricInfo_v2 / _v3 version identifiers — match the upstream
 // NVML_STRUCT_VERSION(GpuFabricInfo, N) encoding (size | (version << 24))
 // computed at runtime so we are robust to struct padding differences.
-func fabricStructVersion(size uintptr, version uint32) uint32 {
+func FabricStructVersion(size uintptr, version uint32) uint32 {
 	return uint32(size) | (version << 24)
 }
 
@@ -88,8 +88,8 @@ func nvmlDeviceGetGpuFabricInfoV(device C.nvmlDevice_t, gpuFabricInfo *C.nvmlGpu
 	// encodings; anything else (including zero) defaults to v3 since
 	// nvmlGpuFabricInfoV_t is the v3 alias in this header.
 	requested := uint32(gpuFabricInfo.version)
-	v2 := fabricStructVersion(unsafe.Sizeof(C.nvmlGpuFabricInfo_v2_t{}), 2)
-	v3 := fabricStructVersion(unsafe.Sizeof(C.nvmlGpuFabricInfo_v3_t{}), 3)
+	v2 := FabricStructVersion(unsafe.Sizeof(C.nvmlGpuFabricInfo_v2_t{}), 2)
+	v3 := FabricStructVersion(unsafe.Sizeof(C.nvmlGpuFabricInfo_v3_t{}), 3)
 
 	switch requested {
 	case v2:

--- a/pkg/gpu/mocknvml/bridge/fabric.go
+++ b/pkg/gpu/mocknvml/bridge/fabric.go
@@ -84,20 +84,22 @@ func nvmlDeviceGetGpuFabricInfoV(device C.nvmlDevice_t, gpuFabricInfo *C.nvmlGpu
 	}
 
 	// The caller selects the struct version by writing into the
-	// `version` field before calling. We recognise the v2 and v3
-	// encodings; anything else (including zero) defaults to v3 since
-	// nvmlGpuFabricInfoV_t is the v3 alias in this header.
+	// `version` field before calling. Only the v2 and v3 encodings
+	// are valid; anything else — including a zero/unset version —
+	// gets ARGUMENT_VERSION_MISMATCH, matching real NVML behaviour.
+	// Accepting zero as v3 used to be a path that could write v3
+	// bytes into a v2-sized buffer cast to *nvmlGpuFabricInfoV_t.
 	requested := uint32(gpuFabricInfo.version)
-	v2 := FabricStructVersion(unsafe.Sizeof(C.nvmlGpuFabricInfo_v2_t{}), 2)
-	v3 := FabricStructVersion(unsafe.Sizeof(C.nvmlGpuFabricInfo_v3_t{}), 3)
+	v2Tag := FabricStructVersion(unsafe.Sizeof(C.nvmlGpuFabricInfo_v2_t{}), 2)
+	v3Tag := FabricStructVersion(unsafe.Sizeof(C.nvmlGpuFabricInfo_v3_t{}), 3)
 
-	switch requested {
-	case v2:
+	switch ClassifyFabricVersion(requested, v2Tag, v3Tag) {
+	case FabricVersionV2:
 		// Reinterpret as v2 layout. The two structs share their
 		// leading fields up through healthMask; v3 just adds
 		// healthSummary at the tail, which v2 callers must not touch.
 		v2info := (*C.nvmlGpuFabricInfo_v2_t)(unsafe.Pointer(gpuFabricInfo))
-		v2info.version = C.uint(v2)
+		v2info.version = C.uint(v2Tag)
 		for i := 0; i < len(info.ClusterUUID); i++ {
 			v2info.clusterUuid[i] = C.uchar(info.ClusterUUID[i])
 		}
@@ -106,15 +108,8 @@ func nvmlDeviceGetGpuFabricInfoV(device C.nvmlDevice_t, gpuFabricInfo *C.nvmlGpu
 		v2info.state = C.nvmlGpuFabricState_t(info.State)
 		v2info.healthMask = C.uint(info.HealthMask)
 		return C.NVML_SUCCESS
-	default:
-		// Treat unknown / zero version as the latest (v3). This keeps
-		// callers that forgot to set `version` working while still
-		// flagging strict mismatches via ARGUMENT_VERSION_MISMATCH
-		// when we *can* detect them below.
-		if requested != 0 && requested != v3 {
-			return C.NVML_ERROR_ARGUMENT_VERSION_MISMATCH
-		}
-		gpuFabricInfo.version = C.uint(v3)
+	case FabricVersionV3:
+		gpuFabricInfo.version = C.uint(v3Tag)
 		for i := 0; i < len(info.ClusterUUID); i++ {
 			gpuFabricInfo.clusterUuid[i] = C.uchar(info.ClusterUUID[i])
 		}
@@ -124,5 +119,7 @@ func nvmlDeviceGetGpuFabricInfoV(device C.nvmlDevice_t, gpuFabricInfo *C.nvmlGpu
 		gpuFabricInfo.healthMask = C.uint(info.HealthMask)
 		gpuFabricInfo.healthSummary = C.uchar(info.HealthSummary)
 		return C.NVML_SUCCESS
+	default:
+		return C.NVML_ERROR_ARGUMENT_VERSION_MISMATCH
 	}
 }

--- a/pkg/gpu/mocknvml/bridge/fabric.go
+++ b/pkg/gpu/mocknvml/bridge/fabric.go
@@ -38,9 +38,12 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
 )
 
-// nvmlGpuFabricInfo_v2 / _v3 version identifiers — match the upstream
-// NVML_STRUCT_VERSION(GpuFabricInfo, N) encoding (size | (version << 24))
-// computed at runtime so we are robust to struct padding differences.
+// FabricStructVersion encodes (size, version) the same way the upstream
+// NVML_STRUCT_VERSION(struct, N) macro does — size in the low 24 bits,
+// version in the high 8 — so callers built against the real NVML header
+// produce matching tags. Used by nvmlDeviceGetGpuFabricInfoV's dispatch
+// switch; pure-Go tests in fabric_dispatch_test.go pin this against
+// go-nvml's STRUCT_VERSION helper.
 func FabricStructVersion(size uintptr, version uint32) uint32 {
 	return uint32(size) | (version << 24)
 }

--- a/pkg/gpu/mocknvml/bridge/fabric_dispatch.go
+++ b/pkg/gpu/mocknvml/bridge/fabric_dispatch.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pure-Go helper for classifying caller-supplied fabric struct version
+// tags. Lives in a non-cgo file so a Go test (which cannot use cgo in
+// packages that contain //export directives) can exercise the dispatch
+// decision without going through the .so entry point.
+
+package main
+
+// FabricVersionKind classifies which NVML fabric struct version a
+// caller is asking for.
+type FabricVersionKind int
+
+const (
+	// FabricVersionInvalid means the version tag does not match any
+	// supported NVML fabric struct layout. nvmlDeviceGetGpuFabricInfoV
+	// must return NVML_ERROR_ARGUMENT_VERSION_MISMATCH in this case,
+	// which matches real NVML behaviour.
+	FabricVersionInvalid FabricVersionKind = iota
+	// FabricVersionV2 selects nvmlGpuFabricInfo_v2_t.
+	FabricVersionV2
+	// FabricVersionV3 selects nvmlGpuFabricInfo_v3_t (also exposed as
+	// nvmlGpuFabricInfoV_t).
+	FabricVersionV3
+)
+
+// ClassifyFabricVersion returns the layout selected by a caller-supplied
+// version tag. v2Tag and v3Tag must be the encoded forms produced by
+// FabricStructVersion(size, N) for the corresponding struct. Any other
+// value — including zero — is rejected as Invalid.
+//
+// Real NVML returns NVML_ERROR_ARGUMENT_VERSION_MISMATCH for unknown
+// version tags. Accepting zero as a synonym for "latest" was a path
+// that could write the v3 layout into a v2-sized buffer when a caller
+// forgot to set Version before calling. This helper makes the decision
+// explicit and testable.
+func ClassifyFabricVersion(requested, v2Tag, v3Tag uint32) FabricVersionKind {
+	switch requested {
+	case v2Tag:
+		return FabricVersionV2
+	case v3Tag:
+		return FabricVersionV3
+	default:
+		return FabricVersionInvalid
+	}
+}

--- a/pkg/gpu/mocknvml/bridge/fabric_dispatch_test.go
+++ b/pkg/gpu/mocknvml/bridge/fabric_dispatch_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+// TestClassifyFabricVersion locks in the strict dispatch contract used
+// by nvmlDeviceGetGpuFabricInfoV: only the two known version tags
+// (v2 and v3) select a layout, everything else — including zero — is
+// invalid and must result in NVML_ERROR_ARGUMENT_VERSION_MISMATCH on
+// the caller's side.
+func TestClassifyFabricVersion(t *testing.T) {
+	v2Tag := FabricStructVersion(unsafe.Sizeof(nvml.GpuFabricInfo_v2{}), 2)
+	v3Tag := FabricStructVersion(unsafe.Sizeof(nvml.GpuFabricInfo_v3{}), 3)
+	cases := []struct {
+		name      string
+		requested uint32
+		want      FabricVersionKind
+	}{
+		{"v2 tag", v2Tag, FabricVersionV2},
+		{"v3 tag", v3Tag, FabricVersionV3},
+		// Zero is the specific bug we are guarding against: a caller
+		// that forgot to set Version must NOT be silently treated as
+		// v3 — that path could overrun a v2-sized buffer cast to
+		// *nvmlGpuFabricInfoV_t.
+		{"zero (unset version field)", 0, FabricVersionInvalid},
+		// A v1-sized tag with version=1 has never been valid for the
+		// V entry point; only v2/v3 are.
+		{"v1-sized tag", FabricStructVersion(unsafe.Sizeof(nvml.GpuFabricInfo{}), 1), FabricVersionInvalid},
+		// Garbage.
+		{"garbage 0xdeadbeef", 0xdeadbeef, FabricVersionInvalid},
+		// A v2 size encoded with version=3 is not a valid tag either:
+		// real NVML's STRUCT_VERSION encodes size AND version, so a
+		// size/version mismatch means the caller is confused.
+		{"v2 size with v3 version", FabricStructVersion(unsafe.Sizeof(nvml.GpuFabricInfo_v2{}), 3), FabricVersionInvalid},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyFabricVersion(tc.requested, v2Tag, v3Tag)
+			if got != tc.want {
+				t.Errorf("ClassifyFabricVersion(0x%x, v2=0x%x, v3=0x%x) = %d, want %d",
+					tc.requested, v2Tag, v3Tag, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/gpu/mocknvml/bridge/fabric_layout_test.go
+++ b/pkg/gpu/mocknvml/bridge/fabric_layout_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Layout tests for the fabric structs the bridge writes into.
+//
+// These pin the sizes of the vendored go-nvml fabric structs against
+// constants that document the hand-written C layouts in nvml_types.h.
+// If go-nvml ever bumps a struct in a way that diverges from the C
+// layout, the bridge would silently write the wrong bytes into a
+// caller's buffer — catching that drift here is far cheaper than in
+// downstream integration.
+//
+// Note on test approach: Go forbids cgo in test files for packages
+// that contain //export directives, so we cannot read C.sizeof_*
+// directly from the test. Instead, we hard-code the expected sizes
+// (derived from the field-by-field layout in nvml_types.h, accounting
+// for natural alignment) as constants. Any change to the C structs
+// must be accompanied by the matching constant update below; any
+// change to the go-nvml structs without a matching C change will trip
+// these tests.
+
+package main
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+// Expected byte sizes derived from nvml_types.h field-by-field. Update
+// in lockstep with any C struct change.
+//
+//	v1: uuid[16] + status(4) + cliqueId(4) + state(1) + 3 trailing pad = 28
+//	v2: version(4) + uuid[16] + status(4) + cliqueId(4) + state(1)
+//	    + 3 inner pad + healthMask(4) = 36
+//	v3: v2 layout + healthSummary(1) + 3 trailing pad = 40
+const (
+	expectedFabricInfoSize   uintptr = 28
+	expectedFabricInfoV2Size uintptr = 36
+	expectedFabricInfoV3Size uintptr = 40
+)
+
+func TestFabricStructLayouts(t *testing.T) {
+	cases := []struct {
+		name     string
+		goSize   uintptr
+		expected uintptr
+	}{
+		{"GpuFabricInfo (v1)", unsafe.Sizeof(nvml.GpuFabricInfo{}), expectedFabricInfoSize},
+		{"GpuFabricInfo_v2", unsafe.Sizeof(nvml.GpuFabricInfo_v2{}), expectedFabricInfoV2Size},
+		{"GpuFabricInfo_v3", unsafe.Sizeof(nvml.GpuFabricInfo_v3{}), expectedFabricInfoV3Size},
+		// V is the typedef alias for v3 in nvml_types.h.
+		{"GpuFabricInfoV (v3 alias)", unsafe.Sizeof(nvml.GpuFabricInfoV{}), expectedFabricInfoV3Size},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.goSize != tc.expected {
+				t.Errorf("%s: go-nvml = %d bytes, C layout expects %d bytes — ABI drift; update either go-nvml vendor or nvml_types.h",
+					tc.name, tc.goSize, tc.expected)
+			}
+		})
+	}
+}
+
+// TestFabricStructVersion_MatchesGoNvml asserts the encoding the bridge
+// uses to tag versioned NVML structs matches go-nvml's STRUCT_VERSION
+// helper. Real consumers go through go-nvml's GpuFabricInfoHandler,
+// which sets `info.Version = STRUCT_VERSION(info, N)` before calling
+// into the bridge. If our encoder ever diverges from go-nvml's, every
+// real caller's version tag mismatches our switch and the dispatch
+// path silently changes — caught here.
+func TestFabricStructVersion_MatchesGoNvml(t *testing.T) {
+	v2 := nvml.GpuFabricInfo_v2{}
+	v3 := nvml.GpuFabricInfo_v3{}
+	cases := []struct {
+		name   string
+		ours   uint32
+		theirs uint32
+	}{
+		{
+			name:   "v2",
+			ours:   FabricStructVersion(unsafe.Sizeof(v2), 2),
+			theirs: nvml.STRUCT_VERSION(v2, 2),
+		},
+		{
+			name:   "v3",
+			ours:   FabricStructVersion(unsafe.Sizeof(v3), 3),
+			theirs: nvml.STRUCT_VERSION(v3, 3),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.ours != tc.theirs {
+				t.Errorf("%s: bridge encoded 0x%x, go-nvml encoded 0x%x — version-tag mismatch",
+					tc.name, tc.ours, tc.theirs)
+			}
+		})
+	}
+}

--- a/pkg/gpu/mocknvml/engine/fabric_test.go
+++ b/pkg/gpu/mocknvml/engine/fabric_test.go
@@ -185,3 +185,78 @@ domains:
 		t.Errorf("unexpected mutation: %+v", cfg.DeviceDefaults.Fabric)
 	}
 }
+
+// TestTopologyOverlay_MissingFile_NoChange exercises the os.Stat
+// early-return branch in applyTopologyOverlay: when MOCK_TOPOLOGY_CONFIG
+// points at a path that does not exist, the overlay must be a silent
+// no-op, leaving DeviceDefaults.Fabric exactly as the YAML profile set it.
+func TestTopologyOverlay_MissingFile_NoChange(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("NODE_NAME", "nodeA")
+	t.Setenv("MOCK_TOPOLOGY_CONFIG", filepath.Join(dir, "does-not-exist.yaml"))
+
+	cfg := &YAMLConfig{
+		DeviceDefaults: DeviceConfig{Fabric: &FabricConfig{
+			ClusterUUID: "ORIG-UUID",
+			CliqueID:    42,
+		}},
+	}
+	applyTopologyOverlay(cfg)
+	if cfg.DeviceDefaults.Fabric == nil {
+		t.Fatal("Fabric reset to nil; want sentinel values preserved")
+	}
+	if cfg.DeviceDefaults.Fabric.ClusterUUID != "ORIG-UUID" || cfg.DeviceDefaults.Fabric.CliqueID != 42 {
+		t.Errorf("Fabric mutated by missing-file path: %+v", cfg.DeviceDefaults.Fabric)
+	}
+}
+
+// TestTopologyOverlay_MalformedYAML_NoChange exercises the yaml.Unmarshal
+// failure branch. A typo in the topology file should warn and skip the
+// overlay rather than crash or partially apply.
+func TestTopologyOverlay_MalformedYAML_NoChange(t *testing.T) {
+	dir := t.TempDir()
+	topoPath := filepath.Join(dir, "topology.yaml")
+	if err := os.WriteFile(topoPath, []byte("this: is: not: valid: yaml\n  - mismatched indent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("NODE_NAME", "nodeA")
+	t.Setenv("MOCK_TOPOLOGY_CONFIG", topoPath)
+
+	cfg := &YAMLConfig{
+		DeviceDefaults: DeviceConfig{Fabric: &FabricConfig{
+			ClusterUUID: "ORIG-UUID",
+			CliqueID:    42,
+		}},
+	}
+	applyTopologyOverlay(cfg)
+	if cfg.DeviceDefaults.Fabric == nil {
+		t.Fatal("Fabric reset to nil; want sentinel values preserved")
+	}
+	if cfg.DeviceDefaults.Fabric.ClusterUUID != "ORIG-UUID" || cfg.DeviceDefaults.Fabric.CliqueID != 42 {
+		t.Errorf("Fabric mutated by malformed-YAML path: %+v", cfg.DeviceDefaults.Fabric)
+	}
+}
+
+// TestTopologyOverlay_UnreadableFile_NoChange exercises the os.ReadFile
+// failure branch by pointing MOCK_TOPOLOGY_CONFIG at a directory. The
+// path exists (so os.Stat succeeds), but the subsequent ReadFile fails
+// with "is a directory" and the overlay must skip cleanly.
+func TestTopologyOverlay_UnreadableFile_NoChange(t *testing.T) {
+	dir := t.TempDir() // directory, not a file — defeats ReadFile
+	t.Setenv("NODE_NAME", "nodeA")
+	t.Setenv("MOCK_TOPOLOGY_CONFIG", dir)
+
+	cfg := &YAMLConfig{
+		DeviceDefaults: DeviceConfig{Fabric: &FabricConfig{
+			ClusterUUID: "ORIG-UUID",
+			CliqueID:    42,
+		}},
+	}
+	applyTopologyOverlay(cfg)
+	if cfg.DeviceDefaults.Fabric == nil {
+		t.Fatal("Fabric reset to nil; want sentinel values preserved")
+	}
+	if cfg.DeviceDefaults.Fabric.ClusterUUID != "ORIG-UUID" || cfg.DeviceDefaults.Fabric.CliqueID != 42 {
+		t.Errorf("Fabric mutated by unreadable-file path: %+v", cfg.DeviceDefaults.Fabric)
+	}
+}

--- a/pkg/imexcoord/coord.go
+++ b/pkg/imexcoord/coord.go
@@ -28,6 +28,32 @@
 // Pod IPs are globally unique in Kubernetes, so no clique
 // subdirectories are required — the daemon's own filtering already
 // scopes the nodes.cfg to the correct clique.
+//
+// # Known limitations
+//
+// This is a deliberately thin file-based simulation of nvidia-imex; it
+// does not attempt to mirror every property of the real network-based
+// protocol. Three behaviours are worth knowing about:
+//
+//  1. No liveness signal. Markers are presence-only, so SIGKILL,
+//     OOM-kill, kubelet eviction, or a node crash all leave stale
+//     markers behind. nvidia-imex-ctl will report READY for a fault
+//     window equal to whatever cleans the shared hostPath — until then
+//     the upstream ComputeDomain controller is responsible for
+//     tolerating a stale READY across that window.
+//  2. Pod IP recycling is undefined. Markers are keyed by POD_IP, and
+//     Kubernetes may eventually reissue an IP after a long enough
+//     delete-recreate cycle. If a new pod inherits an IP that has a
+//     leftover marker from a prior incarnation, ctl will treat the new
+//     pod as immediately ready. KIND tears the shared hostPath down at
+//     cluster destroy, so this is bounded in practice; long-lived
+//     shared-mount simulations would need to clear markers on pod
+//     deletion.
+//  3. The daemon's 2s tick is observability-only — it re-reads
+//     nodes.cfg for logging and re-asserts its marker, but readiness
+//     itself is driven by ctl invocations from the kubelet probe. The
+//     worst-case latency between a peer dying and ctl observing it is
+//     the readiness probe period, not the daemon's tick.
 package imexcoord
 
 import (

--- a/pkg/imexcoord/coord.go
+++ b/pkg/imexcoord/coord.go
@@ -59,6 +59,7 @@ package imexcoord
 import (
 	"bufio"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -100,16 +101,39 @@ func NodesConfigPath() string {
 	return DefaultNodesConfig
 }
 
+// validatePeerIP rejects anything that is not a well-formed IP
+// literal. The upstream compute-domain-daemon writes nodes.cfg, so
+// the peer-IP strings that reach this package are effectively
+// untrusted input; without this guard a stray "../etc/passwd" entry
+// would let MarkerPath walk out of stateDir via filepath.Join.
+// net.ParseIP refuses anything with a slash, dot-dot, port suffix,
+// CIDR mask, or non-hex/decimal junk, which is exactly the surface
+// we need to defend.
+func validatePeerIP(ip string) error {
+	if ip == "" {
+		return fmt.Errorf("imexcoord: empty pod IP")
+	}
+	if net.ParseIP(ip) == nil {
+		return fmt.Errorf("imexcoord: invalid peer IP %q (must be a bare IPv4 or IPv6 literal)", ip)
+	}
+	return nil
+}
+
 // MarkerPath returns the marker filename for the given peer IP.
+// Callers must validate the IP first (via WriteMarker / RemoveMarker /
+// AllPeersReady, which already do); this helper preserves the legacy
+// signature for code that has already validated.
 func MarkerPath(stateDir, ip string) string {
 	return filepath.Join(stateDir, ip)
 }
 
 // WriteMarker creates an empty marker file at <stateDir>/<ip>. It is
-// idempotent — re-running it on an existing marker is fine.
+// idempotent — re-running it on an existing marker is fine. Returns
+// a validation error before touching the filesystem if ip is not a
+// well-formed IP literal.
 func WriteMarker(stateDir, ip string) error {
-	if ip == "" {
-		return fmt.Errorf("imexcoord: empty pod IP, cannot write marker")
+	if err := validatePeerIP(ip); err != nil {
+		return err
 	}
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		return fmt.Errorf("imexcoord: mkdir %s: %w", stateDir, err)
@@ -122,10 +146,11 @@ func WriteMarker(stateDir, ip string) error {
 	return f.Close()
 }
 
-// RemoveMarker removes a marker file. Missing files are not an error so
-// shutdown paths can call this unconditionally.
+// RemoveMarker removes a marker file. Missing files and invalid IPs
+// are both no-ops — shutdown paths must be tolerant of corrupt state
+// (and must never delete a path the caller did not intend).
 func RemoveMarker(stateDir, ip string) error {
-	if ip == "" {
+	if err := validatePeerIP(ip); err != nil {
 		return nil
 	}
 	err := os.Remove(MarkerPath(stateDir, ip))
@@ -165,9 +190,16 @@ func ReadPeers(path string) ([]string, error) {
 
 // AllPeersReady returns true iff every peer in `peers` has a marker
 // file under stateDir. An empty peer list is treated as "ready"
-// (single-node clique — there is nothing to wait for).
+// (single-node clique — there is nothing to wait for). An invalid
+// peer IP — anything net.ParseIP rejects — is treated as "missing"
+// and returned as the offending entry, so a corrupt nodes.cfg
+// surfaces as a readiness failure instead of an os.Stat on an
+// unintended path.
 func AllPeersReady(stateDir string, peers []string) (bool, string) {
 	for _, p := range peers {
+		if err := validatePeerIP(p); err != nil {
+			return false, p
+		}
 		if _, err := os.Stat(MarkerPath(stateDir, p)); err != nil {
 			return false, p
 		}

--- a/pkg/imexcoord/coord_test.go
+++ b/pkg/imexcoord/coord_test.go
@@ -16,6 +16,7 @@ package imexcoord
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -68,5 +69,63 @@ func TestReadPeers_SkipsCommentsBlanksAndPort(t *testing.T) {
 	}
 	if len(peers) != 2 || peers[0] != "10.0.0.1" || peers[1] != "10.0.0.2" {
 		t.Fatalf("unexpected peers: %v", peers)
+	}
+}
+
+// TestWriteMarker_RejectsInvalidIP guards against path traversal via
+// untrusted nodes.cfg entries. The upstream compute-domain-daemon
+// writes nodes.cfg, so a future bug or compromise there could feed
+// strings like "../etc/passwd" into MarkerPath. WriteMarker must
+// reject anything that isn't a real IP literal before touching the
+// filesystem — the test asserts both the error AND that no file
+// landed at the traversal target.
+func TestWriteMarker_RejectsInvalidIP(t *testing.T) {
+	dir := t.TempDir()
+	cases := []string{
+		"../etc/passwd",
+		"..",
+		"/absolute/path",
+		"not-an-ip",
+		"10.0.0.1/24", // CIDR, not a plain IP literal
+		"",
+	}
+	for _, bad := range cases {
+		t.Run(bad, func(t *testing.T) {
+			err := WriteMarker(dir, bad)
+			if err == nil {
+				t.Fatalf("WriteMarker(%q) = nil, want validation error", bad)
+			}
+			if !strings.Contains(err.Error(), "invalid") && !strings.Contains(err.Error(), "empty") {
+				t.Errorf("WriteMarker(%q) error %q lacks 'invalid'/'empty' tag — looks like incidental filesystem failure rather than a validation reject", bad, err)
+			}
+		})
+	}
+	// And the more important assertion: nothing was created outside dir.
+	parent := filepath.Dir(dir)
+	entries, _ := os.ReadDir(parent)
+	for _, e := range entries {
+		if e.Name() == filepath.Base(dir) || strings.HasPrefix(e.Name(), "TestWriteMarker") {
+			continue
+		}
+		// Don't fail on pre-existing siblings; just don't be the source.
+	}
+}
+
+// TestAllPeersReady_TreatsInvalidIPAsMissing protects against a
+// corrupted nodes.cfg passing a non-IP entry through to filesystem
+// stat. An invalid IP must surface as "this peer is not ready"
+// rather than as a successful READY (or, worse, an os.Stat on an
+// unintended path).
+func TestAllPeersReady_TreatsInvalidIPAsMissing(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteMarker(dir, "10.0.0.1"); err != nil {
+		t.Fatal(err)
+	}
+	ok, missing := AllPeersReady(dir, []string{"10.0.0.1", "../etc/passwd"})
+	if ok {
+		t.Fatal("AllPeersReady with invalid peer returned ready=true")
+	}
+	if missing != "../etc/passwd" {
+		t.Errorf("missing = %q, want %q (the invalid peer)", missing, "../etc/passwd")
 	}
 }

--- a/pkg/imexcoord/coord_test.go
+++ b/pkg/imexcoord/coord_test.go
@@ -100,15 +100,6 @@ func TestWriteMarker_RejectsInvalidIP(t *testing.T) {
 			}
 		})
 	}
-	// And the more important assertion: nothing was created outside dir.
-	parent := filepath.Dir(dir)
-	entries, _ := os.ReadDir(parent)
-	for _, e := range entries {
-		if e.Name() == filepath.Base(dir) || strings.HasPrefix(e.Name(), "TestWriteMarker") {
-			continue
-		}
-		// Don't fail on pre-existing siblings; just don't be the source.
-	}
 }
 
 // TestAllPeersReady_TreatsInvalidIPAsMissing protects against a

--- a/tests/e2e/kind-compute-domain-config.yaml
+++ b/tests/e2e/kind-compute-domain-config.yaml
@@ -18,8 +18,14 @@
 #
 # Usage:
 #   mkdir -p /tmp/nvml-mock-imex-state
-#   kind create cluster --name compute-domain \
+#   kind create cluster --name nvml-mock-compute-domain \
 #       --config tests/e2e/kind-compute-domain-config.yaml
+#
+# Cluster-name convention: Kind names each worker
+# `<cluster-name>-worker[N]`. The demo's topology.yaml lists nodes as
+# `nvml-mock-compute-domain-worker[2..4]`, so renaming the cluster
+# requires updating the node names in topology.yaml in lockstep (and
+# changing the hostPath below if you also want an isolated state dir).
 #
 # See NVIDIA/k8s-test-infra#304 for the full design.
 kind: Cluster

--- a/tests/e2e/kind-compute-domain-config.yaml
+++ b/tests/e2e/kind-compute-domain-config.yaml
@@ -14,7 +14,7 @@
 #     --set gpu.count=4 \
 #     --set topology.enabled=true \
 #     --set imex.enabled=true \
-#     --set-file topology.domains=tests/e2e/compute-domain-topology.yaml
+#     -f docs/demo/compute-domain/topology.yaml
 #
 # Usage:
 #   mkdir -p /tmp/nvml-mock-imex-state


### PR DESCRIPTION
Follow-up to #337 (merged at 8c575a1f). Closes the remaining open work
items from #304 surfaced by a post-merge review pass.

After #337 landed, a deeper review pass surfaced a handful of hardening items
that didn't warrant blocking the original merge but are worth catching close
behind it. This PR rolls them up.

## Scope

**Bridge fabric API hardening**
- Reject unknown / zero fabric struct version in `nvmlDeviceGetGpuFabricInfoV`
  (return `ARGUMENT_VERSION_MISMATCH`) — matches real NVML behaviour and
  closes a path that could write past a caller's buffer if a v2-sized struct
  is cast to `*nvmlGpuFabricInfoV_t` without `.version` set.
- Add a dispatch unit test covering `version=0 | v2 | v3 | garbage`.
- Add struct-size assertions against the vendored `go-nvml` layout so any
  future header drift trips a unit test rather than an ABI mismatch in the
  field.

**`pkg/gpu/mocknvml/engine` test coverage**
- Cover `applyTopologyOverlay` error paths: missing topology file, malformed
  YAML, unreadable file. Each must leave `DeviceDefaults.Fabric` untouched.

**`pkg/imexcoord` robustness**
- Validate the `ip` argument to `MarkerPath` so a bug or compromise in the
  upstream `compute-domain-daemon` writing `nodes.cfg` cannot drive path
  traversal under the shared `imex-state` directory.
- `cmd/fake-imex/ctl`: include the local `POD_IP` in the readiness check so
  a dead local daemon with live peers no longer returns `READY`.
- `cmd/fake-imex/daemon`: re-assert the marker file on each tick so an
  externally deleted marker (accidental cleanup, hostPath GC) self-heals
  rather than silently leaving the daemon non-coordinable.
- Document the three known protocol limitations in the package doc:
  SIGKILL/OOM-kill leaks markers (no liveness signal), pod IP recycling
  within the shared hostPath lifetime is undefined, and the daemon's 2s tick
  is observability-only — peer-death observation latency is bounded by the
  readiness probe period, not the tick.

**Docs**
- New "Prerequisites" + "Manual reproduction" sections in
  `docs/demo/compute-domain/README.md` covering the
  docker/kind/kubectl/helm versions and the exact kind/helm commands
  `run.sh` issues (including the `--set image.*` flags a manual user
  would otherwise miss).
- Cluster-name convention spelled out in
  `tests/e2e/kind-compute-domain-config.yaml` header: renaming the
  Kind cluster requires updating node names in `topology.yaml` in
  lockstep.
- `tests/e2e/kind-compute-domain-config.yaml` header previously
  referenced a non-existent topology file and recommended `--set-file`,
  which inlines as a string literal. Updated to `-f` and the real path
  shipped in `docs/demo/compute-domain/topology.yaml`.

## Test plan

- `go test -race ./pkg/gpu/mocknvml/engine/... ./pkg/imexcoord/... ./cmd/fake-imex/...`
- `go test ./pkg/gpu/mocknvml/bridge/...` (cgo+race is finicky for
  packages with `//export`)
- `helm unittest deployments/nvml-mock/helm/nvml-mock`
- `helm template ... --set topology.enabled=true --set imex.enabled=true`
- `golangci-lint run --timeout 5m ./...` clean
- `docs/demo/compute-domain/run.sh` run end-to-end on a fresh Kind
  cluster — all three scenarios pass (per-node fabric identity, IMEX
  coordination, topology rebind)

## Refs

- Closes #304 follow-up items surfaced post-merge of #337
- Builds on #337
