### PR TITLE
fix(ci): revert chart version parse to pre-#319 form

### DIFF
--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Read chart version
         id: chart
         run: |
-          version=$(helm show chart ${{ env.CHART_DIR }}/${{ env.CHART_NAME }} -o json | jq -er .version)
+          version=$(yq -e '.version' ${{ env.CHART_DIR }}/${{ env.CHART_NAME }}/Chart.yaml)
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR


### PR DESCRIPTION
## What This PR Does

Reverts the chart-version parse line in `.github/workflows/helm-publish.yaml` to its pre-#319 form.

## Why

`helm show chart` is a "cat the file" command and does not accept `-o`/`--output` — that flag only exists on Cobra commands that format structured output (`helm list`, `helm get values`, etc.). The first push-to-main after #316 split the publish step into its own workflow surfaced:

```
Error: unknown shorthand flag: 'o' in -o
```

Run: https://github.com/NVIDIA/k8s-test-infra/actions/runs/25729311592/job/75550129676

The pre-#319 form was already correctly anchored:

```
$ helm show chart deployments/nvml-mock/helm/nvml-mock | head
apiVersion: v2
appVersion: 550.163.01
description: ...
...
version: 0.1.0
```

`helm show chart` emits Chart.yaml with keys sorted alphabetically. `^version:` only matches the bare `version:` line — `apiVersion:` and `appVersion:` start with `a` and never match. The "harden parsing" goal of #319 addressed a problem the previous form did not actually have, and the new flag was unsupported.

## Verification

Locally with `helm v4.1.4` (same line as the runner's `azure/setup-helm@v5`):

```
$ helm show chart … -o json
Error: unknown shorthand flag: 'o' in -o          # reproduces failure

$ helm show chart … | grep '^version:' | awk '{print $2}'
0.1.0                                              # restored form
```

## Checklist

- [x] Commits signed off (`git commit -s`) and GPG-signed (`-S`)
- [x] No source changes — CI workflow only
- [x] Failing command reproduced locally; revert verified locally
