### PR TITLE
feat(nvml-mock): add PCIe topology to profiles and render mock sysfs tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- nvml-mock PCIe topology: profiles now carry a `pcie_topology:` block
+  describing PCI root complexes, NUMA nodes, and device-to-root mapping.
+  A new `render-pci-sysfs` binary (built from `cmd/render-pci-sysfs/`,
+  schema and renderer in `pkg/system/mockpcisysfs/`) materializes a fake
+  `/sys/bus/pci/devices` + `/sys/devices/pciDDDD:BB` tree under
+  `/var/lib/nvml-mock/sys/` from the init container, so topology-aware
+  consumers (NVIDIA DRA driver's `dra.k8s.io/pcieRoot`, device-plugin
+  NUMA hints) can resolve PCIe root complex via `readlink()` + path
+  parse. Defaults populated for every profile: `a100`/`b200`/`h100`/`l40s`
+  -> 2 root complexes (dual-socket), `gb200` -> 4 root complexes (one per
+  Grace pair), `t4` -> 1 root complex. (#263)
+
+### Changed
+- nvml-mock profile `bus_id` fields now use the canonical Linux sysfs
+  4-digit-domain form (`0000:07:00.0`) instead of the NVML 8-digit
+  `busIdLegacy` form (`00000000:07:00.0`). The bridge already returned
+  the same string verbatim in `nvmlPciInfo.busId`; the new format aligns
+  the mock with what real Linux PCI sysfs exposes and is a hard
+  prerequisite for the PCIe sysfs renderer above. (#263)
 - InfiniBand mock: real `ibstat`, `ibstatus`, `iblinkinfo`, and other
   `infiniband-diags` / `rdma-core` tools now work inside the nvml-mock
   DaemonSet without IB hardware. Implementation: `LD_PRELOAD` shim

--- a/cmd/render-pci-sysfs/main.go
+++ b/cmd/render-pci-sysfs/main.go
@@ -1,0 +1,92 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// Command render-pci-sysfs reads the `pcie_topology:` block from a
+// mock-nvml profile YAML and writes a fake PCI sysfs tree under --output.
+//
+// The tree carries exactly what topology-aware schedulers need (symlinks
+// under /sys/bus/pci/devices and numa_node under /sys/devices/pciDDDD:BB),
+// matching the layout the k8s deviceattribute library expects when it
+// resolves "PCIe root" for a GPU. See pkg/system/mockpcisysfs/render
+// for the layout details.
+//
+// Usage:
+//
+//	render-pci-sysfs \
+//	    --config /etc/nvml-mock/config.yaml \
+//	    --output /var/lib/nvml-mock
+//
+// When the profile omits `pcie_topology:` the renderer falls back to a
+// flat single-root layout covering every device in `devices:`. Pass
+// --strict to require an explicit topology block (CI-friendly).
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/system/mockpcisysfs/config"
+	"github.com/NVIDIA/k8s-test-infra/pkg/system/mockpcisysfs/render"
+)
+
+func main() {
+	var (
+		cfgPath = flag.String("config", "", "path to mock-nvml profile YAML")
+		outDir  = flag.String("output", "", "fake-root directory; tree is written under <output>/sys/...")
+		strict  = flag.Bool("strict", false, "fail if the profile does not declare `pcie_topology:`")
+		dryRun  = flag.Bool("dry-run", false, "validate the config and exit without writing files")
+	)
+	flag.Parse()
+
+	if *cfgPath == "" || *outDir == "" {
+		fmt.Fprintln(os.Stderr, "usage: render-pci-sysfs --config <yaml> --output <dir> [--strict] [--dry-run]")
+		os.Exit(2)
+	}
+
+	data, err := os.ReadFile(*cfgPath)
+	if err != nil {
+		fatalf("read config: %v", err)
+	}
+	var prof config.Profile
+	if err := yaml.Unmarshal(data, &prof); err != nil {
+		fatalf("parse config: %v", err)
+	}
+	if err := prof.Validate(); err != nil {
+		fatalf("%v", err)
+	}
+
+	topo := prof.EffectiveTopology()
+	if topo == nil {
+		fmt.Fprintf(os.Stderr, "render-pci-sysfs: no devices in %s, nothing to render\n", *cfgPath)
+		return
+	}
+	if *strict && prof.PCIeTopology == nil {
+		fatalf("--strict: profile %s does not declare `pcie_topology:`", *cfgPath)
+	}
+
+	if *dryRun {
+		fmt.Fprintf(os.Stderr, "render-pci-sysfs: %d root complex(es), %d device(s) — config OK\n",
+			len(topo.RootComplexes), countDevices(topo))
+		return
+	}
+
+	if err := render.Render(render.Options{Topology: topo, Output: *outDir}); err != nil {
+		fatalf("render: %v", err)
+	}
+}
+
+func countDevices(t *config.PCIeTopology) int {
+	n := 0
+	for _, rc := range t.RootComplexes {
+		n += len(rc.Devices)
+	}
+	return n
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "render-pci-sysfs: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/deployments/nvml-mock/Dockerfile
+++ b/deployments/nvml-mock/Dockerfile
@@ -20,18 +20,21 @@ COPY vendor/ vendor/
 COPY pkg/gpu/mocknvml/ pkg/gpu/mocknvml/
 COPY pkg/gpu/mockcuda/ pkg/gpu/mockcuda/
 COPY pkg/network/mockibsysfs/ pkg/network/mockibsysfs/
+COPY pkg/system/mockpcisysfs/ pkg/system/mockpcisysfs/
 COPY pkg/imexcoord/ pkg/imexcoord/
 COPY cmd/render-ib-sysfs/ cmd/render-ib-sysfs/
+COPY cmd/render-pci-sysfs/ cmd/render-pci-sysfs/
 COPY cmd/fake-imex/ cmd/fake-imex/
 COPY cmd/check-fabric/ cmd/check-fabric/
 RUN cd pkg/gpu/mocknvml && make clean && make
 RUN cd pkg/gpu/mockcuda && make clean && make
 RUN cd pkg/network/mockibsysfs && make clean && make
 RUN mkdir -p /out \
-    && go build -mod=vendor -o /out/render-ib-sysfs ./cmd/render-ib-sysfs \
-    && go build -mod=vendor -o /out/nvidia-imex     ./cmd/fake-imex/daemon \
-    && go build -mod=vendor -o /out/nvidia-imex-ctl ./cmd/fake-imex/ctl \
-    && go build -mod=vendor -o /out/check-fabric    ./cmd/check-fabric
+    && go build -mod=vendor -o /out/render-ib-sysfs  ./cmd/render-ib-sysfs \
+    && go build -mod=vendor -o /out/render-pci-sysfs ./cmd/render-pci-sysfs \
+    && go build -mod=vendor -o /out/nvidia-imex      ./cmd/fake-imex/daemon \
+    && go build -mod=vendor -o /out/nvidia-imex-ctl  ./cmd/fake-imex/ctl \
+    && go build -mod=vendor -o /out/check-fabric     ./cmd/check-fabric
 
 FROM debian:bookworm-slim
 ARG KUBECTL_VERSION=v1.32.0
@@ -39,7 +42,8 @@ ARG TARGETARCH
 COPY --from=builder /src/pkg/gpu/mocknvml/libnvidia-ml.so.* /usr/local/lib/
 COPY --from=builder /src/pkg/gpu/mockcuda/libcuda.so.* /usr/local/lib/
 COPY --from=builder /src/pkg/network/mockibsysfs/libibmocksys.so.* /usr/local/lib/
-COPY --from=builder /out/render-ib-sysfs /usr/local/bin/render-ib-sysfs
+COPY --from=builder /out/render-ib-sysfs  /usr/local/bin/render-ib-sysfs
+COPY --from=builder /out/render-pci-sysfs /usr/local/bin/render-pci-sysfs
 # Fake IMEX binaries used for ComputeDomain simulation on KIND. Installed
 # at the same paths the upstream compute-domain-daemon expects in $PATH,
 # so the thin daemon image layer (Dockerfile.compute-domain-daemon) can

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -14,6 +14,10 @@ Deploys a DaemonSet that creates on every node:
 - A fake InfiniBand sysfs tree at `/var/lib/nvml-mock/ib/sys/class/infiniband/...`
   paired with `libibmocksys.so` (`LD_PRELOAD`) so real `ibstat`, `ibstatus`,
   `iblinkinfo`, ... read mock HCAs
+- A fake PCI sysfs tree at `/var/lib/nvml-mock/sys/bus/pci/devices/...` (symlinks
+  into `/var/lib/nvml-mock/sys/devices/pciDDDD:BB/...`) so topology-aware
+  consumers (NVIDIA DRA driver `dra.k8s.io/pcieRoot`, NUMA-aware schedulers)
+  resolve PCIe root complex via a standard `readlink()`
 
 Consumers (DRA driver, device plugin) point at `/var/lib/nvml-mock/driver`
 as the NVIDIA driver root and discover GPUs through standard NVML APIs.
@@ -540,6 +544,64 @@ helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
 ```
 
 …or via a custom profile file (preferred for full control).
+
+## PCIe topology mocking
+
+Each profile carries a `pcie_topology:` block describing the host's PCI
+root-complex layout. When the DaemonSet starts, `render-pci-sysfs` reads
+it and writes a fake sysfs tree at `/var/lib/nvml-mock/sys/...` matching
+what real Linux kernels expose. Topology-aware consumers (NVIDIA DRA
+driver, device plugins computing NUMA hints) resolve "which PCIe root
+complex a GPU lives on" via a standard `readlink()` + path parse against
+the rendered tree:
+
+```bash
+$ readlink /var/lib/nvml-mock/sys/bus/pci/devices/0000:07:00.0
+../../../devices/pci0000:00/0000:07:00.0
+
+$ cat /var/lib/nvml-mock/sys/devices/pci0000:00/0000:07:00.0/numa_node
+0
+```
+
+### Defaults per profile
+
+| Profile | Root complexes | NUMA nodes | Devices per root |
+|---|---|---|---|
+| `a100`  | 2 (`pci0000:00`, `pci0000:80`) | 2 (dual EPYC) | 4 |
+| `h100`  | 2 (`pci0000:00`, `pci0000:80`) | 2 (dual socket) | 4 |
+| `b200`  | 2 (`pci0000:00`, `pci0000:80`) | 2 (dual socket) | 4 |
+| `gb200` | 4 (`pci0000:00`, `:40`, `:80`, `:c0`) | 4 (per Grace pair) | 2 |
+| `l40s`  | 2 (`pci0000:00`, `pci0000:80`) | 2 (dual socket) | 4 |
+| `t4`    | 1 (`pci0000:00`) | 1 | 4 |
+
+### `pcie_topology:` block schema
+
+```yaml
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"            # sysfs root-complex dir, format "pciDDDD:BB"
+      numa_node: 0                 # numa_node value for every child device
+      devices:
+        - "0000:07:00.0"           # canonical 4-digit-domain BDF
+        - "0000:0F:00.0"
+    - id: "pci0000:80"
+      numa_node: 1
+      devices:
+        - "0000:87:00.0"
+        - "0000:90:00.0"
+```
+
+`render-pci-sysfs` validates the block at startup and fails the
+DaemonSet under `set -e` if it finds a typo:
+
+- Every BDF listed under a root complex must also appear in `devices[]`.
+- Each BDF may belong to at most one root complex.
+- Root complex IDs must match `pciDDDD:BB`.
+- BDFs must use 4-digit-domain form (`DDDD:BB:DD.F`); the legacy NVML
+  `busIdLegacy` 8-digit form is rejected.
+
+If a profile omits `pcie_topology:` entirely the renderer falls back to
+a flat single-root layout (every device under `pci0000:00`, NUMA 0).
 
 ## Configuration
 

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/a100.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/a100.yaml
@@ -315,56 +315,56 @@ devices:
     uuid: "GPU-12345678-1234-1234-1234-123456780000"
     serial: "1324821083800"
     pci:
-      bus_id: "00000000:07:00.0"
+      bus_id: "0000:07:00.0"
     minor_number: 0
 
   - index: 1
     uuid: "GPU-12345678-1234-1234-1234-123456780001"
     serial: "1324821083801"
     pci:
-      bus_id: "00000000:0F:00.0"
+      bus_id: "0000:0F:00.0"
     minor_number: 1
 
   - index: 2
     uuid: "GPU-12345678-1234-1234-1234-123456780002"
     serial: "1324821083802"
     pci:
-      bus_id: "00000000:47:00.0"
+      bus_id: "0000:47:00.0"
     minor_number: 2
 
   - index: 3
     uuid: "GPU-12345678-1234-1234-1234-123456780003"
     serial: "1324821083803"
     pci:
-      bus_id: "00000000:4E:00.0"
+      bus_id: "0000:4E:00.0"
     minor_number: 3
 
   - index: 4
     uuid: "GPU-12345678-1234-1234-1234-123456780004"
     serial: "1324821083804"
     pci:
-      bus_id: "00000000:87:00.0"
+      bus_id: "0000:87:00.0"
     minor_number: 4
 
   - index: 5
     uuid: "GPU-12345678-1234-1234-1234-123456780005"
     serial: "1324821083805"
     pci:
-      bus_id: "00000000:90:00.0"
+      bus_id: "0000:90:00.0"
     minor_number: 5
 
   - index: 6
     uuid: "GPU-12345678-1234-1234-1234-123456780006"
     serial: "1324821083806"
     pci:
-      bus_id: "00000000:B7:00.0"
+      bus_id: "0000:B7:00.0"
     minor_number: 6
 
   - index: 7
     uuid: "GPU-12345678-1234-1234-1234-123456780007"
     serial: "1324821083807"
     pci:
-      bus_id: "00000000:BD:00.0"
+      bus_id: "0000:BD:00.0"
     minor_number: 7
 
 # =============================================================================
@@ -379,7 +379,7 @@ nvlink:
     - link: 0
       state: "active"
       remote_device_type: "gpu"
-      remote_pci_bus_id: "00000000:0F:00.0"
+      remote_pci_bus_id: "0000:0F:00.0"
     # ... define all 12 links for full topology
 
 # =============================================================================
@@ -398,3 +398,26 @@ infiniband:
   hcas_per_gpu: 1
   guid_prefix: "a288c2:0300:ab"
   node_desc_template: "{node_name} mlx5_{idx}"
+
+# =============================================================================
+# PCIe topology - 2 NUMA nodes (dual EPYC), 4 GPUs each.
+# Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+# under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+# from these symlinks.
+# =============================================================================
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:07:00.0"
+        - "0000:0F:00.0"
+        - "0000:47:00.0"
+        - "0000:4E:00.0"
+    - id: "pci0000:80"
+      numa_node: 1
+      devices:
+        - "0000:87:00.0"
+        - "0000:90:00.0"
+        - "0000:B7:00.0"
+        - "0000:BD:00.0"

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/b200.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/b200.yaml
@@ -322,56 +322,56 @@ devices:
     uuid: "GPU-b2000000-0000-0000-0000-000000000000"
     serial: "1562849203700"
     pci:
-      bus_id: "00000000:1A:00.0"
+      bus_id: "0000:1A:00.0"
     minor_number: 0
 
   - index: 1
     uuid: "GPU-b2000000-0000-0000-0000-000000000001"
     serial: "1562849203701"
     pci:
-      bus_id: "00000000:1B:00.0"
+      bus_id: "0000:1B:00.0"
     minor_number: 1
 
   - index: 2
     uuid: "GPU-b2000000-0000-0000-0000-000000000002"
     serial: "1562849203702"
     pci:
-      bus_id: "00000000:4A:00.0"
+      bus_id: "0000:4A:00.0"
     minor_number: 2
 
   - index: 3
     uuid: "GPU-b2000000-0000-0000-0000-000000000003"
     serial: "1562849203703"
     pci:
-      bus_id: "00000000:4B:00.0"
+      bus_id: "0000:4B:00.0"
     minor_number: 3
 
   - index: 4
     uuid: "GPU-b2000000-0000-0000-0000-000000000004"
     serial: "1562849203704"
     pci:
-      bus_id: "00000000:8A:00.0"
+      bus_id: "0000:8A:00.0"
     minor_number: 4
 
   - index: 5
     uuid: "GPU-b2000000-0000-0000-0000-000000000005"
     serial: "1562849203705"
     pci:
-      bus_id: "00000000:8B:00.0"
+      bus_id: "0000:8B:00.0"
     minor_number: 5
 
   - index: 6
     uuid: "GPU-b2000000-0000-0000-0000-000000000006"
     serial: "1562849203706"
     pci:
-      bus_id: "00000000:CA:00.0"
+      bus_id: "0000:CA:00.0"
     minor_number: 6
 
   - index: 7
     uuid: "GPU-b2000000-0000-0000-0000-000000000007"
     serial: "1562849203707"
     pci:
-      bus_id: "00000000:CB:00.0"
+      bus_id: "0000:CB:00.0"
     minor_number: 7
 
 # =============================================================================
@@ -385,7 +385,7 @@ nvlink:
     - link: 0
       state: "active"
       remote_device_type: "gpu"
-      remote_pci_bus_id: "00000000:1B:00.0"
+      remote_pci_bus_id: "0000:1B:00.0"
 
 # =============================================================================
 # InfiniBand topology - 1 ConnectX-7 NDR HCA per GPU (typical HGX B200)
@@ -403,3 +403,26 @@ infiniband:
   hcas_per_gpu: 1
   guid_prefix: "b288c2:0300:ab"
   node_desc_template: "{node_name} mlx5_{idx}"
+
+# =============================================================================
+# PCIe topology - B200, 2 NUMA nodes, 4 GPUs each.
+# Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+# under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+# from these symlinks.
+# =============================================================================
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:1A:00.0"
+        - "0000:1B:00.0"
+        - "0000:4A:00.0"
+        - "0000:4B:00.0"
+    - id: "pci0000:80"
+      numa_node: 1
+      devices:
+        - "0000:8A:00.0"
+        - "0000:8B:00.0"
+        - "0000:CA:00.0"
+        - "0000:CB:00.0"

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
@@ -348,7 +348,7 @@ devices:
     uuid: "GPU-b200b200-0000-0000-0000-000000000000"
     serial: "1562849103700"
     pci:
-      bus_id: "00000000:0A:00.0"
+      bus_id: "0000:0A:00.0"
     minor_number: 0
     grace_cpu_pair: 0               # Paired with Grace CPU 0
 
@@ -356,7 +356,7 @@ devices:
     uuid: "GPU-b200b200-0000-0000-0000-000000000001"
     serial: "1562849103701"
     pci:
-      bus_id: "00000000:0B:00.0"
+      bus_id: "0000:0B:00.0"
     minor_number: 1
     grace_cpu_pair: 0               # Same superchip as GPU 0
 
@@ -364,7 +364,7 @@ devices:
     uuid: "GPU-b200b200-0000-0000-0000-000000000002"
     serial: "1562849103702"
     pci:
-      bus_id: "00000000:4A:00.0"
+      bus_id: "0000:4A:00.0"
     minor_number: 2
     grace_cpu_pair: 1
 
@@ -372,7 +372,7 @@ devices:
     uuid: "GPU-b200b200-0000-0000-0000-000000000003"
     serial: "1562849103703"
     pci:
-      bus_id: "00000000:4B:00.0"
+      bus_id: "0000:4B:00.0"
     minor_number: 3
     grace_cpu_pair: 1
 
@@ -380,7 +380,7 @@ devices:
     uuid: "GPU-b200b200-0000-0000-0000-000000000004"
     serial: "1562849103704"
     pci:
-      bus_id: "00000000:8A:00.0"
+      bus_id: "0000:8A:00.0"
     minor_number: 4
     grace_cpu_pair: 2
 
@@ -388,7 +388,7 @@ devices:
     uuid: "GPU-b200b200-0000-0000-0000-000000000005"
     serial: "1562849103705"
     pci:
-      bus_id: "00000000:8B:00.0"
+      bus_id: "0000:8B:00.0"
     minor_number: 5
     grace_cpu_pair: 2
 
@@ -396,7 +396,7 @@ devices:
     uuid: "GPU-b200b200-0000-0000-0000-000000000006"
     serial: "1562849103706"
     pci:
-      bus_id: "00000000:CA:00.0"
+      bus_id: "0000:CA:00.0"
     minor_number: 6
     grace_cpu_pair: 3
 
@@ -404,7 +404,7 @@ devices:
     uuid: "GPU-b200b200-0000-0000-0000-000000000007"
     serial: "1562849103707"
     pci:
-      bus_id: "00000000:CB:00.0"
+      bus_id: "0000:CB:00.0"
     minor_number: 7
     grace_cpu_pair: 3
 
@@ -423,7 +423,7 @@ nvlink:
     - link: 0
       state: "active"
       remote_device_type: "gpu"
-      remote_pci_bus_id: "00000000:0B:00.0"
+      remote_pci_bus_id: "0000:0B:00.0"
     - link: 1
       state: "active"
       remote_device_type: "cpu"     # NVLink-C2C to Grace
@@ -446,3 +446,32 @@ infiniband:
   hcas_per_gpu: 1
   guid_prefix: "9b88c2:0300:ab"
   node_desc_template: "{node_name} mlx5_{idx}"
+
+# =============================================================================
+# PCIe topology - GB200, 4 Grace CPU pairs -> 4 NUMA nodes, 2 GPUs each.
+# Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+# under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+# from these symlinks.
+# =============================================================================
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:0A:00.0"
+        - "0000:0B:00.0"
+    - id: "pci0000:40"
+      numa_node: 1
+      devices:
+        - "0000:4A:00.0"
+        - "0000:4B:00.0"
+    - id: "pci0000:80"
+      numa_node: 2
+      devices:
+        - "0000:8A:00.0"
+        - "0000:8B:00.0"
+    - id: "pci0000:c0"
+      numa_node: 3
+      devices:
+        - "0000:CA:00.0"
+        - "0000:CB:00.0"

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/h100.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/h100.yaml
@@ -319,56 +319,56 @@ devices:
     uuid: "GPU-01000100-0000-0000-0000-000000000000"
     serial: "1562821083900"
     pci:
-      bus_id: "00000000:1A:00.0"
+      bus_id: "0000:1A:00.0"
     minor_number: 0
 
   - index: 1
     uuid: "GPU-01000100-0000-0000-0000-000000000001"
     serial: "1562821083901"
     pci:
-      bus_id: "00000000:1B:00.0"
+      bus_id: "0000:1B:00.0"
     minor_number: 1
 
   - index: 2
     uuid: "GPU-01000100-0000-0000-0000-000000000002"
     serial: "1562821083902"
     pci:
-      bus_id: "00000000:4A:00.0"
+      bus_id: "0000:4A:00.0"
     minor_number: 2
 
   - index: 3
     uuid: "GPU-01000100-0000-0000-0000-000000000003"
     serial: "1562821083903"
     pci:
-      bus_id: "00000000:4B:00.0"
+      bus_id: "0000:4B:00.0"
     minor_number: 3
 
   - index: 4
     uuid: "GPU-01000100-0000-0000-0000-000000000004"
     serial: "1562821083904"
     pci:
-      bus_id: "00000000:8A:00.0"
+      bus_id: "0000:8A:00.0"
     minor_number: 4
 
   - index: 5
     uuid: "GPU-01000100-0000-0000-0000-000000000005"
     serial: "1562821083905"
     pci:
-      bus_id: "00000000:8B:00.0"
+      bus_id: "0000:8B:00.0"
     minor_number: 5
 
   - index: 6
     uuid: "GPU-01000100-0000-0000-0000-000000000006"
     serial: "1562821083906"
     pci:
-      bus_id: "00000000:CA:00.0"
+      bus_id: "0000:CA:00.0"
     minor_number: 6
 
   - index: 7
     uuid: "GPU-01000100-0000-0000-0000-000000000007"
     serial: "1562821083907"
     pci:
-      bus_id: "00000000:CB:00.0"
+      bus_id: "0000:CB:00.0"
     minor_number: 7
 
 # =============================================================================
@@ -382,7 +382,7 @@ nvlink:
     - link: 0
       state: "active"
       remote_device_type: "gpu"
-      remote_pci_bus_id: "00000000:1B:00.0"
+      remote_pci_bus_id: "0000:1B:00.0"
 
 # =============================================================================
 # InfiniBand topology - 1 ConnectX-7 NDR HCA per GPU (typical HGX H100)
@@ -400,3 +400,26 @@ infiniband:
   hcas_per_gpu: 1                   # total HCAs = gpu.count * hcas_per_gpu
   guid_prefix: "a088c2:0300:ab"     # last byte = HCA index
   node_desc_template: "{node_name} mlx5_{idx}"
+
+# =============================================================================
+# PCIe topology - HGX H100, 2 NUMA nodes, 4 GPUs each.
+# Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+# under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+# from these symlinks.
+# =============================================================================
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:1A:00.0"
+        - "0000:1B:00.0"
+        - "0000:4A:00.0"
+        - "0000:4B:00.0"
+    - id: "pci0000:80"
+      numa_node: 1
+      devices:
+        - "0000:8A:00.0"
+        - "0000:8B:00.0"
+        - "0000:CA:00.0"
+        - "0000:CB:00.0"

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/l40s.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/l40s.yaml
@@ -311,56 +311,56 @@ devices:
     uuid: "GPU-14050000-0000-0000-0000-000000000000"
     serial: "1562830094500"
     pci:
-      bus_id: "00000000:17:00.0"
+      bus_id: "0000:17:00.0"
     minor_number: 0
 
   - index: 1
     uuid: "GPU-14050000-0000-0000-0000-000000000001"
     serial: "1562830094501"
     pci:
-      bus_id: "00000000:31:00.0"
+      bus_id: "0000:31:00.0"
     minor_number: 1
 
   - index: 2
     uuid: "GPU-14050000-0000-0000-0000-000000000002"
     serial: "1562830094502"
     pci:
-      bus_id: "00000000:B1:00.0"
+      bus_id: "0000:B1:00.0"
     minor_number: 2
 
   - index: 3
     uuid: "GPU-14050000-0000-0000-0000-000000000003"
     serial: "1562830094503"
     pci:
-      bus_id: "00000000:CA:00.0"
+      bus_id: "0000:CA:00.0"
     minor_number: 3
 
   - index: 4
     uuid: "GPU-14050000-0000-0000-0000-000000000004"
     serial: "1562830094504"
     pci:
-      bus_id: "00000000:18:00.0"
+      bus_id: "0000:18:00.0"
     minor_number: 4
 
   - index: 5
     uuid: "GPU-14050000-0000-0000-0000-000000000005"
     serial: "1562830094505"
     pci:
-      bus_id: "00000000:32:00.0"
+      bus_id: "0000:32:00.0"
     minor_number: 5
 
   - index: 6
     uuid: "GPU-14050000-0000-0000-0000-000000000006"
     serial: "1562830094506"
     pci:
-      bus_id: "00000000:B2:00.0"
+      bus_id: "0000:B2:00.0"
     minor_number: 6
 
   - index: 7
     uuid: "GPU-14050000-0000-0000-0000-000000000007"
     serial: "1562830094507"
     pci:
-      bus_id: "00000000:CB:00.0"
+      bus_id: "0000:CB:00.0"
     minor_number: 7
 
 # =============================================================================
@@ -369,3 +369,26 @@ devices:
 # =============================================================================
 infiniband:
   enabled: false
+
+# =============================================================================
+# PCIe topology - L40S, 2 NUMA nodes, 4 GPUs each.
+# Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+# under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+# from these symlinks.
+# =============================================================================
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:17:00.0"
+        - "0000:18:00.0"
+        - "0000:31:00.0"
+        - "0000:32:00.0"
+    - id: "pci0000:80"
+      numa_node: 1
+      devices:
+        - "0000:B1:00.0"
+        - "0000:B2:00.0"
+        - "0000:CA:00.0"
+        - "0000:CB:00.0"

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/t4.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/t4.yaml
@@ -311,28 +311,28 @@ devices:
     uuid: "GPU-00000074-0000-0000-0000-000000000000"
     serial: "0421819085400"
     pci:
-      bus_id: "00000000:3B:00.0"
+      bus_id: "0000:3B:00.0"
     minor_number: 0
 
   - index: 1
     uuid: "GPU-00000074-0000-0000-0000-000000000001"
     serial: "0421819085401"
     pci:
-      bus_id: "00000000:86:00.0"
+      bus_id: "0000:86:00.0"
     minor_number: 1
 
   - index: 2
     uuid: "GPU-00000074-0000-0000-0000-000000000002"
     serial: "0421819085402"
     pci:
-      bus_id: "00000000:AF:00.0"
+      bus_id: "0000:AF:00.0"
     minor_number: 2
 
   - index: 3
     uuid: "GPU-00000074-0000-0000-0000-000000000003"
     serial: "0421819085403"
     pci:
-      bus_id: "00000000:D8:00.0"
+      bus_id: "0000:D8:00.0"
     minor_number: 3
 
 # =============================================================================
@@ -340,3 +340,19 @@ devices:
 # =============================================================================
 infiniband:
   enabled: false
+
+# =============================================================================
+# PCIe topology - T4 inference card, single NUMA node, 4 GPUs.
+# Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+# under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+# from these symlinks.
+# =============================================================================
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:3B:00.0"
+        - "0000:86:00.0"
+        - "0000:AF:00.0"
+        - "0000:D8:00.0"

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
@@ -327,56 +327,56 @@ should match snapshot with b200 profile:
             uuid: "GPU-b2000000-0000-0000-0000-000000000000"
             serial: "1562849203700"
             pci:
-              bus_id: "00000000:1A:00.0"
+              bus_id: "0000:1A:00.0"
             minor_number: 0
 
           - index: 1
             uuid: "GPU-b2000000-0000-0000-0000-000000000001"
             serial: "1562849203701"
             pci:
-              bus_id: "00000000:1B:00.0"
+              bus_id: "0000:1B:00.0"
             minor_number: 1
 
           - index: 2
             uuid: "GPU-b2000000-0000-0000-0000-000000000002"
             serial: "1562849203702"
             pci:
-              bus_id: "00000000:4A:00.0"
+              bus_id: "0000:4A:00.0"
             minor_number: 2
 
           - index: 3
             uuid: "GPU-b2000000-0000-0000-0000-000000000003"
             serial: "1562849203703"
             pci:
-              bus_id: "00000000:4B:00.0"
+              bus_id: "0000:4B:00.0"
             minor_number: 3
 
           - index: 4
             uuid: "GPU-b2000000-0000-0000-0000-000000000004"
             serial: "1562849203704"
             pci:
-              bus_id: "00000000:8A:00.0"
+              bus_id: "0000:8A:00.0"
             minor_number: 4
 
           - index: 5
             uuid: "GPU-b2000000-0000-0000-0000-000000000005"
             serial: "1562849203705"
             pci:
-              bus_id: "00000000:8B:00.0"
+              bus_id: "0000:8B:00.0"
             minor_number: 5
 
           - index: 6
             uuid: "GPU-b2000000-0000-0000-0000-000000000006"
             serial: "1562849203706"
             pci:
-              bus_id: "00000000:CA:00.0"
+              bus_id: "0000:CA:00.0"
             minor_number: 6
 
           - index: 7
             uuid: "GPU-b2000000-0000-0000-0000-000000000007"
             serial: "1562849203707"
             pci:
-              bus_id: "00000000:CB:00.0"
+              bus_id: "0000:CB:00.0"
             minor_number: 7
 
         # =============================================================================
@@ -390,7 +390,7 @@ should match snapshot with b200 profile:
             - link: 0
               state: "active"
               remote_device_type: "gpu"
-              remote_pci_bus_id: "00000000:1B:00.0"
+              remote_pci_bus_id: "0000:1B:00.0"
 
         # =============================================================================
         # InfiniBand topology - 1 ConnectX-7 NDR HCA per GPU (typical HGX B200)
@@ -408,6 +408,29 @@ should match snapshot with b200 profile:
           hcas_per_gpu: 1
           guid_prefix: "b288c2:0300:ab"
           node_desc_template: "{node_name} mlx5_{idx}"
+
+        # =============================================================================
+        # PCIe topology - B200, 2 NUMA nodes, 4 GPUs each.
+        # Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+        # under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+        # from these symlinks.
+        # =============================================================================
+        pcie_topology:
+          root_complexes:
+            - id: "pci0000:00"
+              numa_node: 0
+              devices:
+                - "0000:1A:00.0"
+                - "0000:1B:00.0"
+                - "0000:4A:00.0"
+                - "0000:4B:00.0"
+            - id: "pci0000:80"
+              numa_node: 1
+              devices:
+                - "0000:8A:00.0"
+                - "0000:8B:00.0"
+                - "0000:CA:00.0"
+                - "0000:CB:00.0"
     kind: ConfigMap
     metadata:
       labels:
@@ -739,56 +762,56 @@ should match snapshot with default a100 profile:
             uuid: "GPU-12345678-1234-1234-1234-123456780000"
             serial: "1324821083800"
             pci:
-              bus_id: "00000000:07:00.0"
+              bus_id: "0000:07:00.0"
             minor_number: 0
 
           - index: 1
             uuid: "GPU-12345678-1234-1234-1234-123456780001"
             serial: "1324821083801"
             pci:
-              bus_id: "00000000:0F:00.0"
+              bus_id: "0000:0F:00.0"
             minor_number: 1
 
           - index: 2
             uuid: "GPU-12345678-1234-1234-1234-123456780002"
             serial: "1324821083802"
             pci:
-              bus_id: "00000000:47:00.0"
+              bus_id: "0000:47:00.0"
             minor_number: 2
 
           - index: 3
             uuid: "GPU-12345678-1234-1234-1234-123456780003"
             serial: "1324821083803"
             pci:
-              bus_id: "00000000:4E:00.0"
+              bus_id: "0000:4E:00.0"
             minor_number: 3
 
           - index: 4
             uuid: "GPU-12345678-1234-1234-1234-123456780004"
             serial: "1324821083804"
             pci:
-              bus_id: "00000000:87:00.0"
+              bus_id: "0000:87:00.0"
             minor_number: 4
 
           - index: 5
             uuid: "GPU-12345678-1234-1234-1234-123456780005"
             serial: "1324821083805"
             pci:
-              bus_id: "00000000:90:00.0"
+              bus_id: "0000:90:00.0"
             minor_number: 5
 
           - index: 6
             uuid: "GPU-12345678-1234-1234-1234-123456780006"
             serial: "1324821083806"
             pci:
-              bus_id: "00000000:B7:00.0"
+              bus_id: "0000:B7:00.0"
             minor_number: 6
 
           - index: 7
             uuid: "GPU-12345678-1234-1234-1234-123456780007"
             serial: "1324821083807"
             pci:
-              bus_id: "00000000:BD:00.0"
+              bus_id: "0000:BD:00.0"
             minor_number: 7
 
         # =============================================================================
@@ -803,7 +826,7 @@ should match snapshot with default a100 profile:
             - link: 0
               state: "active"
               remote_device_type: "gpu"
-              remote_pci_bus_id: "00000000:0F:00.0"
+              remote_pci_bus_id: "0000:0F:00.0"
             # ... define all 12 links for full topology
 
         # =============================================================================
@@ -822,6 +845,29 @@ should match snapshot with default a100 profile:
           hcas_per_gpu: 1
           guid_prefix: "a288c2:0300:ab"
           node_desc_template: "{node_name} mlx5_{idx}"
+
+        # =============================================================================
+        # PCIe topology - 2 NUMA nodes (dual EPYC), 4 GPUs each.
+        # Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+        # under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+        # from these symlinks.
+        # =============================================================================
+        pcie_topology:
+          root_complexes:
+            - id: "pci0000:00"
+              numa_node: 0
+              devices:
+                - "0000:07:00.0"
+                - "0000:0F:00.0"
+                - "0000:47:00.0"
+                - "0000:4E:00.0"
+            - id: "pci0000:80"
+              numa_node: 1
+              devices:
+                - "0000:87:00.0"
+                - "0000:90:00.0"
+                - "0000:B7:00.0"
+                - "0000:BD:00.0"
     kind: ConfigMap
     metadata:
       labels:
@@ -1186,7 +1232,7 @@ should match snapshot with gb200 profile:
             uuid: "GPU-b200b200-0000-0000-0000-000000000000"
             serial: "1562849103700"
             pci:
-              bus_id: "00000000:0A:00.0"
+              bus_id: "0000:0A:00.0"
             minor_number: 0
             grace_cpu_pair: 0               # Paired with Grace CPU 0
 
@@ -1194,7 +1240,7 @@ should match snapshot with gb200 profile:
             uuid: "GPU-b200b200-0000-0000-0000-000000000001"
             serial: "1562849103701"
             pci:
-              bus_id: "00000000:0B:00.0"
+              bus_id: "0000:0B:00.0"
             minor_number: 1
             grace_cpu_pair: 0               # Same superchip as GPU 0
 
@@ -1202,7 +1248,7 @@ should match snapshot with gb200 profile:
             uuid: "GPU-b200b200-0000-0000-0000-000000000002"
             serial: "1562849103702"
             pci:
-              bus_id: "00000000:4A:00.0"
+              bus_id: "0000:4A:00.0"
             minor_number: 2
             grace_cpu_pair: 1
 
@@ -1210,7 +1256,7 @@ should match snapshot with gb200 profile:
             uuid: "GPU-b200b200-0000-0000-0000-000000000003"
             serial: "1562849103703"
             pci:
-              bus_id: "00000000:4B:00.0"
+              bus_id: "0000:4B:00.0"
             minor_number: 3
             grace_cpu_pair: 1
 
@@ -1218,7 +1264,7 @@ should match snapshot with gb200 profile:
             uuid: "GPU-b200b200-0000-0000-0000-000000000004"
             serial: "1562849103704"
             pci:
-              bus_id: "00000000:8A:00.0"
+              bus_id: "0000:8A:00.0"
             minor_number: 4
             grace_cpu_pair: 2
 
@@ -1226,7 +1272,7 @@ should match snapshot with gb200 profile:
             uuid: "GPU-b200b200-0000-0000-0000-000000000005"
             serial: "1562849103705"
             pci:
-              bus_id: "00000000:8B:00.0"
+              bus_id: "0000:8B:00.0"
             minor_number: 5
             grace_cpu_pair: 2
 
@@ -1234,7 +1280,7 @@ should match snapshot with gb200 profile:
             uuid: "GPU-b200b200-0000-0000-0000-000000000006"
             serial: "1562849103706"
             pci:
-              bus_id: "00000000:CA:00.0"
+              bus_id: "0000:CA:00.0"
             minor_number: 6
             grace_cpu_pair: 3
 
@@ -1242,7 +1288,7 @@ should match snapshot with gb200 profile:
             uuid: "GPU-b200b200-0000-0000-0000-000000000007"
             serial: "1562849103707"
             pci:
-              bus_id: "00000000:CB:00.0"
+              bus_id: "0000:CB:00.0"
             minor_number: 7
             grace_cpu_pair: 3
 
@@ -1261,7 +1307,7 @@ should match snapshot with gb200 profile:
             - link: 0
               state: "active"
               remote_device_type: "gpu"
-              remote_pci_bus_id: "00000000:0B:00.0"
+              remote_pci_bus_id: "0000:0B:00.0"
             - link: 1
               state: "active"
               remote_device_type: "cpu"     # NVLink-C2C to Grace
@@ -1284,6 +1330,35 @@ should match snapshot with gb200 profile:
           hcas_per_gpu: 1
           guid_prefix: "9b88c2:0300:ab"
           node_desc_template: "{node_name} mlx5_{idx}"
+
+        # =============================================================================
+        # PCIe topology - GB200, 4 Grace CPU pairs -> 4 NUMA nodes, 2 GPUs each.
+        # Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+        # under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+        # from these symlinks.
+        # =============================================================================
+        pcie_topology:
+          root_complexes:
+            - id: "pci0000:00"
+              numa_node: 0
+              devices:
+                - "0000:0A:00.0"
+                - "0000:0B:00.0"
+            - id: "pci0000:40"
+              numa_node: 1
+              devices:
+                - "0000:4A:00.0"
+                - "0000:4B:00.0"
+            - id: "pci0000:80"
+              numa_node: 2
+              devices:
+                - "0000:8A:00.0"
+                - "0000:8B:00.0"
+            - id: "pci0000:c0"
+              numa_node: 3
+              devices:
+                - "0000:CA:00.0"
+                - "0000:CB:00.0"
     kind: ConfigMap
     metadata:
       labels:
@@ -1619,56 +1694,56 @@ should match snapshot with h100 profile:
             uuid: "GPU-01000100-0000-0000-0000-000000000000"
             serial: "1562821083900"
             pci:
-              bus_id: "00000000:1A:00.0"
+              bus_id: "0000:1A:00.0"
             minor_number: 0
 
           - index: 1
             uuid: "GPU-01000100-0000-0000-0000-000000000001"
             serial: "1562821083901"
             pci:
-              bus_id: "00000000:1B:00.0"
+              bus_id: "0000:1B:00.0"
             minor_number: 1
 
           - index: 2
             uuid: "GPU-01000100-0000-0000-0000-000000000002"
             serial: "1562821083902"
             pci:
-              bus_id: "00000000:4A:00.0"
+              bus_id: "0000:4A:00.0"
             minor_number: 2
 
           - index: 3
             uuid: "GPU-01000100-0000-0000-0000-000000000003"
             serial: "1562821083903"
             pci:
-              bus_id: "00000000:4B:00.0"
+              bus_id: "0000:4B:00.0"
             minor_number: 3
 
           - index: 4
             uuid: "GPU-01000100-0000-0000-0000-000000000004"
             serial: "1562821083904"
             pci:
-              bus_id: "00000000:8A:00.0"
+              bus_id: "0000:8A:00.0"
             minor_number: 4
 
           - index: 5
             uuid: "GPU-01000100-0000-0000-0000-000000000005"
             serial: "1562821083905"
             pci:
-              bus_id: "00000000:8B:00.0"
+              bus_id: "0000:8B:00.0"
             minor_number: 5
 
           - index: 6
             uuid: "GPU-01000100-0000-0000-0000-000000000006"
             serial: "1562821083906"
             pci:
-              bus_id: "00000000:CA:00.0"
+              bus_id: "0000:CA:00.0"
             minor_number: 6
 
           - index: 7
             uuid: "GPU-01000100-0000-0000-0000-000000000007"
             serial: "1562821083907"
             pci:
-              bus_id: "00000000:CB:00.0"
+              bus_id: "0000:CB:00.0"
             minor_number: 7
 
         # =============================================================================
@@ -1682,7 +1757,7 @@ should match snapshot with h100 profile:
             - link: 0
               state: "active"
               remote_device_type: "gpu"
-              remote_pci_bus_id: "00000000:1B:00.0"
+              remote_pci_bus_id: "0000:1B:00.0"
 
         # =============================================================================
         # InfiniBand topology - 1 ConnectX-7 NDR HCA per GPU (typical HGX H100)
@@ -1700,6 +1775,29 @@ should match snapshot with h100 profile:
           hcas_per_gpu: 1                   # total HCAs = gpu.count * hcas_per_gpu
           guid_prefix: "a088c2:0300:ab"     # last byte = HCA index
           node_desc_template: "{node_name} mlx5_{idx}"
+
+        # =============================================================================
+        # PCIe topology - HGX H100, 2 NUMA nodes, 4 GPUs each.
+        # Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+        # under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+        # from these symlinks.
+        # =============================================================================
+        pcie_topology:
+          root_complexes:
+            - id: "pci0000:00"
+              numa_node: 0
+              devices:
+                - "0000:1A:00.0"
+                - "0000:1B:00.0"
+                - "0000:4A:00.0"
+                - "0000:4B:00.0"
+            - id: "pci0000:80"
+              numa_node: 1
+              devices:
+                - "0000:8A:00.0"
+                - "0000:8B:00.0"
+                - "0000:CA:00.0"
+                - "0000:CB:00.0"
     kind: ConfigMap
     metadata:
       labels:
@@ -2027,56 +2125,56 @@ should match snapshot with l40s profile:
             uuid: "GPU-14050000-0000-0000-0000-000000000000"
             serial: "1562830094500"
             pci:
-              bus_id: "00000000:17:00.0"
+              bus_id: "0000:17:00.0"
             minor_number: 0
 
           - index: 1
             uuid: "GPU-14050000-0000-0000-0000-000000000001"
             serial: "1562830094501"
             pci:
-              bus_id: "00000000:31:00.0"
+              bus_id: "0000:31:00.0"
             minor_number: 1
 
           - index: 2
             uuid: "GPU-14050000-0000-0000-0000-000000000002"
             serial: "1562830094502"
             pci:
-              bus_id: "00000000:B1:00.0"
+              bus_id: "0000:B1:00.0"
             minor_number: 2
 
           - index: 3
             uuid: "GPU-14050000-0000-0000-0000-000000000003"
             serial: "1562830094503"
             pci:
-              bus_id: "00000000:CA:00.0"
+              bus_id: "0000:CA:00.0"
             minor_number: 3
 
           - index: 4
             uuid: "GPU-14050000-0000-0000-0000-000000000004"
             serial: "1562830094504"
             pci:
-              bus_id: "00000000:18:00.0"
+              bus_id: "0000:18:00.0"
             minor_number: 4
 
           - index: 5
             uuid: "GPU-14050000-0000-0000-0000-000000000005"
             serial: "1562830094505"
             pci:
-              bus_id: "00000000:32:00.0"
+              bus_id: "0000:32:00.0"
             minor_number: 5
 
           - index: 6
             uuid: "GPU-14050000-0000-0000-0000-000000000006"
             serial: "1562830094506"
             pci:
-              bus_id: "00000000:B2:00.0"
+              bus_id: "0000:B2:00.0"
             minor_number: 6
 
           - index: 7
             uuid: "GPU-14050000-0000-0000-0000-000000000007"
             serial: "1562830094507"
             pci:
-              bus_id: "00000000:CB:00.0"
+              bus_id: "0000:CB:00.0"
             minor_number: 7
 
         # =============================================================================
@@ -2085,6 +2183,29 @@ should match snapshot with l40s profile:
         # =============================================================================
         infiniband:
           enabled: false
+
+        # =============================================================================
+        # PCIe topology - L40S, 2 NUMA nodes, 4 GPUs each.
+        # Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+        # under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+        # from these symlinks.
+        # =============================================================================
+        pcie_topology:
+          root_complexes:
+            - id: "pci0000:00"
+              numa_node: 0
+              devices:
+                - "0000:17:00.0"
+                - "0000:18:00.0"
+                - "0000:31:00.0"
+                - "0000:32:00.0"
+            - id: "pci0000:80"
+              numa_node: 1
+              devices:
+                - "0000:B1:00.0"
+                - "0000:B2:00.0"
+                - "0000:CA:00.0"
+                - "0000:CB:00.0"
     kind: ConfigMap
     metadata:
       labels:
@@ -2412,28 +2533,28 @@ should match snapshot with t4 profile:
             uuid: "GPU-00000074-0000-0000-0000-000000000000"
             serial: "0421819085400"
             pci:
-              bus_id: "00000000:3B:00.0"
+              bus_id: "0000:3B:00.0"
             minor_number: 0
 
           - index: 1
             uuid: "GPU-00000074-0000-0000-0000-000000000001"
             serial: "0421819085401"
             pci:
-              bus_id: "00000000:86:00.0"
+              bus_id: "0000:86:00.0"
             minor_number: 1
 
           - index: 2
             uuid: "GPU-00000074-0000-0000-0000-000000000002"
             serial: "0421819085402"
             pci:
-              bus_id: "00000000:AF:00.0"
+              bus_id: "0000:AF:00.0"
             minor_number: 2
 
           - index: 3
             uuid: "GPU-00000074-0000-0000-0000-000000000003"
             serial: "0421819085403"
             pci:
-              bus_id: "00000000:D8:00.0"
+              bus_id: "0000:D8:00.0"
             minor_number: 3
 
         # =============================================================================
@@ -2441,6 +2562,22 @@ should match snapshot with t4 profile:
         # =============================================================================
         infiniband:
           enabled: false
+
+        # =============================================================================
+        # PCIe topology - T4 inference card, single NUMA node, 4 GPUs.
+        # Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+        # under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+        # from these symlinks.
+        # =============================================================================
+        pcie_topology:
+          root_complexes:
+            - id: "pci0000:00"
+              numa_node: 0
+              devices:
+                - "0000:3B:00.0"
+                - "0000:86:00.0"
+                - "0000:AF:00.0"
+                - "0000:D8:00.0"
     kind: ConfigMap
     metadata:
       labels:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -18,7 +18,7 @@ should match snapshot with all overrides:
       template:
         metadata:
           annotations:
-            checksum/config: 204e5d4ea3a64ec98af544c7d6623ba71a2839c2761c1678c655def226cdba68
+            checksum/config: a61c6a3dddda8dbb6d6d0558d54f7687398def2880fdef692b995e798d8da71e
           labels:
             app.kubernetes.io/instance: custom
             app.kubernetes.io/name: nvml-mock
@@ -117,7 +117,7 @@ should match snapshot with b200 profile:
       template:
         metadata:
           annotations:
-            checksum/config: e77c39d7b16109bdf1a87a46bdfa0048811dae86863c83116d3a6b6978ddab5d
+            checksum/config: 39b4be468d3038181d5a5eb63fb5fba75f8ffa2500bc0cba20a308246a0334ca
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: nvml-mock
@@ -205,7 +205,7 @@ should match snapshot with default values:
       template:
         metadata:
           annotations:
-            checksum/config: 5c9770a3246c869d6a5fdcfe2648f185529cc0ea0528548468550be85dad3d63
+            checksum/config: 07b4e38538574cd5b7a6a50321a31a19e14d80a5b43771dff9710afb61c6f563
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: nvml-mock

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -240,6 +240,7 @@ fi
 #     malformed sysfs that downstream `dra.k8s.io/pcieRoot` attributes
 #     would inherit.
 PCI_ROOT="$HOST"
+mkdir -p "$PCI_ROOT"
 if [ -x /usr/local/bin/render-pci-sysfs ]; then
   /usr/local/bin/render-pci-sysfs \
     --config /etc/nvml-mock/config.yaml \

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -230,4 +230,20 @@ if [ -x /usr/local/bin/render-ib-sysfs ]; then
     --output "$IB_ROOT"
 fi
 
+# 10. Render fake PCI sysfs tree (consumed by topology-aware DRA / device
+#     plugins that resolve PCIe root complex via a readlink on
+#     /sys/bus/pci/devices/<bdf>). The renderer parses the profile's
+#     `pcie_topology:` block; profiles without one get a flat default
+#     covering every device under a single root complex (`pci0000:00`,
+#     NUMA 0). Failures are fatal under `set -e` for the same reason as
+#     the IB block above — a topology typo otherwise yields silently
+#     malformed sysfs that downstream `dra.k8s.io/pcieRoot` attributes
+#     would inherit.
+PCI_ROOT="$HOST"
+if [ -x /usr/local/bin/render-pci-sysfs ]; then
+  /usr/local/bin/render-pci-sysfs \
+    --config /etc/nvml-mock/config.yaml \
+    --output "$PCI_ROOT"
+fi
+
 echo "Mock GPU environment ready: $GPU_COUNT GPUs at $HOST"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,11 +50,11 @@ devices:                          # Per-device overrides
   - index: 0
     uuid: "GPU-12345678-1234-1234-1234-123456780000"
     pci:
-      bus_id: "00000000:07:00.0"
+      bus_id: "0000:07:00.0"
   - index: 1
     uuid: "GPU-12345678-1234-1234-1234-123456780001"
     pci:
-      bus_id: "00000000:0F:00.0"
+      bus_id: "0000:0F:00.0"
   # ...
 
 nvlink:                           # Optional NVLink configuration
@@ -110,7 +110,7 @@ device_defaults:
   pci:
     device_id: 0x20B010DE             # A100 device ID
     subsystem_id: 0x134710DE
-    bus_id: "00000000:07:00.0"        # Usually per-device
+    bus_id: "0000:07:00.0"        # Usually per-device
   
   pcie:
     max_link_gen: 4
@@ -316,7 +316,7 @@ devices:
     uuid: "GPU-12345678-1234-1234-1234-123456780000"
     minor_number: 0
     pci:
-      bus_id: "00000000:07:00.0"
+      bus_id: "0000:07:00.0"
     # Override thermal for this device only
     thermal:
       temperature_gpu_c: 35
@@ -325,7 +325,7 @@ devices:
     uuid: "GPU-12345678-1234-1234-1234-123456780001"
     minor_number: 1
     pci:
-      bus_id: "00000000:0F:00.0"
+      bus_id: "0000:0F:00.0"
     thermal:
       temperature_gpu_c: 37
 ```
@@ -344,7 +344,7 @@ nvlink:
     - link: 0
       state: "active"
       remote_device_type: "GPU"
-      remote_pci_bus_id: "00000000:0F:00.0"
+      remote_pci_bus_id: "0000:0F:00.0"
 ```
 
 ## Available GPU Profiles

--- a/docs/demo/standalone/demo.sh
+++ b/docs/demo/standalone/demo.sh
@@ -91,7 +91,67 @@ fi
 info "Found ${HCA_COUNT} mock HCA(s)"
 
 ###############################################################################
-# Step 9 -- Show node labels
+# Step 9 -- Verify: PCI sysfs mock (render-pci-sysfs)
+#
+# The init container materialized a fake /sys/bus/pci tree at
+# /var/lib/nvml-mock/sys/... from the profile's `pcie_topology:` block.
+# Topology-aware consumers (NVIDIA DRA driver `dra.k8s.io/pcieRoot`,
+# device-plugin NUMA hints) resolve PCIe root complex via readlink() on
+# /sys/bus/pci/devices/<bdf>, so we exercise the same path here: list,
+# readlink, and read a numa_node file through the symlink.
+###############################################################################
+PCI_DEV_DIR="/var/lib/nvml-mock/sys/bus/pci/devices"
+
+info "Listing rendered PCI devices under ${PCI_DEV_DIR}"
+kubectl exec "${POD}" -- ls "${PCI_DEV_DIR}"
+
+PCI_DEV_COUNT=$(kubectl exec "${POD}" -- sh -c "ls ${PCI_DEV_DIR} 2>/dev/null | wc -l" \
+  | tr -d ' ')
+# H100 profile defines 8 GPUs across 2 NUMA root complexes (pci0000:00,
+# pci0000:80). One symlink per device must appear under bus/pci/devices.
+if [[ "${PCI_DEV_COUNT}" -ne 8 ]]; then
+  fail "Expected 8 rendered PCI devices (h100 / gpu.count=8), found ${PCI_DEV_COUNT}"
+fi
+info "Found ${PCI_DEV_COUNT} rendered PCI device symlink(s)"
+
+# The deviceattribute library extracts the PCIe root complex by
+# readlink()'ing the device path and parsing out the "pciDDDD:BB"
+# component. Exercise that exact contract on the first device so a
+# missing or absolute-path symlink would fail the demo loudly.
+FIRST_DEV=$(kubectl exec "${POD}" -- sh -c "ls ${PCI_DEV_DIR} | sort | head -1" \
+  | tr -d '[:space:]')
+TARGET=$(kubectl exec "${POD}" -- readlink "${PCI_DEV_DIR}/${FIRST_DEV}" \
+  | tr -d '[:space:]')
+info "readlink ${FIRST_DEV} -> ${TARGET}"
+if [[ "${TARGET}" != ../../../devices/pci*/* ]]; then
+  fail "Expected relative ../../../devices/pciDDDD:BB/<bdf> target, got '${TARGET}'"
+fi
+
+# numa_node is the second half of the contract: the DRA driver may also
+# read it to surface a NUMA hint alongside pcieRoot.
+NUMA_NODE=$(kubectl exec "${POD}" -- cat "${PCI_DEV_DIR}/${FIRST_DEV}/numa_node" \
+  | tr -d '[:space:]')
+if ! [[ "${NUMA_NODE}" =~ ^-?[0-9]+$ ]]; then
+  fail "numa_node for ${FIRST_DEV} is not a number: '${NUMA_NODE}'"
+fi
+info "${FIRST_DEV} numa_node=${NUMA_NODE}"
+
+# Count distinct root complexes the symlinks resolve to. For h100 this
+# must be 2 (pci0000:00 + pci0000:80); a regression that collapsed all
+# devices onto a single root would silently break NUMA-aware scheduling.
+# readlink target shape: "../../../devices/pciDDDD:BB/<bdf>"
+# Splitting on "/" yields: $1=.. $2=.. $3=.. $4=devices $5=pciDDDD:BB
+# so the root complex is field #5.
+ROOT_COUNT=$(kubectl exec "${POD}" -- sh -c \
+  "for d in ${PCI_DEV_DIR}/*; do readlink \"\$d\"; done" \
+  | awk -F/ '{print $5}' | sort -u | wc -l | tr -d ' ')
+if [[ "${ROOT_COUNT}" -ne 2 ]]; then
+  fail "Expected 2 distinct PCI root complexes for h100, found ${ROOT_COUNT}"
+fi
+info "Devices span ${ROOT_COUNT} distinct PCI root complex(es)"
+
+###############################################################################
+# Step 10 -- Show node labels
 ###############################################################################
 info "Node labels"
 kubectl get nodes --show-labels
@@ -108,5 +168,6 @@ info "  Cluster   : ${CLUSTER_NAME}"
 info "  Workers   : ${#WORKERS[@]}"
 info "  ConfigMaps: ${CM_COUNT}"
 info "  Mock HCAs : ${HCA_COUNT} per pod"
+info "  PCI devs  : ${PCI_DEV_COUNT} across ${ROOT_COUNT} root complex(es)"
 info ""
 info "To tear down: kind delete cluster --name ${CLUSTER_NAME}"

--- a/docs/demo/standalone/demo.sh
+++ b/docs/demo/standalone/demo.sh
@@ -82,7 +82,14 @@ info "Listing simulated InfiniBand HCAs (ibstat -l)"
 kubectl exec "${POD}" -- ibstat -l
 
 info "Running ibstatus inside the DaemonSet pod"
+# `head -40` closes the pipe after 40 lines, but `ibstatus` keeps writing
+# (8 HCAs * ~8 lines each = ~64 lines). The producer dies with SIGPIPE
+# and pipefail propagates exit code 141 to the whole script, aborting
+# the demo before any later verification (PCI sysfs, node labels) runs.
+# Scope pipefail down for just this one cosmetic truncation.
+set +o pipefail
 kubectl exec "${POD}" -- ibstatus | head -40
+set -o pipefail
 
 HCA_COUNT=$(kubectl exec "${POD}" -- ibstat -l | wc -l | tr -d ' ')
 if [[ "${HCA_COUNT}" -lt 1 ]]; then

--- a/docs/demo/standalone/demo.sh
+++ b/docs/demo/standalone/demo.sh
@@ -7,11 +7,33 @@ set -euo pipefail
 
 ###############################################################################
 # Configuration
+#
+# GPU_PROFILE / GPU_COUNT are env-overridable so the same demo can drive any
+# of the chart's built-in profiles, e.g.
+#   GPU_PROFILE=gb200 GPU_COUNT=8 ./demo.sh
+#   GPU_PROFILE=t4    GPU_COUNT=4 ./demo.sh
+# The PCI-sysfs assertions in step 9 derive their expected values from
+# GPU_COUNT and from the profile's `pcie_topology:` block, so switching
+# profile keeps the demo correct without further edits.
 ###############################################################################
 CLUSTER_NAME="nvml-mock-demo"
 IMAGE_NAME="nvml-mock:demo"
 CHART_PATH="deployments/nvml-mock/helm/nvml-mock"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+: "${GPU_PROFILE:=h100}"
+: "${GPU_COUNT:=8}"
+
+PROFILE_YAML="${REPO_ROOT}/${CHART_PATH}/profiles/${GPU_PROFILE}.yaml"
+if [[ ! -f "${PROFILE_YAML}" ]]; then
+  echo "ERROR: profile YAML not found: ${PROFILE_YAML}" >&2
+  echo "       set GPU_PROFILE to one of: $(ls "${REPO_ROOT}/${CHART_PATH}/profiles/" | sed 's/\.yaml$//' | tr '\n' ' ')" >&2
+  exit 1
+fi
+
+# Count the `- id: "pci...` rows under `pcie_topology.root_complexes`. The
+# renderer falls back to a flat single-root layout for profiles without an
+# explicit block, so default to 1 if the YAML carries no pcie_topology.
+EXPECTED_ROOTS=$(awk '/^    - id: "pci/ {n++} END {print (n>0)?n:1}' "${PROFILE_YAML}")
 
 ###############################################################################
 # Helpers
@@ -40,13 +62,13 @@ kind load docker-image "${IMAGE_NAME}" --name "${CLUSTER_NAME}"
 ###############################################################################
 # Step 4 -- Install nvml-mock via Helm
 ###############################################################################
-info "Installing nvml-mock Helm chart"
+info "Installing nvml-mock Helm chart (profile=${GPU_PROFILE}, count=${GPU_COUNT})"
 helm install nvml-mock "${REPO_ROOT}/${CHART_PATH}" \
   --set image.repository=nvml-mock \
   --set image.tag=demo \
   --set integrations.fakeGpuOperator.enabled=true \
-  --set gpu.profile=h100 \
-  --set gpu.count=8 \
+  --set "gpu.profile=${GPU_PROFILE}" \
+  --set "gpu.count=${GPU_COUNT}" \
   --set gpu.dynamicMetrics.enabled=true \
   --wait --timeout 120s
 
@@ -114,10 +136,11 @@ kubectl exec "${POD}" -- ls "${PCI_DEV_DIR}"
 
 PCI_DEV_COUNT=$(kubectl exec "${POD}" -- sh -c "ls ${PCI_DEV_DIR} 2>/dev/null | wc -l" \
   | tr -d ' ')
-# H100 profile defines 8 GPUs across 2 NUMA root complexes (pci0000:00,
-# pci0000:80). One symlink per device must appear under bus/pci/devices.
-if [[ "${PCI_DEV_COUNT}" -ne 8 ]]; then
-  fail "Expected 8 rendered PCI devices (h100 / gpu.count=8), found ${PCI_DEV_COUNT}"
+# One symlink per device must appear under bus/pci/devices. We expect
+# exactly GPU_COUNT of them (the helm install above set gpu.count to the
+# same value, and the chart wires that into the profile's `devices:` list).
+if [[ "${PCI_DEV_COUNT}" -ne "${GPU_COUNT}" ]]; then
+  fail "Expected ${GPU_COUNT} rendered PCI devices (profile=${GPU_PROFILE}, gpu.count=${GPU_COUNT}), found ${PCI_DEV_COUNT}"
 fi
 info "Found ${PCI_DEV_COUNT} rendered PCI device symlink(s)"
 
@@ -143,17 +166,19 @@ if ! [[ "${NUMA_NODE}" =~ ^-?[0-9]+$ ]]; then
 fi
 info "${FIRST_DEV} numa_node=${NUMA_NODE}"
 
-# Count distinct root complexes the symlinks resolve to. For h100 this
-# must be 2 (pci0000:00 + pci0000:80); a regression that collapsed all
-# devices onto a single root would silently break NUMA-aware scheduling.
+# Count distinct root complexes the symlinks resolve to. The expected
+# count was derived from the profile's `pcie_topology.root_complexes`
+# block at the top of the script, so e.g. h100/a100/b200/l40s -> 2,
+# gb200 -> 4, t4 -> 1. A regression that collapsed all devices onto a
+# single root would silently break NUMA-aware scheduling.
 # readlink target shape: "../../../devices/pciDDDD:BB/<bdf>"
 # Splitting on "/" yields: $1=.. $2=.. $3=.. $4=devices $5=pciDDDD:BB
 # so the root complex is field #5.
 ROOT_COUNT=$(kubectl exec "${POD}" -- sh -c \
   "for d in ${PCI_DEV_DIR}/*; do readlink \"\$d\"; done" \
   | awk -F/ '{print $5}' | sort -u | wc -l | tr -d ' ')
-if [[ "${ROOT_COUNT}" -ne 2 ]]; then
-  fail "Expected 2 distinct PCI root complexes for h100, found ${ROOT_COUNT}"
+if [[ "${ROOT_COUNT}" -ne "${EXPECTED_ROOTS}" ]]; then
+  fail "Expected ${EXPECTED_ROOTS} distinct PCI root complexes for ${GPU_PROFILE}, found ${ROOT_COUNT}"
 fi
 info "Devices span ${ROOT_COUNT} distinct PCI root complex(es)"
 
@@ -172,6 +197,7 @@ WORKERS=($(kubectl get nodes --no-headers -o custom-columns=":metadata.name" \
 echo
 info "Demo complete."
 info "  Cluster   : ${CLUSTER_NAME}"
+info "  Profile   : ${GPU_PROFILE} (gpu.count=${GPU_COUNT})"
 info "  Workers   : ${#WORKERS[@]}"
 info "  ConfigMaps: ${CM_COUNT}"
 info "  Mock HCAs : ${HCA_COUNT} per pod"

--- a/docs/development.md
+++ b/docs/development.md
@@ -245,7 +245,7 @@ devices:
   - index: 0
     uuid: "GPU-ae000000-0000-0000-0000-000000000000"
     pci:
-      bus_id: "00000000:07:00.0"
+      bus_id: "0000:07:00.0"
   # ... add all devices
 ```
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -134,7 +134,7 @@ devices:
   - index: 0
     uuid: "GPU-40900000-0000-0000-0000-000000000000"
     pci:
-      bus_id: "00000000:01:00.0"
+      bus_id: "0000:01:00.0"
 ```
 
 ```bash
@@ -165,7 +165,7 @@ devices:
     memory:
       total_bytes: 85899345920  # 80 GiB
     pci:
-      bus_id: "00000000:07:00.0"
+      bus_id: "0000:07:00.0"
   
   - index: 1
     uuid: "GPU-01000100-0000-0000-0000-000000000001"
@@ -174,7 +174,7 @@ devices:
     memory:
       total_bytes: 85899345920
     pci:
-      bus_id: "00000000:0F:00.0"
+      bus_id: "0000:0F:00.0"
 ```
 
 ### Simulating GPU Under Load
@@ -211,7 +211,7 @@ devices:
   - index: 0
     uuid: "GPU-10ad0000-0000-0000-0000-000000000000"
     pci:
-      bus_id: "00000000:07:00.0"
+      bus_id: "0000:07:00.0"
     processes:
       - pid: 12345
         type: "C"
@@ -328,7 +328,7 @@ data:
       - index: 0
         uuid: "GPU-7e570000-0000-0000-0000-000000000000"
         pci:
-          bus_id: "00000000:00:00.0"
+          bus_id: "0000:00:00.0"
 ---
 apiVersion: v1
 kind: Pod

--- a/pkg/gpu/mocknvml/README.md
+++ b/pkg/gpu/mocknvml/README.md
@@ -111,13 +111,69 @@ devices:
   - index: 0
     uuid: "GPU-12345678-1234-1234-1234-123456780000"
     pci:
-      bus_id: "00000000:07:00.0"
+      bus_id: "0000:07:00.0"
   - index: 1
     uuid: "GPU-12345678-1234-1234-1234-123456780001"
     pci:
-      bus_id: "00000000:0F:00.0"
+      bus_id: "0000:0F:00.0"
   # ... define each GPU
 ```
+
+> **Note:** `bus_id` uses the canonical Linux sysfs form `DDDD:BB:DD.F`
+> (4-digit PCI domain). The 8-digit NVML `busIdLegacy` form
+> (`00000000:07:00.0`) is **not accepted** — the PCI sysfs renderer
+> rejects it at validation time so half-migrated profiles don't silently
+> produce trees the DRA driver can't resolve.
+
+#### PCIe Topology (optional)
+
+Topology-aware schedulers (e.g. the NVIDIA DRA driver's
+`dra.k8s.io/pcieRoot` resource attribute) resolve "which PCIe root
+complex a GPU lives on" by `readlink()`ing
+`/sys/bus/pci/devices/<bdf>` and parsing the resulting path. The
+DaemonSet runs `render-pci-sysfs` (built from `cmd/render-pci-sysfs/`)
+to materialize a fake tree under `/var/lib/nvml-mock/sys/` from the
+profile's `pcie_topology:` block:
+
+```yaml
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"             # sysfs root-complex dir; "pciDDDD:BB"
+      numa_node: 0                  # numa_node value for every child device
+      devices:
+        - "0000:07:00.0"
+        - "0000:0F:00.0"
+    - id: "pci0000:80"
+      numa_node: 1
+      devices:
+        - "0000:87:00.0"
+        - "0000:90:00.0"
+```
+
+Rendered tree (matches what the kernel exposes):
+
+```
+/var/lib/nvml-mock/sys/
+├── bus/pci/devices/
+│   ├── 0000:07:00.0 -> ../../../devices/pci0000:00/0000:07:00.0
+│   └── 0000:0f:00.0 -> ../../../devices/pci0000:00/0000:0f:00.0
+└── devices/
+    └── pci0000:00/
+        ├── 0000:07:00.0/numa_node     # "0"
+        └── 0000:0f:00.0/numa_node     # "0"
+```
+
+Constraints (enforced at validation time):
+
+- Every BDF in `pcie_topology.root_complexes[*].devices` must appear in
+  `devices[]` — typos fail loudly instead of producing orphan entries.
+- Each device may belong to at most one root complex.
+- Root complex IDs must match the kernel format `pciDDDD:BB`.
+- BDFs use the 4-digit-domain canonical form (`DDDD:BB:DD.F`).
+
+If `pcie_topology:` is omitted, the renderer falls back to a flat
+single-root layout: every device under `pci0000:00`, `numa_node: 0`.
+Run `render-pci-sysfs --strict` to require an explicit block.
 
 #### Dynamic Metrics (optional)
 

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-a100.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-a100.yaml
@@ -313,56 +313,56 @@ devices:
     uuid: "GPU-12345678-1234-1234-1234-123456780000"
     serial: "1324821083800"
     pci:
-      bus_id: "00000000:07:00.0"
+      bus_id: "0000:07:00.0"
     minor_number: 0
 
   - index: 1
     uuid: "GPU-12345678-1234-1234-1234-123456780001"
     serial: "1324821083801"
     pci:
-      bus_id: "00000000:0F:00.0"
+      bus_id: "0000:0F:00.0"
     minor_number: 1
 
   - index: 2
     uuid: "GPU-12345678-1234-1234-1234-123456780002"
     serial: "1324821083802"
     pci:
-      bus_id: "00000000:47:00.0"
+      bus_id: "0000:47:00.0"
     minor_number: 2
 
   - index: 3
     uuid: "GPU-12345678-1234-1234-1234-123456780003"
     serial: "1324821083803"
     pci:
-      bus_id: "00000000:4E:00.0"
+      bus_id: "0000:4E:00.0"
     minor_number: 3
 
   - index: 4
     uuid: "GPU-12345678-1234-1234-1234-123456780004"
     serial: "1324821083804"
     pci:
-      bus_id: "00000000:87:00.0"
+      bus_id: "0000:87:00.0"
     minor_number: 4
 
   - index: 5
     uuid: "GPU-12345678-1234-1234-1234-123456780005"
     serial: "1324821083805"
     pci:
-      bus_id: "00000000:90:00.0"
+      bus_id: "0000:90:00.0"
     minor_number: 5
 
   - index: 6
     uuid: "GPU-12345678-1234-1234-1234-123456780006"
     serial: "1324821083806"
     pci:
-      bus_id: "00000000:B7:00.0"
+      bus_id: "0000:B7:00.0"
     minor_number: 6
 
   - index: 7
     uuid: "GPU-12345678-1234-1234-1234-123456780007"
     serial: "1324821083807"
     pci:
-      bus_id: "00000000:BD:00.0"
+      bus_id: "0000:BD:00.0"
     minor_number: 7
 
 # =============================================================================
@@ -377,5 +377,28 @@ nvlink:
     - link: 0
       state: "active"
       remote_device_type: "gpu"
-      remote_pci_bus_id: "00000000:0F:00.0"
+      remote_pci_bus_id: "0000:0F:00.0"
     # ... define all 12 links for full topology
+
+# =============================================================================
+# PCIe topology - 2 NUMA nodes (dual EPYC), 4 GPUs each.
+# Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+# under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+# from these symlinks.
+# =============================================================================
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:07:00.0"
+        - "0000:0F:00.0"
+        - "0000:47:00.0"
+        - "0000:4E:00.0"
+    - id: "pci0000:80"
+      numa_node: 1
+      devices:
+        - "0000:87:00.0"
+        - "0000:90:00.0"
+        - "0000:B7:00.0"
+        - "0000:BD:00.0"

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-b200.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-b200.yaml
@@ -322,56 +322,56 @@ devices:
     uuid: "GPU-b2000000-0000-0000-0000-000000000000"
     serial: "1562849203700"
     pci:
-      bus_id: "00000000:1A:00.0"
+      bus_id: "0000:1A:00.0"
     minor_number: 0
 
   - index: 1
     uuid: "GPU-b2000000-0000-0000-0000-000000000001"
     serial: "1562849203701"
     pci:
-      bus_id: "00000000:1B:00.0"
+      bus_id: "0000:1B:00.0"
     minor_number: 1
 
   - index: 2
     uuid: "GPU-b2000000-0000-0000-0000-000000000002"
     serial: "1562849203702"
     pci:
-      bus_id: "00000000:4A:00.0"
+      bus_id: "0000:4A:00.0"
     minor_number: 2
 
   - index: 3
     uuid: "GPU-b2000000-0000-0000-0000-000000000003"
     serial: "1562849203703"
     pci:
-      bus_id: "00000000:4B:00.0"
+      bus_id: "0000:4B:00.0"
     minor_number: 3
 
   - index: 4
     uuid: "GPU-b2000000-0000-0000-0000-000000000004"
     serial: "1562849203704"
     pci:
-      bus_id: "00000000:8A:00.0"
+      bus_id: "0000:8A:00.0"
     minor_number: 4
 
   - index: 5
     uuid: "GPU-b2000000-0000-0000-0000-000000000005"
     serial: "1562849203705"
     pci:
-      bus_id: "00000000:8B:00.0"
+      bus_id: "0000:8B:00.0"
     minor_number: 5
 
   - index: 6
     uuid: "GPU-b2000000-0000-0000-0000-000000000006"
     serial: "1562849203706"
     pci:
-      bus_id: "00000000:CA:00.0"
+      bus_id: "0000:CA:00.0"
     minor_number: 6
 
   - index: 7
     uuid: "GPU-b2000000-0000-0000-0000-000000000007"
     serial: "1562849203707"
     pci:
-      bus_id: "00000000:CB:00.0"
+      bus_id: "0000:CB:00.0"
     minor_number: 7
 
 # =============================================================================
@@ -385,4 +385,27 @@ nvlink:
     - link: 0
       state: "active"
       remote_device_type: "gpu"
-      remote_pci_bus_id: "00000000:1B:00.0"
+      remote_pci_bus_id: "0000:1B:00.0"
+
+# =============================================================================
+# PCIe topology - B200, 2 NUMA nodes, 4 GPUs each.
+# Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+# under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+# from these symlinks.
+# =============================================================================
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:1A:00.0"
+        - "0000:1B:00.0"
+        - "0000:4A:00.0"
+        - "0000:4B:00.0"
+    - id: "pci0000:80"
+      numa_node: 1
+      devices:
+        - "0000:8A:00.0"
+        - "0000:8B:00.0"
+        - "0000:CA:00.0"
+        - "0000:CB:00.0"

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml
@@ -332,7 +332,7 @@ devices:
     uuid: "GPU-b200b200-0000-0000-0000-000000000000"
     serial: "1562849103700"
     pci:
-      bus_id: "00000000:0A:00.0"
+      bus_id: "0000:0A:00.0"
     minor_number: 0
     grace_cpu_pair: 0               # Paired with Grace CPU 0
 
@@ -340,7 +340,7 @@ devices:
     uuid: "GPU-b200b200-0000-0000-0000-000000000001"
     serial: "1562849103701"
     pci:
-      bus_id: "00000000:0B:00.0"
+      bus_id: "0000:0B:00.0"
     minor_number: 1
     grace_cpu_pair: 0               # Same superchip as GPU 0
 
@@ -348,7 +348,7 @@ devices:
     uuid: "GPU-b200b200-0000-0000-0000-000000000002"
     serial: "1562849103702"
     pci:
-      bus_id: "00000000:4A:00.0"
+      bus_id: "0000:4A:00.0"
     minor_number: 2
     grace_cpu_pair: 1
 
@@ -356,7 +356,7 @@ devices:
     uuid: "GPU-b200b200-0000-0000-0000-000000000003"
     serial: "1562849103703"
     pci:
-      bus_id: "00000000:4B:00.0"
+      bus_id: "0000:4B:00.0"
     minor_number: 3
     grace_cpu_pair: 1
 
@@ -364,7 +364,7 @@ devices:
     uuid: "GPU-b200b200-0000-0000-0000-000000000004"
     serial: "1562849103704"
     pci:
-      bus_id: "00000000:8A:00.0"
+      bus_id: "0000:8A:00.0"
     minor_number: 4
     grace_cpu_pair: 2
 
@@ -372,7 +372,7 @@ devices:
     uuid: "GPU-b200b200-0000-0000-0000-000000000005"
     serial: "1562849103705"
     pci:
-      bus_id: "00000000:8B:00.0"
+      bus_id: "0000:8B:00.0"
     minor_number: 5
     grace_cpu_pair: 2
 
@@ -380,7 +380,7 @@ devices:
     uuid: "GPU-b200b200-0000-0000-0000-000000000006"
     serial: "1562849103706"
     pci:
-      bus_id: "00000000:CA:00.0"
+      bus_id: "0000:CA:00.0"
     minor_number: 6
     grace_cpu_pair: 3
 
@@ -388,7 +388,7 @@ devices:
     uuid: "GPU-b200b200-0000-0000-0000-000000000007"
     serial: "1562849103707"
     pci:
-      bus_id: "00000000:CB:00.0"
+      bus_id: "0000:CB:00.0"
     minor_number: 7
     grace_cpu_pair: 3
 
@@ -407,9 +407,38 @@ nvlink:
     - link: 0
       state: "active"
       remote_device_type: "gpu"
-      remote_pci_bus_id: "00000000:0B:00.0"
+      remote_pci_bus_id: "0000:0B:00.0"
     - link: 1
       state: "active"
       remote_device_type: "cpu"     # NVLink-C2C to Grace
       remote_pci_bus_id: "N/A"
     # ... define all 18 links for full topology
+
+# =============================================================================
+# PCIe topology - GB200, 4 Grace CPU pairs -> 4 NUMA nodes, 2 GPUs each.
+# Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+# under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+# from these symlinks.
+# =============================================================================
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:0A:00.0"
+        - "0000:0B:00.0"
+    - id: "pci0000:40"
+      numa_node: 1
+      devices:
+        - "0000:4A:00.0"
+        - "0000:4B:00.0"
+    - id: "pci0000:80"
+      numa_node: 2
+      devices:
+        - "0000:8A:00.0"
+        - "0000:8B:00.0"
+    - id: "pci0000:c0"
+      numa_node: 3
+      devices:
+        - "0000:CA:00.0"
+        - "0000:CB:00.0"

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-h100.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-h100.yaml
@@ -319,56 +319,56 @@ devices:
     uuid: "GPU-01000100-0000-0000-0000-000000000000"
     serial: "1562821083900"
     pci:
-      bus_id: "00000000:1A:00.0"
+      bus_id: "0000:1A:00.0"
     minor_number: 0
 
   - index: 1
     uuid: "GPU-01000100-0000-0000-0000-000000000001"
     serial: "1562821083901"
     pci:
-      bus_id: "00000000:1B:00.0"
+      bus_id: "0000:1B:00.0"
     minor_number: 1
 
   - index: 2
     uuid: "GPU-01000100-0000-0000-0000-000000000002"
     serial: "1562821083902"
     pci:
-      bus_id: "00000000:4A:00.0"
+      bus_id: "0000:4A:00.0"
     minor_number: 2
 
   - index: 3
     uuid: "GPU-01000100-0000-0000-0000-000000000003"
     serial: "1562821083903"
     pci:
-      bus_id: "00000000:4B:00.0"
+      bus_id: "0000:4B:00.0"
     minor_number: 3
 
   - index: 4
     uuid: "GPU-01000100-0000-0000-0000-000000000004"
     serial: "1562821083904"
     pci:
-      bus_id: "00000000:8A:00.0"
+      bus_id: "0000:8A:00.0"
     minor_number: 4
 
   - index: 5
     uuid: "GPU-01000100-0000-0000-0000-000000000005"
     serial: "1562821083905"
     pci:
-      bus_id: "00000000:8B:00.0"
+      bus_id: "0000:8B:00.0"
     minor_number: 5
 
   - index: 6
     uuid: "GPU-01000100-0000-0000-0000-000000000006"
     serial: "1562821083906"
     pci:
-      bus_id: "00000000:CA:00.0"
+      bus_id: "0000:CA:00.0"
     minor_number: 6
 
   - index: 7
     uuid: "GPU-01000100-0000-0000-0000-000000000007"
     serial: "1562821083907"
     pci:
-      bus_id: "00000000:CB:00.0"
+      bus_id: "0000:CB:00.0"
     minor_number: 7
 
 # =============================================================================
@@ -382,4 +382,27 @@ nvlink:
     - link: 0
       state: "active"
       remote_device_type: "gpu"
-      remote_pci_bus_id: "00000000:1B:00.0"
+      remote_pci_bus_id: "0000:1B:00.0"
+
+# =============================================================================
+# PCIe topology - HGX H100, 2 NUMA nodes, 4 GPUs each.
+# Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+# under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+# from these symlinks.
+# =============================================================================
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:1A:00.0"
+        - "0000:1B:00.0"
+        - "0000:4A:00.0"
+        - "0000:4B:00.0"
+    - id: "pci0000:80"
+      numa_node: 1
+      devices:
+        - "0000:8A:00.0"
+        - "0000:8B:00.0"
+        - "0000:CA:00.0"
+        - "0000:CB:00.0"

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-l40s.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-l40s.yaml
@@ -309,54 +309,77 @@ devices:
     uuid: "GPU-14050000-0000-0000-0000-000000000000"
     serial: "1562830094500"
     pci:
-      bus_id: "00000000:17:00.0"
+      bus_id: "0000:17:00.0"
     minor_number: 0
 
   - index: 1
     uuid: "GPU-14050000-0000-0000-0000-000000000001"
     serial: "1562830094501"
     pci:
-      bus_id: "00000000:31:00.0"
+      bus_id: "0000:31:00.0"
     minor_number: 1
 
   - index: 2
     uuid: "GPU-14050000-0000-0000-0000-000000000002"
     serial: "1562830094502"
     pci:
-      bus_id: "00000000:B1:00.0"
+      bus_id: "0000:B1:00.0"
     minor_number: 2
 
   - index: 3
     uuid: "GPU-14050000-0000-0000-0000-000000000003"
     serial: "1562830094503"
     pci:
-      bus_id: "00000000:CA:00.0"
+      bus_id: "0000:CA:00.0"
     minor_number: 3
 
   - index: 4
     uuid: "GPU-14050000-0000-0000-0000-000000000004"
     serial: "1562830094504"
     pci:
-      bus_id: "00000000:18:00.0"
+      bus_id: "0000:18:00.0"
     minor_number: 4
 
   - index: 5
     uuid: "GPU-14050000-0000-0000-0000-000000000005"
     serial: "1562830094505"
     pci:
-      bus_id: "00000000:32:00.0"
+      bus_id: "0000:32:00.0"
     minor_number: 5
 
   - index: 6
     uuid: "GPU-14050000-0000-0000-0000-000000000006"
     serial: "1562830094506"
     pci:
-      bus_id: "00000000:B2:00.0"
+      bus_id: "0000:B2:00.0"
     minor_number: 6
 
   - index: 7
     uuid: "GPU-14050000-0000-0000-0000-000000000007"
     serial: "1562830094507"
     pci:
-      bus_id: "00000000:CB:00.0"
+      bus_id: "0000:CB:00.0"
     minor_number: 7
+
+# =============================================================================
+# PCIe topology - L40S, 2 NUMA nodes, 4 GPUs each.
+# Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+# under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+# from these symlinks.
+# =============================================================================
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:17:00.0"
+        - "0000:18:00.0"
+        - "0000:31:00.0"
+        - "0000:32:00.0"
+    - id: "pci0000:80"
+      numa_node: 1
+      devices:
+        - "0000:B1:00.0"
+        - "0000:B2:00.0"
+        - "0000:CA:00.0"
+        - "0000:CB:00.0"

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-t4.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-t4.yaml
@@ -309,26 +309,42 @@ devices:
     uuid: "GPU-00000074-0000-0000-0000-000000000000"
     serial: "0421819085400"
     pci:
-      bus_id: "00000000:3B:00.0"
+      bus_id: "0000:3B:00.0"
     minor_number: 0
 
   - index: 1
     uuid: "GPU-00000074-0000-0000-0000-000000000001"
     serial: "0421819085401"
     pci:
-      bus_id: "00000000:86:00.0"
+      bus_id: "0000:86:00.0"
     minor_number: 1
 
   - index: 2
     uuid: "GPU-00000074-0000-0000-0000-000000000002"
     serial: "0421819085402"
     pci:
-      bus_id: "00000000:AF:00.0"
+      bus_id: "0000:AF:00.0"
     minor_number: 2
 
   - index: 3
     uuid: "GPU-00000074-0000-0000-0000-000000000003"
     serial: "0421819085403"
     pci:
-      bus_id: "00000000:D8:00.0"
+      bus_id: "0000:D8:00.0"
     minor_number: 3
+
+# =============================================================================
+# PCIe topology - T4 inference card, single NUMA node, 4 GPUs.
+# Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+# under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+# from these symlinks.
+# =============================================================================
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:3B:00.0"
+        - "0000:86:00.0"
+        - "0000:AF:00.0"
+        - "0000:D8:00.0"

--- a/pkg/gpu/mocknvml/engine/engine.go
+++ b/pkg/gpu/mocknvml/engine/engine.go
@@ -180,7 +180,7 @@ func (e *Engine) createDefaultDevices(server *MockServer, base *dgxa100.Server) 
 
 		// Deterministic UUID and PCI bus ID based on device index.
 		uuid := fmt.Sprintf("GPU-00000000-0000-0000-0000-%012d", i)
-		pciBusID := fmt.Sprintf("00000000:%02X:00.0", i+1)
+		pciBusID := fmt.Sprintf("0000:%02X:00.0", i+1)
 
 		server.configurableDevices[i] = NewConfigurableDevice(
 			i,

--- a/pkg/gpu/mocknvml/engine/fabric_test.go
+++ b/pkg/gpu/mocknvml/engine/fabric_test.go
@@ -27,7 +27,7 @@ func makeFabricDevice(t *testing.T, fabric *FabricConfig) *ConfigurableDevice {
 	base := dgxa100.New()
 	bd, _ := base.Devices[0].(*dgxa100.Device)
 	return NewConfigurableDevice(0, bd, &DeviceConfig{Fabric: fabric},
-		"GPU-00000000-0000-0000-0000-000000000000", "00000000:01:00.0", 0, nil)
+		"GPU-00000000-0000-0000-0000-000000000000", "0000:01:00.0", 0, nil)
 }
 
 func TestGetMockFabricInfo_NotSupportedWhenNil(t *testing.T) {

--- a/pkg/system/mockpcisysfs/config/types.go
+++ b/pkg/system/mockpcisysfs/config/types.go
@@ -1,0 +1,153 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// Package config defines the YAML schema for the `pcie_topology:` block
+// embedded in mock-nvml profile configs. The renderer consumes this to
+// populate a fake `/sys/bus/pci/devices` + `/sys/devices/pciDDDD:BB` tree
+// under MOCK_PCI_ROOT.
+//
+// Keeping the schema in a standalone package (no cgo dependency on the
+// mocknvml engine) mirrors `pkg/network/mockibsysfs/config` and lets the
+// renderer CLI build into a small static binary.
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Profile is the minimal slice of the mock-nvml profile YAML that the PCI
+// sysfs renderer cares about. It deliberately ignores every GPU detail
+// other than the per-device bus_id, which is the join key into the
+// topology block.
+type Profile struct {
+	Devices      []Device      `json:"devices"      yaml:"devices"`
+	PCIeTopology *PCIeTopology `json:"pcie_topology,omitempty" yaml:"pcie_topology,omitempty"`
+}
+
+// Device captures only the fields the renderer needs: the device index
+// (used for --gpu-count clipping) and the PCI bus_id. Every other profile
+// field is ignored at unmarshal time.
+type Device struct {
+	Index int `json:"index" yaml:"index"`
+	PCI   PCI `json:"pci"   yaml:"pci"`
+}
+
+// PCI is the inner block on each device entry. Only bus_id matters here.
+type PCI struct {
+	BusID string `json:"bus_id" yaml:"bus_id"`
+}
+
+// PCIeTopology describes the root-complex layout that the renderer
+// materializes into sysfs. Each entry under root_complexes lists the
+// devices physically attached to that root.
+type PCIeTopology struct {
+	RootComplexes []RootComplex `json:"root_complexes" yaml:"root_complexes"`
+}
+
+// RootComplex represents a single PCI host bridge (`pciDDDD:BB` in real
+// Linux sysfs) along with the NUMA node it lives on and the BDFs of
+// every device attached underneath.
+type RootComplex struct {
+	// ID is the sysfs directory name, e.g. "pci0000:00". Must start with
+	// "pci" and match the kernel's printf format ("pciDDDD:BB").
+	ID string `json:"id" yaml:"id"`
+
+	// NUMANode is the value written into each child device's `numa_node`
+	// file. Real x86 hosts use -1 for "no affinity"; the renderer accepts
+	// any int (including negatives) verbatim.
+	NUMANode int `json:"numa_node" yaml:"numa_node"`
+
+	// Devices is the list of GPU PCI BDFs (4-digit-domain form, e.g.
+	// "0000:07:00.0") that live under this root complex.
+	Devices []string `json:"devices" yaml:"devices"`
+}
+
+// bdfRE matches a canonical Linux sysfs BDF ("0000:07:00.0"). NVML's
+// `busIdLegacy` 8-digit form is intentionally rejected here so the
+// renderer fails loudly if a profile still carries it.
+var bdfRE = regexp.MustCompile(`^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F]$`)
+
+// rootRE matches a sysfs root-complex directory name ("pci0000:00").
+var rootRE = regexp.MustCompile(`^pci[0-9a-fA-F]{4}:[0-9a-fA-F]{2}$`)
+
+// Validate cross-checks the topology against the device list. It returns
+// the first violation encountered:
+//   - root complex IDs are well-formed and unique
+//   - every device BDF is well-formed (4-digit domain) and unique across
+//     the whole topology
+//   - every BDF mentioned in the topology also exists in `devices:`
+//
+// The reverse implication is intentionally NOT enforced: profiles may
+// declare devices that aren't part of the rendered topology yet, and
+// the renderer treats those as "no sysfs entry" rather than an error.
+func (p *Profile) Validate() error {
+	if p.PCIeTopology == nil {
+		return nil
+	}
+
+	devSet := make(map[string]struct{}, len(p.Devices))
+	for _, d := range p.Devices {
+		if d.PCI.BusID == "" {
+			continue
+		}
+		devSet[strings.ToLower(d.PCI.BusID)] = struct{}{}
+	}
+
+	seenRoot := make(map[string]struct{}, len(p.PCIeTopology.RootComplexes))
+	seenBDF := make(map[string]struct{})
+	for _, rc := range p.PCIeTopology.RootComplexes {
+		if !rootRE.MatchString(rc.ID) {
+			return fmt.Errorf("pcie_topology: invalid root complex id %q (want %q)", rc.ID, "pciDDDD:BB")
+		}
+		key := strings.ToLower(rc.ID)
+		if _, dup := seenRoot[key]; dup {
+			return fmt.Errorf("pcie_topology: duplicate root complex %q", rc.ID)
+		}
+		seenRoot[key] = struct{}{}
+
+		for _, bdf := range rc.Devices {
+			if !bdfRE.MatchString(bdf) {
+				return fmt.Errorf("pcie_topology: invalid device BDF %q under %q (want DDDD:BB:DD.F; the 8-digit busIdLegacy form is not accepted)", bdf, rc.ID)
+			}
+			lb := strings.ToLower(bdf)
+			if _, dup := seenBDF[lb]; dup {
+				return fmt.Errorf("pcie_topology: device %q appears under multiple root complexes", bdf)
+			}
+			seenBDF[lb] = struct{}{}
+
+			if _, ok := devSet[lb]; !ok {
+				return fmt.Errorf("pcie_topology: device %q (under %q) is not declared in `devices:`", bdf, rc.ID)
+			}
+		}
+	}
+	return nil
+}
+
+// DefaultTopology synthesizes a single-root topology covering every
+// device in the profile. Use this when the profile omits an explicit
+// `pcie_topology:` block — the resulting tree is well-formed but flat
+// (every GPU shares one root complex and NUMA node).
+func (p *Profile) DefaultTopology() *PCIeTopology {
+	rc := RootComplex{ID: "pci0000:00", NUMANode: 0}
+	for _, d := range p.Devices {
+		if d.PCI.BusID == "" {
+			continue
+		}
+		rc.Devices = append(rc.Devices, strings.ToLower(d.PCI.BusID))
+	}
+	if len(rc.Devices) == 0 {
+		return nil
+	}
+	return &PCIeTopology{RootComplexes: []RootComplex{rc}}
+}
+
+// EffectiveTopology returns the explicit topology if set, otherwise the
+// flat default. Returns nil only when the profile has no devices at all.
+func (p *Profile) EffectiveTopology() *PCIeTopology {
+	if p.PCIeTopology != nil && len(p.PCIeTopology.RootComplexes) > 0 {
+		return p.PCIeTopology
+	}
+	return p.DefaultTopology()
+}

--- a/pkg/system/mockpcisysfs/config/types.go
+++ b/pkg/system/mockpcisysfs/config/types.go
@@ -26,9 +26,10 @@ type Profile struct {
 	PCIeTopology *PCIeTopology `json:"pcie_topology,omitempty" yaml:"pcie_topology,omitempty"`
 }
 
-// Device captures only the fields the renderer needs: the device index
-// (used for --gpu-count clipping) and the PCI bus_id. Every other profile
-// field is ignored at unmarshal time.
+// Device captures the per-GPU PCI bus_id used as the join key into the
+// topology block. Index is unmarshaled for YAML shape compatibility with
+// the full profile but is not consulted by Validate or the renderer.
+// Every other profile field is ignored at unmarshal time.
 type Device struct {
 	Index int `json:"index" yaml:"index"`
 	PCI   PCI `json:"pci"   yaml:"pci"`

--- a/pkg/system/mockpcisysfs/render/render.go
+++ b/pkg/system/mockpcisysfs/render/render.go
@@ -1,0 +1,147 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// Package render writes a fake PCI sysfs tree from a
+// [config.PCIeTopology] specification.
+//
+// The layout mimics what real Linux kernels expose to userspace, so any
+// consumer that resolves "PCIe root complex" via a single readlink + path
+// parse (e.g. the k8s deviceattribute library used by the NVIDIA DRA
+// driver) gets the right answer when pointed at the rendered tree:
+//
+//	<output>/sys/bus/pci/devices/0000:07:00.0 ->
+//	    ../../../devices/pci0000:00/0000:07:00.0
+//	<output>/sys/devices/pci0000:00/0000:07:00.0/numa_node    # "0"
+//
+// The tree only carries what topology resolution needs (symlinks +
+// numa_node). It is *not* a full sysfs simulation — device class files
+// (vendor, device, config, resource, ...) are out of scope; callers that
+// need richer attributes can stack additional generators on top of this
+// tree without conflict.
+package render
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/system/mockpcisysfs/config"
+)
+
+// Options controls a single rendering pass.
+type Options struct {
+	// Topology is the resolved layout to render. Callers typically pass
+	// `profile.EffectiveTopology()` so empty `pcie_topology:` blocks
+	// still produce a flat default tree.
+	Topology *config.PCIeTopology
+
+	// Output is the fake-root directory. The renderer writes under
+	// <Output>/sys/... — Output itself is created if missing.
+	Output string
+}
+
+// Render writes the entire tree. It is idempotent: existing directories
+// are reused, existing files are truncated and rewritten, and existing
+// symlinks are removed and recreated so a stale relative target does not
+// linger across re-renders.
+func Render(o Options) error {
+	if o.Topology == nil || len(o.Topology.RootComplexes) == 0 {
+		// Nothing to do — caller decided to render a profile with no
+		// declared topology and no devices. Treat as a no-op so the
+		// renderer can be invoked unconditionally from setup.sh.
+		return nil
+	}
+	if o.Output == "" {
+		return fmt.Errorf("pcisysfs render: Output is required")
+	}
+
+	root := o.Output
+	if err := mkdirAll(root, "sys/bus/pci/devices"); err != nil {
+		return err
+	}
+	if err := mkdirAll(root, "sys/devices"); err != nil {
+		return err
+	}
+
+	for _, rc := range o.Topology.RootComplexes {
+		if err := renderRootComplex(root, rc); err != nil {
+			return fmt.Errorf("rendering %s: %w", rc.ID, err)
+		}
+	}
+	return nil
+}
+
+func renderRootComplex(root string, rc config.RootComplex) error {
+	rcDir := filepath.Join("sys/devices", rc.ID)
+	if err := mkdirAll(root, rcDir); err != nil {
+		return err
+	}
+
+	for _, bdf := range rc.Devices {
+		// Normalize once: sysfs paths are case-insensitive on most
+		// filesystems but tooling (libpciaccess, lspci) compares
+		// strings literally, so render lowercase to match the kernel.
+		bdfLC := strings.ToLower(bdf)
+
+		// 1. /sys/devices/<root>/<bdf>/numa_node
+		devDir := filepath.Join(rcDir, bdfLC)
+		if err := mkdirAll(root, devDir); err != nil {
+			return err
+		}
+		if err := writeFile(root, filepath.Join(devDir, "numa_node"),
+			fmt.Sprintf("%d\n", rc.NUMANode)); err != nil {
+			return err
+		}
+
+		// 2. /sys/bus/pci/devices/<bdf> -> ../../../devices/<root>/<bdf>
+		// Relative target matches what the kernel emits, so any
+		// readlink() consumer (`realpath`, deviceattribute, etc.)
+		// resolves to the same canonical path it would on real Linux.
+		linkPath := filepath.Join(root, "sys/bus/pci/devices", bdfLC)
+		linkTarget := filepath.Join("..", "..", "..", "devices", rc.ID, bdfLC)
+		if err := replaceSymlink(linkPath, linkTarget); err != nil {
+			return fmt.Errorf("symlink %s -> %s: %w",
+				filepath.Join("sys/bus/pci/devices", bdfLC), linkTarget, err)
+		}
+	}
+	return nil
+}
+
+// replaceSymlink ensures `path` is a symlink pointing at `target`,
+// removing any stale file/symlink in the way first. Symlink atomicity
+// matters less here than predictable re-render behavior: a previous run
+// may have left a symlink to a different root complex if the topology
+// was edited between runs.
+func replaceSymlink(path, target string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	}
+	// `os.Remove` returns nil if the path doesn't exist on some
+	// platforms but errors on others; tolerate both shapes.
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("clear %s: %w", path, err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		return fmt.Errorf("create symlink %s: %w", path, err)
+	}
+	return nil
+}
+
+func mkdirAll(root, rel string) error {
+	if err := os.MkdirAll(filepath.Join(root, rel), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", rel, err)
+	}
+	return nil
+}
+
+func writeFile(root, rel, contents string) error {
+	full := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(rel), err)
+	}
+	if err := os.WriteFile(full, []byte(contents), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", rel, err)
+	}
+	return nil
+}

--- a/pkg/system/mockpcisysfs/render/render.go
+++ b/pkg/system/mockpcisysfs/render/render.go
@@ -38,6 +38,11 @@ type Options struct {
 
 	// Output is the fake-root directory. The renderer writes under
 	// <Output>/sys/... — Output itself is created if missing.
+	//
+	// When Topology is nil or has no root complexes, Render is a no-op
+	// even if Output is empty (so setup.sh can invoke the renderer
+	// unconditionally). A non-nil Topology with a non-empty Output is
+	// required; otherwise Render returns an error.
 	Output string
 }
 

--- a/pkg/system/mockpcisysfs/render/render_test.go
+++ b/pkg/system/mockpcisysfs/render/render_test.go
@@ -227,6 +227,19 @@ func TestValidate_RejectsMalformedRoot(t *testing.T) {
 	}
 }
 
+func TestValidate_RejectsDuplicateRoot(t *testing.T) {
+	p := config.Profile{
+		Devices: []config.Device{{Index: 0, PCI: config.PCI{BusID: "0000:07:00.0"}}},
+		PCIeTopology: &config.PCIeTopology{RootComplexes: []config.RootComplex{
+			{ID: "pci0000:00", NUMANode: 0, Devices: []string{"0000:07:00.0"}},
+			{ID: "pci0000:00", NUMANode: 1, Devices: []string{}},
+		}},
+	}
+	if err := p.Validate(); err == nil {
+		t.Fatal("expected error for duplicate root complex, got nil")
+	}
+}
+
 func TestValidate_RejectsDuplicateBDF(t *testing.T) {
 	// A device under two root complexes would silently overwrite its
 	// own numa_node on the second pass; catching duplicates at parse

--- a/pkg/system/mockpcisysfs/render/render_test.go
+++ b/pkg/system/mockpcisysfs/render/render_test.go
@@ -1,0 +1,296 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package render
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/system/mockpcisysfs/config"
+)
+
+func TestRender_NoTopologyNoOp(t *testing.T) {
+	dir := t.TempDir()
+	if err := Render(Options{Output: dir}); err != nil {
+		t.Fatalf("Render(no topology): %v", err)
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Fatalf("expected empty output for nil topology, got %d entries", len(entries))
+	}
+}
+
+func TestRender_RequiresOutput(t *testing.T) {
+	err := Render(Options{Topology: &config.PCIeTopology{
+		RootComplexes: []config.RootComplex{{
+			ID: "pci0000:00", NUMANode: 0,
+			Devices: []string{"0000:07:00.0"},
+		}},
+	}})
+	if err == nil {
+		t.Fatal("expected error with empty Output")
+	}
+}
+
+// TestRender_FullTree exercises the documented sysfs layout end-to-end:
+// two GPUs on one root complex must produce a populated devices dir,
+// a populated symlink dir, and numa_node files with the configured
+// value. This is the regression net for the issue's acceptance test:
+// "k8s deviceattribute resolves PCIe root via readlink + path parse".
+func TestRender_FullTree(t *testing.T) {
+	dir := t.TempDir()
+	topo := &config.PCIeTopology{
+		RootComplexes: []config.RootComplex{
+			{
+				ID:       "pci0000:00",
+				NUMANode: 0,
+				Devices:  []string{"0000:07:00.0", "0000:0F:00.0"},
+			},
+			{
+				ID:       "pci0000:80",
+				NUMANode: 1,
+				Devices:  []string{"0000:87:00.0"},
+			},
+		},
+	}
+	if err := Render(Options{Topology: topo, Output: dir}); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	// numa_node files must contain the per-root NUMA value (and *only*
+	// that — a trailing-newline regression would silently bake "0\n0\n"
+	// into a re-render).
+	mustRead := func(rel, want string) {
+		t.Helper()
+		got, err := os.ReadFile(filepath.Join(dir, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if string(got) != want {
+			t.Errorf("%s: got %q want %q", rel, string(got), want)
+		}
+	}
+	mustRead("sys/devices/pci0000:00/0000:07:00.0/numa_node", "0\n")
+	mustRead("sys/devices/pci0000:00/0000:0f:00.0/numa_node", "0\n")
+	mustRead("sys/devices/pci0000:80/0000:87:00.0/numa_node", "1\n")
+
+	// The symlink target must be *relative* — the deviceattribute
+	// library walks readlink() output to extract the pciDDDD:BB
+	// component, which only works when the target is the kernel-style
+	// "../../../devices/pciDDDD:BB/<bdf>" string.
+	mustLink := func(rel, wantTarget string) {
+		t.Helper()
+		target, err := os.Readlink(filepath.Join(dir, rel))
+		if err != nil {
+			t.Fatalf("readlink %s: %v", rel, err)
+		}
+		if target != wantTarget {
+			t.Errorf("%s: target=%q want %q", rel, target, wantTarget)
+		}
+	}
+	mustLink("sys/bus/pci/devices/0000:07:00.0", "../../../devices/pci0000:00/0000:07:00.0")
+	mustLink("sys/bus/pci/devices/0000:0f:00.0", "../../../devices/pci0000:00/0000:0f:00.0")
+	mustLink("sys/bus/pci/devices/0000:87:00.0", "../../../devices/pci0000:80/0000:87:00.0")
+
+	// Resolving the symlink (the path-parse step the deviceattribute
+	// library actually performs) must land on the real numa_node file.
+	resolved, err := filepath.EvalSymlinks(
+		filepath.Join(dir, "sys/bus/pci/devices/0000:07:00.0"))
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	if !strings.HasSuffix(resolved, "sys/devices/pci0000:00/0000:07:00.0") {
+		t.Errorf("resolved=%q does not land under expected root complex", resolved)
+	}
+}
+
+func TestRender_IdempotentRerender(t *testing.T) {
+	dir := t.TempDir()
+	topoA := &config.PCIeTopology{
+		RootComplexes: []config.RootComplex{{
+			ID: "pci0000:00", NUMANode: 0,
+			Devices: []string{"0000:07:00.0"},
+		}},
+	}
+	// First pass.
+	if err := Render(Options{Topology: topoA, Output: dir}); err != nil {
+		t.Fatalf("Render pass 1: %v", err)
+	}
+
+	// Second pass with a *different* root complex for the same BDF.
+	// Re-render must point the symlink at the new root and overwrite
+	// numa_node — a stale symlink would silently misattribute pcieRoot.
+	topoB := &config.PCIeTopology{
+		RootComplexes: []config.RootComplex{{
+			ID: "pci0000:c0", NUMANode: 3,
+			Devices: []string{"0000:07:00.0"},
+		}},
+	}
+	if err := Render(Options{Topology: topoB, Output: dir}); err != nil {
+		t.Fatalf("Render pass 2: %v", err)
+	}
+
+	target, err := os.Readlink(filepath.Join(dir, "sys/bus/pci/devices/0000:07:00.0"))
+	if err != nil {
+		t.Fatalf("readlink: %v", err)
+	}
+	if target != "../../../devices/pci0000:c0/0000:07:00.0" {
+		t.Errorf("symlink target stale across rerender: got %q", target)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "sys/devices/pci0000:c0/0000:07:00.0/numa_node"))
+	if err != nil {
+		t.Fatalf("read numa_node: %v", err)
+	}
+	if string(got) != "3\n" {
+		t.Errorf("numa_node not updated: got %q", string(got))
+	}
+}
+
+func TestRender_NormalizesUppercaseBDF(t *testing.T) {
+	dir := t.TempDir()
+	topo := &config.PCIeTopology{
+		RootComplexes: []config.RootComplex{{
+			ID: "pci0000:00", NUMANode: 0,
+			Devices: []string{"0000:BD:00.0"}, // uppercase BDF
+		}},
+	}
+	if err := Render(Options{Topology: topo, Output: dir}); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	// Real sysfs is lowercase. Render must lowercase before writing so
+	// downstream tools (lspci, libpciaccess) that string-compare BDFs
+	// see what they expect.
+	if _, err := os.Stat(filepath.Join(dir, "sys/bus/pci/devices/0000:bd:00.0")); err != nil {
+		t.Errorf("expected lowercase symlink, missing: %v", err)
+	}
+}
+
+// --- Config / Validate tests --------------------------------------------------
+
+func TestValidate_AcceptsCanonicalProfile(t *testing.T) {
+	var p config.Profile
+	if err := yaml.Unmarshal([]byte(`
+devices:
+  - index: 0
+    pci:
+      bus_id: "0000:07:00.0"
+  - index: 1
+    pci:
+      bus_id: "0000:0F:00.0"
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:07:00.0"
+        - "0000:0F:00.0"
+`), &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := p.Validate(); err != nil {
+		t.Errorf("Validate: %v", err)
+	}
+}
+
+func TestValidate_RejectsLegacy8DigitBDF(t *testing.T) {
+	// The whole point of the BDF migration is to stop using busIdLegacy
+	// form in profile YAMLs. Validation must catch it explicitly so a
+	// half-migrated profile doesn't silently render a tree the DRA
+	// driver can't resolve.
+	p := config.Profile{
+		Devices: []config.Device{{Index: 0, PCI: config.PCI{BusID: "00000000:07:00.0"}}},
+		PCIeTopology: &config.PCIeTopology{RootComplexes: []config.RootComplex{{
+			ID: "pci0000:00", NUMANode: 0,
+			Devices: []string{"00000000:07:00.0"},
+		}}},
+	}
+	if err := p.Validate(); err == nil {
+		t.Fatal("expected error for 8-digit BDF, got nil")
+	}
+}
+
+func TestValidate_RejectsMalformedRoot(t *testing.T) {
+	p := config.Profile{
+		Devices: []config.Device{{Index: 0, PCI: config.PCI{BusID: "0000:07:00.0"}}},
+		PCIeTopology: &config.PCIeTopology{RootComplexes: []config.RootComplex{{
+			ID: "0000:00", // missing "pci" prefix
+			Devices: []string{"0000:07:00.0"},
+		}}},
+	}
+	if err := p.Validate(); err == nil {
+		t.Fatal("expected error for malformed root id, got nil")
+	}
+}
+
+func TestValidate_RejectsDuplicateBDF(t *testing.T) {
+	// A device under two root complexes would silently overwrite its
+	// own numa_node on the second pass; catching duplicates at parse
+	// time makes the topology unambiguous.
+	p := config.Profile{
+		Devices: []config.Device{{Index: 0, PCI: config.PCI{BusID: "0000:07:00.0"}}},
+		PCIeTopology: &config.PCIeTopology{RootComplexes: []config.RootComplex{
+			{ID: "pci0000:00", NUMANode: 0, Devices: []string{"0000:07:00.0"}},
+			{ID: "pci0000:80", NUMANode: 1, Devices: []string{"0000:07:00.0"}},
+		}},
+	}
+	if err := p.Validate(); err == nil {
+		t.Fatal("expected error for duplicate BDF, got nil")
+	}
+}
+
+func TestValidate_RejectsUnknownBDF(t *testing.T) {
+	// A BDF in the topology that has no matching `devices:` entry
+	// indicates a profile typo. Validate must surface it instead of
+	// quietly rendering an orphan sysfs entry.
+	p := config.Profile{
+		Devices: []config.Device{{Index: 0, PCI: config.PCI{BusID: "0000:07:00.0"}}},
+		PCIeTopology: &config.PCIeTopology{RootComplexes: []config.RootComplex{{
+			ID: "pci0000:00", NUMANode: 0,
+			Devices: []string{"0000:99:00.0"},
+		}}},
+	}
+	if err := p.Validate(); err == nil {
+		t.Fatal("expected error for unknown BDF, got nil")
+	}
+}
+
+func TestEffectiveTopology_DefaultFlatRoot(t *testing.T) {
+	// Profiles that don't carry an explicit `pcie_topology:` block
+	// must still produce a renderable, well-formed tree.
+	p := config.Profile{Devices: []config.Device{
+		{Index: 0, PCI: config.PCI{BusID: "0000:07:00.0"}},
+		{Index: 1, PCI: config.PCI{BusID: "0000:0F:00.0"}},
+	}}
+	topo := p.EffectiveTopology()
+	if topo == nil || len(topo.RootComplexes) != 1 {
+		t.Fatalf("expected single default root, got %+v", topo)
+	}
+	if topo.RootComplexes[0].ID != "pci0000:00" {
+		t.Errorf("default root id = %q want pci0000:00", topo.RootComplexes[0].ID)
+	}
+	if topo.RootComplexes[0].NUMANode != 0 {
+		t.Errorf("default numa_node = %d want 0", topo.RootComplexes[0].NUMANode)
+	}
+	if len(topo.RootComplexes[0].Devices) != 2 {
+		t.Errorf("default root should contain all devices, got %v", topo.RootComplexes[0].Devices)
+	}
+}
+
+func TestEffectiveTopology_PrefersExplicit(t *testing.T) {
+	p := config.Profile{
+		Devices: []config.Device{{Index: 0, PCI: config.PCI{BusID: "0000:07:00.0"}}},
+		PCIeTopology: &config.PCIeTopology{RootComplexes: []config.RootComplex{{
+			ID: "pci0000:80", NUMANode: 1,
+			Devices: []string{"0000:07:00.0"},
+		}}},
+	}
+	topo := p.EffectiveTopology()
+	if topo.RootComplexes[0].ID != "pci0000:80" {
+		t.Errorf("explicit topology lost: %+v", topo)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #263.

The DRA driver and topology-aware schedulers resolve "which PCIe root complex a GPU lives on" (`dra.k8s.io/pcieRoot`) by `readlink()`ing `/sys/bus/pci/devices/<bdf>` and parsing the path. The mock NVML library returned valid PCI BDFs via NVML but produced no corresponding `/sys/bus/pci` tree, so any consumer doing the readlink dance came back empty-handed and could not surface topology hints for scheduling.

This PR closes that gap end-to-end:

### Schema

- New `pcie_topology:` block in every profile (a100, b200, gb200, h100, l40s, t4) describing PCI root complexes, NUMA nodes, and device-to-root mapping.
- Defaults populated for all six profiles:
  | Profile | Root complexes | NUMA nodes | Layout |
  |---|---|---|---|
  | `a100` / `b200` / `h100` / `l40s` | 2 (`pci0000:00`, `pci0000:80`) | 2 (dual socket) | 4 GPUs each |
  | `gb200` | 4 (`pci0000:00`, `:40`, `:80`, `:c0`) | 4 (per Grace pair) | 2 GPUs each |
  | `t4` | 1 (`pci0000:00`) | 1 | 4 GPUs |
- Same block lives in both `pkg/gpu/mocknvml/configs/` and `deployments/.../profiles/`.

### BDF format migration (canonical Linux 4-digit-domain form)

- Profile `bus_id` fields now use `0000:07:00.0` instead of the NVML `busIdLegacy` `00000000:07:00.0`. The bridge already copied the string verbatim into `nvmlPciInfo.busId`, so this aligns with what real Linux PCI sysfs exposes and is a hard prerequisite for the renderer's readlink contract.
- `Validate()` in the schema rejects the legacy 8-digit form **explicitly** so a half-migrated profile fails loudly instead of silently producing a tree the DRA driver can't resolve.
- Default fallback in `engine.go` (used when no YAML is loaded) migrated; tests / docs / nvidia-smi output examples updated (the `nvidia-smi` Bus-Id column intentionally keeps the 8-digit form because that's what real `nvidia-smi` prints).

### Renderer + CLI

New package `pkg/system/mockpcisysfs/` (decoupled from cgo / the engine, same pattern as `pkg/network/mockibsysfs`):

- `config/types.go` — Profile / PCIeTopology / RootComplex schema with `Validate()` (rejects 8-digit BDFs, duplicate root complex IDs, BDFs under multiple roots, BDFs that have no matching `devices:` entry) + `EffectiveTopology()` (flat single-root fallback for profiles without an explicit block).
- `render/render.go` — writes:
  - `<output>/sys/devices/pciDDDD:BB/<bdf>/numa_node`
  - `<output>/sys/bus/pci/devices/<bdf>` → relative symlink `../../../devices/pciDDDD:BB/<bdf>`
  
  Mirrors what the kernel exposes so `EvalSymlinks` lands on the right path. Idempotent: re-renders replace stale symlinks so editing a topology between runs cannot leave a misattributed pcieRoot in place. BDFs lowercased on write to match the kernel.
- `cmd/render-pci-sysfs/` — CLI binary mirroring `render-ib-sysfs`. Supports `--strict` (require explicit `pcie_topology:`) and `--dry-run`.

### DaemonSet wiring

- `Dockerfile` builds the new binary and installs it at `/usr/local/bin/render-pci-sysfs`.
- `setup.sh` invokes it after the IB renderer. Failures are **fatal under `set -e`** for the same reason as the IB block — a typo would silently render an empty/malformed tree that downstream `pcieRoot` attributes would inherit.
- Output lands at `/var/lib/nvml-mock/sys/...` — the canonical hostPath the rest of the nvml-mock plumbing already mounts.

### Tests

- **Schema:** canonical accept, legacy 8-digit BDF reject, malformed root reject, duplicate-BDF reject, unknown-BDF reject, `EffectiveTopology` default + override.
- **Renderer:** full tree end-to-end (verifies the `EvalSymlinks` round-trip the deviceattribute library performs), relative-symlink target shape, idempotent rerender across topology changes, uppercase-BDF normalization, no-op when topology is nil, error when `Output` is empty.
- **Helm unittest:** all 94 tests + 14 snapshots pass after regeneration. The daemonset snapshot diff is driven entirely by the `checksum/config` annotation hashing the new profile content.
- **All existing `pkg/gpu/mocknvml/...` tests still pass** (bridge, engine, fabric).

### Acceptance criteria (from #263)

| Criterion | Status |
|---|---|
| Fix BDF format in profile YAMLs (8-digit -> 4-digit) | ✅ |
| Add `pcie_topology` section with root complex IDs, NUMA nodes, device mappings | ✅ |
| Populate PCIe topology for all profiles (A100, H100, B200, GB200, L40S, T4) | ✅ |
| Go sysfs generator creating symlinks + `numa_node` files from profile data | ✅ |
| Integrate generator into `setup.sh` init container | ✅ |
| Unit tests for sysfs tree structure validation | ✅ |

### Design note on schema placement

The schema lives in `pkg/system/mockpcisysfs/config` rather than being added to the engine's `YAMLConfig` in `pkg/gpu/mocknvml/engine/config_types.go`. This follows the established sidecar pattern from `pkg/network/mockibsysfs/config` (the IB renderer parses its own slice of the profile YAML and the engine's `YAMLConfig` doesn't carry an `Infiniband` field either). Keeping the renderer cgo-free means it builds into a small static binary for the init container.

## Test plan

Local verification on darwin (cross-build host):

- [x] `go test ./pkg/system/mockpcisysfs/... ./cmd/render-pci-sysfs/...` — pass
- [x] `go test ./pkg/gpu/mocknvml/...` — pass (no regressions)
- [x] `go build -mod=vendor ./...` — clean
- [x] `go vet ./pkg/system/mockpcisysfs/... ./cmd/render-pci-sysfs/...` — clean
- [x] `helm unittest deployments/nvml-mock/helm/nvml-mock` — 94/94 tests, 14/14 snapshots pass
- [x] `helm lint deployments/nvml-mock/helm/nvml-mock` — clean
- [x] `render-pci-sysfs --strict --dry-run` against all 12 profile YAMLs — accepts every one (2/2/4/2/2/1 root complexes, 8/8/8/8/8/4 devices respectively)
- [x] Smoke: `render-pci-sysfs --config configs/mock-nvml-config-a100.yaml --output /tmp/pci-test` produces the expected symlinks + `numa_node` files; `EvalSymlinks` of `sys/bus/pci/devices/0000:07:00.0` lands on `sys/devices/pci0000:00/0000:07:00.0`.

CI to verify on Linux:

- [ ] `make docker-build` (multi-arch) — confirm the new binary ships in the image.
- [ ] e2e: DaemonSet starts cleanly on KIND and `kubectl exec ds/nvml-mock -- ls /var/lib/nvml-mock/sys/bus/pci/devices` shows the expected BDFs per profile.
- [ ] DRA driver pointed at the mock surfaces `dra.k8s.io/pcieRoot` on ResourceSlices (follow-up if not in scope of the existing e2e jobs).