### PR TITLE
fix(fetcher): cap pagination + size errCh for the 5y/9-repo fanout

### DIFF
--- a/artifact_fetcher.go
+++ b/artifact_fetcher.go
@@ -62,6 +62,18 @@ import (
 // abort callback. Tests may override this via the package-level variable.
 var secondarySleepCap = 5 * time.Minute
 
+// maxIssuesPRsPages caps each pagination loop inside fetchIssuesPRs.
+// GitHub's `Since` filter on Issues.ListByRepo matches updated_at, not
+// created_at, so a long-lived repo's closed-issues page-walk can pull in
+// thousands of pre-cutoff items that got recent activity. Without a cap the
+// fetcher pages indefinitely and the deploy stalls (verified empirically
+// on cancelled run 2026-05-11T13:12:35Z, 5h 20m of silent hang).
+//
+// At 100 entries/page × 30 pages × 4 loops × 9 repos this gives a ceiling
+// of ~108k API events per deploy — comfortably within the 5000/hr primary
+// rate-limit budget when amortized across a 6-hour deploy cron.
+const maxIssuesPRsPages = 30
+
 // -----------------------------------------------------------------------------
 // CLI flags
 // -----------------------------------------------------------------------------
@@ -599,7 +611,15 @@ func main() {
 	client, ctx := buildClient(ctx, token, logger)
 
 	resCh := make(chan TestResult, len(repos))
-	errCh := make(chan error, len(repos))
+	// errCh must be wide enough to absorb every potential error writer in the
+	// fanouts below without blocking — otherwise a burst of failures fills the
+	// channel and the producing goroutines deadlock on the send (the drain
+	// only runs after wg.Wait()). Writers, in order:
+	//   - repos             (processRepo failures)
+	//   - defaultImages     (fetchLatestImageTag failures)
+	//   - allRepos × 3      (workflows / repo info / traffic failures)
+	//   - +1                (loadPreviousIssuesPRs I/O error, surfaced from main)
+	errCh := make(chan error, len(repos)+len(defaultImages)+3*len(allRepos)+1)
 
 	sem := make(chan struct{}, *workers)
 	var wg sync.WaitGroup
@@ -1223,7 +1243,7 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 		State:       "open",
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
-	for {
+	for page := 0; page < maxIssuesPRsPages; page++ {
 		issues, resp, err := client.Issues.ListByRepo(ctx, owner, name, issueOpt)
 		if err != nil {
 			return RepoIssuesPRs{}, fmt.Errorf("list open issues: %w", err)
@@ -1236,6 +1256,10 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 		if resp == nil || resp.NextPage == 0 {
 			break
 		}
+		if page == maxIssuesPRsPages-1 {
+			log.Printf("warning: open issues for %s hit pagination cap (%d pages); truncating", repo, maxIssuesPRsPages)
+			break
+		}
 		issueOpt.Page = resp.NextPage
 	}
 
@@ -1245,13 +1269,17 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 		State:       "open",
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
-	for {
+	for page := 0; page < maxIssuesPRsPages; page++ {
 		prs, resp, err := client.PullRequests.List(ctx, owner, name, prOpt)
 		if err != nil {
 			return RepoIssuesPRs{}, fmt.Errorf("list open PRs: %w", err)
 		}
 		openPRs = append(openPRs, prs...)
 		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		if page == maxIssuesPRsPages-1 {
+			log.Printf("warning: open PRs for %s hit pagination cap (%d pages); truncating", repo, maxIssuesPRsPages)
 			break
 		}
 		prOpt.Page = resp.NextPage
@@ -1264,7 +1292,7 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 		Since:       fiveYearsAgo,
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
-	for {
+	for page := 0; page < maxIssuesPRsPages; page++ {
 		issues, resp, err := client.Issues.ListByRepo(ctx, owner, name, closedOpt)
 		if err != nil {
 			log.Printf("warning: failed to fetch closed issues for %s: %v", repo, err)
@@ -1272,6 +1300,10 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 		}
 		closedItems = append(closedItems, issues...)
 		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		if page == maxIssuesPRsPages-1 {
+			log.Printf("warning: closed issues for %s hit pagination cap (%d pages); truncating", repo, maxIssuesPRsPages)
 			break
 		}
 		closedOpt.Page = resp.NextPage
@@ -1285,7 +1317,7 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 		Direction:   "desc",
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
-	for {
+	for page := 0; page < maxIssuesPRsPages; page++ {
 		prs, resp, err := client.PullRequests.List(ctx, owner, name, mergedOpt)
 		if err != nil {
 			log.Printf("warning: failed to fetch merged PRs for %s: %v", repo, err)
@@ -1303,6 +1335,10 @@ func fetchIssuesPRs(ctx context.Context, client *github.Client, repo string) (Re
 			mergedPRs = append(mergedPRs, pr)
 		}
 		if pastCutoff || resp == nil || resp.NextPage == 0 {
+			break
+		}
+		if page == maxIssuesPRsPages-1 {
+			log.Printf("warning: merged PRs for %s hit pagination cap (%d pages); truncating", repo, maxIssuesPRsPages)
 			break
 		}
 		mergedOpt.Page = resp.NextPage

--- a/artifact_fetcher_e2e_test.go
+++ b/artifact_fetcher_e2e_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -340,6 +341,85 @@ func srvURLOf(r *http.Request) string {
 //
 // Mutation check: a special-case "if no events, return nil arrays"
 // fails the length assertion.
+// TestFetchIssuesPRs_PaginationCap pins the per-loop pagination cap that
+// prevents runaway page-walking on a repo with very long history. Without
+// the cap, the fetcher pages indefinitely through every closed issue whose
+// updated_at falls within the 5y window — GitHub's `Since` filter uses
+// updated_at, not created_at, so old issues with recent comments stay in
+// the result set. Long-lived repos (gpu-operator, k8s-device-plugin) have
+// thousands of such issues; without a cap the deploy stalls for hours and
+// exhausts the rate-limit budget. Verified empirically on the cancelled
+// run 2026-05-11T13:12:35Z (5h 20m of silence post traffic phase).
+//
+// The stub server always returns a full page (100 issues) AND advertises a
+// next page via Link header, simulating an infinite-pagination repo. The
+// fetcher must stop at maxIssuesPRsPages and return cleanly.
+//
+// Mutation: removing the page-cap exit causes the fetcher to keep paging
+// past 30 calls; the openCalls assertion fires.
+func TestFetchIssuesPRs_PaginationCap(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+
+	var openCalls int32
+	var openCallsMu sync.Mutex
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/issues") || r.URL.Query().Get("state") != "open" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, "[]")
+			return
+		}
+		openCallsMu.Lock()
+		openCalls++
+		thisPage := openCalls
+		openCallsMu.Unlock()
+
+		// Always advertise a "next" page — the fetcher never sees end-of-list.
+		w.Header().Set("Link", fmt.Sprintf(`<%s/repos/test/repo/issues?state=open&page=%d>; rel="next"`, srvURLOf(r), thisPage+1))
+		w.Header().Set("Content-Type", "application/json")
+
+		// 100 distinct open issues per page, all with createdAt in the last year
+		// so they all land in the velocity window.
+		fixtures := make([]issueFixture, 0, 100)
+		for i := 0; i < 100; i++ {
+			fixtures = append(fixtures, issueFixture{
+				Number:    int(thisPage)*1000 + i,
+				State:     "open",
+				CreatedAt: now.Add(-time.Duration(i) * time.Hour),
+				Labels:    []string{"bug"},
+			})
+		}
+		_, _ = io.WriteString(w, buildIssuesJSON(fixtures))
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	client, ctx := buildClient(ctx, "fake-token", silentLogger())
+	parsed, _ := client.BaseURL.Parse(srv.URL + "/")
+	client.BaseURL = parsed
+
+	got, err := fetchIssuesPRs(ctx, client, "test/repo")
+	if err != nil {
+		t.Fatalf("fetchIssuesPRs: %v", err)
+	}
+
+	// The cap is maxIssuesPRsPages; verify the fetcher honored it.
+	if openCalls > int32(maxIssuesPRsPages) {
+		t.Errorf("open-issues API calls = %d; want <= %d (page cap leaked)", openCalls, maxIssuesPRsPages)
+	}
+	if openCalls < int32(maxIssuesPRsPages) {
+		t.Errorf("open-issues API calls = %d; want exactly %d (cap should be reached)", openCalls, maxIssuesPRsPages)
+	}
+	// And the events do actually flow into the aggregator (100 per page × cap).
+	wantTotal := int(maxIssuesPRsPages) * 100
+	if got.Issues.Total != wantTotal {
+		t.Errorf("Issues.Total = %d; want %d (cap × per_page)", got.Issues.Total, wantTotal)
+	}
+}
+
 func TestFetchIssuesPRs_EmptyResponse(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Sync of PR #341 (cherry-picked hotfix on `gh-pages`) back to `feat/dashboard-enhancements`, so future promotes carry the deadlock fix.

Same diff as #341: adds `maxIssuesPRsPages = 30` cap on the four pagination loops in `fetchIssuesPRs`, resizes `errCh` to `len(repos)+len(defaultImages)+3*len(allRepos)+1` to absorb the full goroutine fanout.

## Test plan

`TestFetchIssuesPRs_PaginationCap` — infinite-pagination httptest stub; mutation against unbounded loop hits the 30s context deadline (production hang signature). Verified pre-commit.

Locally clean: `go vet ./... && go test -race -count=1 ./...`.

Refs: cancelled run https://github.com/NVIDIA/k8s-test-infra/actions/runs/25672322008, PR #341.
