### PR TITLE
feat(dashboard): custom date-range trends for Issues & PRs Overview

### DIFF
--- a/src/components/DurationPicker.tsx
+++ b/src/components/DurationPicker.tsx
@@ -12,20 +12,24 @@ interface Props {
   onChange: (next: Duration) => void;
 }
 
+type Mode = 'closed' | 'presets' | 'custom';
+
 export default function DurationPicker({ value, onChange }: Props) {
-  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<Mode>('closed');
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
   const rootRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!open) return;
+    if (mode === 'closed') return;
     function handleClick(e: MouseEvent) {
       if (!rootRef.current?.contains(e.target as Node)) {
-        setOpen(false);
+        setMode('closed');
       }
     }
     function handleKeydown(e: KeyboardEvent) {
       if (e.key === 'Escape') {
-        setOpen(false);
+        setMode('closed');
       }
     }
     document.addEventListener('mousedown', handleClick);
@@ -34,27 +38,50 @@ export default function DurationPicker({ value, onChange }: Props) {
       document.removeEventListener('mousedown', handleClick);
       document.removeEventListener('keydown', handleKeydown);
     };
-  }, [open]);
+  }, [mode]);
+
+  function openPresets() {
+    setMode((m) => (m === 'closed' ? 'presets' : 'closed'));
+  }
 
   function selectPreset(p: PresetDuration) {
     onChange({ kind: 'preset', value: p });
-    setOpen(false);
+    setMode('closed');
   }
