### PR TITLE
feat(nvml-mock): add gb300 profile (Grace-Blackwell Ultra Superchip)

### DIFF
--- a/.github/workflows/nvml-mock-e2e.yaml
+++ b/.github/workflows/nvml-mock-e2e.yaml
@@ -37,7 +37,7 @@ on:
       gpu_profiles:
         description: 'GPU profiles to test (JSON array)'
         required: false
-        default: '["a100", "h100", "b200", "gb200", "l40s", "t4"]'
+        default: '["a100", "h100", "b200", "gb200", "gb300", "l40s", "t4"]'
         type: string
 
 jobs:
@@ -58,6 +58,7 @@ jobs:
             h100) echo "gpu-name=NVIDIA H100" >> "$GITHUB_OUTPUT" ;;
             b200) echo "gpu-name=NVIDIA B200" >> "$GITHUB_OUTPUT" ;;
             gb200) echo "gpu-name=NVIDIA GB200" >> "$GITHUB_OUTPUT" ;;
+            gb300) echo "gpu-name=NVIDIA GB300" >> "$GITHUB_OUTPUT" ;;
             l40s) echo "gpu-name=NVIDIA L40S" >> "$GITHUB_OUTPUT" ;;
             t4)   echo "gpu-name=NVIDIA T4" >> "$GITHUB_OUTPUT" ;;
             *)    echo "gpu-name=Unknown" >> "$GITHUB_OUTPUT" ;;
@@ -246,6 +247,7 @@ jobs:
             h100) echo "gpu-name=NVIDIA H100" >> "$GITHUB_OUTPUT" ;;
             b200) echo "gpu-name=NVIDIA B200" >> "$GITHUB_OUTPUT" ;;
             gb200) echo "gpu-name=NVIDIA GB200" >> "$GITHUB_OUTPUT" ;;
