### PR TITLE
fix(ci): actually revert chart version parse line

### DIFF
--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Read chart version
         id: chart
         run: |
-          version=$(yq -e '.version' ${{ env.CHART_DIR }}/${{ env.CHART_NAME }}/Chart.yaml)
+          version=$(helm show chart ${{ env.CHART_DIR }}/${{ env.CHART_NAME }} | grep '^version:' | awk '{print $2}')
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR


### PR DESCRIPTION
## What This PR Does

Replaces the `yq -e '.version' Chart.yaml` line that landed in #343 with the actual pre-#319 form:

```bash
version=$(helm show chart ${{ env.CHART_DIR }}/${{ env.CHART_NAME }} | grep '^version:' | awk '{print $2}')
```

## Why

#343 was supposed to be a straight revert of #319's broken `helm show chart … -o json` line. The amend that swapped the interim `yq` content for the revert content only updated the commit message — the file change was never staged, so #343 actually landed `yq -e '.version' Chart.yaml`. yq is not guaranteed to be on every runner image, so the publish step still fails on push-to-main.

## Verification

Locally with helm v4.1.4 (matches `azure/setup-helm@v5`):

```
$ helm show chart deployments/nvml-mock/helm/nvml-mock | grep '^version:' | awk '{print $2}'
0.1.0

$ # robust to quoted versions because helm re-emits canonical YAML:
$ sed -i.bak 's/^version: 0.1.0$/version: "0.1.0"/' Chart.yaml
$ helm show chart … | grep '^version:' | awk '{print $2}'
0.1.0
```

Committed diff verified with `git show HEAD --` before push.

## Checklist

- [x] Commit signed off (`-s`) and GPG-signed (`-S`)
- [x] No source changes — CI workflow only
- [x] Commit content verified post-amend this time