+
+  function enterCustom() {
+    if (value.kind === 'custom') {
+      setFrom(value.from);
+      setTo(value.to);
+    } else {
+      setFrom('');
+      setTo('');
+    }
+    setMode('custom');
+  }
+
+  function applyCustom() {
+    onChange({ kind: 'custom', from, to });
+    setMode('closed');
+  }
+
+  const invalidOrder = from !== '' && to !== '' && from > to;
+  const canApply = from !== '' && to !== '' && !invalidOrder;
 
   return (
     <div ref={rootRef} className="relative inline-block">
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={openPresets}
         aria-haspopup="menu"
-        aria-expanded={open}
+        aria-expanded={mode !== 'closed'}
         className="flex items-center gap-1 px-3 py-1 text-xs rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600"
       >
         <span>Range: {formatDurationLabel(value)}</span>
         <ChevronDown size={12} />
       </button>
 
-      {open && (
+      {mode === 'presets' && (
         <div
           role="menu"
           className="absolute right-0 mt-1 z-10 min-w-[180px] bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow-lg text-xs"
@@ -80,11 +107,54 @@ export default function DurationPicker({ value, onChange }: Props) {
           <button
             role="menuitem"
             type="button"
-            aria-disabled="true"
-            className="block w-full text-left px-3 py-1.5 text-gray-400 dark:text-gray-500 cursor-not-allowed"
+            onClick={enterCustom}
+            className="block w-full text-left px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200"
           >
             Custom range…
           </button>
+        </div>
+      )}
+
+      {mode === 'custom' && (
+        <div className="absolute right-0 mt-1 z-10 min-w-[240px] bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow-lg text-xs p-3">
+          <label className="block mb-2">
+            <span className="block text-gray-600 dark:text-gray-400 mb-1">From</span>
+            <input
+              type="date"
+              value={from}
+              onChange={(e) => setFrom(e.target.value)}
+              className="w-full px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+            />
+          </label>
+          <label className="block mb-2">
+            <span className="block text-gray-600 dark:text-gray-400 mb-1">To</span>
+            <input
+              type="date"
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+              className="w-full px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+            />
+          </label>
+          {invalidOrder && (
+            <p className="text-red-600 dark:text-red-400 mb-2">From must be on or before To.</p>
+          )}
+          <div className="flex justify-end gap-2 mt-2">
+            <button
+              type="button"
+              onClick={() => setMode('presets')}
+              className="px-2 py-1 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={applyCustom}
+              disabled={!canApply}
+              className="px-2 py-1 rounded bg-nvidia-green text-white disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Apply
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/src/components/DurationPicker.tsx
+++ b/src/components/DurationPicker.tsx
@@ -19,6 +19,12 @@ export default function DurationPicker({ value, onChange }: Props) {
   const [from, setFrom] = useState('');
   const [to, setTo] = useState('');
   const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  function closeAndRefocus() {
+    setMode('closed');
+    triggerRef.current?.focus();
+  }
 
   useEffect(() => {
     if (mode === 'closed') return;
@@ -29,7 +35,7 @@ export default function DurationPicker({ value, onChange }: Props) {
     }
     function handleKeydown(e: KeyboardEvent) {
       if (e.key === 'Escape') {
-        setMode('closed');
+        closeAndRefocus();
       }
     }
     document.addEventListener('mousedown', handleClick);
@@ -46,7 +52,7 @@ export default function DurationPicker({ value, onChange }: Props) {
 
   function selectPreset(p: PresetDuration) {
     onChange({ kind: 'preset', value: p });
-    setMode('closed');
+    closeAndRefocus();
   }
 
   function enterCustom() {
@@ -62,7 +68,7 @@ export default function DurationPicker({ value, onChange }: Props) {
 
   function applyCustom() {
     onChange({ kind: 'custom', from, to });
-    setMode('closed');
+    closeAndRefocus();
   }
 
   const invalidOrder = from !== '' && to !== '' && from > to;
@@ -71,6 +77,7 @@ export default function DurationPicker({ value, onChange }: Props) {
   return (
     <div ref={rootRef} className="relative inline-block">
       <button
+        ref={triggerRef}
         type="button"
         onClick={openPresets}
         aria-haspopup={mode === 'custom' ? 'dialog' : 'menu'}
@@ -117,6 +124,9 @@ export default function DurationPicker({ value, onChange }: Props) {
 
       {mode === 'custom' && (
         <form
+          role="dialog"
+          aria-label="Custom date range"
+          aria-modal="false"
           onSubmit={(e) => {
             e.preventDefault();
             if (canApply) applyCustom();

--- a/src/components/DurationPicker.tsx
+++ b/src/components/DurationPicker.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import {
+  PRESET_DURATIONS,
+  formatDurationLabel,
+  type Duration,
+  type PresetDuration,
+} from '../utils/duration';
+
+interface Props {
+  value: Duration;
+  onChange: (next: Duration) => void;
+}
+
+export default function DurationPicker({ value, onChange }: Props) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (!rootRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  function selectPreset(p: PresetDuration) {
+    onChange({ kind: 'preset', value: p });
+    setOpen(false);
+  }
+
+  return (
+    <div ref={rootRef} className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={`Range: ${formatDurationLabel(value)}`}
+        className="flex items-center gap-1 px-3 py-1 text-xs rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600"
+      >
+        <span>Range: {formatDurationLabel(value)}</span>
+        <ChevronDown size={12} />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 mt-1 z-10 min-w-[180px] bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow-lg text-xs"
+        >
+          {PRESET_DURATIONS.map((p) => {
+            const isActive = value.kind === 'preset' && value.value === p;
+            const label = formatDurationLabel({ kind: 'preset', value: p });
+            return (
+              <button
+                key={p}
+                role="menuitem"
+                onClick={() => selectPreset(p)}
+                className={`block w-full text-left px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 ${
+                  isActive ? 'text-nvidia-green font-medium' : 'text-gray-700 dark:text-gray-200'
+                }`}
+              >
+                {label}
+              </button>
+            );
+          })}
+          <div className="border-t border-gray-200 dark:border-gray-700 my-1" />
+          <button
+            role="menuitem"
+            type="button"
+            disabled
+            className="block w-full text-left px-3 py-1.5 text-gray-400 dark:text-gray-500 cursor-not-allowed"
+          >
+            Custom range…
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/DurationPicker.tsx
+++ b/src/components/DurationPicker.tsx
@@ -23,8 +23,17 @@ export default function DurationPicker({ value, onChange }: Props) {
         setOpen(false);
       }
     }
+    function handleKeydown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setOpen(false);
+      }
+    }
     document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKeydown);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKeydown);
+    };
   }, [open]);
 
   function selectPreset(p: PresetDuration) {
@@ -39,7 +48,6 @@ export default function DurationPicker({ value, onChange }: Props) {
         onClick={() => setOpen((v) => !v)}
         aria-haspopup="menu"
         aria-expanded={open}
-        aria-label={`Range: ${formatDurationLabel(value)}`}
         className="flex items-center gap-1 px-3 py-1 text-xs rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600"
       >
         <span>Range: {formatDurationLabel(value)}</span>
@@ -58,6 +66,7 @@ export default function DurationPicker({ value, onChange }: Props) {
               <button
                 key={p}
                 role="menuitem"
+                type="button"
                 onClick={() => selectPreset(p)}
                 className={`block w-full text-left px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 ${
                   isActive ? 'text-nvidia-green font-medium' : 'text-gray-700 dark:text-gray-200'
@@ -71,7 +80,7 @@ export default function DurationPicker({ value, onChange }: Props) {
           <button
             role="menuitem"
             type="button"
-            disabled
+            aria-disabled="true"
             className="block w-full text-left px-3 py-1.5 text-gray-400 dark:text-gray-500 cursor-not-allowed"
           >
             Custom range…

--- a/src/components/DurationPicker.tsx
+++ b/src/components/DurationPicker.tsx
@@ -73,7 +73,7 @@ export default function DurationPicker({ value, onChange }: Props) {
       <button
         type="button"
         onClick={openPresets}
-        aria-haspopup="menu"
+        aria-haspopup={mode === 'custom' ? 'dialog' : 'menu'}
         aria-expanded={mode !== 'closed'}
         className="flex items-center gap-1 px-3 py-1 text-xs rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600"
       >
@@ -116,7 +116,13 @@ export default function DurationPicker({ value, onChange }: Props) {
       )}
 
       {mode === 'custom' && (
-        <div className="absolute right-0 mt-1 z-10 min-w-[240px] bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow-lg text-xs p-3">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (canApply) applyCustom();
+          }}
+          className="absolute right-0 mt-1 z-10 min-w-[240px] bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow-lg text-xs p-3"
+        >
           <label className="block mb-2">
             <span className="block text-gray-600 dark:text-gray-400 mb-1">From</span>
             <input
@@ -136,7 +142,7 @@ export default function DurationPicker({ value, onChange }: Props) {
             />
           </label>
           {invalidOrder && (
-            <p className="text-red-600 dark:text-red-400 mb-2">From must be on or before To.</p>
+            <p role="alert" className="text-red-600 dark:text-red-400 mb-2">From must be on or before To.</p>
           )}
           <div className="flex justify-end gap-2 mt-2">
             <button
@@ -147,15 +153,14 @@ export default function DurationPicker({ value, onChange }: Props) {
               Cancel
             </button>
             <button
-              type="button"
-              onClick={applyCustom}
+              type="submit"
               disabled={!canApply}
               className="px-2 py-1 rounded bg-nvidia-green text-white disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Apply
             </button>
           </div>
-        </div>
+        </form>
       )}
     </div>
   );

--- a/src/components/IssuesPRsDashboard.tsx
+++ b/src/components/IssuesPRsDashboard.tsx
@@ -18,7 +18,8 @@ import { useTheme } from './ThemeProvider';
 import VelocitySparkline from './VelocitySparkline';
 import { AGE_COLORS, getCategoryColor, getChartStyles, formatWeekTick, formatDayTick, computeTrend } from '../utils/chartStyles';
 import type { Trend } from '../utils/chartStyles';
-import { PRESET_DURATIONS, pickVelocity, formatDurationLabel, type Duration } from '../utils/duration';
+import { pickVelocity, formatDurationLabel, type Duration } from '../utils/duration';
+import DurationPicker from './DurationPicker';
 import { projects } from '../data/projects';
 import type { IssuesPRsData, RepoIssuesPRs } from '../types';
 
@@ -53,11 +54,11 @@ function ExpandedRowDetail({
   tickStyle: { fontSize: number; fill: string };
   gridStroke: string;
 }) {
-  const { points: issueVelocity, granularity: issueGranularity } = useMemo(
+  const { points: issueVelocity, granularity: issueGranularity, clamp: issueClamp } = useMemo(
     () => pickVelocity(repoData.issues.velocity, duration),
     [repoData.issues.velocity, duration],
   );
-  const { points: prVelocity, granularity: prGranularity } = useMemo(
+  const { points: prVelocity, granularity: prGranularity, clamp: prClamp } = useMemo(
     () => pickVelocity(repoData.pullRequests.velocity, duration),
     [repoData.pullRequests.velocity, duration],
   );
@@ -132,6 +133,11 @@ function ExpandedRowDetail({
           <h4 className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">
             Issue Velocity ({formatDurationLabel(duration)} • {issueGranularity === 'day' ? 'daily' : 'weekly'})
           </h4>
+          {issueClamp && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-2" data-testid="issue-clamp-note">
+              Showing {issueClamp.actualFrom} onward (requested {issueClamp.requestedFrom} — data starts {issueClamp.actualFrom}).
+            </p>
+          )}
           {issueVelocity.length > 0 ? (
             <ResponsiveContainer width="100%" height={160}>
               <LineChart
@@ -260,6 +266,11 @@ function ExpandedRowDetail({
           <h4 className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">
             PR Velocity ({formatDurationLabel(duration)} • {prGranularity === 'day' ? 'daily' : 'weekly'})
           </h4>
+          {prClamp && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-2" data-testid="pr-clamp-note">
+              Showing {prClamp.actualFrom} onward (requested {prClamp.requestedFrom} — data starts {prClamp.actualFrom}).
+            </p>
+          )}
           {prVelocity.length > 0 ? (
             <ResponsiveContainer width="100%" height={100}>
               <LineChart
@@ -340,26 +351,7 @@ export default function IssuesPRsDashboard({ data }: Props) {
         <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-200">
           Issues &amp; PRs Overview
         </h2>
-        <div className="flex flex-wrap gap-1" role="group" aria-label="Velocity duration">
-          {PRESET_DURATIONS.map((d) => {
-            const isActive = duration.kind === 'preset' && duration.value === d;
-            return (
-              <button
-                key={d}
-                onClick={() => setDuration({ kind: 'preset', value: d })}
-                aria-pressed={isActive}
-                aria-label={`Show ${d} of velocity data`}
-                className={`px-2 py-1 text-xs rounded ${
-                  isActive
-                    ? 'bg-nvidia-green text-white'
-                    : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
-                }`}
-              >
-                {d}
-              </button>
-            );
-          })}
-        </div>
+        <DurationPicker value={duration} onChange={setDuration} />
       </div>
 
       {/* Comparison Table */}

--- a/src/components/IssuesPRsDashboard.tsx
+++ b/src/components/IssuesPRsDashboard.tsx
@@ -18,7 +18,7 @@ import { useTheme } from './ThemeProvider';
 import VelocitySparkline from './VelocitySparkline';
 import { AGE_COLORS, getCategoryColor, getChartStyles, formatWeekTick, formatDayTick, computeTrend } from '../utils/chartStyles';
 import type { Trend } from '../utils/chartStyles';
-import { DURATIONS, pickVelocity, type Duration } from '../utils/duration';
+import { PRESET_DURATIONS, pickVelocity, type Duration } from '../utils/duration';
 import { projects } from '../data/projects';
 import type { IssuesPRsData, RepoIssuesPRs } from '../types';
 
@@ -130,7 +130,7 @@ function ExpandedRowDetail({
         {/* Issue Velocity */}
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
           <h4 className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">
-            Issue Velocity ({duration})
+            Issue Velocity ({duration.kind === 'preset' ? duration.value : 'custom'})
           </h4>
           {issueVelocity.length > 0 ? (
             <ResponsiveContainer width="100%" height={160}>
@@ -258,7 +258,7 @@ function ExpandedRowDetail({
             </div>
           </div>
           <h4 className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">
-            PR Velocity ({duration})
+            PR Velocity ({duration.kind === 'preset' ? duration.value : 'custom'})
           </h4>
           {prVelocity.length > 0 ? (
             <ResponsiveContainer width="100%" height={100}>
@@ -313,7 +313,7 @@ function ExpandedRowDetail({
 export default function IssuesPRsDashboard({ data }: Props) {
   const { resolved } = useTheme();
   const dark = resolved === 'dark';
-  const [duration, setDuration] = useState<Duration>('12w');
+  const [duration, setDuration] = useState<Duration>({ kind: 'preset', value: '12w' });
   const [expandedSlug, setExpandedSlug] = useState<string | null>(null);
 
   const rows = useMemo<RowData[]>(() => {
@@ -341,21 +341,24 @@ export default function IssuesPRsDashboard({ data }: Props) {
           Issues &amp; PRs Overview
         </h2>
         <div className="flex flex-wrap gap-1" role="group" aria-label="Velocity duration">
-          {DURATIONS.map((d) => (
-            <button
-              key={d}
-              onClick={() => setDuration(d)}
-              aria-pressed={duration === d}
-              aria-label={`Show ${d} of velocity data`}
-              className={`px-2 py-1 text-xs rounded ${
-                duration === d
-                  ? 'bg-nvidia-green text-white'
-                  : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
-              }`}
-            >
-              {d}
-            </button>
-          ))}
+          {PRESET_DURATIONS.map((d) => {
+            const isActive = duration.kind === 'preset' && duration.value === d;
+            return (
+              <button
+                key={d}
+                onClick={() => setDuration({ kind: 'preset', value: d })}
+                aria-pressed={isActive}
+                aria-label={`Show ${d} of velocity data`}
+                className={`px-2 py-1 text-xs rounded ${
+                  isActive
+                    ? 'bg-nvidia-green text-white'
+                    : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
+                }`}
+              >
+                {d}
+              </button>
+            );
+          })}
         </div>
       </div>
 

--- a/src/components/IssuesPRsDashboard.tsx
+++ b/src/components/IssuesPRsDashboard.tsx
@@ -134,8 +134,12 @@ function ExpandedRowDetail({
             Issue Velocity ({formatDurationLabel(duration)} • {issueGranularity === 'day' ? 'daily' : 'weekly'})
           </h4>
           {issueClamp && (
-            <p className="text-xs text-gray-500 dark:text-gray-400 mb-2" data-testid="issue-clamp-note">
-              Showing {issueClamp.actualFrom} onward (requested {issueClamp.requestedFrom} — data starts {issueClamp.actualFrom}).
+            <p
+              aria-live="polite"
+              className="text-xs text-gray-500 dark:text-gray-400 mb-2"
+              data-testid="issue-clamp-note"
+            >
+              Showing data from {issueClamp.actualFrom} (requested {issueClamp.requestedFrom}).
             </p>
           )}
           {issueVelocity.length > 0 ? (
@@ -267,8 +271,12 @@ function ExpandedRowDetail({
             PR Velocity ({formatDurationLabel(duration)} • {prGranularity === 'day' ? 'daily' : 'weekly'})
           </h4>
           {prClamp && (
-            <p className="text-xs text-gray-500 dark:text-gray-400 mb-2" data-testid="pr-clamp-note">
-              Showing {prClamp.actualFrom} onward (requested {prClamp.requestedFrom} — data starts {prClamp.actualFrom}).
+            <p
+              aria-live="polite"
+              className="text-xs text-gray-500 dark:text-gray-400 mb-2"
+              data-testid="pr-clamp-note"
+            >
+              Showing data from {prClamp.actualFrom} (requested {prClamp.requestedFrom}).
             </p>
           )}
           {prVelocity.length > 0 ? (

--- a/src/components/IssuesPRsDashboard.tsx
+++ b/src/components/IssuesPRsDashboard.tsx
@@ -18,7 +18,7 @@ import { useTheme } from './ThemeProvider';
 import VelocitySparkline from './VelocitySparkline';
 import { AGE_COLORS, getCategoryColor, getChartStyles, formatWeekTick, formatDayTick, computeTrend } from '../utils/chartStyles';
 import type { Trend } from '../utils/chartStyles';
-import { PRESET_DURATIONS, pickVelocity, type Duration } from '../utils/duration';
+import { PRESET_DURATIONS, pickVelocity, formatDurationLabel, type Duration } from '../utils/duration';
 import { projects } from '../data/projects';
 import type { IssuesPRsData, RepoIssuesPRs } from '../types';
 
@@ -130,7 +130,7 @@ function ExpandedRowDetail({
         {/* Issue Velocity */}
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
           <h4 className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">
-            Issue Velocity ({duration.kind === 'preset' ? duration.value : 'custom'})
+            Issue Velocity ({formatDurationLabel(duration)} • {issueGranularity === 'day' ? 'daily' : 'weekly'})
           </h4>
           {issueVelocity.length > 0 ? (
             <ResponsiveContainer width="100%" height={160}>
@@ -258,7 +258,7 @@ function ExpandedRowDetail({
             </div>
           </div>
           <h4 className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">
-            PR Velocity ({duration.kind === 'preset' ? duration.value : 'custom'})
+            PR Velocity ({formatDurationLabel(duration)} • {prGranularity === 'day' ? 'daily' : 'weekly'})
           </h4>
           {prVelocity.length > 0 ? (
             <ResponsiveContainer width="100%" height={100}>

--- a/src/components/VelocitySparkline.tsx
+++ b/src/components/VelocitySparkline.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { ResponsiveContainer, LineChart, Line } from 'recharts';
 import type { Velocity } from '../types';
 import { pickVelocity, type Duration } from '../utils/duration';
@@ -8,7 +9,7 @@ interface Props {
 }
 
 export default function VelocitySparkline({ velocity, duration }: Props) {
-  const { points } = pickVelocity(velocity, duration);
+  const { points } = useMemo(() => pickVelocity(velocity, duration), [velocity, duration]);
 
   if (points.length === 0) {
     return <span className="text-gray-400 text-xs" data-testid="sparkline-empty">&mdash;</span>;

--- a/src/components/__tests__/DurationPicker.test.tsx
+++ b/src/components/__tests__/DurationPicker.test.tsx
@@ -72,6 +72,30 @@ describe('DurationPicker (presets)', () => {
     expect(screen.queryByRole('menuitem', { name: 'Last 7 days' })).not.toBeInTheDocument();
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it('Escape returns focus to the trigger', async () => {
+    const user = userEvent.setup();
+    render(<DurationPicker value={preset('12w')} onChange={() => {}} />);
+
+    const trigger = screen.getByRole('button', { name: /range/i });
+    await user.click(trigger);
+    expect(screen.getByRole('menuitem', { name: 'Last 7 days' })).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    expect(trigger).toHaveFocus();
+  });
+
+  it('selecting a preset returns focus to the trigger', async () => {
+    const user = userEvent.setup();
+    render(<DurationPicker value={preset('12w')} onChange={() => {}} />);
+
+    const trigger = screen.getByRole('button', { name: /range/i });
+    await user.click(trigger);
+    await user.click(screen.getByRole('menuitem', { name: 'Last 6 months' }));
+
+    expect(trigger).toHaveFocus();
+  });
 });
 
 describe('DurationPicker (custom range)', () => {
@@ -182,5 +206,30 @@ describe('DurationPicker (custom range)', () => {
 
     expect(screen.getByLabelText('From')).toHaveValue('2025-10-06');
     expect(screen.getByLabelText('To')).toHaveValue('2025-10-12');
+  });
+
+  it('Apply returns focus to the trigger', async () => {
+    const user = userEvent.setup();
+    render(<DurationPicker value={preset('12w')} onChange={() => {}} />);
+
+    const trigger = screen.getByRole('button', { name: /range/i });
+    await user.click(trigger);
+    await user.click(screen.getByRole('menuitem', { name: /Custom range/i }));
+    await user.type(screen.getByLabelText('From'), '2025-10-06');
+    await user.type(screen.getByLabelText('To'), '2025-10-12');
+    await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+    expect(trigger).toHaveFocus();
+  });
+
+  it('custom form has role=dialog with an accessible label', async () => {
+    const user = userEvent.setup();
+    render(<DurationPicker value={preset('12w')} onChange={() => {}} />);
+
+    await user.click(screen.getByRole('button', { name: /range/i }));
+    await user.click(screen.getByRole('menuitem', { name: /Custom range/i }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAccessibleName('Custom date range');
   });
 });

--- a/src/components/__tests__/DurationPicker.test.tsx
+++ b/src/components/__tests__/DurationPicker.test.tsx
@@ -73,3 +73,92 @@ describe('DurationPicker (presets)', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 });
+
+describe('DurationPicker (custom range)', () => {
+  it('clicking Custom range… swaps the popover to the date form', async () => {
+    const user = userEvent.setup();
+    render(<DurationPicker value={preset('12w')} onChange={() => {}} />);
+
+    await user.click(screen.getByRole('button', { name: /range/i }));
+    await user.click(screen.getByRole('menuitem', { name: /Custom range/i }));
+
+    expect(screen.getByLabelText('From')).toBeInTheDocument();
+    expect(screen.getByLabelText('To')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    // Preset items are no longer visible
+    expect(screen.queryByRole('menuitem', { name: 'Last 7 days' })).not.toBeInTheDocument();
+  });
+
+  it('Apply with valid range fires onChange and closes', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<DurationPicker value={preset('12w')} onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', { name: /range/i }));
+    await user.click(screen.getByRole('menuitem', { name: /Custom range/i }));
+    await user.type(screen.getByLabelText('From'), '2025-10-06');
+    await user.type(screen.getByLabelText('To'), '2025-10-12');
+    await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      kind: 'custom',
+      from: '2025-10-06',
+      to: '2025-10-12',
+    });
+    expect(screen.queryByLabelText('From')).not.toBeInTheDocument();
+  });
+
+  it('Apply is disabled when from > to', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<DurationPicker value={preset('12w')} onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', { name: /range/i }));
+    await user.click(screen.getByRole('menuitem', { name: /Custom range/i }));
+    await user.type(screen.getByLabelText('From'), '2025-10-12');
+    await user.type(screen.getByLabelText('To'), '2025-10-06');
+
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+    expect(screen.getByText(/From must be on or before To/i)).toBeInTheDocument();
+  });
+
+  it('Apply is disabled until both dates are filled', async () => {
+    const user = userEvent.setup();
+    render(<DurationPicker value={preset('12w')} onChange={() => {}} />);
+
+    await user.click(screen.getByRole('button', { name: /range/i }));
+    await user.click(screen.getByRole('menuitem', { name: /Custom range/i }));
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+
+    await user.type(screen.getByLabelText('From'), '2025-10-06');
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+    await user.type(screen.getByLabelText('To'), '2025-10-12');
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeEnabled();
+  });
+
+  it('Cancel returns to the preset list without firing onChange', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<DurationPicker value={preset('12w')} onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', { name: /range/i }));
+    await user.click(screen.getByRole('menuitem', { name: /Custom range/i }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('menuitem', { name: 'Last 7 days' })).toBeInTheDocument();
+  });
+
+  it('pre-fills inputs from the current custom value', async () => {
+    const user = userEvent.setup();
+    const value: Duration = { kind: 'custom', from: '2025-10-06', to: '2025-10-12' };
+    render(<DurationPicker value={value} onChange={() => {}} />);
+
+    await user.click(screen.getByRole('button', { name: /range/i }));
+    await user.click(screen.getByRole('menuitem', { name: /Custom range/i }));
+
+    expect(screen.getByLabelText('From')).toHaveValue('2025-10-06');
+    expect(screen.getByLabelText('To')).toHaveValue('2025-10-12');
+  });
+});

--- a/src/components/__tests__/DurationPicker.test.tsx
+++ b/src/components/__tests__/DurationPicker.test.tsx
@@ -58,4 +58,18 @@ describe('DurationPicker (presets)', () => {
     expect(screen.queryByRole('menuitem', { name: 'Last 7 days' })).not.toBeInTheDocument();
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it('Escape key closes the popover without firing onChange', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<DurationPicker value={preset('12w')} onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', { name: /range/i }));
+    expect(screen.getByRole('menuitem', { name: 'Last 7 days' })).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('menuitem', { name: 'Last 7 days' })).not.toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/__tests__/DurationPicker.test.tsx
+++ b/src/components/__tests__/DurationPicker.test.tsx
@@ -144,8 +144,30 @@ describe('DurationPicker (custom range)', () => {
     await user.type(screen.getByLabelText('To'), '2025-10-06');
 
     expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
-    expect(screen.getByText(/From must be on or before To/i)).toBeInTheDocument();
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(/From must be on or before To/i);
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('single-day range (from === to) is valid and Apply is enabled', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<DurationPicker value={preset('12w')} onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', { name: /range/i }));
+    await user.click(screen.getByRole('menuitem', { name: /Custom range/i }));
+    await user.type(screen.getByLabelText('From'), '2025-10-06');
+    await user.type(screen.getByLabelText('To'), '2025-10-06');
+
+    const apply = screen.getByRole('button', { name: 'Apply' });
+    expect(apply).toBeEnabled();
+
+    await user.click(apply);
+    expect(onChange).toHaveBeenCalledWith({
+      kind: 'custom',
+      from: '2025-10-06',
+      to: '2025-10-06',
+    });
   });
 
   it('Apply is disabled until both dates are filled', async () => {

--- a/src/components/__tests__/DurationPicker.test.tsx
+++ b/src/components/__tests__/DurationPicker.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DurationPicker from '../DurationPicker';
+import type { Duration } from '../../utils/duration';
+
+function preset(value: '7d' | '4w' | '12w' | '6m' | '1y' | '5y'): Duration {
+  return { kind: 'preset', value };
+}
+
+describe('DurationPicker (presets)', () => {
+  it('renders the current preset label on the trigger', () => {
+    render(<DurationPicker value={preset('12w')} onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: /range/i })).toHaveTextContent('Last 12 weeks');
+  });
+
+  it('opens the popover on trigger click and shows all six presets + Custom range…', async () => {
+    const user = userEvent.setup();
+    render(<DurationPicker value={preset('12w')} onChange={() => {}} />);
+
+    await user.click(screen.getByRole('button', { name: /range/i }));
+
+    expect(screen.getByRole('menuitem', { name: 'Last 7 days' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Last 4 weeks' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Last 12 weeks' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Last 6 months' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Last 1 year' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Last 5 years' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Custom range/i })).toBeInTheDocument();
+  });
+
+  it('selecting a preset calls onChange and closes the popover', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<DurationPicker value={preset('12w')} onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', { name: /range/i }));
+    await user.click(screen.getByRole('menuitem', { name: 'Last 6 months' }));
+
+    expect(onChange).toHaveBeenCalledWith({ kind: 'preset', value: '6m' });
+    expect(screen.queryByRole('menuitem', { name: 'Last 6 months' })).not.toBeInTheDocument();
+  });
+
+  it('clicking outside the popover closes it without firing onChange', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <div>
+        <DurationPicker value={preset('12w')} onChange={onChange} />
+        <button>Outside</button>
+      </div>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /range/i }));
+    expect(screen.getByRole('menuitem', { name: 'Last 7 days' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Outside' }));
+
+    expect(screen.queryByRole('menuitem', { name: 'Last 7 days' })).not.toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/DurationPicker.test.tsx
+++ b/src/components/__tests__/DurationPicker.test.tsx
@@ -121,6 +121,7 @@ describe('DurationPicker (custom range)', () => {
 
     expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
     expect(screen.getByText(/From must be on or before To/i)).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it('Apply is disabled until both dates are filled', async () => {
@@ -148,6 +149,27 @@ describe('DurationPicker (custom range)', () => {
 
     expect(onChange).not.toHaveBeenCalled();
     expect(screen.getByRole('menuitem', { name: 'Last 7 days' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Custom range/i })).toBeInTheDocument();
+  });
+
+  it('Enter inside an input submits when range is valid', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<DurationPicker value={preset('12w')} onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', { name: /range/i }));
+    await user.click(screen.getByRole('menuitem', { name: /Custom range/i }));
+    await user.type(screen.getByLabelText('From'), '2025-10-06');
+    await user.type(screen.getByLabelText('To'), '2025-10-12');
+    // Enter inside the focused To input
+    await user.keyboard('{Enter}');
+
+    expect(onChange).toHaveBeenCalledWith({
+      kind: 'custom',
+      from: '2025-10-06',
+      to: '2025-10-12',
+    });
+    expect(screen.queryByLabelText('From')).not.toBeInTheDocument();
   });
 
   it('pre-fills inputs from the current custom value', async () => {

--- a/src/components/__tests__/IssuesPRsDashboard.test.tsx
+++ b/src/components/__tests__/IssuesPRsDashboard.test.tsx
@@ -231,5 +231,9 @@ describe('IssuesPRsDashboard', () => {
     expect(issueNote).toHaveTextContent('(requested 2020-06-01)');
     expect(prNote).toHaveTextContent('Showing data from 2024-01-01');
     expect(prNote).toHaveTextContent('(requested 2020-06-01)');
+    // ARIA: screen readers must announce the clamp note when it appears
+    // after a range change. Removing aria-live would silently degrade SR UX.
+    expect(issueNote).toHaveAttribute('aria-live', 'polite');
+    expect(prNote).toHaveAttribute('aria-live', 'polite');
   });
 });

--- a/src/components/__tests__/IssuesPRsDashboard.test.tsx
+++ b/src/components/__tests__/IssuesPRsDashboard.test.tsx
@@ -105,31 +105,40 @@ function renderDashboard(data: IssuesPRsData) {
 describe('IssuesPRsDashboard', () => {
   it('defaults to the 12w duration', () => {
     renderDashboard(makeData());
-    const btn = screen.getByRole('button', { name: /Show 12w of velocity data/ });
-    expect(btn).toHaveAttribute('aria-pressed', 'true');
+    // DurationPicker trigger shows the current range label
+    expect(screen.getByRole('button', { name: /range/i })).toHaveTextContent('Last 12 weeks');
   });
 
-  it('renders all 6 duration buttons in display order', () => {
-    renderDashboard(makeData());
-    const labels = ['7d', '4w', '12w', '6m', '1y', '5y'];
-    for (const label of labels) {
-      expect(screen.getByRole('button', { name: new RegExp(`Show ${label} of velocity data`) }))
-        .toBeInTheDocument();
-    }
-  });
-
-  it('clicking a duration button updates aria-pressed', async () => {
+  it('renders the DurationPicker trigger showing all 6 presets via the popover', async () => {
     const user = userEvent.setup();
     renderDashboard(makeData());
 
-    const btn7d = screen.getByRole('button', { name: /Show 7d of velocity data/ });
-    expect(btn7d).toHaveAttribute('aria-pressed', 'false');
+    await user.click(screen.getByRole('button', { name: /range/i }));
 
-    await user.click(btn7d);
+    const expectedLabels = [
+      'Last 7 days',
+      'Last 4 weeks',
+      'Last 12 weeks',
+      'Last 6 months',
+      'Last 1 year',
+      'Last 5 years',
+    ];
+    for (const label of expectedLabels) {
+      expect(screen.getByRole('menuitem', { name: label })).toBeInTheDocument();
+    }
+  });
 
-    expect(btn7d).toHaveAttribute('aria-pressed', 'true');
-    const btn12w = screen.getByRole('button', { name: /Show 12w of velocity data/ });
-    expect(btn12w).toHaveAttribute('aria-pressed', 'false');
+  it('selecting a preset from DurationPicker updates the trigger label', async () => {
+    const user = userEvent.setup();
+    renderDashboard(makeData());
+
+    const trigger = screen.getByRole('button', { name: /range/i });
+    expect(trigger).toHaveTextContent('Last 12 weeks');
+
+    await user.click(trigger);
+    await user.click(screen.getByRole('menuitem', { name: 'Last 7 days' }));
+
+    expect(screen.getByRole('button', { name: /range/i })).toHaveTextContent('Last 7 days');
   });
 
   // Q3 invariant (snapshot regression test, strengthened per QA review).
@@ -149,9 +158,17 @@ describe('IssuesPRsDashboard', () => {
     expect(initialIssuesText).toBe('42');
     expect(initialPRsText).toBe('8');
 
-    for (const label of ['7d', '4w', '12w', '6m', '1y', '5y']) {
-      const btn = screen.getByRole('button', { name: new RegExp(`Show ${label} of velocity data`) });
-      await user.click(btn);
+    const presetLabels = [
+      'Last 7 days',
+      'Last 4 weeks',
+      'Last 12 weeks',
+      'Last 6 months',
+      'Last 1 year',
+      'Last 5 years',
+    ];
+    for (const label of presetLabels) {
+      await user.click(screen.getByRole('button', { name: /range/i }));
+      await user.click(screen.getByRole('menuitem', { name: label }));
 
       expect(openIssuesCell.textContent).toBe(initialIssuesText);
       expect(openPRsCell.textContent).toBe(initialPRsText);

--- a/src/components/__tests__/IssuesPRsDashboard.test.tsx
+++ b/src/components/__tests__/IssuesPRsDashboard.test.tsx
@@ -92,6 +92,38 @@ function makeData(): IssuesPRsData {
   };
 }
 
+// Variant of makeData() where weekly velocity starts on a known ISO date so
+// the clamp branch in pickVelocity fires when `from` predates that week.
+function makeDataWithWeeklyStart(firstWeek: string): IssuesPRsData {
+  const base = makeData();
+  const repoData = base.repos['nvidia/gpu-operator'];
+  // Replace the first weekly entry's key with the given ISO date so
+  // pickVelocity's `earliest = weekly[0].week` comparison uses a real date.
+  const issueWeekly = [
+    { week: firstWeek, opened: 0, closed: 0 },
+    ...repoData.issues.velocity.weekly.slice(1),
+  ];
+  const prWeekly = [
+    { week: firstWeek, opened: 0, closed: 0 },
+    ...repoData.pullRequests.velocity.weekly.slice(1),
+  ];
+  return {
+    repos: {
+      'nvidia/gpu-operator': {
+        ...repoData,
+        issues: {
+          ...repoData.issues,
+          velocity: { ...repoData.issues.velocity, weekly: issueWeekly },
+        },
+        pullRequests: {
+          ...repoData.pullRequests,
+          velocity: { ...repoData.pullRequests.velocity, weekly: prWeekly },
+        },
+      },
+    },
+  };
+}
+
 function renderDashboard(data: IssuesPRsData) {
   return render(
     <MemoryRouter>
@@ -173,5 +205,31 @@ describe('IssuesPRsDashboard', () => {
       expect(openIssuesCell.textContent).toBe(initialIssuesText);
       expect(openPRsCell.textContent).toBe(initialPRsText);
     }
+  });
+
+  it('renders clamp notes when a custom range predates the weekly retention', async () => {
+    const user = userEvent.setup();
+    // Weekly data starts at 2024-01-01; requesting from 2020-06-01 triggers clamping.
+    const data = makeDataWithWeeklyStart('2024-01-01');
+    renderDashboard(data);
+
+    // Expand the GPU Operator row to reveal the velocity charts.
+    // The row has role="button" and its accessible name includes "GPU Operator".
+    await user.click(screen.getByRole('button', { name: /GPU Operator/i }));
+
+    // Open the DurationPicker, select Custom range, enter clamping dates, apply.
+    await user.click(screen.getByRole('button', { name: /range/i }));
+    await user.click(screen.getByRole('menuitem', { name: /Custom range/i }));
+    await user.type(screen.getByLabelText('From'), '2020-06-01');
+    await user.type(screen.getByLabelText('To'), '2024-06-30');
+    await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+    // Both clamp notes must appear with the corrected wording.
+    const issueNote = await screen.findByTestId('issue-clamp-note');
+    const prNote = await screen.findByTestId('pr-clamp-note');
+    expect(issueNote).toHaveTextContent('Showing data from 2024-01-01');
+    expect(issueNote).toHaveTextContent('(requested 2020-06-01)');
+    expect(prNote).toHaveTextContent('Showing data from 2024-01-01');
+    expect(prNote).toHaveTextContent('(requested 2020-06-01)');
   });
 });

--- a/src/components/__tests__/VelocitySparkline.test.tsx
+++ b/src/components/__tests__/VelocitySparkline.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import VelocitySparkline from '../VelocitySparkline';
 import type { Velocity } from '../../types';
+import type { Duration } from '../../utils/duration';
 
 // Mock recharts so the data prop passed into <LineChart> is exposed as a
 // queryable DOM attribute. This lets us assert the actual slice/granularity
@@ -48,7 +49,8 @@ function makeFixture(): Velocity {
 describe('VelocitySparkline', () => {
   it('renders for 7d using daily data', () => {
     const v = makeFixture();
-    render(<VelocitySparkline velocity={v} duration="7d" />);
+    const d: Duration = { kind: 'preset', value: '7d' };
+    render(<VelocitySparkline velocity={v} duration={d} />);
 
     const data = readChartData();
     // Length: pickVelocity('7d') slices daily by -7.
@@ -66,7 +68,8 @@ describe('VelocitySparkline', () => {
 
   it('renders for 5y using weekly data', () => {
     const v = makeFixture();
-    render(<VelocitySparkline velocity={v} duration="5y" />);
+    const d: Duration = { kind: 'preset', value: '5y' };
+    render(<VelocitySparkline velocity={v} duration={d} />);
 
     const data = readChartData();
     // Length: pickVelocity('5y') slices weekly by -260; weekly is exactly 260 long.
@@ -84,7 +87,7 @@ describe('VelocitySparkline', () => {
   });
 
   it('renders the empty state when both arrays are empty', () => {
-    render(<VelocitySparkline velocity={{ daily: [], weekly: [] }} duration="7d" />);
+    render(<VelocitySparkline velocity={{ daily: [], weekly: [] }} duration={{ kind: 'preset', value: '7d' }} />);
     expect(screen.getByTestId('sparkline-empty')).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/VelocitySparkline.test.tsx
+++ b/src/components/__tests__/VelocitySparkline.test.tsx
@@ -53,13 +53,13 @@ describe('VelocitySparkline', () => {
     render(<VelocitySparkline velocity={v} duration={d} />);
 
     const data = readChartData();
-    // Length: pickVelocity('7d') slices daily by -7.
+    // Length: pickVelocity({ kind: 'preset', value: '7d' }) slices daily by -7.
     expect(data).toHaveLength(7);
     // Last 7 of daily (length 365) is indices 358..364.
     expect(data[0].label).toBe('D358');
     expect(data[6].label).toBe('D364');
     // Source: opened values must come from daily (10000-range), not weekly (100-range).
-    // If pickVelocity wrongly returned weekly for 7d, opened would be in 100..359.
+    // If pickVelocity({ kind: 'preset', value: '7d' }) wrongly returned weekly, opened would be in 100..359.
     expect(data[0].opened).toBe(10358);
     expect(data[6].opened).toBe(10364);
     // Closed series must also come from daily (1000-range), not weekly (50-range).
@@ -72,13 +72,13 @@ describe('VelocitySparkline', () => {
     render(<VelocitySparkline velocity={v} duration={d} />);
 
     const data = readChartData();
-    // Length: pickVelocity('5y') slices weekly by -260; weekly is exactly 260 long.
+    // Length: pickVelocity({ kind: 'preset', value: '5y' }) slices weekly by -260; weekly is exactly 260 long.
     expect(data).toHaveLength(260);
     // slice(-260) on a 260-length array is the whole array.
     expect(data[0].label).toBe('W0');
     expect(data[259].label).toBe('W259');
     // Source: opened values must come from weekly (100-range), not daily (10000-range).
-    // If pickVelocity wrongly returned daily for 5y, opened would be in 10000..10364
+    // If pickVelocity({ kind: 'preset', value: '5y' }) wrongly returned daily, opened would be in 10000..10364
     // and length would be 7, not 260.
     expect(data[0].opened).toBe(100);
     expect(data[259].opened).toBe(359);

--- a/src/utils/__tests__/duration.test.ts
+++ b/src/utils/__tests__/duration.test.ts
@@ -201,4 +201,21 @@ describe('pickVelocity (custom)', () => {
 
     expect(got.points).toEqual([]);
   });
+
+  it('rejects malformed from (empty string)', () => {
+    const v = makeFixture();
+    const got = pickVelocity(v, custom('', '2026-01-07'), new Date('2026-12-04T00:00:00Z'));
+
+    expect(got.points).toEqual([]);
+    expect(got.granularity).toBe('week');
+    expect(got.clamp).toBeUndefined();
+  });
+
+  it('rejects malformed to (not ISO)', () => {
+    const v = makeFixture();
+    const got = pickVelocity(v, custom('2026-01-01', 'not-a-date'), new Date('2026-12-04T00:00:00Z'));
+
+    expect(got.points).toEqual([]);
+    expect(got.granularity).toBe('week');
+  });
 });

--- a/src/utils/__tests__/duration.test.ts
+++ b/src/utils/__tests__/duration.test.ts
@@ -111,6 +111,11 @@ describe('pickVelocity (custom)', () => {
     expect(got.points).toHaveLength(7);
     expect(got.points[0].label).toBe('2026-01-01');
     expect(got.points[6].label).toBe('2026-01-07');
+    // Daily fixture starts at index 0 = 2026-01-01 with opened=1000+0, closed=500+0.
+    expect(got.points[0].opened).toBe(1000);
+    expect(got.points[0].closed).toBe(500);
+    expect(got.points[6].opened).toBe(1006);
+    expect(got.points[6].closed).toBe(506);
     expect(got.clamp).toBeUndefined();
   });
 
@@ -118,12 +123,12 @@ describe('pickVelocity (custom)', () => {
     const v = makeFixture();
     const now = new Date('2026-12-04T00:00:00Z');
     // Range 2026-01-01..2026-07-20 = 200+ days → falls through to weekly.
-    // Weekly fixture has Mondays in this range; filter should return them.
+    // Exactly 29 Mondays in this range (verified via fixture: 2021-12-27 + 7n
+    // for n = 213..241 land in [2026-01-01, 2026-07-20]).
     const got = pickVelocity(v, custom('2026-01-01', '2026-07-20'), now);
 
     expect(got.granularity).toBe('week');
-    expect(got.points.length).toBeGreaterThan(0);
-    // All returned weeks must be inside the requested range.
+    expect(got.points).toHaveLength(29);
     for (const p of got.points) {
       expect(p.label >= '2026-01-01').toBe(true);
       expect(p.label <= '2026-07-20').toBe(true);
@@ -131,13 +136,21 @@ describe('pickVelocity (custom)', () => {
     expect(got.clamp).toBeUndefined();
   });
 
-  it('range > 90 days starting earlier than 365d ago → weekly', () => {
+  it('short range starting earlier than 365d ago → weekly (age gate)', () => {
     const v = makeFixture();
-    const now = new Date('2027-06-01T00:00:00Z'); // 2026-01-01 is > 365d before this
-    const got = pickVelocity(v, custom('2026-01-01', '2026-12-04'), now);
+    // Range = 7 days (≤ 90), but `from` is ~517 days before `now` → age gate
+    // forces weekly. Deleting the `ageDays <= 365` clause from pickCustom
+    // would let daily through, breaking this test.
+    // 2024-01-01 is a Monday and exists in the weekly fixture.
+    const got = pickVelocity(
+      v,
+      custom('2024-01-01', '2024-01-07'),
+      new Date('2025-06-01T00:00:00Z'),
+    );
 
     expect(got.granularity).toBe('week');
-    expect(got.points.length).toBeGreaterThan(0);
+    expect(got.points).toHaveLength(1);
+    expect(got.points[0].label).toBe('2024-01-01');
     expect(got.clamp).toBeUndefined();
   });
 
@@ -176,6 +189,9 @@ describe('pickVelocity (custom)', () => {
     expect(got.granularity).toBe('day');
     expect(got.points).toHaveLength(1);
     expect(got.points[0].label).toBe('2026-01-15');
+    // 2026-01-15 is at index 14 in the daily fixture (0=2026-01-01).
+    expect(got.points[0].opened).toBe(1014);
+    expect(got.points[0].closed).toBe(514);
   });
 
   it('from > to → empty (defensive)', () => {

--- a/src/utils/__tests__/duration.test.ts
+++ b/src/utils/__tests__/duration.test.ts
@@ -84,3 +84,94 @@ describe('formatDurationLabel', () => {
       .toBe('Oct 6, 2025');
   });
 });
+
+describe('pickVelocity (custom)', () => {
+  // The fixture's daily array uses synthetic dates 2026-01-01..2026-12-04
+  // (12 months × 31 day slots, 365 entries) so we can test against known
+  // dates. Use a fixed `now` to make daily-retention assertions deterministic.
+
+  // Wrap pickVelocity with a fixed "today" so the 365-day daily retention
+  // check is deterministic. Production calls Date.now() inside pickVelocity;
+  // tests inject via the optional 3rd arg added below.
+  function custom(from: string, to: string): Duration {
+    return { kind: 'custom', from, to };
+  }
+
+  it('range ≤ 90 days inside daily window → daily granularity', () => {
+    const v = makeFixture();
+    // daily[0] = 2026-01-01, daily[6] = 2026-01-07; the fixture's modulo-28
+    // day formula produces some duplicate dates within the month, so the
+    // filter returns 10 entries for this 7-calendar-day window. The key
+    // assertions are granularity, boundary labels, and absence of clamping.
+    const now = new Date('2026-12-04T00:00:00Z'); // well within 365-day retention
+    const got = pickVelocity(v, custom('2026-01-01', '2026-01-07'), now);
+
+    expect(got.granularity).toBe('day');
+    expect(got.points.length).toBeGreaterThan(0);
+    expect(got.points[0].label).toBe('2026-01-01');
+    expect(got.points[6].label).toBe('2026-01-07');
+    expect(got.clamp).toBeUndefined();
+  });
+
+  it('range > 90 days inside daily window → weekly granularity', () => {
+    const v = makeFixture();
+    const now = new Date('2026-12-04T00:00:00Z');
+    // rangeDays = floor((Jul-20 - Jan-1) / 1day) + 1 = 200 > 90 → weekly
+    const got = pickVelocity(v, custom('2026-01-01', '2026-07-20'), now);
+
+    // Granularity rule forces weekly even though start is within 365d retention.
+    expect(got.granularity).toBe('week');
+    // The fixture uses synthetic "2026-week-N" labels which don't overlap ISO
+    // date boundaries, so points is empty. This test asserts the granularity
+    // decision only — point filtering is covered by the clamp/retention tests.
+    expect(got.clamp).toBeUndefined();
+  });
+
+  it('range > 90 days starting earlier than 365d ago → weekly', () => {
+    const v = makeFixture();
+    const now = new Date('2027-06-01T00:00:00Z'); // far enough that 2026-01-01 is > 365d
+    const got = pickVelocity(v, custom('2026-01-01', '2026-12-04'), now);
+
+    expect(got.granularity).toBe('week');
+    expect(got.clamp).toBeUndefined();
+  });
+
+  it('range partially before weekly retention → clamps', () => {
+    const v = makeFixture();
+    // weekly fixture entries are labelled "2026-week-0" through "2026-week-259";
+    // the earliest weekly label is "2026-week-0". Asking for a range that
+    // starts before that should clamp.
+    const got = pickVelocity(v, custom('2025-week-50', '2026-week-10'), new Date('2027-01-01T00:00:00Z'));
+
+    expect(got.granularity).toBe('week');
+    expect(got.points.length).toBeGreaterThan(0);
+    expect(got.points[0].label).toBe('2026-week-0');
+    expect(got.clamp).toEqual({ requestedFrom: '2025-week-50', actualFrom: '2026-week-0' });
+  });
+
+  it('range entirely before retention → empty', () => {
+    const v = makeFixture();
+    const got = pickVelocity(v, custom('2020-01-01', '2020-12-31'), new Date('2027-01-01T00:00:00Z'));
+
+    expect(got.points).toEqual([]);
+    expect(got.granularity).toBe('week');
+  });
+
+  it('single-day range → one daily point', () => {
+    const v = makeFixture();
+    const now = new Date('2026-12-04T00:00:00Z');
+    const got = pickVelocity(v, custom('2026-01-15', '2026-01-15'), now);
+
+    expect(got.granularity).toBe('day');
+    expect(got.points).toHaveLength(1);
+    expect(got.points[0].label).toBe('2026-01-15');
+  });
+
+  it('from > to → empty (defensive)', () => {
+    const v = makeFixture();
+    const now = new Date('2026-12-04T00:00:00Z');
+    const got = pickVelocity(v, custom('2026-02-01', '2026-01-01'), now);
+
+    expect(got.points).toEqual([]);
+  });
+});

--- a/src/utils/__tests__/duration.test.ts
+++ b/src/utils/__tests__/duration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { pickVelocity, DURATIONS, type Duration } from '../duration';
+import { pickVelocity, PRESET_DURATIONS, type Duration, type PresetDuration } from '../duration';
 import type { Velocity, VelocityDay, VelocityWeek } from '../../types';
 
 // Build distinguishable fixtures so daily and weekly arrays return DIFFERENT
@@ -9,37 +9,37 @@ import type { Velocity, VelocityDay, VelocityWeek } from '../../types';
 function makeFixture(): Velocity {
   const daily: VelocityDay[] = Array.from({ length: 365 }, (_, i) => ({
     date: `2026-${String(Math.floor(i / 31) + 1).padStart(2, '0')}-${String((i % 28) + 1).padStart(2, '0')}`,
-    opened: 1000 + i, // distinct values starting at 1000
-    closed: 500 + i, // distinct from opened
+    opened: 1000 + i,
+    closed: 500 + i,
   }));
   const weekly: VelocityWeek[] = Array.from({ length: 260 }, (_, i) => ({
     week: `2026-week-${i}`,
-    opened: i, // distinct values starting at 0
-    closed: 500 - i, // distinct from opened
+    opened: i,
+    closed: 500 - i,
   }));
   return { daily, weekly };
 }
 
-describe('pickVelocity', () => {
-  it.each<[Duration, 'day' | 'week', number]>([
+function preset(value: PresetDuration): Duration {
+  return { kind: 'preset', value };
+}
+
+describe('pickVelocity (preset)', () => {
+  it.each<[PresetDuration, 'day' | 'week', number]>([
     ['7d', 'day', 7],
     ['4w', 'week', 4],
     ['12w', 'week', 12],
     ['6m', 'week', 26],
     ['1y', 'week', 52],
     ['5y', 'week', 260],
-  ])('duration=%s → granularity=%s, length=%d', (duration, wantGranularity, wantLength) => {
+  ])('preset=%s → granularity=%s, length=%d', (value, wantGranularity, wantLength) => {
     const v = makeFixture();
-    const got = pickVelocity(v, duration);
+    const got = pickVelocity(v, preset(value));
 
     expect(got.granularity).toBe(wantGranularity);
     expect(got.points).toHaveLength(wantLength);
 
-    // Each duration's points must come from the matching array; spot-check
-    // the first and last point to catch off-by-one slicing bugs. Also assert
-    // on `closed` to catch an opened/closed swap regression.
     if (wantGranularity === 'day') {
-      // 7d → daily.slice(-7); first point's `opened` is 1000 + (365-7)
       expect(got.points[0].opened).toBe(1000 + (365 - wantLength));
       expect(got.points[wantLength - 1].opened).toBe(1000 + 364);
       expect(got.points[0].closed).toBe(500 + (365 - wantLength));
@@ -52,7 +52,7 @@ describe('pickVelocity', () => {
     }
   });
 
-  it('exposes DURATIONS in display order', () => {
-    expect(DURATIONS).toEqual(['7d', '4w', '12w', '6m', '1y', '5y']);
+  it('exposes PRESET_DURATIONS in display order', () => {
+    expect(PRESET_DURATIONS).toEqual(['7d', '4w', '12w', '6m', '1y', '5y']);
   });
 });

--- a/src/utils/__tests__/duration.test.ts
+++ b/src/utils/__tests__/duration.test.ts
@@ -6,17 +6,25 @@ import type { Velocity, VelocityDay, VelocityWeek } from '../../types';
 // values for any given index. This catches a bug where pickVelocity maps a
 // daily-granularity duration ('7d') to the weekly array. `closed` values
 // are also distinct from `opened` to catch a swap regression.
+//
+// Daily: sequential ISO dates 2026-01-01 through 2026-12-31 (365 unique days).
+// Weekly: sequential ISO Monday dates 2021-12-27 through 2026-12-21 (260 weeks).
+// Both match production data shape (artifact_fetcher.go uses Format("2006-01-02")).
 function makeFixture(): Velocity {
-  const daily: VelocityDay[] = Array.from({ length: 365 }, (_, i) => ({
-    date: `2026-${String(Math.floor(i / 31) + 1).padStart(2, '0')}-${String((i % 28) + 1).padStart(2, '0')}`,
-    opened: 1000 + i,
-    closed: 500 + i,
-  }));
-  const weekly: VelocityWeek[] = Array.from({ length: 260 }, (_, i) => ({
-    week: `2026-week-${i}`,
-    opened: i,
-    closed: 500 - i,
-  }));
+  const dailyStart = Date.UTC(2026, 0, 1); // 2026-01-01
+  const daily: VelocityDay[] = Array.from({ length: 365 }, (_, i) => {
+    const date = new Date(dailyStart + i * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    return { date, opened: 1000 + i, closed: 500 + i };
+  });
+  const weeklyStart = Date.UTC(2021, 11, 27); // 2021-12-27 (Monday)
+  const weekly: VelocityWeek[] = Array.from({ length: 260 }, (_, i) => {
+    const week = new Date(weeklyStart + i * 7 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    return { week, opened: i, closed: 500 - i };
+  });
   return { daily, weekly };
 }
 
@@ -86,28 +94,21 @@ describe('formatDurationLabel', () => {
 });
 
 describe('pickVelocity (custom)', () => {
-  // The fixture's daily array uses synthetic dates 2026-01-01..2026-12-04
-  // (12 months × 31 day slots, 365 entries) so we can test against known
-  // dates. Use a fixed `now` to make daily-retention assertions deterministic.
-
-  // Wrap pickVelocity with a fixed "today" so the 365-day daily retention
-  // check is deterministic. Production calls Date.now() inside pickVelocity;
-  // tests inject via the optional 3rd arg added below.
+  // Daily fixture: 2026-01-01..2026-12-31 (365 unique sequential ISO dates).
+  // Weekly fixture: 2021-12-27..2026-12-21 (260 sequential ISO Monday dates).
+  // Both match production data shape (artifact_fetcher.go uses Format("2006-01-02")).
+  // Use a fixed `now` to make 365-day daily-retention assertions deterministic.
   function custom(from: string, to: string): Duration {
     return { kind: 'custom', from, to };
   }
 
   it('range ≤ 90 days inside daily window → daily granularity', () => {
     const v = makeFixture();
-    // daily[0] = 2026-01-01, daily[6] = 2026-01-07; the fixture's modulo-28
-    // day formula produces some duplicate dates within the month, so the
-    // filter returns 10 entries for this 7-calendar-day window. The key
-    // assertions are granularity, boundary labels, and absence of clamping.
-    const now = new Date('2026-12-04T00:00:00Z'); // well within 365-day retention
+    const now = new Date('2026-12-04T00:00:00Z');
     const got = pickVelocity(v, custom('2026-01-01', '2026-01-07'), now);
 
     expect(got.granularity).toBe('day');
-    expect(got.points.length).toBeGreaterThan(0);
+    expect(got.points).toHaveLength(7);
     expect(got.points[0].label).toBe('2026-01-01');
     expect(got.points[6].label).toBe('2026-01-07');
     expect(got.clamp).toBeUndefined();
@@ -116,42 +117,52 @@ describe('pickVelocity (custom)', () => {
   it('range > 90 days inside daily window → weekly granularity', () => {
     const v = makeFixture();
     const now = new Date('2026-12-04T00:00:00Z');
-    // rangeDays = floor((Jul-20 - Jan-1) / 1day) + 1 = 200 > 90 → weekly
+    // Range 2026-01-01..2026-07-20 = 200+ days → falls through to weekly.
+    // Weekly fixture has Mondays in this range; filter should return them.
     const got = pickVelocity(v, custom('2026-01-01', '2026-07-20'), now);
 
-    // Granularity rule forces weekly even though start is within 365d retention.
     expect(got.granularity).toBe('week');
-    // The fixture uses synthetic "2026-week-N" labels which don't overlap ISO
-    // date boundaries, so points is empty. This test asserts the granularity
-    // decision only — point filtering is covered by the clamp/retention tests.
+    expect(got.points.length).toBeGreaterThan(0);
+    // All returned weeks must be inside the requested range.
+    for (const p of got.points) {
+      expect(p.label >= '2026-01-01').toBe(true);
+      expect(p.label <= '2026-07-20').toBe(true);
+    }
     expect(got.clamp).toBeUndefined();
   });
 
   it('range > 90 days starting earlier than 365d ago → weekly', () => {
     const v = makeFixture();
-    const now = new Date('2027-06-01T00:00:00Z'); // far enough that 2026-01-01 is > 365d
+    const now = new Date('2027-06-01T00:00:00Z'); // 2026-01-01 is > 365d before this
     const got = pickVelocity(v, custom('2026-01-01', '2026-12-04'), now);
 
     expect(got.granularity).toBe('week');
+    expect(got.points.length).toBeGreaterThan(0);
     expect(got.clamp).toBeUndefined();
   });
 
   it('range partially before weekly retention → clamps', () => {
     const v = makeFixture();
-    // weekly fixture entries are labelled "2026-week-0" through "2026-week-259";
-    // the earliest weekly label is "2026-week-0". Asking for a range that
-    // starts before that should clamp.
-    const got = pickVelocity(v, custom('2025-week-50', '2026-week-10'), new Date('2027-01-01T00:00:00Z'));
+    // Earliest weekly Monday is 2021-12-27. Request a range that starts before.
+    const got = pickVelocity(
+      v,
+      custom('2020-06-01', '2022-03-01'),
+      new Date('2027-01-01T00:00:00Z'),
+    );
 
     expect(got.granularity).toBe('week');
     expect(got.points.length).toBeGreaterThan(0);
-    expect(got.points[0].label).toBe('2026-week-0');
-    expect(got.clamp).toEqual({ requestedFrom: '2025-week-50', actualFrom: '2026-week-0' });
+    expect(got.points[0].label).toBe('2021-12-27');
+    expect(got.clamp).toEqual({ requestedFrom: '2020-06-01', actualFrom: '2021-12-27' });
   });
 
   it('range entirely before retention → empty', () => {
     const v = makeFixture();
-    const got = pickVelocity(v, custom('2020-01-01', '2020-12-31'), new Date('2027-01-01T00:00:00Z'));
+    const got = pickVelocity(
+      v,
+      custom('2019-01-01', '2019-12-31'),
+      new Date('2027-01-01T00:00:00Z'),
+    );
 
     expect(got.points).toEqual([]);
     expect(got.granularity).toBe('week');

--- a/src/utils/__tests__/duration.test.ts
+++ b/src/utils/__tests__/duration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { pickVelocity, PRESET_DURATIONS, type Duration, type PresetDuration } from '../duration';
+import { pickVelocity, PRESET_DURATIONS, formatDurationLabel, type Duration, type PresetDuration } from '../duration';
 import type { Velocity, VelocityDay, VelocityWeek } from '../../types';
 
 // Build distinguishable fixtures so daily and weekly arrays return DIFFERENT
@@ -54,5 +54,33 @@ describe('pickVelocity (preset)', () => {
 
   it('exposes PRESET_DURATIONS in display order', () => {
     expect(PRESET_DURATIONS).toEqual(['7d', '4w', '12w', '6m', '1y', '5y']);
+  });
+});
+
+describe('formatDurationLabel', () => {
+  it.each<[PresetDuration, string]>([
+    ['7d', 'Last 7 days'],
+    ['4w', 'Last 4 weeks'],
+    ['12w', 'Last 12 weeks'],
+    ['6m', 'Last 6 months'],
+    ['1y', 'Last 1 year'],
+    ['5y', 'Last 5 years'],
+  ])('preset %s → %s', (value, want) => {
+    expect(formatDurationLabel({ kind: 'preset', value })).toBe(want);
+  });
+
+  it('custom range same year → "MMM d – MMM d, YYYY"', () => {
+    expect(formatDurationLabel({ kind: 'custom', from: '2025-10-06', to: '2025-10-12' }))
+      .toBe('Oct 6 – Oct 12, 2025');
+  });
+
+  it('custom range crossing years → "MMM d, YYYY – MMM d, YYYY"', () => {
+    expect(formatDurationLabel({ kind: 'custom', from: '2024-12-29', to: '2025-01-04' }))
+      .toBe('Dec 29, 2024 – Jan 4, 2025');
+  });
+
+  it('custom single-day range → "MMM d, YYYY"', () => {
+    expect(formatDurationLabel({ kind: 'custom', from: '2025-10-06', to: '2025-10-06' }))
+      .toBe('Oct 6, 2025');
   });
 });

--- a/src/utils/duration.ts
+++ b/src/utils/duration.ts
@@ -1,8 +1,12 @@
 import type { Velocity } from '../types';
 
-export type Duration = '7d' | '4w' | '12w' | '6m' | '1y' | '5y';
+export type PresetDuration = '7d' | '4w' | '12w' | '6m' | '1y' | '5y';
 
-export const DURATIONS: Duration[] = ['7d', '4w', '12w', '6m', '1y', '5y'];
+export type Duration =
+  | { kind: 'preset'; value: PresetDuration }
+  | { kind: 'custom'; from: string; to: string }; // ISO "YYYY-MM-DD"
+
+export const PRESET_DURATIONS: PresetDuration[] = ['7d', '4w', '12w', '6m', '1y', '5y'];
 
 export interface VelocityPoint {
   label: string;
@@ -14,9 +18,11 @@ export interface VelocityPoint {
 export interface PickedVelocity {
   points: VelocityPoint[];
   granularity: 'day' | 'week';
+  /** When the requested range was clamped to fit available data. */
+  clamp?: { requestedFrom: string; actualFrom: string };
 }
 
-const DURATION_TABLE: Record<Duration, { granularity: 'day' | 'week'; n: number }> = {
+const PRESET_TABLE: Record<PresetDuration, { granularity: 'day' | 'week'; n: number }> = {
   '7d':  { granularity: 'day',  n: 7   },
   '4w':  { granularity: 'week', n: 4   },
   '12w': { granularity: 'week', n: 12  },
@@ -31,11 +37,18 @@ const DURATION_TABLE: Record<Duration, { granularity: 'day' | 'week'; n: number 
  * come from the underlying entry's `date` (daily) or `week` (weekly).
  *
  * Snapshot stats (Open Issues, age buckets, categories) deliberately do
- * NOT pass through this helper — they always reflect "right now" per the
- * Q3 invariant in the spec.
+ * NOT pass through this helper — they always reflect "right now".
  */
 export function pickVelocity(v: Velocity, d: Duration): PickedVelocity {
-  const cfg = DURATION_TABLE[d];
+  if (d.kind === 'preset') {
+    return pickPreset(v, d.value);
+  }
+  // Custom case implemented in Task 3.
+  return { points: [], granularity: 'week' };
+}
+
+function pickPreset(v: Velocity, preset: PresetDuration): PickedVelocity {
+  const cfg = PRESET_TABLE[preset];
   if (cfg.granularity === 'day') {
     const slice = v.daily.slice(-cfg.n);
     return {

--- a/src/utils/duration.ts
+++ b/src/utils/duration.ts
@@ -31,20 +31,76 @@ const PRESET_TABLE: Record<PresetDuration, { granularity: 'day' | 'week'; n: num
   '5y':  { granularity: 'week', n: 260 },
 };
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const DAILY_RETENTION_DAYS = 365;
+const DAILY_MAX_RANGE_DAYS = 90;
+
 /**
  * pickVelocity selects the right velocity array (daily or weekly) for the
- * requested duration and slices it to the appropriate length. The labels
- * come from the underlying entry's `date` (daily) or `week` (weekly).
+ * requested duration and slices it. For custom ranges, granularity is
+ * chosen by the rule:
+ *   daily if range_days ≤ 90 AND from ≥ today − 365d, else weekly.
+ * Out-of-retention starts are clamped to the earliest available label.
  *
- * Snapshot stats (Open Issues, age buckets, categories) deliberately do
- * NOT pass through this helper — they always reflect "right now".
+ * The optional `now` parameter exists so tests can pin "today" for the
+ * 365-day retention check. Production callers omit it (defaults to
+ * `new Date()`).
  */
-export function pickVelocity(v: Velocity, d: Duration): PickedVelocity {
+export function pickVelocity(v: Velocity, d: Duration, now?: Date): PickedVelocity {
   if (d.kind === 'preset') {
     return pickPreset(v, d.value);
   }
-  // Custom case implemented in Task 3.
-  return { points: [], granularity: 'week' };
+  return pickCustom(v, d.from, d.to, now ?? new Date());
+}
+
+function pickCustom(v: Velocity, from: string, to: string, now: Date): PickedVelocity {
+  if (from > to) {
+    return { points: [], granularity: 'week' };
+  }
+
+  const rangeDays = daysBetweenInclusive(from, to);
+  const fromDate = new Date(`${from}T00:00:00Z`);
+  const ageDays = (now.getTime() - fromDate.getTime()) / ONE_DAY_MS;
+  const wantDaily = rangeDays <= DAILY_MAX_RANGE_DAYS && ageDays <= DAILY_RETENTION_DAYS;
+
+  if (wantDaily) {
+    const points = v.daily
+      .filter((entry) => entry.date >= from && entry.date <= to)
+      .map((day) => ({
+        label: day.date,
+        opened: day.opened,
+        closed: day.closed,
+        merged: day.merged,
+      }));
+    return { points, granularity: 'day' };
+  }
+
+  const weekly = v.weekly;
+  if (weekly.length === 0) {
+    return { points: [], granularity: 'week' };
+  }
+  const earliest = weekly[0].week;
+  const filtered = weekly.filter((entry) => entry.week >= from && entry.week <= to);
+  const points = filtered.map((wk) => ({
+    label: wk.week,
+    opened: wk.opened,
+    closed: wk.closed,
+    merged: wk.merged,
+  }));
+  if (from < earliest && points.length > 0) {
+    return {
+      points,
+      granularity: 'week',
+      clamp: { requestedFrom: from, actualFrom: points[0].label },
+    };
+  }
+  return { points, granularity: 'week' };
+}
+
+function daysBetweenInclusive(fromISO: string, toISO: string): number {
+  const from = new Date(`${fromISO}T00:00:00Z`).getTime();
+  const to = new Date(`${toISO}T00:00:00Z`).getTime();
+  return Math.floor((to - from) / ONE_DAY_MS) + 1;
 }
 
 // en-US short month names. Update if i18n support is added.

--- a/src/utils/duration.ts
+++ b/src/utils/duration.ts
@@ -47,17 +47,19 @@ export function pickVelocity(v: Velocity, d: Duration): PickedVelocity {
   return { points: [], granularity: 'week' };
 }
 
+// en-US short month names. Update if i18n support is added.
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
-function parseISO(d: string): { y: number; m: number; day: number } {
+type ParsedDate = { y: number; m: number; day: number };
+
+function parseISO(d: string): ParsedDate {
   const [y, m, day] = d.split('-').map(Number);
   return { y, m, day };
 }
 
-function shortDate(iso: string, includeYear: boolean): string {
-  const { y, m, day } = parseISO(iso);
-  const base = `${MONTHS[m - 1]} ${day}`;
-  return includeYear ? `${base}, ${y}` : base;
+function shortDate(p: ParsedDate, includeYear: boolean): string {
+  const base = `${MONTHS[p.m - 1]} ${p.day}`;
+  return includeYear ? `${base}, ${p.y}` : base;
 }
 
 const PRESET_LABELS: Record<PresetDuration, string> = {
@@ -73,15 +75,15 @@ export function formatDurationLabel(d: Duration): string {
   if (d.kind === 'preset') {
     return PRESET_LABELS[d.value];
   }
+  const from = parseISO(d.from);
   if (d.from === d.to) {
-    return shortDate(d.from, true);
+    return shortDate(from, true);
   }
-  const fromY = parseISO(d.from).y;
-  const toY = parseISO(d.to).y;
-  if (fromY === toY) {
-    return `${shortDate(d.from, false)} – ${shortDate(d.to, true)}`;
+  const to = parseISO(d.to);
+  if (from.y === to.y) {
+    return `${shortDate(from, false)} – ${shortDate(to, true)}`;
   }
-  return `${shortDate(d.from, true)} – ${shortDate(d.to, true)}`;
+  return `${shortDate(from, true)} – ${shortDate(to, true)}`;
 }
 
 function pickPreset(v: Velocity, preset: PresetDuration): PickedVelocity {

--- a/src/utils/duration.ts
+++ b/src/utils/duration.ts
@@ -47,6 +47,43 @@ export function pickVelocity(v: Velocity, d: Duration): PickedVelocity {
   return { points: [], granularity: 'week' };
 }
 
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function parseISO(d: string): { y: number; m: number; day: number } {
+  const [y, m, day] = d.split('-').map(Number);
+  return { y, m, day };
+}
+
+function shortDate(iso: string, includeYear: boolean): string {
+  const { y, m, day } = parseISO(iso);
+  const base = `${MONTHS[m - 1]} ${day}`;
+  return includeYear ? `${base}, ${y}` : base;
+}
+
+const PRESET_LABELS: Record<PresetDuration, string> = {
+  '7d':  'Last 7 days',
+  '4w':  'Last 4 weeks',
+  '12w': 'Last 12 weeks',
+  '6m':  'Last 6 months',
+  '1y':  'Last 1 year',
+  '5y':  'Last 5 years',
+};
+
+export function formatDurationLabel(d: Duration): string {
+  if (d.kind === 'preset') {
+    return PRESET_LABELS[d.value];
+  }
+  if (d.from === d.to) {
+    return shortDate(d.from, true);
+  }
+  const fromY = parseISO(d.from).y;
+  const toY = parseISO(d.to).y;
+  if (fromY === toY) {
+    return `${shortDate(d.from, false)} – ${shortDate(d.to, true)}`;
+  }
+  return `${shortDate(d.from, true)} – ${shortDate(d.to, true)}`;
+}
+
 function pickPreset(v: Velocity, preset: PresetDuration): PickedVelocity {
   const cfg = PRESET_TABLE[preset];
   if (cfg.granularity === 'day') {

--- a/src/utils/duration.ts
+++ b/src/utils/duration.ts
@@ -34,6 +34,7 @@ const PRESET_TABLE: Record<PresetDuration, { granularity: 'day' | 'week'; n: num
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const DAILY_RETENTION_DAYS = 365;
 const DAILY_MAX_RANGE_DAYS = 90;
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
 /**
  * pickVelocity selects the right velocity array (daily or weekly) for the
@@ -55,6 +56,9 @@ export function pickVelocity(v: Velocity, d: Duration, now?: Date): PickedVeloci
 
 function pickCustom(v: Velocity, from: string, to: string, now: Date): PickedVelocity {
   if (from > to) {
+    return { points: [], granularity: 'week' };
+  }
+  if (!ISO_DATE.test(from) || !ISO_DATE.test(to)) {
     return { points: [], granularity: 'week' };
   }
 


### PR DESCRIPTION
## Problem

The Issues & PRs Overview section's duration selector only supports six trailing windows anchored to "now". TPM request: inspect trends for an arbitrary historical window ("one week sometime in Q4 last year").

## Approach

Replace the six-button preset row with a dropdown that includes the six presets plus a "Custom range…" option. Selecting Custom opens a popover with native date inputs. The underlying \`Duration\` type becomes a discriminated \`preset | custom\` union; \`pickVelocity\` dispatches on \`kind\`. Custom ranges use daily granularity when the range is ≤90 days and starts within 365 days of today, else weekly. Out-of-retention starts are clamped to the earliest available date with a visible note.

## Testing

- 7 new \`pickVelocity\` custom-range cases (daily window, daily-too-long fallback, retention edges, single day, defensive \`from > to\`). Mutation-tested: deleting the age clause OR the range-days clause from the granularity rule fails the suite.
- 4 new \`formatDurationLabel\` cases (presets, same-year, cross-year, single day).
- 12 new \`DurationPicker\` component tests (preset open/select/close + Escape, custom-range form, validation, pre-fill, Cancel, Enter-key submit).
- 1 new \`IssuesPRsDashboard\` integration test exercising the clamp branch end-to-end.
- Existing preset and \`VelocitySparkline\` tests migrated and passing.
- 67/67 tests pass, lint clean, build succeeds.
- Manual browser verification (Chrome): golden path + edge cases pass.

## Out of scope (deliberate)

- URL-encoded duration state — preset selector isn't URL-encoded today; parity preserved.
- Named-period quick-picks ("Q4 2025", "Last quarter") — YAGNI until a second user asks.
- Custom range on \`Dashboard.tsx\` workflow chart or \`ProjectDetail.tsx\` traffic charts.

## Known review feedback (to address before promoting)

Two parallel panel reviews (principal-engineer + qa-engineer) returned "Ready with caveats":

**A11y polish:**
- Focus restoration on Escape/Apply/preset-select (return focus to trigger)
- \`aria-haspopup\` should be consistent between presets ("menu") and custom mode (which needs \`role="dialog"\` on the \`<form>\` to honor the dialog promise)

**Defensive code:**
- \`pickCustom\` should reject malformed ISO strings (empty \`from\` currently produces a spurious clamp note if called programmatically)
- \`VelocitySparkline\` should \`useMemo\` \`pickVelocity\` for consistency with \`ExpandedRowDetail\`

**Test coverage gaps:**
- Single-day custom-range component test (mutation survived on \`from > to\` → \`from >= to\`)
- Assertions on \`aria-live="polite"\` and \`role="alert"\` attributes

Will land as follow-up commits before promoting from draft.