+            gb300) echo "gpu-name=NVIDIA GB300" >> "$GITHUB_OUTPUT" ;;
             l40s) echo "gpu-name=NVIDIA L40S" >> "$GITHUB_OUTPUT" ;;
             t4)   echo "gpu-name=NVIDIA T4" >> "$GITHUB_OUTPUT" ;;
             *)    echo "gpu-name=Unknown" >> "$GITHUB_OUTPUT" ;;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- New GPU profile `gb300` modeling the NVIDIA GB300 NVL (Grace-Blackwell
+  Ultra Superchip): 8 GPUs/node arranged as 4 Grace+2×B300 trays, 288 GiB
+  HBM3e per GPU, 1.4 kW default TDP / 1.6 kW boost, PCIe Gen6, NVLink v5
+  with NVLink-C2C to Grace, FP4/FP6/FP8 + Transformer Engine, MIG-capable,
+  and the Blackwell Ultra driver line (`570.124.06`). Ships with a
+  canonical 4-digit-BDF layout and a `pcie_topology:` block describing
+  4 PCI root complexes (one per Grace pair, 2 B300 GPUs each), so the
+  `render-pci-sysfs` step lights up an NVL72-shaped `/sys/bus/pci/devices`
+  tree out of the box. Driver-version derivation, NOTES.txt profile list,
+  fake-gpu-operator ConfigMap fanout, the e2e workflow profile matrix,
+  and Helm unittests / Go profile-consistency tests were all extended to
+  cover `gb300` in lockstep with the existing profiles.
 - nvml-mock PCIe topology: profiles now carry a `pcie_topology:` block
   describing PCI root complexes, NUMA nodes, and device-to-root mapping.
   A new `render-pci-sysfs` binary (built from `cmd/render-pci-sysfs/`,

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ on PRs.
 | **GPU Operator** | Operator components: device plugin + GFD + validator (CDI injection) | A100, H100, T4 |
 | **Multi-Node Fleet** | Cross-node scheduling with heterogeneous GPUs | A100 + T4 |
 
-Manual dispatch supports all 6 profiles: `a100`, `h100`, `b200`, `gb200`, `l40s`, `t4`.
+Manual dispatch supports all 7 profiles: `a100`, `h100`, `b200`, `gb200`, `gb300`, `l40s`, `t4`.
 
 See [`.github/workflows/nvml-mock-e2e.yaml`](.github/workflows/nvml-mock-e2e.yaml) for details.
 

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -476,6 +476,7 @@ nvml-mock-profile-a100            1      10s
 nvml-mock-profile-h100            1      10s
 nvml-mock-profile-b200            1      10s
 nvml-mock-profile-gb200           1      10s
+nvml-mock-profile-gb300           1      10s
 nvml-mock-profile-l40s            1      10s
 nvml-mock-profile-t4              1      10s
 ```
@@ -609,7 +610,7 @@ a flat single-root layout (every device under `pci0000:00`, NUMA 0).
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `gpu.profile` | `a100` | GPU profile: `a100`, `h100`, `b200`, `gb200`, `l40s`, or `t4` |
+| `gpu.profile` | `a100` | GPU profile: `a100`, `h100`, `b200`, `gb200`, `gb300`, `l40s`, or `t4` |
 | `gpu.count` | `8` | Number of mock GPUs per node |
 | `gpu.customConfig` | `""` | Inline YAML to override profile config entirely |
 | `gpu.dynamicMetrics.enabled` | `false` | Make the mock return time-varying temperature / power / utilization readings instead of the static profile values. See [Dynamic Metrics](#dynamic-metrics) below. |
@@ -654,23 +655,24 @@ helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
 
 #### Profile Comparison
 
-| | A100 | H100 | B200 | GB200 | L40S | T4 |
-|---|---|---|---|---|---|---|
-| **Profile name** | `a100` | `h100` | `b200` | `gb200` | `l40s` | `t4` |
-| **Full name** | A100-SXM4-40GB | H100 80GB HBM3 | B200 | GB200 NVL | L40S | Tesla T4 |
-| **Architecture** | Ampere | Hopper | Blackwell | Blackwell | Ada Lovelace | Turing |
-| **Compute capability** | 8.0 | 9.0 | 10.0 | 10.0 | 8.9 | 7.5 |
-| **CUDA cores** | 6,912 | 16,896 | 18,432 | 18,432 | 18,176 | 2,560 |
-| **Memory** | 40 GiB HBM2e | 80 GiB HBM3 | 192 GiB HBM3e | 192 GiB HBM3e | 48 GiB GDDR6 | 16 GiB GDDR6 |
-| **NVLink** | v3, 12 links | v4, 18 links | v5, 18 links | v5, 18 links | — | — |
-| **NVLink BW** | 600 GB/s | 900 GB/s | 1.8 TB/s | 1.8 TB/s | — | — |
-| **TDP** | 400W | 700W | 1,000W | 1,000W | 350W | 70W |
-| **PCIe** | Gen4 | Gen5 | Gen6 | Gen6 | Gen4 | Gen3 |
-| **MIG instances** | 7 | 7 | 7 | 7 | 0 | 0 |
-| **Grace CPU** | — | — | — | Yes (NVLink-C2C) | — | — |
-| **FP8** | — | Yes | Yes | Yes | Yes | — |
-| **FP4** | — | — | Yes | Yes | — | — |
-| **Driver version** | 550.163.01 | 550.163.01 | 560.35.03 | 560.35.03 | 550.163.01 | 550.163.01 |
+| | A100 | H100 | B200 | GB200 | GB300 | L40S | T4 |
+|---|---|---|---|---|---|---|---|
+| **Profile name** | `a100` | `h100` | `b200` | `gb200` | `gb300` | `l40s` | `t4` |
+| **Full name** | A100-SXM4-40GB | H100 80GB HBM3 | B200 | GB200 NVL | GB300 NVL | L40S | Tesla T4 |
+| **Architecture** | Ampere | Hopper | Blackwell | Blackwell | Blackwell Ultra | Ada Lovelace | Turing |
+| **Compute capability** | 8.0 | 9.0 | 10.0 | 10.0 | 10.0 | 8.9 | 7.5 |
+| **CUDA cores** | 6,912 | 16,896 | 18,432 | 18,432 | 21,632 | 18,176 | 2,560 |
+| **Memory** | 40 GiB HBM2e | 80 GiB HBM3 | 192 GiB HBM3e | 192 GiB HBM3e | 288 GiB HBM3e | 48 GiB GDDR6 | 16 GiB GDDR6 |
+| **NVLink** | v3, 12 links | v4, 18 links | v5, 18 links | v5, 18 links | v5, 18 links | — | — |
+| **NVLink BW** | 600 GB/s | 900 GB/s | 1.8 TB/s | 1.8 TB/s | 1.8 TB/s | — | — |
+| **TDP** | 400W | 700W | 1,000W | 1,000W | 1,400W | 350W | 70W |
+| **PCIe** | Gen4 | Gen5 | Gen6 | Gen6 | Gen6 | Gen4 | Gen3 |
+| **MIG instances** | 7 | 7 | 7 | 7 | 7 | 0 | 0 |
+| **Grace CPU** | — | — | — | Yes (NVLink-C2C) | Yes (NVLink-C2C) | — | — |
+| **FP8** | — | Yes | Yes | Yes | Yes | Yes | — |
+| **FP4** | — | — | Yes | Yes | Yes | — | — |
+| **FP6** | — | — | — | — | Yes | — | — |
+| **Driver version** | 550.163.01 | 550.163.01 | 560.35.03 | 560.35.03 | 570.124.06 | 550.163.01 | 550.163.01 |
 
 #### When to Use Each Profile
 
@@ -678,6 +680,7 @@ helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
 - **`h100`** — testing Hopper-specific features: FP8, Transformer Engine, PCIe Gen5, or NVLink v4 topology.
 - **`b200`** — testing next-gen Blackwell features: FP4, NVLink v5, PCIe Gen6. Standalone GPU (no Grace CPU).
 - **`gb200`** — testing Grace-Blackwell Superchip: NVLink-C2C to Grace CPU, unified memory, and Blackwell features.
+- **`gb300`** — testing Grace-Blackwell Ultra Superchip: 288 GiB HBM3e per GPU, 1.4 kW TDP, FP6 in addition to FP4/FP8, and Blackwell Ultra driver line (570.124.06).
 - **`l40s`** — testing Ada Lovelace inference workloads: FP8, PCIe Gen4, no NVLink (PCIe-only topology).
 - **`t4`** — testing Turing inference GPUs: low power (70W), small memory (16 GiB), 4 GPUs per node.
 

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/gb300.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/gb300.yaml
@@ -1,0 +1,480 @@
+# Mock NVML Configuration: GB300 NVL (Grace-Blackwell Ultra Superchip)
+# Full configuration for nvidia-smi -x -q compatibility
+# Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
+
+version: "1.0"
+
+# =============================================================================
+# System-level configuration
+# =============================================================================
+system:
+  driver_version: "570.124.06"
+  nvml_version: "12.570.124.06"
+  cuda_version: "12.8"
+  cuda_version_major: 12
+  cuda_version_minor: 8
+
+# =============================================================================
+# Default device configuration (applied to all devices unless overridden)
+# =============================================================================
+device_defaults:
+  # ---------------------------------------------------------------------------
+  # Basic identification
+  # ---------------------------------------------------------------------------
+  name: "NVIDIA GB300 NVL"
+  brand: "nvidia"
+  serial: "1573041103750"
+  board_part_number: "699-2G530-0300-000"
+  vbios_version: "97.00.41.00.01"
+
+  # ---------------------------------------------------------------------------
+  # Architecture - Blackwell Ultra (still sm_100 family for compute_capability,
+  # but with higher TFLOPS per SM than the standard Blackwell B200/GB200)
+  # ---------------------------------------------------------------------------
+  architecture: "blackwell"
+  compute_capability:
+    major: 10
+    minor: 0
+  num_gpu_cores: 21632             # Blackwell Ultra: more cores than B200/GB200
+
+  # ---------------------------------------------------------------------------
+  # NVLink fabric (GB300 ComputeDomain). The clique_id / cluster_uuid below
+  # are placeholder defaults; the topology-overlay step in the engine
+  # rewrites them per-node based on the cluster-level topology ConfigMap
+  # (set Helm value `topology.enabled=true`). Nodes that don't appear in
+  # the topology fall through to these defaults, which is sufficient for
+  # single-node experiments. See pkg/gpu/mocknvml/engine/fabric.go.
+  # ---------------------------------------------------------------------------
+  fabric:
+    cluster_uuid: "00000000-0000-0000-0000-000000000001"
+    clique_id: 0
+    state: "completed"
+    health_mask: 0
+
+  # ---------------------------------------------------------------------------
+  # InfoROM versions
+  # ---------------------------------------------------------------------------
+  inforom:
+    image_version: "G530.0300.00.01"
+    oem_object: "2.1"
+    ecc_object: "7.20"
+    pwr_object: "1.0"
+
+  # ---------------------------------------------------------------------------
+  # Memory configuration - 288 GiB HBM3e per GPU (1.5x GB200's 192 GiB)
+  # ---------------------------------------------------------------------------
+  memory:
+    total_bytes: 309237645312       # 288 GiB HBM3e
+    reserved_bytes: 1610612736      # ~1.5 GiB reserved
+    free_bytes: 307627032576        # total - reserved at idle
+    used_bytes: 0
+    memory_bus_width: 8192
+
+  bar1_memory:
+    total_bytes: 824633720832       # 768 GiB (unified memory with Grace, grown for B300)
+    free_bytes: 824633720832
+    used_bytes: 0
+
+  # ---------------------------------------------------------------------------
+  # PCI configuration
+  # ---------------------------------------------------------------------------
+  pci:
+    device_id: 0x294110DE           # GB300 NVL (mock placeholder, Blackwell Ultra)
+    subsystem_id: 0x183010DE
+
+  pcie:
+    max_link_gen: 6                 # PCIe Gen6 (or NVLink-C2C to Grace)
+    current_link_gen: 6
+    max_link_width: 16              # x16
+    current_link_width: 16
+    replay_counter: 0
+    tx_throughput_kbps: 0
+    rx_throughput_kbps: 0
+
+  # ---------------------------------------------------------------------------
+  # Power configuration - GB300 is higher TDP than GB200
+  # (B300 GPU alone advertised at up to 1.4 kW; full superchip headroom higher)
+  # ---------------------------------------------------------------------------
+  power:
+    management_supported: true
+    management_mode: "enabled"
+    default_limit_mw: 1400000       # 1400W per B300 GPU
+    enforced_limit_mw: 1400000
+    min_limit_mw: 500000            # 500W minimum
+    max_limit_mw: 1600000           # 1600W boost ceiling
+    current_draw_mw: 175000         # 175W idle (liquid cooled)
+    power_state: "P0"
+    total_energy_consumption_mj: 1000000  # millijoules since boot
+
+  # ---------------------------------------------------------------------------
+  # Thermal configuration (same liquid-cooled envelope as GB200)
+  # ---------------------------------------------------------------------------
+  thermal:
+    temperature_gpu_c: 38           # Idle temperature (liquid cooled)
+    temperature_memory_c: 36
+    shutdown_threshold_c: 95
+    slowdown_threshold_c: 90
+    max_operating_c: 85
+    target_temperature_c: 85
+
+  # ---------------------------------------------------------------------------
+  # Fan configuration (N/A - liquid cooled)
+  # ---------------------------------------------------------------------------
+  fan:
+    count: 0                        # Liquid cooled, no fans
+    speed_percent: "N/A"
+    target_speed_percent: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Clock speeds (MHz) - Blackwell Ultra pushes boost slightly higher
+  # ---------------------------------------------------------------------------
+  clocks:
+    graphics_current: 345           # Idle
+    graphics_max: 2200              # Boost
+    graphics_app: 2200
+    graphics_app_default: 2200
+    sm_current: 345
+    sm_max: 2200
+    memory_current: 2625            # HBM3e 8 Gbps (1.05x GB200's 2500)
+    memory_max: 2625
+    memory_app: 2625
+    memory_app_default: 2625
+    video_current: 1200
+    video_max: 2200
+
+  # ---------------------------------------------------------------------------
+  # Clocks throttle reasons
+  # ---------------------------------------------------------------------------
+  clocks_throttle_reasons:
+    gpu_idle: true
+    applications_clocks_setting: false
+    sw_power_cap: false
+    hw_slowdown: false
+    hw_thermal_slowdown: false
+    hw_power_brake_slowdown: false
+    sync_boost: false
+    sw_thermal_slowdown: false
+    display_clocks_setting: false
+
+  # ---------------------------------------------------------------------------
+  # Supported clocks
+  # ---------------------------------------------------------------------------
+  supported_clocks:
+    memory_clocks:
+      - freq_mhz: 2625
+        graphics_clocks: [345, 690, 1035, 1380, 1725, 1980, 2200]
+
+  # ---------------------------------------------------------------------------
+  # Performance state
+  # ---------------------------------------------------------------------------
+  performance_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Utilization (percentage, 0-100)
+  # ---------------------------------------------------------------------------
+  utilization:
+    gpu: 0
+    memory: 0
+    encoder: 0
+    decoder: 0
+    jpeg: 0
+    ofa: 0
+
+  # ---------------------------------------------------------------------------
+  # Encoder/Decoder statistics
+  # ---------------------------------------------------------------------------
+  encoder_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  fbc_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  # ---------------------------------------------------------------------------
+  # ECC configuration
+  # ---------------------------------------------------------------------------
+  ecc:
+    mode_current: "enabled"
+    mode_pending: "enabled"
+    default_mode: "enabled"
+    errors:
+      volatile:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+      aggregate:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+
+  # ---------------------------------------------------------------------------
+  # Retired pages
+  # ---------------------------------------------------------------------------
+  retired_pages:
+    single_bit_retirement:
+      count: 0
+      addresses: []
+    double_bit_retirement:
+      count: 0
+      addresses: []
+    pending_blacklist: false
+    pending_retirement: false
+
+  # ---------------------------------------------------------------------------
+  # Remapped rows
+  # ---------------------------------------------------------------------------
+  remapped_rows:
+    correctable: 0
+    uncorrectable: 0
+    pending: false
+    failure_occurred: false
+
+  # ---------------------------------------------------------------------------
+  # Display configuration
+  # ---------------------------------------------------------------------------
+  display:
+    mode: "disabled"
+    active: "disabled"
+
+  # ---------------------------------------------------------------------------
+  # Persistence mode
+  # ---------------------------------------------------------------------------
+  persistence_mode: "enabled"
+
+  # ---------------------------------------------------------------------------
+  # Compute mode
+  # ---------------------------------------------------------------------------
+  compute_mode: "default"
+
+  # ---------------------------------------------------------------------------
+  # MIG configuration - GB300 supports MIG
+  # ---------------------------------------------------------------------------
+  mig:
+    mode_current: "disabled"
+    mode_pending: "disabled"
+    max_gpu_instances: 7
+
+  # ---------------------------------------------------------------------------
+  # GPU operation mode (GOM)
+  # ---------------------------------------------------------------------------
+  gpu_operation_mode:
+    current: "all_on"
+    pending: "all_on"
+
+  # ---------------------------------------------------------------------------
+  # Driver model (Windows only)
+  # ---------------------------------------------------------------------------
+  driver_model:
+    current: "N/A"
+    pending: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Accounting mode
+  # ---------------------------------------------------------------------------
+  accounting:
+    mode: "disabled"
+    buffer_size: 4000
+
+  # ---------------------------------------------------------------------------
+  # Virtualization
+  # ---------------------------------------------------------------------------
+  virtualization:
+    mode: "none"
+    host_vgpu_mode: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # GSP Firmware
+  # ---------------------------------------------------------------------------
+  gsp_firmware:
+    mode: "enabled"
+    version: "570.124.06"
+
+  # ---------------------------------------------------------------------------
+  # Blackwell Ultra-specific features
+  # ---------------------------------------------------------------------------
+  features:
+    transformer_engine: true        # 2nd gen Transformer Engine
+    fp4_support: true               # FP4 precision support
+    fp6_support: true               # FP6 precision (Blackwell Ultra)
+    fp8_support: true               # FP8 precision support
+    confidential_compute: true      # CC/TEE support
+    nvlink_c2c: true                # NVLink Chip-to-Chip (Grace connection)
+    decompression_engine: true      # Hardware decompression
+    fifth_gen_tensor_cores: true    # 5th generation tensor cores
+
+  # ---------------------------------------------------------------------------
+  # Grace CPU pairing (GB300 superchip)
+  # ---------------------------------------------------------------------------
+  grace_superchip:
+    enabled: true
+    cpu_cores: 72                   # Grace CPU cores (same Grace as GB200)
+    cpu_memory_gb: 480              # LPDDR5X per Grace CPU
+    coherent_memory: true           # NVLink-C2C coherent memory
+
+  # ---------------------------------------------------------------------------
+  # Processes (empty at idle)
+  # ---------------------------------------------------------------------------
+  processes: []
+
+# =============================================================================
+# Device-specific overrides
+# GB300 NVL72 has 72 GPUs, but we define 8 for testing (4 superchip trays,
+# each with 1 Grace CPU + 2 B300 GPUs, matching the GB200 layout).
+# =============================================================================
+devices:
+  - index: 0
+    uuid: "GPU-b300b300-0000-0000-0000-000000000000"
+    serial: "1573041103700"
+    pci:
+      bus_id: "0000:0A:00.0"
+    minor_number: 0
+    grace_cpu_pair: 0               # Paired with Grace CPU 0
+
+  - index: 1
+    uuid: "GPU-b300b300-0000-0000-0000-000000000001"
+    serial: "1573041103701"
+    pci:
+      bus_id: "0000:0B:00.0"
+    minor_number: 1
+    grace_cpu_pair: 0               # Same superchip as GPU 0
+
+  - index: 2
+    uuid: "GPU-b300b300-0000-0000-0000-000000000002"
+    serial: "1573041103702"
+    pci:
+      bus_id: "0000:4A:00.0"
+    minor_number: 2
+    grace_cpu_pair: 1
+
+  - index: 3
+    uuid: "GPU-b300b300-0000-0000-0000-000000000003"
+    serial: "1573041103703"
+    pci:
+      bus_id: "0000:4B:00.0"
+    minor_number: 3
+    grace_cpu_pair: 1
+
+  - index: 4
+    uuid: "GPU-b300b300-0000-0000-0000-000000000004"
+    serial: "1573041103704"
+    pci:
+      bus_id: "0000:8A:00.0"
+    minor_number: 4
+    grace_cpu_pair: 2
+
+  - index: 5
+    uuid: "GPU-b300b300-0000-0000-0000-000000000005"
+    serial: "1573041103705"
+    pci:
+      bus_id: "0000:8B:00.0"
+    minor_number: 5
+    grace_cpu_pair: 2
+
+  - index: 6
+    uuid: "GPU-b300b300-0000-0000-0000-000000000006"
+    serial: "1573041103706"
+    pci:
+      bus_id: "0000:CA:00.0"
+    minor_number: 6
+    grace_cpu_pair: 3
+
+  - index: 7
+    uuid: "GPU-b300b300-0000-0000-0000-000000000007"
+    serial: "1573041103707"
+    pci:
+      bus_id: "0000:CB:00.0"
+    minor_number: 7
+    grace_cpu_pair: 3
+
+# =============================================================================
+# NVLink topology - GB300 uses NVLink 5.0 (same fabric as GB200)
+# =============================================================================
+nvlink:
+  version: 5
+  links_per_gpu: 18
+  bandwidth_per_link_gbps: 100      # 100 GB/s per link = 1.8 TB/s total per GPU
+  switch_support: true              # NVLink Switch for scale-out
+  switch_count: 0                   # Set for NVL72 configurations (up to 9 switches)
+  c2c_enabled: true                 # NVLink-C2C to Grace CPU
+  # NVLink state per link (18 links)
+  links:
+    - link: 0
+      state: "active"
+      remote_device_type: "gpu"
+      remote_pci_bus_id: "0000:0B:00.0"
+    - link: 1
+      state: "active"
+      remote_device_type: "cpu"     # NVLink-C2C to Grace
+      remote_pci_bus_id: "N/A"
+    # ... define all 18 links for full topology
+
+# =============================================================================
+# InfiniBand topology - 1 ConnectX-7 NDR HCA per GPU (typical GB300 NVL72)
+# =============================================================================
+infiniband:
+  enabled: true
+  hca_type: "MT4129"
+  fw_version: "28.43.1000"
+  hw_rev: "0x0"
+  board_id: "MT_0000000838"
+  link_layer: "InfiniBand"
+  rate_gbps: 400
+  port_state: "ACTIVE"
+  phys_state: "LinkUp"
+  hcas_per_gpu: 1
+  guid_prefix: "9b88c2:0301:cd"
+  node_desc_template: "{node_name} mlx5_{idx}"
+
+# =============================================================================
+# PCIe topology (consumed by render-pci-sysfs to materialize
+# /sys/bus/pci/devices/<bdf> -> ../../../devices/pciDDDD:BB/<bdf> symlinks
+# and per-device numa_node files). Mirrors the GB300 NVL superchip layout:
+# one PCI root complex per Grace+2×B300 tray, NUMA-aligned per tray.
+# =============================================================================
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:0A:00.0"
+        - "0000:0B:00.0"
+    - id: "pci0000:40"
+      numa_node: 1
+      devices:
+        - "0000:4A:00.0"
+        - "0000:4B:00.0"
+    - id: "pci0000:80"
+      numa_node: 2
+      devices:
+        - "0000:8A:00.0"
+        - "0000:8B:00.0"
+    - id: "pci0000:c0"
+      numa_node: 3
+      devices:
+        - "0000:CA:00.0"
+        - "0000:CB:00.0"

--- a/deployments/nvml-mock/helm/nvml-mock/templates/NOTES.txt
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/NOTES.txt
@@ -2,7 +2,7 @@ Mock GPU environment deployed on all nodes!
 
   Profile: {{ .Values.gpu.profile }}
   GPUs per node: {{ .Values.gpu.count }}
-  Available profiles: a100, h100, b200, gb200, l40s, t4
+  Available profiles: a100, h100, b200, gb200, gb300, l40s, t4
   Driver version: {{ include "nvml-mock.driverVersion" . }}
   Mock driver root: /var/lib/nvml-mock/driver
   Mock config: /var/lib/nvml-mock/config/config.yaml

--- a/deployments/nvml-mock/helm/nvml-mock/templates/_helpers.tpl
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/_helpers.tpl
@@ -110,25 +110,30 @@ and key order) or round-trip it through fromYaml/toYaml for overlays.
 {{- .Files.Get "profiles/b200.yaml" }}
 {{- else if eq .Values.gpu.profile "gb200" }}
 {{- .Files.Get "profiles/gb200.yaml" }}
+{{- else if eq .Values.gpu.profile "gb300" }}
+{{- .Files.Get "profiles/gb300.yaml" }}
 {{- else if eq .Values.gpu.profile "l40s" }}
 {{- .Files.Get "profiles/l40s.yaml" }}
 {{- else if eq .Values.gpu.profile "t4" }}
 {{- .Files.Get "profiles/t4.yaml" }}
 {{- else }}
-{{- fail (printf "Unknown GPU profile %q. Supported profiles: a100, h100, b200, gb200, l40s, t4. Or set gpu.customConfig with inline YAML." .Values.gpu.profile) }}
+{{- fail (printf "Unknown GPU profile %q. Supported profiles: a100, h100, b200, gb200, gb300, l40s, t4. Or set gpu.customConfig with inline YAML." .Values.gpu.profile) }}
 {{- end }}
 {{- end }}
 
 {{/*
 Driver version helper.
 Returns the user-provided driverVersion, or derives it from gpu.profile.
-Blackwell profiles (b200, gb200) use 560.35.03; all others use 550.163.01.
+Blackwell profiles (b200, gb200) use 560.35.03; Blackwell Ultra (gb300)
+uses 570.124.06; all others use 550.163.01.
 Note: when gpu.customConfig is set, derivation still uses gpu.profile —
 users with custom configs should set driverVersion explicitly.
 */}}
 {{- define "nvml-mock.driverVersion" -}}
 {{- if .Values.driverVersion -}}
 {{- .Values.driverVersion -}}
+{{- else if eq .Values.gpu.profile "gb300" -}}
+570.124.06
 {{- else if or (eq .Values.gpu.profile "b200") (eq .Values.gpu.profile "gb200") -}}
 560.35.03
 {{- else -}}

--- a/deployments/nvml-mock/helm/nvml-mock/templates/integrations-fgo.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/integrations-fgo.yaml
@@ -1,7 +1,7 @@
 # Copyright 2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 {{- if .Values.integrations.fakeGpuOperator.enabled }}
-{{- $profiles := list "a100" "h100" "b200" "gb200" "l40s" "t4" }}
+{{- $profiles := list "a100" "h100" "b200" "gb200" "gb300" "l40s" "t4" }}
 {{- range $profile := $profiles }}
 {{- $content := $.Files.Get (printf "profiles/%s.yaml" $profile) }}
 {{- if $content }}

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
@@ -1368,6 +1368,500 @@ should match snapshot with gb200 profile:
         app.kubernetes.io/version: 550.163.01
         helm.sh/chart: nvml-mock-0.1.0
       name: RELEASE-NAME-nvml-mock-config
+should match snapshot with gb300 profile:
+  1: |
+    apiVersion: v1
+    data:
+      config.yaml: |
+        # Mock NVML Configuration: GB300 NVL (Grace-Blackwell Ultra Superchip)
+        # Full configuration for nvidia-smi -x -q compatibility
+        # Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
+
+        version: "1.0"
+
+        # =============================================================================
+        # System-level configuration
+        # =============================================================================
+        system:
+          driver_version: "570.124.06"
+          nvml_version: "12.570.124.06"
+          cuda_version: "12.8"
+          cuda_version_major: 12
+          cuda_version_minor: 8
+
+        # =============================================================================
+        # Default device configuration (applied to all devices unless overridden)
+        # =============================================================================
+        device_defaults:
+          # ---------------------------------------------------------------------------
+          # Basic identification
+          # ---------------------------------------------------------------------------
+          name: "NVIDIA GB300 NVL"
+          brand: "nvidia"
+          serial: "1573041103750"
+          board_part_number: "699-2G530-0300-000"
+          vbios_version: "97.00.41.00.01"
+
+          # ---------------------------------------------------------------------------
+          # Architecture - Blackwell Ultra (still sm_100 family for compute_capability,
+          # but with higher TFLOPS per SM than the standard Blackwell B200/GB200)
+          # ---------------------------------------------------------------------------
+          architecture: "blackwell"
+          compute_capability:
+            major: 10
+            minor: 0
+          num_gpu_cores: 21632             # Blackwell Ultra: more cores than B200/GB200
+
+          # ---------------------------------------------------------------------------
+          # NVLink fabric (GB300 ComputeDomain). The clique_id / cluster_uuid below
+          # are placeholder defaults; the topology-overlay step in the engine
+          # rewrites them per-node based on the cluster-level topology ConfigMap
+          # (set Helm value `topology.enabled=true`). Nodes that don't appear in
+          # the topology fall through to these defaults, which is sufficient for
+          # single-node experiments. See pkg/gpu/mocknvml/engine/fabric.go.
+          # ---------------------------------------------------------------------------
+          fabric:
+            cluster_uuid: "00000000-0000-0000-0000-000000000001"
+            clique_id: 0
+            state: "completed"
+            health_mask: 0
+
+          # ---------------------------------------------------------------------------
+          # InfoROM versions
+          # ---------------------------------------------------------------------------
+          inforom:
+            image_version: "G530.0300.00.01"
+            oem_object: "2.1"
+            ecc_object: "7.20"
+            pwr_object: "1.0"
+
+          # ---------------------------------------------------------------------------
+          # Memory configuration - 288 GiB HBM3e per GPU (1.5x GB200's 192 GiB)
+          # ---------------------------------------------------------------------------
+          memory:
+            total_bytes: 309237645312       # 288 GiB HBM3e
+            reserved_bytes: 1610612736      # ~1.5 GiB reserved
+            free_bytes: 307627032576        # total - reserved at idle
+            used_bytes: 0
+            memory_bus_width: 8192
+
+          bar1_memory:
+            total_bytes: 824633720832       # 768 GiB (unified memory with Grace, grown for B300)
+            free_bytes: 824633720832
+            used_bytes: 0
+
+          # ---------------------------------------------------------------------------
+          # PCI configuration
+          # ---------------------------------------------------------------------------
+          pci:
+            device_id: 0x294110DE           # GB300 NVL (mock placeholder, Blackwell Ultra)
+            subsystem_id: 0x183010DE
+
+          pcie:
+            max_link_gen: 6                 # PCIe Gen6 (or NVLink-C2C to Grace)
+            current_link_gen: 6
+            max_link_width: 16              # x16
+            current_link_width: 16
+            replay_counter: 0
+            tx_throughput_kbps: 0
+            rx_throughput_kbps: 0
+
+          # ---------------------------------------------------------------------------
+          # Power configuration - GB300 is higher TDP than GB200
+          # (B300 GPU alone advertised at up to 1.4 kW; full superchip headroom higher)
+          # ---------------------------------------------------------------------------
+          power:
+            management_supported: true
+            management_mode: "enabled"
+            default_limit_mw: 1400000       # 1400W per B300 GPU
+            enforced_limit_mw: 1400000
+            min_limit_mw: 500000            # 500W minimum
+            max_limit_mw: 1600000           # 1600W boost ceiling
+            current_draw_mw: 175000         # 175W idle (liquid cooled)
+            power_state: "P0"
+            total_energy_consumption_mj: 1000000  # millijoules since boot
+
+          # ---------------------------------------------------------------------------
+          # Thermal configuration (same liquid-cooled envelope as GB200)
+          # ---------------------------------------------------------------------------
+          thermal:
+            temperature_gpu_c: 38           # Idle temperature (liquid cooled)
+            temperature_memory_c: 36
+            shutdown_threshold_c: 95
+            slowdown_threshold_c: 90
+            max_operating_c: 85
+            target_temperature_c: 85
+
+          # ---------------------------------------------------------------------------
+          # Fan configuration (N/A - liquid cooled)
+          # ---------------------------------------------------------------------------
+          fan:
+            count: 0                        # Liquid cooled, no fans
+            speed_percent: "N/A"
+            target_speed_percent: "N/A"
+
+          # ---------------------------------------------------------------------------
+          # Clock speeds (MHz) - Blackwell Ultra pushes boost slightly higher
+          # ---------------------------------------------------------------------------
+          clocks:
+            graphics_current: 345           # Idle
+            graphics_max: 2200              # Boost
+            graphics_app: 2200
+            graphics_app_default: 2200
+            sm_current: 345
+            sm_max: 2200
+            memory_current: 2625            # HBM3e 8 Gbps (1.05x GB200's 2500)
+            memory_max: 2625
+            memory_app: 2625
+            memory_app_default: 2625
+            video_current: 1200
+            video_max: 2200
+
+          # ---------------------------------------------------------------------------
+          # Clocks throttle reasons
+          # ---------------------------------------------------------------------------
+          clocks_throttle_reasons:
+            gpu_idle: true
+            applications_clocks_setting: false
+            sw_power_cap: false
+            hw_slowdown: false
+            hw_thermal_slowdown: false
+            hw_power_brake_slowdown: false
+            sync_boost: false
+            sw_thermal_slowdown: false
+            display_clocks_setting: false
+
+          # ---------------------------------------------------------------------------
+          # Supported clocks
+          # ---------------------------------------------------------------------------
+          supported_clocks:
+            memory_clocks:
+              - freq_mhz: 2625
+                graphics_clocks: [345, 690, 1035, 1380, 1725, 1980, 2200]
+
+          # ---------------------------------------------------------------------------
+          # Performance state
+          # ---------------------------------------------------------------------------
+          performance_state: "P0"
+
+          # ---------------------------------------------------------------------------
+          # Utilization (percentage, 0-100)
+          # ---------------------------------------------------------------------------
+          utilization:
+            gpu: 0
+            memory: 0
+            encoder: 0
+            decoder: 0
+            jpeg: 0
+            ofa: 0
+
+          # ---------------------------------------------------------------------------
+          # Encoder/Decoder statistics
+          # ---------------------------------------------------------------------------
+          encoder_stats:
+            session_count: 0
+            average_fps: 0
+            average_latency_us: 0
+
+          fbc_stats:
+            session_count: 0
+            average_fps: 0
+            average_latency_us: 0
+
+          # ---------------------------------------------------------------------------
+          # ECC configuration
+          # ---------------------------------------------------------------------------
+          ecc:
+            mode_current: "enabled"
+            mode_pending: "enabled"
+            default_mode: "enabled"
+            errors:
+              volatile:
+                single_bit:
+                  device_memory: 0
+                  l1_cache: 0
+                  l2_cache: 0
+                  register_file: 0
+                  texture_memory: 0
+                  total: 0
+                double_bit:
+                  device_memory: 0
+                  l1_cache: 0
+                  l2_cache: 0
+                  register_file: 0
+                  texture_memory: 0
+                  total: 0
+              aggregate:
+                single_bit:
+                  device_memory: 0
+                  l1_cache: 0
+                  l2_cache: 0
+                  register_file: 0
+                  texture_memory: 0
+                  total: 0
+                double_bit:
+                  device_memory: 0
+                  l1_cache: 0
+                  l2_cache: 0
+                  register_file: 0
+                  texture_memory: 0
+                  total: 0
+
+          # ---------------------------------------------------------------------------
+          # Retired pages
+          # ---------------------------------------------------------------------------
+          retired_pages:
+            single_bit_retirement:
+              count: 0
+              addresses: []
+            double_bit_retirement:
+              count: 0
+              addresses: []
+            pending_blacklist: false
+            pending_retirement: false
+
+          # ---------------------------------------------------------------------------
+          # Remapped rows
+          # ---------------------------------------------------------------------------
+          remapped_rows:
+            correctable: 0
+            uncorrectable: 0
+            pending: false
+            failure_occurred: false
+
+          # ---------------------------------------------------------------------------
+          # Display configuration
+          # ---------------------------------------------------------------------------
+          display:
+            mode: "disabled"
+            active: "disabled"
+
+          # ---------------------------------------------------------------------------
+          # Persistence mode
+          # ---------------------------------------------------------------------------
+          persistence_mode: "enabled"
+
+          # ---------------------------------------------------------------------------
+          # Compute mode
+          # ---------------------------------------------------------------------------
+          compute_mode: "default"
+
+          # ---------------------------------------------------------------------------
+          # MIG configuration - GB300 supports MIG
+          # ---------------------------------------------------------------------------
+          mig:
+            mode_current: "disabled"
+            mode_pending: "disabled"
+            max_gpu_instances: 7
+
+          # ---------------------------------------------------------------------------
+          # GPU operation mode (GOM)
+          # ---------------------------------------------------------------------------
+          gpu_operation_mode:
+            current: "all_on"
+            pending: "all_on"
+
+          # ---------------------------------------------------------------------------
+          # Driver model (Windows only)
+          # ---------------------------------------------------------------------------
+          driver_model:
+            current: "N/A"
+            pending: "N/A"
+
+          # ---------------------------------------------------------------------------
+          # Accounting mode
+          # ---------------------------------------------------------------------------
+          accounting:
+            mode: "disabled"
+            buffer_size: 4000
+
+          # ---------------------------------------------------------------------------
+          # Virtualization
+          # ---------------------------------------------------------------------------
+          virtualization:
+            mode: "none"
+            host_vgpu_mode: "N/A"
+
+          # ---------------------------------------------------------------------------
+          # GSP Firmware
+          # ---------------------------------------------------------------------------
+          gsp_firmware:
+            mode: "enabled"
+            version: "570.124.06"
+
+          # ---------------------------------------------------------------------------
+          # Blackwell Ultra-specific features
+          # ---------------------------------------------------------------------------
+          features:
+            transformer_engine: true        # 2nd gen Transformer Engine
+            fp4_support: true               # FP4 precision support
+            fp6_support: true               # FP6 precision (Blackwell Ultra)
+            fp8_support: true               # FP8 precision support
+            confidential_compute: true      # CC/TEE support
+            nvlink_c2c: true                # NVLink Chip-to-Chip (Grace connection)
+            decompression_engine: true      # Hardware decompression
+            fifth_gen_tensor_cores: true    # 5th generation tensor cores
+
+          # ---------------------------------------------------------------------------
+          # Grace CPU pairing (GB300 superchip)
+          # ---------------------------------------------------------------------------
+          grace_superchip:
+            enabled: true
+            cpu_cores: 72                   # Grace CPU cores (same Grace as GB200)
+            cpu_memory_gb: 480              # LPDDR5X per Grace CPU
+            coherent_memory: true           # NVLink-C2C coherent memory
+
+          # ---------------------------------------------------------------------------
+          # Processes (empty at idle)
+          # ---------------------------------------------------------------------------
+          processes: []
+
+        # =============================================================================
+        # Device-specific overrides
+        # GB300 NVL72 has 72 GPUs, but we define 8 for testing (4 superchip trays,
+        # each with 1 Grace CPU + 2 B300 GPUs, matching the GB200 layout).
+        # =============================================================================
+        devices:
+          - index: 0
+            uuid: "GPU-b300b300-0000-0000-0000-000000000000"
+            serial: "1573041103700"
+            pci:
+              bus_id: "0000:0A:00.0"
+            minor_number: 0
+            grace_cpu_pair: 0               # Paired with Grace CPU 0
+
+          - index: 1
+            uuid: "GPU-b300b300-0000-0000-0000-000000000001"
+            serial: "1573041103701"
+            pci:
+              bus_id: "0000:0B:00.0"
+            minor_number: 1
+            grace_cpu_pair: 0               # Same superchip as GPU 0
+
+          - index: 2
+            uuid: "GPU-b300b300-0000-0000-0000-000000000002"
+            serial: "1573041103702"
+            pci:
+              bus_id: "0000:4A:00.0"
+            minor_number: 2
+            grace_cpu_pair: 1
+
+          - index: 3
+            uuid: "GPU-b300b300-0000-0000-0000-000000000003"
+            serial: "1573041103703"
+            pci:
+              bus_id: "0000:4B:00.0"
+            minor_number: 3
+            grace_cpu_pair: 1
+
+          - index: 4
+            uuid: "GPU-b300b300-0000-0000-0000-000000000004"
+            serial: "1573041103704"
+            pci:
+              bus_id: "0000:8A:00.0"
+            minor_number: 4
+            grace_cpu_pair: 2
+
+          - index: 5
+            uuid: "GPU-b300b300-0000-0000-0000-000000000005"
+            serial: "1573041103705"
+            pci:
+              bus_id: "0000:8B:00.0"
+            minor_number: 5
+            grace_cpu_pair: 2
+
+          - index: 6
+            uuid: "GPU-b300b300-0000-0000-0000-000000000006"
+            serial: "1573041103706"
+            pci:
+              bus_id: "0000:CA:00.0"
+            minor_number: 6
+            grace_cpu_pair: 3
+
+          - index: 7
+            uuid: "GPU-b300b300-0000-0000-0000-000000000007"
+            serial: "1573041103707"
+            pci:
+              bus_id: "0000:CB:00.0"
+            minor_number: 7
+            grace_cpu_pair: 3
+
+        # =============================================================================
+        # NVLink topology - GB300 uses NVLink 5.0 (same fabric as GB200)
+        # =============================================================================
+        nvlink:
+          version: 5
+          links_per_gpu: 18
+          bandwidth_per_link_gbps: 100      # 100 GB/s per link = 1.8 TB/s total per GPU
+          switch_support: true              # NVLink Switch for scale-out
+          switch_count: 0                   # Set for NVL72 configurations (up to 9 switches)
+          c2c_enabled: true                 # NVLink-C2C to Grace CPU
+          # NVLink state per link (18 links)
+          links:
+            - link: 0
+              state: "active"
+              remote_device_type: "gpu"
+              remote_pci_bus_id: "0000:0B:00.0"
+            - link: 1
+              state: "active"
+              remote_device_type: "cpu"     # NVLink-C2C to Grace
+              remote_pci_bus_id: "N/A"
+            # ... define all 18 links for full topology
+
+        # =============================================================================
+        # InfiniBand topology - 1 ConnectX-7 NDR HCA per GPU (typical GB300 NVL72)
+        # =============================================================================
+        infiniband:
+          enabled: true
+          hca_type: "MT4129"
+          fw_version: "28.43.1000"
+          hw_rev: "0x0"
+          board_id: "MT_0000000838"
+          link_layer: "InfiniBand"
+          rate_gbps: 400
+          port_state: "ACTIVE"
+          phys_state: "LinkUp"
+          hcas_per_gpu: 1
+          guid_prefix: "9b88c2:0301:cd"
+          node_desc_template: "{node_name} mlx5_{idx}"
+
+        # =============================================================================
+        # PCIe topology (consumed by render-pci-sysfs to materialize
+        # /sys/bus/pci/devices/<bdf> -> ../../../devices/pciDDDD:BB/<bdf> symlinks
+        # and per-device numa_node files). Mirrors the GB300 NVL superchip layout:
+        # one PCI root complex per Grace+2×B300 tray, NUMA-aligned per tray.
+        # =============================================================================
+        pcie_topology:
+          root_complexes:
+            - id: "pci0000:00"
+              numa_node: 0
+              devices:
+                - "0000:0A:00.0"
+                - "0000:0B:00.0"
+            - id: "pci0000:40"
+              numa_node: 1
+              devices:
+                - "0000:4A:00.0"
+                - "0000:4B:00.0"
+            - id: "pci0000:80"
+              numa_node: 2
+              devices:
+                - "0000:8A:00.0"
+                - "0000:8B:00.0"
+            - id: "pci0000:c0"
+              numa_node: 3
+              devices:
+                - "0000:CA:00.0"
+                - "0000:CB:00.0"
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: nvml-mock
+        app.kubernetes.io/version: 550.163.01
+        helm.sh/chart: nvml-mock-0.1.0
+      name: RELEASE-NAME-nvml-mock-config
 should match snapshot with h100 profile:
   1: |
     apiVersion: v1

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/notes_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/notes_test.yaml.snap
@@ -5,7 +5,7 @@ should match snapshot with b200 profile:
 
         Profile: b200
         GPUs per node: 4
-        Available profiles: a100, h100, b200, gb200, l40s, t4
+        Available profiles: a100, h100, b200, gb200, gb300, l40s, t4
         Driver version: 560.35.03
         Mock driver root: /var/lib/nvml-mock/driver
         Mock config: /var/lib/nvml-mock/config/config.yaml
@@ -75,7 +75,7 @@ should match snapshot with default values:
 
         Profile: a100
         GPUs per node: 8
-        Available profiles: a100, h100, b200, gb200, l40s, t4
+        Available profiles: a100, h100, b200, gb200, gb300, l40s, t4
         Driver version: 550.163.01
         Mock driver root: /var/lib/nvml-mock/driver
         Mock config: /var/lib/nvml-mock/config/config.yaml

--- a/deployments/nvml-mock/helm/nvml-mock/tests/configmap_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/configmap_test.yaml
@@ -36,6 +36,14 @@ tests:
     asserts:
       - matchSnapshot: {}
 
+  - it: should match snapshot with gb300 profile
+    set:
+      gpu:
+        profile: gb300
+        count: 8
+    asserts:
+      - matchSnapshot: {}
+
   - it: should match snapshot with l40s profile
     set:
       gpu:
@@ -129,6 +137,19 @@ tests:
           path: data["config.yaml"]
           pattern: "architecture: .blackwell."
 
+  - it: should load gb300 profile
+    set:
+      gpu:
+        profile: gb300
+        count: 8
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "NVIDIA GB300"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "architecture: .blackwell."
+
   - it: should load l40s profile
     set:
       gpu:
@@ -195,7 +216,7 @@ tests:
         count: 1
     asserts:
       - failedTemplate:
-          errorMessage: 'Unknown GPU profile "invalid-gpu". Supported profiles: a100, h100, b200, gb200, l40s, t4. Or set gpu.customConfig with inline YAML.'
+          errorMessage: 'Unknown GPU profile "invalid-gpu". Supported profiles: a100, h100, b200, gb200, gb300, l40s, t4. Or set gpu.customConfig with inline YAML.'
 
   - it: should respect fullnameOverride in ConfigMap name
     set:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -165,6 +165,18 @@ tests:
             name: DRIVER_VERSION
             value: "560.35.03"
 
+  - it: should derive Blackwell Ultra driver version for gb300 profile
+    set:
+      gpu:
+        profile: gb300
+        count: 8
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DRIVER_VERSION
+            value: "570.124.06"
+
   - it: should use explicit driverVersion when provided
     set:
       driverVersion: "999.99.99"

--- a/deployments/nvml-mock/helm/nvml-mock/tests/notes_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/notes_test.yaml
@@ -49,6 +49,15 @@ tests:
       - matchRegexRaw:
           pattern: "Driver version: 560.35.03"
 
+  - it: should render Blackwell Ultra driver version for gb300
+    set:
+      gpu:
+        profile: gb300
+        count: 8
+    asserts:
+      - matchRegexRaw:
+          pattern: "Driver version: 570.124.06"
+
   - it: should render explicit driver version
     set:
       driverVersion: "999.99.99"
@@ -59,7 +68,7 @@ tests:
   - it: should list available profiles
     asserts:
       - matchRegexRaw:
-          pattern: "a100, h100, b200, gb200, l40s, t4"
+          pattern: "a100, h100, b200, gb200, gb300, l40s, t4"
 
   - it: should contain all three option sections
     asserts:

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 gpu:
-  profile: a100           # a100 | h100 | b200 | gb200 | l40s | t4
+  profile: a100           # a100 | h100 | b200 | gb200 | gb300 | l40s | t4
   count: 8
   customConfig: ""
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Linux system -- no hardware required.
 | `h100` | H100 80GB HBM3 | 80 GiB | Hopper |
 | `b200` | B200 | 192 GiB | Blackwell |
 | `gb200` | GB200 | 192 GiB | Blackwell |
+| `gb300` | GB300 NVL | 288 GiB | Blackwell Ultra |
 | `l40s` | L40S | 48 GiB | Ada Lovelace |
 | `t4` | Tesla T4 | 16 GiB | Turing |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -326,6 +326,7 @@ pkg/gpu/mocknvml/
 │   ├── mock-nvml-config-a100.yaml
 │   ├── mock-nvml-config-b200.yaml
 │   ├── mock-nvml-config-gb200.yaml
+│   ├── mock-nvml-config-gb300.yaml
 │   ├── mock-nvml-config-h100.yaml
 │   ├── mock-nvml-config-l40s.yaml
 │   └── mock-nvml-config-t4.yaml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -357,6 +357,7 @@ Standalone configuration files are provided for each supported GPU model:
 | `pkg/gpu/mocknvml/configs/mock-nvml-config-h100.yaml` | NVIDIA H100 80GB HBM3 | 80 GiB | Hopper |
 | `pkg/gpu/mocknvml/configs/mock-nvml-config-b200.yaml` | NVIDIA B200 | 192 GiB | Blackwell |
 | `pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml` | NVIDIA GB200 NVL | 192 GiB | Blackwell |
+| `pkg/gpu/mocknvml/configs/mock-nvml-config-gb300.yaml` | NVIDIA GB300 NVL | 288 GiB | Blackwell Ultra |
 | `pkg/gpu/mocknvml/configs/mock-nvml-config-l40s.yaml` | NVIDIA L40S | 48 GiB | Ada Lovelace |
 | `pkg/gpu/mocknvml/configs/mock-nvml-config-t4.yaml` | NVIDIA T4 | 16 GiB | Turing |
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -36,6 +36,7 @@ pkg/gpu/mocknvml/
 │   ├── mock-nvml-config-a100.yaml
 │   ├── mock-nvml-config-b200.yaml
 │   ├── mock-nvml-config-gb200.yaml
+│   ├── mock-nvml-config-gb300.yaml
 │   ├── mock-nvml-config-h100.yaml
 │   ├── mock-nvml-config-l40s.yaml
 │   └── mock-nvml-config-t4.yaml

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -24,6 +24,12 @@ LD_LIBRARY_PATH=. MOCK_NVML_CONFIG=configs/mock-nvml-config-a100.yaml nvidia-smi
 LD_LIBRARY_PATH=. MOCK_NVML_CONFIG=configs/mock-nvml-config-gb200.yaml nvidia-smi
 ```
 
+### With GB300 YAML Profile
+
+```bash
+LD_LIBRARY_PATH=. MOCK_NVML_CONFIG=configs/mock-nvml-config-gb300.yaml nvidia-smi
+```
+
 ## nvidia-smi Commands
 
 ### List GPUs

--- a/docs/integrations/fake-gpu-operator.md
+++ b/docs/integrations/fake-gpu-operator.md
@@ -133,6 +133,7 @@ The following profiles are created by default:
 | `nvml-mock-profile-h100` | NVIDIA H100 80GB HBM3 | 80 GiB |
 | `nvml-mock-profile-b200` | NVIDIA B200 | 192 GiB |
 | `nvml-mock-profile-gb200` | NVIDIA GB200 NVL | 192 GiB |
+| `nvml-mock-profile-gb300` | NVIDIA GB300 NVL | 288 GiB |
 | `nvml-mock-profile-l40s` | NVIDIA L40S | 48 GiB |
 | `nvml-mock-profile-t4` | NVIDIA T4 | 16 GiB |
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -41,6 +41,9 @@ LD_LIBRARY_PATH=. MOCK_NVML_CONFIG=configs/mock-nvml-config-a100.yaml nvidia-smi
 
 # GB200 profile (192GB, 1000W)
 LD_LIBRARY_PATH=. MOCK_NVML_CONFIG=configs/mock-nvml-config-gb200.yaml nvidia-smi
+
+# GB300 profile (288GB, 1400W, Blackwell Ultra)
+LD_LIBRARY_PATH=. MOCK_NVML_CONFIG=configs/mock-nvml-config-gb300.yaml nvidia-smi
 ```
 
 ## Option 2: Docker Build (Cross-Platform)

--- a/pkg/gpu/mocknvml/README.md
+++ b/pkg/gpu/mocknvml/README.md
@@ -31,6 +31,9 @@ LD_LIBRARY_PATH=. MOCK_NVML_CONFIG=configs/mock-nvml-config-a100.yaml nvidia-smi
 
 # 3. GB200 profile (8x GB200 NVL, 192GB, 1000W)
 LD_LIBRARY_PATH=. MOCK_NVML_CONFIG=configs/mock-nvml-config-gb200.yaml nvidia-smi
+
+# 4. GB300 profile (8x GB300 NVL Blackwell Ultra, 288GB, 1400W)
+LD_LIBRARY_PATH=. MOCK_NVML_CONFIG=configs/mock-nvml-config-gb300.yaml nvidia-smi
 ```
 
 ### Docker Build (Cross-platform)
@@ -80,6 +83,7 @@ YAML configs allow full control over GPU properties. See `configs/` for examples
 - `mock-nvml-config-h100.yaml` - HGX H100 (8x H100 80GB HBM3)
 - `mock-nvml-config-b200.yaml` - B200 (8x B200, 192 GiB HBM3e)
 - `mock-nvml-config-gb200.yaml` - GB200 NVL (8x GB200 with 192 GiB HBM3e)
+- `mock-nvml-config-gb300.yaml` - GB300 NVL (8x Blackwell Ultra with 288 GiB HBM3e, 1.4 kW TDP)
 - `mock-nvml-config-l40s.yaml` - L40S (8x L40S, 48 GiB)
 - `mock-nvml-config-t4.yaml` - T4 (8x T4, 16 GiB)
 
@@ -459,6 +463,7 @@ pkg/gpu/mocknvml/
 │   ├── mock-nvml-config-a100.yaml
 │   ├── mock-nvml-config-b200.yaml
 │   ├── mock-nvml-config-gb200.yaml
+│   ├── mock-nvml-config-gb300.yaml
 │   ├── mock-nvml-config-h100.yaml
 │   ├── mock-nvml-config-l40s.yaml
 │   └── mock-nvml-config-t4.yaml

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-gb300.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-gb300.yaml
@@ -1,0 +1,447 @@
+# Mock NVML Configuration: GB300 NVL (Grace-Blackwell Ultra Superchip)
+# Full configuration for nvidia-smi -x -q compatibility
+# Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
+
+version: "1.0"
+
+# =============================================================================
+# System-level configuration
+# =============================================================================
+system:
+  driver_version: "570.124.06"
+  nvml_version: "12.570.124.06"
+  cuda_version: "12.8"
+  cuda_version_major: 12
+  cuda_version_minor: 8
+
+# =============================================================================
+# Default device configuration (applied to all devices unless overridden)
+# =============================================================================
+device_defaults:
+  # ---------------------------------------------------------------------------
+  # Basic identification
+  # ---------------------------------------------------------------------------
+  name: "NVIDIA GB300 NVL"
+  brand: "nvidia"
+  serial: "1573041103750"
+  board_part_number: "699-2G530-0300-000"
+  vbios_version: "97.00.41.00.01"
+
+  # ---------------------------------------------------------------------------
+  # Architecture - Blackwell Ultra (still sm_100 family for compute_capability,
+  # but with higher TFLOPS per SM than the standard Blackwell B200/GB200)
+  # ---------------------------------------------------------------------------
+  architecture: "blackwell"
+  compute_capability:
+    major: 10
+    minor: 0
+  num_gpu_cores: 21632             # Blackwell Ultra: more cores than B200/GB200
+
+  # ---------------------------------------------------------------------------
+  # InfoROM versions
+  # ---------------------------------------------------------------------------
+  inforom:
+    image_version: "G530.0300.00.01"
+    oem_object: "2.1"
+    ecc_object: "7.20"
+    pwr_object: "1.0"
+
+  # ---------------------------------------------------------------------------
+  # Memory configuration - 288 GiB HBM3e per GPU (1.5x GB200's 192 GiB)
+  # ---------------------------------------------------------------------------
+  memory:
+    total_bytes: 309237645312       # 288 GiB HBM3e
+    reserved_bytes: 1610612736      # ~1.5 GiB reserved
+    free_bytes: 307627032576        # total - reserved at idle
+    used_bytes: 0
+
+  bar1_memory:
+    total_bytes: 824633720832       # 768 GiB (unified memory with Grace, grown for B300)
+    free_bytes: 824633720832
+    used_bytes: 0
+
+  # ---------------------------------------------------------------------------
+  # PCI configuration
+  # ---------------------------------------------------------------------------
+  pci:
+    device_id: 0x294110DE           # GB300 NVL (mock placeholder, Blackwell Ultra)
+    subsystem_id: 0x183010DE
+
+  pcie:
+    max_link_gen: 6                 # PCIe Gen6 (or NVLink-C2C to Grace)
+    current_link_gen: 6
+    max_link_width: 16              # x16
+    current_link_width: 16
+    replay_counter: 0
+    tx_throughput_kbps: 0
+    rx_throughput_kbps: 0
+
+  # ---------------------------------------------------------------------------
+  # Power configuration - GB300 is higher TDP than GB200
+  # (B300 GPU alone advertised at up to 1.4 kW; full superchip headroom higher)
+  # ---------------------------------------------------------------------------
+  power:
+    management_supported: true
+    management_mode: "enabled"
+    default_limit_mw: 1400000       # 1400W per B300 GPU
+    enforced_limit_mw: 1400000
+    min_limit_mw: 500000            # 500W minimum
+    max_limit_mw: 1600000           # 1600W boost ceiling
+    current_draw_mw: 175000         # 175W idle (liquid cooled)
+    power_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Thermal configuration (same liquid-cooled envelope as GB200)
+  # ---------------------------------------------------------------------------
+  thermal:
+    temperature_gpu_c: 38           # Idle temperature (liquid cooled)
+    temperature_memory_c: 36
+    shutdown_threshold_c: 95
+    slowdown_threshold_c: 90
+    max_operating_c: 85
+    target_temperature_c: 85
+
+  # ---------------------------------------------------------------------------
+  # Fan configuration (N/A - liquid cooled)
+  # ---------------------------------------------------------------------------
+  fan:
+    count: 0                        # Liquid cooled, no fans
+    speed_percent: "N/A"
+    target_speed_percent: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Clock speeds (MHz) - Blackwell Ultra pushes boost slightly higher
+  # ---------------------------------------------------------------------------
+  clocks:
+    graphics_current: 345           # Idle
+    graphics_max: 2200              # Boost
+    graphics_app: 2200
+    graphics_app_default: 2200
+    sm_current: 345
+    sm_max: 2200
+    memory_current: 2625            # HBM3e 8 Gbps (1.05x GB200's 2500)
+    memory_max: 2625
+    memory_app: 2625
+    memory_app_default: 2625
+    video_current: 1200
+    video_max: 2200
+
+  # ---------------------------------------------------------------------------
+  # Clocks throttle reasons
+  # ---------------------------------------------------------------------------
+  clocks_throttle_reasons:
+    gpu_idle: true
+    applications_clocks_setting: false
+    sw_power_cap: false
+    hw_slowdown: false
+    hw_thermal_slowdown: false
+    hw_power_brake_slowdown: false
+    sync_boost: false
+    sw_thermal_slowdown: false
+    display_clocks_setting: false
+
+  # ---------------------------------------------------------------------------
+  # Supported clocks
+  # ---------------------------------------------------------------------------
+  supported_clocks:
+    memory_clocks:
+      - freq_mhz: 2625
+        graphics_clocks: [345, 690, 1035, 1380, 1725, 1980, 2200]
+
+  # ---------------------------------------------------------------------------
+  # Performance state
+  # ---------------------------------------------------------------------------
+  performance_state: "P0"
+
+  # ---------------------------------------------------------------------------
+  # Utilization (percentage, 0-100)
+  # ---------------------------------------------------------------------------
+  utilization:
+    gpu: 0
+    memory: 0
+    encoder: 0
+    decoder: 0
+    jpeg: 0
+    ofa: 0
+
+  # ---------------------------------------------------------------------------
+  # Encoder/Decoder statistics
+  # ---------------------------------------------------------------------------
+  encoder_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  fbc_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  # ---------------------------------------------------------------------------
+  # ECC configuration
+  # ---------------------------------------------------------------------------
+  ecc:
+    mode_current: "enabled"
+    mode_pending: "enabled"
+    default_mode: "enabled"
+    errors:
+      volatile:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+      aggregate:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+
+  # ---------------------------------------------------------------------------
+  # Retired pages
+  # ---------------------------------------------------------------------------
+  retired_pages:
+    single_bit_retirement:
+      count: 0
+      addresses: []
+    double_bit_retirement:
+      count: 0
+      addresses: []
+    pending_blacklist: false
+    pending_retirement: false
+
+  # ---------------------------------------------------------------------------
+  # Remapped rows
+  # ---------------------------------------------------------------------------
+  remapped_rows:
+    correctable: 0
+    uncorrectable: 0
+    pending: false
+    failure_occurred: false
+
+  # ---------------------------------------------------------------------------
+  # Display configuration
+  # ---------------------------------------------------------------------------
+  display:
+    mode: "disabled"
+    active: "disabled"
+
+  # ---------------------------------------------------------------------------
+  # Persistence mode
+  # ---------------------------------------------------------------------------
+  persistence_mode: "enabled"
+
+  # ---------------------------------------------------------------------------
+  # Compute mode
+  # ---------------------------------------------------------------------------
+  compute_mode: "default"
+
+  # ---------------------------------------------------------------------------
+  # MIG configuration - GB300 supports MIG
+  # ---------------------------------------------------------------------------
+  mig:
+    mode_current: "disabled"
+    mode_pending: "disabled"
+    max_gpu_instances: 7
+
+  # ---------------------------------------------------------------------------
+  # GPU operation mode (GOM)
+  # ---------------------------------------------------------------------------
+  gpu_operation_mode:
+    current: "all_on"
+    pending: "all_on"
+
+  # ---------------------------------------------------------------------------
+  # Driver model (Windows only)
+  # ---------------------------------------------------------------------------
+  driver_model:
+    current: "N/A"
+    pending: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Accounting mode
+  # ---------------------------------------------------------------------------
+  accounting:
+    mode: "disabled"
+    buffer_size: 4000
+
+  # ---------------------------------------------------------------------------
+  # Virtualization
+  # ---------------------------------------------------------------------------
+  virtualization:
+    mode: "none"
+    host_vgpu_mode: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # GSP Firmware
+  # ---------------------------------------------------------------------------
+  gsp_firmware:
+    mode: "enabled"
+    version: "570.124.06"
+
+  # ---------------------------------------------------------------------------
+  # Blackwell Ultra-specific features
+  # ---------------------------------------------------------------------------
+  features:
+    transformer_engine: true        # 2nd gen Transformer Engine
+    fp4_support: true               # FP4 precision support
+    fp6_support: true               # FP6 precision (Blackwell Ultra)
+    fp8_support: true               # FP8 precision support
+    confidential_compute: true      # CC/TEE support
+    nvlink_c2c: true                # NVLink Chip-to-Chip (Grace connection)
+    decompression_engine: true      # Hardware decompression
+    fifth_gen_tensor_cores: true    # 5th generation tensor cores
+
+  # ---------------------------------------------------------------------------
+  # Grace CPU pairing (GB300 superchip)
+  # ---------------------------------------------------------------------------
+  grace_superchip:
+    enabled: true
+    cpu_cores: 72                   # Grace CPU cores (same Grace as GB200)
+    cpu_memory_gb: 480              # LPDDR5X per Grace CPU
+    coherent_memory: true           # NVLink-C2C coherent memory
+
+  # ---------------------------------------------------------------------------
+  # Processes (empty at idle)
+  # ---------------------------------------------------------------------------
+  processes: []
+
+# =============================================================================
+# Device-specific overrides
+# GB300 NVL72 has 72 GPUs, but we define 8 for testing (4 superchip trays,
+# each with 1 Grace CPU + 2 B300 GPUs, matching the GB200 layout).
+# =============================================================================
+devices:
+  - index: 0
+    uuid: "GPU-b300b300-0000-0000-0000-000000000000"
+    serial: "1573041103700"
+    pci:
+      bus_id: "0000:0A:00.0"
+    minor_number: 0
+    grace_cpu_pair: 0               # Paired with Grace CPU 0
+
+  - index: 1
+    uuid: "GPU-b300b300-0000-0000-0000-000000000001"
+    serial: "1573041103701"
+    pci:
+      bus_id: "0000:0B:00.0"
+    minor_number: 1
+    grace_cpu_pair: 0               # Same superchip as GPU 0
+
+  - index: 2
+    uuid: "GPU-b300b300-0000-0000-0000-000000000002"
+    serial: "1573041103702"
+    pci:
+      bus_id: "0000:4A:00.0"
+    minor_number: 2
+    grace_cpu_pair: 1
+
+  - index: 3
+    uuid: "GPU-b300b300-0000-0000-0000-000000000003"
+    serial: "1573041103703"
+    pci:
+      bus_id: "0000:4B:00.0"
+    minor_number: 3
+    grace_cpu_pair: 1
+
+  - index: 4
+    uuid: "GPU-b300b300-0000-0000-0000-000000000004"
+    serial: "1573041103704"
+    pci:
+      bus_id: "0000:8A:00.0"
+    minor_number: 4
+    grace_cpu_pair: 2
+
+  - index: 5
+    uuid: "GPU-b300b300-0000-0000-0000-000000000005"
+    serial: "1573041103705"
+    pci:
+      bus_id: "0000:8B:00.0"
+    minor_number: 5
+    grace_cpu_pair: 2
+
+  - index: 6
+    uuid: "GPU-b300b300-0000-0000-0000-000000000006"
+    serial: "1573041103706"
+    pci:
+      bus_id: "0000:CA:00.0"
+    minor_number: 6
+    grace_cpu_pair: 3
+
+  - index: 7
+    uuid: "GPU-b300b300-0000-0000-0000-000000000007"
+    serial: "1573041103707"
+    pci:
+      bus_id: "0000:CB:00.0"
+    minor_number: 7
+    grace_cpu_pair: 3
+
+# =============================================================================
+# NVLink topology - GB300 uses NVLink 5.0 (same fabric as GB200)
+# =============================================================================
+nvlink:
+  version: 5
+  links_per_gpu: 18
+  bandwidth_per_link_gbps: 100      # 100 GB/s per link = 1.8 TB/s total per GPU
+  switch_support: true              # NVLink Switch for scale-out
+  switch_count: 0                   # Set for NVL72 configurations (up to 9 switches)
+  c2c_enabled: true                 # NVLink-C2C to Grace CPU
+  # NVLink state per link (18 links)
+  links:
+    - link: 0
+      state: "active"
+      remote_device_type: "gpu"
+      remote_pci_bus_id: "0000:0B:00.0"
+    - link: 1
+      state: "active"
+      remote_device_type: "cpu"     # NVLink-C2C to Grace
+      remote_pci_bus_id: "N/A"
+    # ... define all 18 links for full topology
+
+# =============================================================================
+# PCIe topology (consumed by render-pci-sysfs to materialize
+# /sys/bus/pci/devices/<bdf> -> ../../../devices/pciDDDD:BB/<bdf> symlinks
+# and per-device numa_node files). Mirrors the GB300 NVL superchip layout:
+# one PCI root complex per Grace+2×B300 tray, NUMA-aligned per tray.
+# =============================================================================
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:0A:00.0"
+        - "0000:0B:00.0"
+    - id: "pci0000:40"
+      numa_node: 1
+      devices:
+        - "0000:4A:00.0"
+        - "0000:4B:00.0"
+    - id: "pci0000:80"
+      numa_node: 2
+      devices:
+        - "0000:8A:00.0"
+        - "0000:8B:00.0"
+    - id: "pci0000:c0"
+      numa_node: 3
+      devices:
+        - "0000:CA:00.0"
+        - "0000:CB:00.0"

--- a/pkg/gpu/mocknvml/engine/config_profiles_test.go
+++ b/pkg/gpu/mocknvml/engine/config_profiles_test.go
@@ -177,6 +177,79 @@ func TestLoadConfig_T4Profile(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_GB300Profile(t *testing.T) {
+	profilePath := filepath.Join(testdataDir(), "gb300.yaml")
+
+	yamlCfg, err := LoadYAMLConfig(profilePath)
+	if err != nil {
+		t.Fatalf("Failed to load GB300 profile: %v", err)
+	}
+
+	// 8 GPUs: 4 Grace-Blackwell Ultra superchips × 2 B300 GPUs each.
+	if got := len(yamlCfg.Devices); got != 8 {
+		t.Errorf("GB300 device count: got %d, want 8", got)
+	}
+
+	if got := yamlCfg.DeviceDefaults.Name; got != "NVIDIA GB300 NVL" {
+		t.Errorf("GB300 name: got %q, want %q", got, "NVIDIA GB300 NVL")
+	}
+
+	// 288 GiB HBM3e per GPU is the headline GB300 vs. GB200 delta — make
+	// sure a regression in the YAML can never quietly drop us back to 192.
+	mem := yamlCfg.DeviceDefaults.Memory
+	if mem == nil {
+		t.Fatal("GB300 memory config is nil")
+	}
+	expectedMemBytes := uint64(288) * 1024 * 1024 * 1024
+	if mem.TotalBytes != expectedMemBytes {
+		t.Errorf("GB300 memory total_bytes: got %d, want %d (288 GiB)", mem.TotalBytes, expectedMemBytes)
+	}
+
+	// Blackwell Ultra uses the 570.x driver line; the chart's
+	// driverVersion helper relies on this value being consistent.
+	if got := yamlCfg.System.DriverVersion; got != "570.124.06" {
+		t.Errorf("GB300 driver_version: got %q, want %q", got, "570.124.06")
+	}
+
+	// PCIe Gen6 (or NVLink-C2C to Grace).
+	pcie := yamlCfg.DeviceDefaults.PCIe
+	if pcie == nil {
+		t.Fatal("GB300 PCIe config is nil")
+	}
+	if pcie.MaxLinkGen != 6 {
+		t.Errorf("GB300 PCIe max_link_gen: got %d, want 6", pcie.MaxLinkGen)
+	}
+
+	// 1400W default TDP (vs. GB200's 1000W).
+	power := yamlCfg.DeviceDefaults.Power
+	if power == nil {
+		t.Fatal("GB300 power config is nil")
+	}
+	if power.DefaultLimitMW != 1400000 {
+		t.Errorf("GB300 power default_limit_mw: got %d, want 1400000", power.DefaultLimitMW)
+	}
+
+	// Grace pairing must be wired up — GB300 is a superchip part.
+	grace := yamlCfg.DeviceDefaults.GraceSuperchip
+	if grace == nil {
+		t.Fatal("GB300 grace_superchip config is nil")
+	}
+	if !grace.Enabled {
+		t.Error("GB300 grace_superchip.enabled: got false, want true")
+	}
+
+	// NVLink v5, 18 links @ 100 GB/s (same fabric as GB200).
+	if yamlCfg.NVLink == nil {
+		t.Fatal("GB300 NVLink config is nil")
+	}
+	if yamlCfg.NVLink.Version != 5 {
+		t.Errorf("GB300 nvlink.version: got %d, want 5", yamlCfg.NVLink.Version)
+	}
+	if yamlCfg.NVLink.LinksPerGPU != 18 {
+		t.Errorf("GB300 nvlink.links_per_gpu: got %d, want 18", yamlCfg.NVLink.LinksPerGPU)
+	}
+}
+
 func TestLoadConfig_AllProfilesConsistent(t *testing.T) {
 	profiles := []struct {
 		name         string
@@ -191,6 +264,7 @@ func TestLoadConfig_AllProfilesConsistent(t *testing.T) {
 		{"H100", "h100.yaml", "hopper", 9, 0, 80, 8},
 		{"B200", "b200.yaml", "blackwell", 10, 0, 192, 8},
 		{"GB200", "gb200.yaml", "blackwell", 10, 0, 192, 8},
+		{"GB300", "gb300.yaml", "blackwell", 10, 0, 288, 8},
 		{"L40S", "l40s.yaml", "ada_lovelace", 8, 9, 48, 8},
 		{"T4", "t4.yaml", "turing", 7, 5, 16, 4},
 	}

--- a/tests/poc-validation/README.md
+++ b/tests/poc-validation/README.md
@@ -37,7 +37,7 @@ Reproducible scripts for validating NVIDIA GPU consumers (device plugin, DRA dri
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GPU_PROFILE` | `a100` | GPU profile (a100, h100, b200, gb200, l40s, t4) |
+| `GPU_PROFILE` | `a100` | GPU profile (a100, h100, b200, gb200, gb300, l40s, t4) |
 | `GPU_COUNT` | `8` | Number of mock GPUs |
 | `CLUSTER_NAME` | `nvml-mock-poc` | Kind cluster name |
 | `MOCK_NVML_DEBUG` | `1` | Enable NVML debug traces |


### PR DESCRIPTION
## Summary

Adds a first-class `gb300` profile modeling the NVIDIA GB300 NVL (Grace-Blackwell Ultra Superchip) alongside the existing `a100` / `h100` / `b200` / `gb200` / `l40s` / `t4` profiles. The new profile is selectable as `--set gpu.profile=gb300` from the Helm chart and as a standalone CLI config at `pkg/gpu/mocknvml/configs/mock-nvml-config-gb300.yaml`.

> [!IMPORTANT]
> **Depends on #353.** The GB300 profile is born aligned with the invariants that PR establishes:
> - `bus_id` fields use the canonical Linux sysfs 4-digit-domain form (`0000:0A:00.0`), so `pkg/system/mockpcisysfs/config.Validate()` accepts it under `--strict`.
> - Carries an explicit `pcie_topology:` block describing 4 PCI root complexes (`pci0000:00 / :40 / :80 / :c0`), one per Grace+2×B300 tray, with NUMA nodes `0..3`. `render-pci-sysfs` lights up an NVL72-shaped `/sys/bus/pci/devices` tree out of the box:
>
> ```
> $ render-pci-sysfs --config profiles/gb300.yaml --strict
> render-pci-sysfs: 4 root complex(es), 8 device(s) — config OK
> ```
>
> The diff in this PR until #353 merges will include the three commits from #353 at the bottom and the GB300 commit on top. Only the top commit is in scope for review here.

### GB300 vs. GB200 deltas baked into the YAML

| | GB200 | **GB300** |
|---|---|---|
| HBM3e per GPU | 192 GiB | **288 GiB** (+50%) |
| BAR1 aperture | 512 GiB | **768 GiB** |
| Default TDP / boost | 1.0 kW / 1.2 kW | **1.4 kW / 1.6 kW** |
| Memory clock | 2,500 MHz | **2,625 MHz** |
| Graphics boost | 2,100 MHz | **2,200 MHz** |
| CUDA cores | 18,432 | **21,632** (Blackwell Ultra) |
| Driver line | 560.35.03 | **570.124.06** |
| CUDA | 12.6 | **12.8** |
| FP6 support | — | **Yes** (Blackwell Ultra-only) |
| Grace pairing | Yes | Yes (same Grace) |
| NVLink | v5, 18 links, 1.8 TB/s | v5, 18 links, 1.8 TB/s |
| PCIe | Gen6 | Gen6 |
| InfiniBand | ConnectX-7 NDR | ConnectX-7 NDR |

### Everything that enumerates the profile set extended in lockstep

So adding `gb300` cannot half-work:

- **Helm chart**: profile lookup (`_helpers.tpl`) + driver-version helper (now routes `gb300` to `570.124.06` instead of falling through to the Blackwell `560.35.03`) + `NOTES.txt` + `integrations-fgo.yaml` (FGO ConfigMap fanout) + the unknown-profile error message + `values.yaml` comment.
- **Helm unittests**: new `gb300` snapshot, load test, NOTES driver-version test, DaemonSet `DRIVER_VERSION` env test, profile-list assertion; snapshots regenerated (98 tests / 15 snapshots all green).
- **Go**: new `TestLoadConfig_GB300Profile` covers the 288 GiB / 1.4 kW / PCIe Gen6 / Grace-paired / NVLink-v5 invariants; `TestLoadConfig_AllProfilesConsistent` now sweeps `gb300` too.
- **E2E workflow** (`.github/workflows/nvml-mock-e2e.yaml`): default profile matrix and both case-statement display-name lookups.
- **Docs**: top-level `README`, `docs/README`, chart README profile comparison table (now 7 columns, with explicit Blackwell Ultra / FP6 / 1.4 kW / 570.124.06 cells), `quickstart`, `configuration`, `examples`, `development`, `architecture`, `integrations/fake-gpu-operator`, `pkg/gpu/mocknvml/README`, `tests/poc-validation/README`, `CHANGELOG`.

## Test plan

Local verification (on top of #353):

- [x] `helm lint deployments/nvml-mock/helm/nvml-mock` — clean
- [x] `helm unittest deployments/nvml-mock/helm/nvml-mock` — 98 / 98 tests, 15 / 15 snapshots pass
- [x] `go test ./pkg/gpu/mocknvml/engine/... ./pkg/system/mockpcisysfs/...` — pass (no regressions)
- [x] `helm template ... --set gpu.profile=gb300` renders the ConfigMap with `NVIDIA GB300 NVL`, `architecture: blackwell`, `default_limit_mw: 1400000`, `cuda_version: "12.8"`, and the DaemonSet's `DRIVER_VERSION` env evaluates to `570.124.06`
- [x] `render-pci-sysfs --strict` accepts both the helm profile and the standalone CLI config (4 root complexes / 8 devices) — readlink targets match the relative `../../../devices/pciDDDD:BB/<bdf>` shape `EvalSymlinks` expects, and `numa_node` files match each Grace pair (`0/0, 1/1, 2/2, 3/3`)
- [x] FGO fanout emits the new `t-nvml-mock-profile-gb300` ConfigMap alongside the other six

CI to verify on Linux:

- [ ] The e2e workflow's expanded matrix (`["a100", "h100", "b200", "gb200", "gb300", "l40s", "t4"]`) passes the device-plugin and DRA-driver jobs for `gb300`.
- [ ] `make docker-build` (multi-arch) succeeds with the new profile bundled in the chart.

Closes — n/a (no tracking issue; follow-up to the Blackwell Ultra hardware announcement).

Signed-off-by: Giulio Calzolari <gcalzolari@nvidia.com>