### PR TITLE
nvml-mock: write toolkit-ready marker for GPU Operator compat

### DIFF
--- a/deployments/nvml-mock/scripts/cleanup.sh
+++ b/deployments/nvml-mock/scripts/cleanup.sh
@@ -13,6 +13,8 @@ if [ -L "/host/run/nvidia/driver" ]; then
   rm -f "/host/run/nvidia/driver"
   echo "GPU Operator driver symlink removed"
 fi
+# Remove GPU Operator toolkit-ready marker (counterpart to setup.sh:8b)
+rm -f "/host/run/nvidia/validations/toolkit-ready"
 # Remove CDI spec
 CDI_FILE="/host/var/run/cdi/nvidia.yaml"
 if [ -f "$CDI_FILE" ]; then

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -205,6 +205,16 @@ fi
 mkdir -p /host/run/nvidia
 ln -sfn /var/lib/nvml-mock/driver /host/run/nvidia/driver
 
+# 8b. Write the toolkit-ready marker that GPU Operator operand pods poll for.
+#     Operand DaemonSets (device-plugin, gpu-feature-discovery) ship with a
+#     hardcoded `toolkit-validation` init container that loops on:
+#       until [ -f /run/nvidia/validations/toolkit-ready ]; do sleep 5; done
+#     Real nvidia-container-toolkit writes this marker as part of its install.
+#     When nvml-mock substitutes for the toolkit, no other component writes
+#     it — so we do, here, alongside the existing /run/nvidia/driver setup.
+mkdir -p /host/run/nvidia/validations
+touch /host/run/nvidia/validations/toolkit-ready
+
 # 9. Render fake InfiniBand sysfs tree (consumed via libibmocksys.so LD_PRELOAD).
 #    Only writes anything when the profile has `infiniband.enabled: true`.
 #    Failures are fatal under `set -e`: a profile typo here would otherwise


### PR DESCRIPTION
## Summary

`nvml-mock`'s `setup.sh` does host-state setup for the "GPU Operator compatibility" flow (section 8 creates the `/run/nvidia/driver` symlink), but it does NOT write `/run/nvidia/validations/toolkit-ready`. That marker file is **load-bearing for every gpu-operator operand pod** on mock-NVML nodes — without it, the entire mock-backend flow blocks before workloads can schedule.

This PR adds the marker write in `setup.sh` (section 8b) and a symmetric removal in `cleanup.sh`.

## Why this is load-bearing, not cosmetic

GPU Operator's operand DaemonSets — `nvidia-device-plugin-daemonset`, `gpu-feature-discovery`, and `nvidia-operator-validator` — ship with a hardcoded `toolkit-validation` init container whose only job is to shell-poll for the marker:

```sh
until [ -f /run/nvidia/validations/toolkit-ready ]; do
  echo waiting for nvidia container stack to be setup
  sleep 5
done
```

On a real-toolkit cluster this marker is written by gpu-operator's own validator DaemonSet after `exec nvidia-smi` succeeds. On a mock-NVML cluster (where `nvml-mock` substitutes for `nvidia-container-toolkit`), the validator's `toolkit-validation` init container runs in an isolated mount namespace without access to `/run/nvidia/driver` or the mock library, so it never reaches "exec nvidia-smi" success and never writes the marker. **Every operand pod stays at `Init:0/1` forever** — `nvidia-device-plugin-daemonset` never starts → `nvidia.com/gpu` is never advertised on the node → no workload can request mock GPUs.

Empirically verified on a KIND cluster (single mock pool, nvml-mock pod running, gpu-operator subchart installed with `toolkit.env: [CREATE_DEVICE_NODES=none]`):

| State | Operand pod status | Worker `nvidia.com/gpu` allocatable | Workload pod with `runtimeClassName: nvidia` |
|---|---|---|---|
| Before this PR | `Init:0/1` indefinitely (3 DaemonSets stuck) | `0` (device-plugin never starts) | Pending forever |
| After `touch /run/nvidia/validations/toolkit-ready` | `1/1 Running` within ~5s | `8` | **Schedules, completes, `nvidia-smi` inside container reports `Mock NVIDIA A100-SXM4-40GB`** |

The marker is *the* gate between "mock setup ran" and "operands can actually serve GPU resources." Writing it from `setup.sh` closes the gap that the existing `/run/nvidia/driver` symlink work already partly addressed.

## Diff

```
deployments/nvml-mock/scripts/setup.sh   | 10 ++++++++++
deployments/nvml-mock/scripts/cleanup.sh |  2 ++
```

`setup.sh` (new section 8b, immediately after the existing `/run/nvidia/driver` symlink — same intent, "GPU Operator compatibility"):

```sh
mkdir -p /host/run/nvidia/validations
touch /host/run/nvidia/validations/toolkit-ready
```

`cleanup.sh` (symmetric removal in the `preStop` counterpart):

```sh
rm -f "/host/run/nvidia/validations/toolkit-ready"
```

## What this PR doesn't fix (out of scope)

`gpu-operator`'s validator DaemonSet still crashes on mock-NVML nodes — its `toolkit-validation` init container hardcodes `exec nvidia-smi` and has no host volume mount for the mock binary. After this PR, `ClusterPolicy` will still report `NotReady` due to `state-operator-validation`. **But this is now purely a status-reporting concern** — operand pods work, workloads schedule, mock GPUs are usable. The validator gap is a `gpu-operator` issue (`state_manager.go:state-operator-validation` is hardcoded to `return true` — non-conditional), tracked separately.

## Compatibility

- Pure additive change to setup/cleanup scripts. No values, RBAC, image, or DaemonSet-spec changes.
- Marker is a 0-byte sentinel file. Existence is the only thing consumers check.
- On real-toolkit clusters (the file already written by validator after real `nvidia-smi` succeeds), this is a no-op `touch` of an existing file.
- `cleanup.sh` runs as `preStop`. Same force-delete caveat (`--grace-period=0` skips it) that already applies to the existing `/run/nvidia/driver` symlink work.

## Verification environment

- KIND v0.30, single worker, no real NVIDIA hardware
- `nvml-mock` DS running, mock libraries at `/var/lib/nvml-mock/driver/`
- `gpu-operator` subchart `v26.3.1` installed with `toolkit.enabled: true` + `toolkit.env: [CREATE_DEVICE_NODES=none]`
- Workload pod with `runtimeClassName: nvidia` + `nvidia.com/gpu: 1` resource request

Without this PR, the same workload pod stays in `Pending` indefinitely (`UnexpectedAdmissionError` from device-plugin not yet registered with kubelet). With this PR, the same pod completes successfully with mock devices injected.