### PR TITLE
feat(mockibsysfs): ibping support via synthetic umad emulation

### DIFF
--- a/.github/workflows/nvml-mock-e2e.yaml
+++ b/.github/workflows/nvml-mock-e2e.yaml
@@ -41,7 +41,22 @@ on:
         type: string
 
 jobs:
+  mockib-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install infiniband-diags
+        run: sudo apt-get update && sudo apt-get install -y infiniband-diags
+
+      - name: Build libibmocksys and run integration tests
+        run: |
+          make -C pkg/network/mockibsysfs
+          go test ./pkg/network/mockibsysfs/...
+          go test -tags=integration ./pkg/network/mockibsysfs/render/...
+
   e2e-device-plugin:
+    needs: mockib-integration
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -139,6 +154,13 @@ jobs:
           # gpu.count=2 in this job; profiles ship hcas_per_gpu=1, so
           # IB-enabled profiles are expected to expose 2 HCAs.
           ./tests/e2e/validate-ibstat.sh "$POD" "${{ matrix.gpu-profile }}" 2
+
+      - name: Validate ibping (vendor MAD / libibumad)
+        run: |
+          chmod +x tests/e2e/validate-ibping.sh
+          POD=$(kubectl get pods -l app.kubernetes.io/name=nvml-mock \
+            -o jsonpath='{.items[0].metadata.name}')
+          ./tests/e2e/validate-ibping.sh "$POD" "${{ matrix.gpu-profile }}" 2
 
       - name: Deploy NVIDIA device plugin
         run: |
@@ -777,6 +799,13 @@ jobs:
           T4_POD=$(kubectl get pods -l app.kubernetes.io/instance=nvml-mock-t4 \
             -o jsonpath='{.items[0].metadata.name}')
           ./tests/e2e/validate-ibstat.sh "$T4_POD" t4 2
+
+      - name: Validate ibping on A100 worker
+        run: |
+          chmod +x tests/e2e/validate-ibping.sh
+          A100_POD=$(kubectl get pods -l app.kubernetes.io/instance=nvml-mock-a100 \
+            -o jsonpath='{.items[0].metadata.name}')
+          ./tests/e2e/validate-ibping.sh "$A100_POD" a100 2
 
       - name: Deploy NVIDIA device plugin
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 
 # Agentic working artifacts
 .agents/
+.cursor/
+.worktrees/
 AGENTS.md
+CLAUDE.md
 docs/plans/
 docs/superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- InfiniBand mock: `ibping` (OpenIB vendor ping MAD class only) via synthetic
+  umad fds, global `umad-bus/` for cross-HCA server/client, TID-matched replies,
+  `REGISTER_AGENT2`, and mixed-fd `poll()` with libc.
 - InfiniBand mock: real `ibstat`, `ibstatus`, `iblinkinfo`, and other
   `infiniband-diags` / `rdma-core` tools now work inside the nvml-mock
   DaemonSet without IB hardware. Implementation: `LD_PRELOAD` shim

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -13,7 +13,7 @@ Deploys a DaemonSet that creates on every node:
 - Node label `nvidia.com/gpu.present=true`
 - A fake InfiniBand sysfs tree at `/var/lib/nvml-mock/ib/sys/class/infiniband/...`
   paired with `libibmocksys.so` (`LD_PRELOAD`) so real `ibstat`, `ibstatus`,
-  `iblinkinfo`, ... read mock HCAs
+  `iblinkinfo`, `ibping`, ... use mock HCAs (sysfs + synthetic umad)
 
 Consumers (DRA driver, device plugin) point at `/var/lib/nvml-mock/driver`
 as the NVIDIA driver root and discover GPUs through standard NVML APIs.
@@ -498,7 +498,20 @@ read from the rendered tree:
 POD=$(kubectl get pods -l app.kubernetes.io/name=nvml-mock -o jsonpath='{.items[0].metadata.name}')
 kubectl exec "$POD" -- ibstat
 kubectl exec "$POD" -- ibstatus
+kubectl exec "$POD" -- ibping -c 1 -C mlx5_0 -P 1 1
 ```
+
+**Environment (DaemonSet):**
+
+| Variable | Value | Purpose |
+|----------|--------|---------|
+| `LD_PRELOAD` | `/usr/local/lib/libibmocksys.so.1` | Sysfs redirect + synthetic umad |
+| `MOCK_IB_ROOT` | `/var/lib/nvml-mock/ib` | Fake sysfs + `umad-bus/` runtime dir |
+| `MOCK_IB_DISABLE` | unset (set `1` to bypass) | Debug escape hatch |
+
+**Limitations:** sysfs tools (`ibstat`, …) read the rendered tree. **`ibping`**
+uses emulated umad (vendor ping MADs only), not real HCAs or RDMA. Runtime
+MAD relay files live under `/var/lib/nvml-mock/ib/umad-bus/`.
 
 ### Defaults per profile
 

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -79,9 +79,8 @@ spec:
             {{- end }}
             # LD_PRELOAD installs the InfiniBand sysfs redirector in every
             # process spawned in this container (e.g. `kubectl exec ibstat`).
-            # The shim only rewrites paths under /sys/class/infiniband*,
-            # /sys/class/infiniband_mad/, /sys/class/infiniband_verbs/ and
-            # /dev/infiniband — every other path passes through unchanged.
+            # The shim rewrites IB sysfs/dev paths and emulates umad for ibping.
+            # Every other path passes through unchanged.
             - name: LD_PRELOAD
               value: "/usr/local/lib/libibmocksys.so.1"
             - name: MOCK_IB_ROOT

--- a/pkg/network/mockibsysfs/Makefile
+++ b/pkg/network/mockibsysfs/Makefile
@@ -2,20 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 CC      ?= gcc
-CFLAGS  ?= -O2 -Wall -Wextra -fPIC -fvisibility=default
-LDFLAGS ?= -shared -Wl,-soname,libibmocksys.so.1 -ldl
+CFLAGS  ?= -O2 -Wall -Wextra -Wno-format-truncation -fPIC -fvisibility=default
+LDFLAGS ?= -shared -Wl,-soname,libibmocksys.so.1 -ldl -lpthread
 
 LIB_NAME    := libibmocksys.so
 LIB_SONAME  := $(LIB_NAME).1
-LIB_VERSION ?= 1.0.0
+LIB_VERSION ?= 1.2.0
 LIB_REAL    := $(LIB_NAME).$(LIB_VERSION)
 
 .PHONY: all clean
 
 all: $(LIB_NAME)
 
-$(LIB_REAL): shim.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $<
+$(LIB_REAL): shim.c umad_mock.c mock_ib_root.c umad_mock.h mock_ib_root.h
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ shim.c umad_mock.c mock_ib_root.c
 
 $(LIB_NAME): $(LIB_REAL)
 	ln -sf $(LIB_REAL) $(LIB_SONAME)

--- a/pkg/network/mockibsysfs/README.md
+++ b/pkg/network/mockibsysfs/README.md
@@ -1,116 +1,79 @@
 # mockibsysfs
 
 Mock InfiniBand fabric for Kubernetes testing. Lets unmodified userspace
-tools (`ibstat`, `ibstatus`, `iblinkinfo`, `libibverbs` consumers, ...)
-read realistic per-HCA topology data on hosts that have no IB hardware.
+tools read realistic per-HCA topology on hosts without IB hardware.
 
-This package is the InfiniBand counterpart of [`pkg/gpu/mocknvml`](../../gpu/mocknvml/):
-mocknvml ships a fake `libnvidia-ml.so` so `nvidia-smi` works without
-GPUs; mockibsysfs ships a fake sysfs tree so `ibstat` works without HCAs.
+| Tool class | Supported via |
+|------------|----------------|
+| `ibstat`, `ibstatus`, `iblinkinfo` | Fake sysfs under `$MOCK_IB_ROOT` |
+| **`ibping`** | Synthetic umad fds + vendor ping MAD (`0x32`) |
+| `libibverbs` / RDMA workloads | **Not supported** (placeholder device nodes only) |
+
+This package is the InfiniBand counterpart of [`pkg/gpu/mocknvml`](../../gpu/mocknvml/).
 
 ## Components
 
 ```
 pkg/network/mockibsysfs/
-├── shim.c            # LD_PRELOAD library: redirects libc filesystem calls
-├── Makefile          # builds libibmocksys.so from shim.c
+├── shim.c            # LD_PRELOAD: sysfs path rewrite + umad fd dispatch
+├── umad_mock.c       # ibping-oriented umad(4) emulation
+├── mock_ib_root.c    # shared MOCK_IB_ROOT default (/var/lib/nvml-mock/ib)
+├── Makefile          # builds libibmocksys.so
 ├── config/           # YAML schema for the `infiniband:` profile block
 └── render/           # writes a kernel-faithful sysfs tree from the schema
 
 cmd/render-ib-sysfs/  # CLI wrapper that reads a profile YAML and invokes render
 ```
 
-Two pieces work together:
+Three pieces work together:
 
-1. **`libibmocksys.so` (LD_PRELOAD shim, C).** Hooks ~15 libc functions
-   (`open`, `openat`, `opendir`, `scandir`/`scandir64`, `stat`, `lstat`,
-   `fstatat`, `statx`, `fopen`, `access`, `faccessat`, `readlink`,
-   `readlinkat`, `chdir`) and rewrites paths starting with
+1. **`libibmocksys.so` (LD_PRELOAD shim, C).** Rewrites paths under
    `/sys/class/infiniband*`, `/sys/class/infiniband_mad/`,
-   `/sys/class/infiniband_verbs/`, or `/dev/infiniband` to point under
-   `$MOCK_IB_ROOT/...`. Everything else passes through to real libc via
-   `dlsym(RTLD_NEXT, ...)`. C is the right choice here — see
-   [Why C, not Go](#why-c-not-go).
+   `/sys/class/infiniband_verbs/`, `/sys/class/infiniband_cm/`, and
+   `/dev/infiniband` to `$MOCK_IB_ROOT/...`. Opens on `/dev/infiniband/umad*`
+   become synthetic fds handled by `umad_mock.c`.
 
-2. **`render-ib-sysfs` (Go binary).** Reads the `infiniband:` block from
-   the active mock-nvml profile YAML and writes a kernel-faithful tree
-   under `--output`: per-CA `node_type`, `node_guid`, `sys_image_guid`,
-   `fw_ver`, `hw_rev`, `board_id`, `hca_type`, `node_desc`; per-port
-   `state`, `phys_state`, `rate`, `lid`, `sm_lid`, `cap_mask`,
-   `link_layer`, `gids/0`, `pkeys/0`, `counters/*`; plus
-   `infiniband_mad/{abi_version,umad*,issm*}` for `libibumad`,
-   `infiniband_verbs/{abi_version,uverbs*}` for `libibverbs`, and the
-   matching `dev/infiniband/*` files.
+2. **`render-ib-sysfs` (Go).** Writes the fake sysfs tree from the profile
+   `infiniband:` block. Does **not** create `umad-bus/` (runtime only).
+
+3. **`umad_mock.c` (C).** Implements `ioctl` / `read` / `write` / `poll` for
+   ibping. Same-LID pings are answered in-process; other LIDs use a global
+   file bus at `$MOCK_IB_ROOT/umad-bus/{in,out}/` for server/client mode.
 
 In the nvml-mock DaemonSet:
 
-- The Dockerfile builds both pieces and installs `infiniband-diags` +
-  `rdma-core` for the real userspace tools.
-- `setup.sh` invokes `render-ib-sysfs` once at startup against
-  `/host/var/lib/nvml-mock/ib`.
-- The pod env sets `LD_PRELOAD=/usr/local/lib/libibmocksys.so.1` and
-  `MOCK_IB_ROOT=/var/lib/nvml-mock/ib`, so every process in the
-  container — including `kubectl exec ... ibstat` — sees the fake fabric.
+- `setup.sh` renders to `/host/var/lib/nvml-mock/ib`.
+- Env: `LD_PRELOAD=/usr/local/lib/libibmocksys.so.1`,
+  `MOCK_IB_ROOT=/var/lib/nvml-mock/ib`.
+- `infiniband-diags` in the image provides `ibping`, `ibstat`, etc.
 
-Set `MOCK_IB_DISABLE=1` in any process to bypass the shim (escape hatch
-for debugging the host filesystem).
+Set `MOCK_IB_DISABLE=1` to bypass the shim.
+
+## Limitations
+
+- **Not real InfiniBand** — no `ib_umad` kernel driver, no RDMA, no SM.
+- **`ibping` only** for the umad path (OpenIB vendor ping class `0x32`).
+  Other `infiniband-diags` tools that need full MAD routing may fail.
+- **`umad-bus/`** is shared state on the hostPath volume; isolate mock nodes
+  accordingly.
+- Default `MOCK_IB_ROOT` when unset: `/var/lib/nvml-mock/ib` (must match
+  `render-ib-sysfs --output`).
 
 ## YAML schema
 
-The renderer consumes the `infiniband:` block of a mock-nvml profile.
-Defaults are applied per-field, so `enabled: true` is the minimum useful
-configuration.
-
-| Field                | Default              | Description                                                                |
-|----------------------|----------------------|----------------------------------------------------------------------------|
-| `enabled`            | `false`              | Must be `true` to render any tree.                                         |
-| `hca_type`           | `MT4129`             | Mellanox HCA model. Shows up as `CA type` in `ibstat`.                     |
-| `fw_version`         | `28.39.2048`         | Firmware version string.                                                   |
-| `hw_rev`             | `0x0`                | Hardware revision.                                                         |
-| `board_id`           | `MT_0000000838`      | Mellanox board ID.                                                         |
-| `link_layer`         | `InfiniBand`         | `InfiniBand` (true IB) or `Ethernet` (RoCE).                               |
-| `rate_gbps`          | `400`                | One of `100` (EDR), `200` (HDR), `400` (NDR), `800` (XDR).                 |
-| `port_state`         | `ACTIVE`             | `DOWN`, `INIT`, `ARMED`, `ACTIVE`, `ACTIVE_DEFER`.                         |
-| `phys_state`         | `LinkUp`             | `Disabled`, `Polling`, `Training`, `LinkUp`, `LinkErrorRecovery`, ...      |
-| `hcas_per_gpu`       | `1`                  | Total HCAs = `gpu.count * hcas_per_gpu`.                                   |
-| `hca_count`          | `0`                  | If non-zero, used instead of `gpu.count * hcas_per_gpu`.                   |
-| `guid_prefix`        | `a088c2:0300:ab`     | First 12 hex digits of every node/port GUID; HCA index encodes lower bytes. |
-| `node_desc_template` | `{node_name} mlx5_{idx}` | `{node_name}` and `{idx}` are interpolated.                            |
-
-### Defaults per built-in profile
-
-| Profile  | Enabled | HCA model              | Speed        | HCAs / GPU |
-|----------|---------|------------------------|--------------|------------|
-| `a100`   | yes     | ConnectX-6 (`MT4123`)  | HDR 200 Gb/s | 1          |
-| `h100`   | yes     | ConnectX-7 (`MT4129`)  | NDR 400 Gb/s | 1          |
-| `b200`   | yes     | ConnectX-7 (`MT4129`)  | NDR 400 Gb/s | 1          |
-| `gb200`  | yes     | ConnectX-7 (`MT4129`)  | NDR 400 Gb/s | 1          |
-| `l40s`   | no      | —                      | —            | —          |
-| `t4`     | no      | —                      | —            | —          |
+See the table in the previous revision — fields unchanged. Built-in profiles:
+`a100`, `h100`, `b200`, `gb200` enable IB; `l40s`, `t4` disable it.
 
 ## Standalone usage
 
-You can use mockibsysfs outside the nvml-mock chart — for example, in a
-unit test or on a developer laptop running Linux.
-
-### 1. Build the shim
+### Build
 
 ```bash
 cd pkg/network/mockibsysfs
 make
-# produces libibmocksys.so -> libibmocksys.so.1 -> libibmocksys.so.1.0.0
 ```
 
-The shim only builds on Linux (uses `dlfcn.h`, glibc-specific signatures
-like `statx`). On macOS, build inside a Linux container:
-
-```bash
-docker run --rm -v "$PWD/../../..:/work" -w /work/pkg/network/mockibsysfs \
-  debian:bookworm-slim sh -c \
-  'apt-get update -qq && apt-get install -y -qq build-essential >/dev/null && make'
-```
-
-### 2. Render a tree
+### Render
 
 ```bash
 go build -o /tmp/render-ib-sysfs ./cmd/render-ib-sysfs
@@ -125,59 +88,57 @@ EOF
 
 /tmp/render-ib-sysfs \
   --config /tmp/profile.yaml \
-  --gpu-count 4 \
+  --gpu-count 2 \
   --node-name dev-laptop \
   --output /tmp/ibroot
 ```
 
-### 3. Run real `ibstat` against it
+### ibstat
 
 ```bash
 sudo apt-get install -y infiniband-diags
 
 LD_PRELOAD=$PWD/libibmocksys.so.1 \
   MOCK_IB_ROOT=/tmp/ibroot \
-  ibstat
+  ibstat -l
 ```
 
-You should see four `mlx5_X` HCAs reported as `Active` / `LinkUp` at
-400 Gb/sec (4X NDR).
+### ibping
+
+```bash
+# Self-ping (mlx5_0 port 1 → LID 1 with default render layout)
+LD_PRELOAD=$PWD/libibmocksys.so.1 \
+  MOCK_IB_ROOT=/tmp/ibroot \
+  ibping -c 1 -C mlx5_0 -P 1 1
+
+# Server on mlx5_1, client on mlx5_0 pinging LID 2
+LD_PRELOAD=$PWD/libibmocksys.so.1 MOCK_IB_ROOT=/tmp/ibroot \
+  ibping -S -C mlx5_1 -P 1 &
+sleep 1
+LD_PRELOAD=$PWD/libibmocksys.so.1 MOCK_IB_ROOT=/tmp/ibroot \
+  ibping -c 1 -C mlx5_0 -P 1 2
+```
 
 ## Tests
 
 ```bash
-# Unit tests (renderer only, no shim required)
 go test ./pkg/network/mockibsysfs/...
 
-# Integration test: builds the shim, runs real ibstat against a rendered
-# tree, asserts on the output. Linux-only; skipped otherwise.
-make -C pkg/network/mockibsysfs                       # build shim
+make -C pkg/network/mockibsysfs
 go test -tags=integration ./pkg/network/mockibsysfs/render/...
 ```
 
+Integration tests require Linux, `infiniband-diags`, and a built shim.
+
 ## Why C, not Go
 
-The shim is loaded into **every process** in the container via
-`LD_PRELOAD` — `bash`, `cat`, `kubectl`, `nvidia-smi`, every probe. A
-Go-based `c-shared` library would inject the entire Go runtime
-(scheduler, GC, signal handlers, ~5–10 MB resident, multiple pthreads)
-into every one of those processes. Concretely:
-
-- Go's runtime calls `mmap`, `open`, `stat` during init — our hooks would
-  intercept its own filesystem accesses, risking re-entrancy / deadlock.
-- Go installs its own `SIGSEGV`/`SIGURG`/`SIGPROF` handlers, which would
-  hijack signal handling in unrelated host binaries.
-- Variadic and function-pointer signatures (`open(..., flags, ...)`,
-  `scandir(path, namelist, filter, compar)`, `statx(...)`) cannot be
-  expressed cleanly through cgo — we'd write C trampolines anyway.
-- Each cgo barrier crossing costs ~100 ns vs. ~5 ns for a direct call;
-  `ls -R /` would slow down measurably.
-
-The current C file is ~300 lines, mechanical, and isolated. Path-rewrite
-logic is the only state. This is the textbook LD_PRELOAD-shim shape.
+The shim is loaded into **every process** in the container via `LD_PRELOAD`.
+A Go `c-shared` library would inject the runtime into `bash`, `kubectl`,
+probes, etc. The umad and path-rewrite logic stay in ~1k lines of C; see
+history in this package for the full rationale.
 
 ## See also
 
-- [Helm chart README](../../../deployments/nvml-mock/helm/nvml-mock/README.md) — install instructions, profile reference, troubleshooting.
-- [Standalone demo](../../../docs/demo/standalone/README.md) — full Kind walkthrough that exercises both `nvidia-smi` and `ibstat`.
-- [`pkg/gpu/mocknvml`](../../gpu/mocknvml/) — sister package that mocks the NVML library.
+- [Helm chart README](../../../deployments/nvml-mock/helm/nvml-mock/README.md)
+- [E2E validation scripts](../../../tests/e2e/validate-ibping.sh)
+- [Standalone demo](../../../docs/demo/standalone/README.md)

--- a/pkg/network/mockibsysfs/mock_ib_root.c
+++ b/pkg/network/mockibsysfs/mock_ib_root.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "mock_ib_root.h"
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *root_cached;
+static pthread_once_t root_once = PTHREAD_ONCE_INIT;
+
+static void init_root(void) {
+	const char *root = getenv("MOCK_IB_ROOT");
+	if (!root || root[0] == '\0')
+		root = MOCK_IB_ROOT_DEFAULT;
+	root_cached = root;
+}
+
+const char *mock_ib_root(void) {
+	pthread_once(&root_once, init_root);
+	return root_cached;
+}

--- a/pkg/network/mockibsysfs/mock_ib_root.h
+++ b/pkg/network/mockibsysfs/mock_ib_root.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef MOCK_IB_ROOT_H
+#define MOCK_IB_ROOT_H
+
+/* Must match nvml-mock Helm MOCK_IB_ROOT and setup.sh render --output parent. */
+#define MOCK_IB_ROOT_DEFAULT "/var/lib/nvml-mock/ib"
+
+const char *mock_ib_root(void);
+
+#endif /* MOCK_IB_ROOT_H */

--- a/pkg/network/mockibsysfs/render/ibping_integration_test.go
+++ b/pkg/network/mockibsysfs/render/ibping_integration_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package render
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockibsysfs/config"
+)
+
+func TestIbping_Integration(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("integration test requires linux")
+	}
+	ibping, err := exec.LookPath("ibping")
+	if err != nil {
+		t.Skip("ibping not installed (apt-get install infiniband-diags)")
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	shim := filepath.Join(wd, "..", "libibmocksys.so")
+	if _, err := os.Stat(shim); err != nil {
+		t.Skipf("shim not built: %v (run `make -C pkg/network/mockibsysfs`)", err)
+	}
+
+	root := t.TempDir()
+	if err := Render(Options{
+		IB: config.Infiniband{
+			Enabled:   true,
+			HCAType:   "MT4129",
+			FWVersion: "28.39.2048",
+			RateGbps:  400,
+		},
+		GPUCount: 2,
+		NodeName: "test-node",
+		Output:   root,
+	}); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	env := append(os.Environ(),
+		"LD_PRELOAD="+shim,
+		"MOCK_IB_ROOT="+root,
+	)
+
+	cmd := exec.Command(ibping, "-c", "1", "-C", "mlx5_0", "-P", "1", "1")
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ibping self-ping failed: %v\noutput:\n%s", err, out)
+	}
+	got := string(out)
+	if !strings.Contains(got, "Pong from") {
+		t.Fatalf("ibping output missing Pong from:\n%s", got)
+	}
+	if !strings.Contains(got, "1 packets transmitted, 1 received") {
+		t.Fatalf("ibping did not report 1/1 packets:\n%s", got)
+	}
+}

--- a/pkg/network/mockibsysfs/render/render.go
+++ b/pkg/network/mockibsysfs/render/render.go
@@ -207,9 +207,9 @@ func renderHCA(root string, ib config.Infiniband, guidPrefix string, idx int, no
 	}
 
 	// /dev/infiniband device files. Real char-dev creation requires
-	// CAP_MKNOD; regular files are sufficient for sysfs-only consumers
-	// (ibstat, ibstatus, iblinkinfo). umad_open_port / ibv_open_device
-	// will fail at ioctl time, which is out of scope.
+	// CAP_MKNOD; placeholder files are enough for sysfs-only tools.
+	// libibumad consumers (ibping, ...) use synthetic umad fds from
+	// libibmocksys.so instead of opening these nodes.
 	for _, f := range []string{
 		fmt.Sprintf("dev/infiniband/umad%d", idx),
 		fmt.Sprintf("dev/infiniband/issm%d", idx),

--- a/pkg/network/mockibsysfs/shim.c
+++ b/pkg/network/mockibsysfs/shim.c
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * libibmocksys.so -- LD_PRELOAD shim that redirects InfiniBand sysfs/dev
- * lookups to a fake tree under $MOCK_IB_ROOT (default /var/lib/nvml-mock).
+ * lookups to a fake tree under $MOCK_IB_ROOT (default /var/lib/nvml-mock/ib).
  *
- * Real `ibstat`, `ibstatus`, `iblinkinfo`, `ibv_devinfo`, ... read from
+ * Real `ibstat`, `ibstatus`, `iblinkinfo`, `ibping`, `ibv_devinfo`, ... read from
  * /sys/class/infiniband*, /sys/class/infiniband_mad*,
  * /sys/class/infiniband_verbs*, /sys/class/infiniband_cm*, and
  * /dev/infiniband*. We hook the libc syscall wrappers, and for any path
@@ -16,8 +16,7 @@
  *   - dlsym(RTLD_NEXT, ...) is resolved lazily on first call and cached.
  *   - Path rewriting uses a thread-local fixed buffer (PATH_MAX) -- no
  *     allocations on the hot path.
- *   - When MOCK_IB_DISABLE=1 (or root is unset and "/var/lib/nvml-mock" does
- *     not exist) the shim becomes a true no-op.
+ *   - When MOCK_IB_DISABLE=1 the shim becomes a true no-op.
  *   - Variadic open()/openat() are handled with the `mode_t` extraction
  *     pattern recommended by glibc's headers: read as `unsigned int` from
  *     va_arg (post default-argument-promotion) and cast back to mode_t.
@@ -43,6 +42,15 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <sys/ioctl.h>
+
+#include "mock_ib_root.h"
+#include "umad_mock.h"
+
+/* glibc may expose ioctl as a macro; we provide the variadic symbol. */
+#ifdef ioctl
+#undef ioctl
+#endif
 
 #ifndef PATH_MAX
 #define PATH_MAX 4096
@@ -74,12 +82,8 @@ static void init_root(void) {
         disabled_cached = 1;
         return;
     }
-    const char *root = getenv("MOCK_IB_ROOT");
-    if (!root || root[0] == '\0') {
-        root = "/var/lib/nvml-mock";
-    }
-    root_cached = root;
-    root_len_cached = strlen(root);
+    root_cached = mock_ib_root();
+    root_len_cached = strlen(root_cached);
     disabled_cached = 0;
 }
 
@@ -152,6 +156,9 @@ int open(const char *path, int flags, ...) {
     va_end(ap);
     int rc = rewrite_path(path, buf, sizeof(buf));
     if (rc == 1) {
+        int umad_fd = umad_mock_open(buf);
+        if (umad_fd >= 0)
+            return umad_fd;
         return real_open(buf, flags, mode);
     }
     return real_open(path, flags, mode);
@@ -167,6 +174,9 @@ int open64(const char *path, int flags, ...) {
     va_end(ap);
     int rc = rewrite_path(path, buf, sizeof(buf));
     if (rc == 1) {
+        int umad_fd = umad_mock_open(buf);
+        if (umad_fd >= 0)
+            return umad_fd;
         return real_open64(buf, flags, mode);
     }
     return real_open64(path, flags, mode);
@@ -184,6 +194,9 @@ int openat(int dirfd, const char *path, int flags, ...) {
      * points at a redirected directory if appropriate. */
     int rc = rewrite_path(path, buf, sizeof(buf));
     if (rc == 1) {
+        int umad_fd = umad_mock_open(buf);
+        if (umad_fd >= 0)
+            return umad_fd;
         return real_openat(dirfd, buf, flags, mode);
     }
     return real_openat(dirfd, path, flags, mode);
@@ -199,9 +212,81 @@ int openat64(int dirfd, const char *path, int flags, ...) {
     va_end(ap);
     int rc = rewrite_path(path, buf, sizeof(buf));
     if (rc == 1) {
+        int umad_fd = umad_mock_open(buf);
+        if (umad_fd >= 0)
+            return umad_fd;
         return real_openat64(dirfd, buf, flags, mode);
     }
     return real_openat64(dirfd, path, flags, mode);
+}
+
+/* ---------- read / write / ioctl / close / poll (umad mock) ---------- */
+
+REAL(read);
+REAL(write);
+REAL(close);
+REAL(poll);
+
+static int (*real_ioctl)(int fd, unsigned long request, ...) = NULL;
+
+ssize_t read(int fd, void *buf, size_t count) {
+    LOAD_REAL(read);
+    if (umad_mock_is_mock_fd(fd))
+        return umad_mock_read(fd, buf, count);
+    return real_read(fd, buf, count);
+}
+
+ssize_t write(int fd, const void *buf, size_t count) {
+    LOAD_REAL(write);
+    if (umad_mock_is_mock_fd(fd))
+        return umad_mock_write(fd, buf, count);
+    return real_write(fd, buf, count);
+}
+
+int ioctl(int fd, unsigned long request, ...) {
+    void *arg = NULL;
+    va_list ap;
+    int ret;
+
+    if (!real_ioctl) {
+        real_ioctl = (int (*)(int, unsigned long, ...))dlsym(RTLD_NEXT, "ioctl");
+    }
+
+    va_start(ap, request);
+    arg = va_arg(ap, void *);
+    va_end(ap);
+
+    if (umad_mock_is_mock_fd(fd)) {
+        ret = umad_mock_ioctl(fd, request, arg);
+        if (ret >= 0 || errno != ENOTTY)
+            return ret;
+    }
+    if (!real_ioctl) {
+        errno = ENOSYS;
+        return -1;
+    }
+    return real_ioctl(fd, request, arg);
+}
+
+int close(int fd) {
+    LOAD_REAL(close);
+    if (umad_mock_is_mock_fd(fd))
+        umad_mock_close(fd);
+    return real_close(fd);
+}
+
+int poll(struct pollfd *fds, nfds_t nfds, int timeout) {
+    LOAD_REAL(poll);
+    int has_mock = 0;
+    for (nfds_t i = 0; i < nfds; i++) {
+        if (umad_mock_is_mock_fd(fds[i].fd)) {
+            has_mock = 1;
+            break;
+        }
+    }
+    if (has_mock)
+        return umad_mock_poll(fds, nfds, timeout);
+    return real_poll(fds, nfds, timeout);
 }
 
 /* ---------- fopen ---------- */

--- a/pkg/network/mockibsysfs/umad_mock.c
+++ b/pkg/network/mockibsysfs/umad_mock.c
@@ -1,0 +1,748 @@
+/*
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Minimal umad(4) emulation for ibping (OpenIB vendor ping MAD class 0x32).
+ * Sysfs is redirected by shim.c; synthetic umad fds implement libibumad
+ * ioctl/read/write/poll. Cross-process server/client uses a global file bus
+ * under $MOCK_IB_ROOT/umad-bus/{in,out}.
+ */
+
+#define _GNU_SOURCE
+#include "umad_mock.h"
+
+#include "mock_ib_root.h"
+
+#include <dlfcn.h>
+#include <dirent.h>
+#include <endian.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <poll.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+/* Match libibumad/umad.h ioctl layout. */
+#define IB_IOCTL_MAGIC 0x1b
+#define IB_USER_MAD_REGISTER_AGENT _IOWR(IB_IOCTL_MAGIC, 1, struct ib_user_mad_reg_req)
+#define IB_USER_MAD_UNREGISTER_AGENT _IOW(IB_IOCTL_MAGIC, 2, uint32_t)
+#define IB_USER_MAD_ENABLE_PKEY _IO(IB_IOCTL_MAGIC, 3)
+#define IB_USER_MAD_REGISTER_AGENT2 _IOWR(IB_IOCTL_MAGIC, 4, struct ib_user_mad_reg_req2)
+
+struct ib_user_mad_reg_req {
+	uint32_t id;
+	uint32_t method_mask[4];
+	uint8_t qpn;
+	uint8_t mgmt_class;
+	uint8_t mgmt_class_version;
+	uint8_t oui[3];
+	uint8_t rmpp_version;
+};
+
+struct ib_user_mad_reg_req2 {
+	uint32_t id;
+	uint32_t qpn;
+	uint8_t mgmt_class;
+	uint8_t mgmt_class_version;
+	uint16_t res;
+	uint32_t flags;
+	uint64_t method_mask[2];
+	uint32_t oui;
+	uint8_t rmpp_version;
+	uint8_t reserved[3];
+};
+
+typedef struct ib_mad_addr {
+	uint32_t qpn;
+	uint32_t qkey;
+	uint16_t lid;
+	uint8_t sl;
+	uint8_t path_bits;
+	uint8_t grh_present;
+	uint8_t gid_index;
+	uint8_t hop_limit;
+	uint8_t traffic_class;
+	uint8_t gid[16];
+	uint32_t flow_label;
+	uint16_t pkey_index;
+	uint8_t reserved[6];
+} ib_mad_addr_t;
+
+typedef struct ib_user_mad_hdr {
+	uint32_t agent_id;
+	uint32_t status;
+	uint32_t timeout_ms;
+	uint32_t retries;
+	uint32_t length;
+	ib_mad_addr_t addr;
+} ib_user_mad_hdr_t;
+
+#define UMAD_HDR_SIZE sizeof(ib_user_mad_hdr_t)
+#define UMAD_MAX_PKT (UMAD_HDR_SIZE + 256)
+
+#define IB_VENDOR_OPENIB_PING_CLASS 0x32
+#define IB_MAD_METHOD_GET 0x01
+#define IB_MAD_METHOD_GET_RESP 0x81
+#define IB_VENDOR_RANGE2_DATA_OFFS 40
+
+struct mad_hdr_simple {
+	uint8_t base_version;
+	uint8_t mgmt_class;
+	uint8_t class_version;
+	uint8_t method;
+	uint16_t status;
+	uint16_t class_specific;
+	uint64_t tid;
+	uint16_t attr_id;
+	uint16_t resv;
+	uint32_t attr_mod;
+} __attribute__((packed));
+
+#define MAX_UMAD_MOCK_FDS 32
+#define MAX_AGENTS 8
+#define MAX_RX_QUEUE 8
+
+typedef struct {
+	int active;
+	int fd;
+	int umad_idx;
+	int local_lid;
+	int pkey_enabled;
+	int next_agent_id;
+	int agents[MAX_AGENTS];
+	int agent_count;
+	uint64_t pending_tid;
+	int awaiting_resp;
+	uint8_t rx_queue[MAX_RX_QUEUE][UMAD_MAX_PKT];
+	size_t rx_len[MAX_RX_QUEUE];
+	int rx_head;
+	int rx_tail;
+	pthread_mutex_t lock;
+} umad_slot_t;
+
+static umad_slot_t g_slots[MAX_UMAD_MOCK_FDS];
+static pthread_mutex_t g_table_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static umad_slot_t *slot_for_fd(int fd) {
+	for (int i = 0; i < MAX_UMAD_MOCK_FDS; i++) {
+		if (g_slots[i].active && g_slots[i].fd == fd)
+			return &g_slots[i];
+	}
+	return NULL;
+}
+
+static int alloc_slot(int umad_idx, int fd, int local_lid) {
+	for (int i = 0; i < MAX_UMAD_MOCK_FDS; i++) {
+		if (!g_slots[i].active) {
+			memset(&g_slots[i], 0, sizeof(g_slots[i]));
+			g_slots[i].active = 1;
+			g_slots[i].fd = fd;
+			g_slots[i].umad_idx = umad_idx;
+			g_slots[i].local_lid = local_lid;
+			g_slots[i].next_agent_id = 1;
+			pthread_mutex_init(&g_slots[i].lock, NULL);
+			return i;
+		}
+	}
+	return -1;
+}
+
+static void bus_mkdir_p(const char *path, mode_t mode) {
+	char tmp[PATH_MAX];
+	char *p;
+
+	snprintf(tmp, sizeof(tmp), "%s", path);
+	for (p = tmp + 1; *p; p++) {
+		if (*p != '/')
+			continue;
+		*p = '\0';
+		mkdir(tmp, mode);
+		*p = '/';
+	}
+	mkdir(tmp, mode);
+}
+
+static void ensure_bus_dirs(void) {
+	const char *root = mock_ib_root();
+	char path[PATH_MAX];
+
+	snprintf(path, sizeof(path), "%s/umad-bus", root);
+	bus_mkdir_p(path, 0700);
+	snprintf(path, sizeof(path), "%s/umad-bus/in", root);
+	bus_mkdir_p(path, 0700);
+	snprintf(path, sizeof(path), "%s/umad-bus/out", root);
+	bus_mkdir_p(path, 0700);
+}
+
+static int read_port_lid(int umad_idx, int port) {
+	char path[PATH_MAX];
+	char ibdev[32];
+	char buf[32];
+	FILE *f;
+
+	snprintf(path, sizeof(path), "%s/sys/class/infiniband_mad/umad%d/ibdev",
+		 mock_ib_root(), umad_idx);
+	f = fopen(path, "r");
+	if (!f)
+		return umad_idx + 1;
+	if (!fgets(ibdev, sizeof(ibdev), f)) {
+		fclose(f);
+		return umad_idx + 1;
+	}
+	fclose(f);
+	ibdev[strcspn(ibdev, "\n")] = '\0';
+
+	snprintf(path, sizeof(path), "%s/sys/class/infiniband/%s/ports/%d/lid",
+		 mock_ib_root(), ibdev, port);
+	f = fopen(path, "r");
+	if (!f)
+		return umad_idx + 1;
+	if (!fgets(buf, sizeof(buf), f)) {
+		fclose(f);
+		return umad_idx + 1;
+	}
+	fclose(f);
+	return (int)strtol(buf, NULL, 0);
+}
+
+static int read_local_lid_for_umad(int umad_idx) {
+	char path[PATH_MAX];
+	char buf[32];
+	int port = 1;
+	FILE *f;
+
+	snprintf(path, sizeof(path), "%s/sys/class/infiniband_mad/umad%d/port",
+		 mock_ib_root(), umad_idx);
+	f = fopen(path, "r");
+	if (f && fgets(buf, sizeof(buf), f))
+		port = atoi(buf);
+	if (f)
+		fclose(f);
+	return read_port_lid(umad_idx, port);
+}
+
+static void rx_push(umad_slot_t *slot, const void *buf, size_t len) {
+	int next = (slot->rx_tail + 1) % MAX_RX_QUEUE;
+
+	if (next == slot->rx_head)
+		return;
+	if (len > UMAD_MAX_PKT)
+		len = UMAD_MAX_PKT;
+	memcpy(slot->rx_queue[slot->rx_tail], buf, len);
+	slot->rx_len[slot->rx_tail] = len;
+	slot->rx_tail = next;
+}
+
+static int rx_pop(umad_slot_t *slot, void *buf, size_t count) {
+	size_t len;
+
+	if (slot->rx_head == slot->rx_tail) {
+		errno = EAGAIN;
+		return -1;
+	}
+	len = slot->rx_len[slot->rx_head];
+	if (len > count)
+		len = count;
+	memcpy(buf, slot->rx_queue[slot->rx_head], len);
+	slot->rx_head = (slot->rx_head + 1) % MAX_RX_QUEUE;
+	return (int)len;
+}
+
+static int rx_pending(const umad_slot_t *slot) {
+	return slot->rx_head != slot->rx_tail;
+}
+
+static int bus_has_in(void) {
+	char dir[PATH_MAX];
+	DIR *d;
+	struct dirent *de;
+
+	snprintf(dir, sizeof(dir), "%s/umad-bus/in", mock_ib_root());
+	d = opendir(dir);
+	if (!d)
+		return 0;
+	while ((de = readdir(d)) != NULL) {
+		if (de->d_name[0] != '.') {
+			closedir(d);
+			return 1;
+		}
+	}
+	closedir(d);
+	return 0;
+}
+
+static int bus_has_out_tid(uint64_t tid) {
+	char path[PATH_MAX];
+	struct stat st;
+
+	snprintf(path, sizeof(path), "%s/umad-bus/out/%016llx.mad",
+		 mock_ib_root(), (unsigned long long)tid);
+	return stat(path, &st) == 0 && S_ISREG(st.st_mode);
+}
+
+static void fill_hostname(char *dest, size_t dest_sz) {
+	char host[128];
+	char domain[128];
+	size_t n;
+
+	if (gethostname(host, sizeof(host)) != 0)
+		snprintf(host, sizeof(host), "mockib");
+	host[sizeof(host) - 1] = '\0';
+	if (getdomainname(domain, sizeof(domain)) != 0 || domain[0] == '\0') {
+		snprintf(dest, dest_sz, "%s", host);
+		return;
+	}
+	domain[sizeof(domain) - 1] = '\0';
+	n = snprintf(dest, dest_sz, "%s.%s", host, domain);
+	if (n >= dest_sz)
+		dest[dest_sz - 1] = '\0';
+}
+
+static int build_ping_response(const uint8_t *req_pkt, size_t req_len,
+			       uint8_t *resp_pkt, size_t resp_sz) {
+	const struct mad_hdr_simple *req_mad;
+	struct mad_hdr_simple *resp_mad;
+	size_t need;
+	char hostdom[256];
+
+	if (req_len < UMAD_HDR_SIZE + sizeof(struct mad_hdr_simple))
+		return -1;
+	req_mad = (const struct mad_hdr_simple *)(req_pkt + UMAD_HDR_SIZE);
+	if (req_mad->mgmt_class != IB_VENDOR_OPENIB_PING_CLASS ||
+	    req_mad->method != IB_MAD_METHOD_GET)
+		return -1;
+
+	need = UMAD_HDR_SIZE + sizeof(struct mad_hdr_simple) + IB_VENDOR_RANGE2_DATA_OFFS + 64;
+	if (resp_sz < need)
+		return -1;
+
+	memset(resp_pkt, 0, need);
+	memcpy(resp_pkt, req_pkt, UMAD_HDR_SIZE);
+	{
+		ib_user_mad_hdr_t *rh = (ib_user_mad_hdr_t *)resp_pkt;
+		rh->status = 0;
+		rh->length = (uint32_t)(need - UMAD_HDR_SIZE);
+	}
+	memcpy(resp_pkt + UMAD_HDR_SIZE, req_mad, sizeof(*req_mad));
+	resp_mad = (struct mad_hdr_simple *)(resp_pkt + UMAD_HDR_SIZE);
+	resp_mad->method = IB_MAD_METHOD_GET_RESP;
+	resp_mad->status = 0;
+	fill_hostname(hostdom, sizeof(hostdom));
+	memcpy(resp_pkt + UMAD_HDR_SIZE + IB_VENDOR_RANGE2_DATA_OFFS, hostdom,
+	       strlen(hostdom) + 1);
+	return (int)need;
+}
+
+static void bus_publish_in(const void *buf, size_t len) {
+	const char *root = mock_ib_root();
+	char dir[PATH_MAX];
+	char path[PATH_MAX];
+	char tmp[PATH_MAX];
+	int fd;
+	static unsigned seq;
+
+	ensure_bus_dirs();
+	snprintf(dir, sizeof(dir), "%s/umad-bus/in", root);
+	snprintf(tmp, sizeof(tmp), "%s/%u.%d.tmp", dir, (unsigned)getpid(), seq++);
+	fd = open(tmp, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+	if (fd < 0)
+		return;
+	if (write(fd, buf, len) != (ssize_t)len) {
+		close(fd);
+		unlink(tmp);
+		return;
+	}
+	close(fd);
+	snprintf(path, sizeof(path), "%s/%s", dir, strrchr(tmp, '/') + 1);
+	rename(tmp, path);
+}
+
+static int bus_take_in(void *buf, size_t count) {
+	const char *root = mock_ib_root();
+	char dir[PATH_MAX];
+	DIR *d;
+	struct dirent *de;
+	char path[PATH_MAX];
+	int fd, n;
+	struct stat st;
+	char oldest[PATH_MAX];
+	time_t oldest_mtime = 0;
+	int found = 0;
+
+	snprintf(dir, sizeof(dir), "%s/umad-bus/in", root);
+	d = opendir(dir);
+	if (!d)
+		return -1;
+	oldest[0] = '\0';
+	while ((de = readdir(d)) != NULL) {
+		if (de->d_name[0] == '.')
+			continue;
+		snprintf(path, sizeof(path), "%s/%s", dir, de->d_name);
+		if (stat(path, &st) != 0 || !S_ISREG(st.st_mode))
+			continue;
+		if (!found || st.st_mtime <= oldest_mtime) {
+			oldest_mtime = st.st_mtime;
+			strncpy(oldest, path, sizeof(oldest) - 1);
+			oldest[sizeof(oldest) - 1] = '\0';
+			found = 1;
+		}
+	}
+	closedir(d);
+	if (!found) {
+		errno = EAGAIN;
+		return -1;
+	}
+	fd = open(oldest, O_RDONLY);
+	if (fd < 0)
+		return -1;
+	n = (int)read(fd, buf, count);
+	close(fd);
+	unlink(oldest);
+	return n;
+}
+
+static void bus_publish_out(uint64_t tid, const void *buf, size_t len) {
+	const char *root = mock_ib_root();
+	char path[PATH_MAX];
+	char tmp[PATH_MAX];
+	int fd;
+
+	ensure_bus_dirs();
+	snprintf(path, sizeof(path), "%s/umad-bus/out/%016llx.mad", root,
+		 (unsigned long long)tid);
+	snprintf(tmp, sizeof(tmp), "%s.tmp", path);
+	fd = open(tmp, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+	if (fd < 0)
+		return;
+	if (write(fd, buf, len) == (ssize_t)len)
+		rename(tmp, path);
+	else
+		unlink(tmp);
+	close(fd);
+}
+
+static int bus_take_out(uint64_t tid, void *buf, size_t count) {
+	const char *root = mock_ib_root();
+	char path[PATH_MAX];
+	int fd, n;
+
+	snprintf(path, sizeof(path), "%s/umad-bus/out/%016llx.mad", root,
+		 (unsigned long long)tid);
+	fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		errno = EAGAIN;
+		return -1;
+	}
+	n = (int)read(fd, buf, count);
+	close(fd);
+	unlink(path);
+	return n;
+}
+
+static int dest_lid_from_pkt(const uint8_t *pkt) {
+	const ib_user_mad_hdr_t *hdr = (const ib_user_mad_hdr_t *)pkt;
+	return (int)be16toh(hdr->addr.lid);
+}
+
+static uint64_t mad_tid_from_pkt(const uint8_t *pkt) {
+	const struct mad_hdr_simple *mad;
+
+	if (UMAD_HDR_SIZE + sizeof(*mad) > UMAD_MAX_PKT)
+		return 0;
+	mad = (const struct mad_hdr_simple *)(pkt + UMAD_HDR_SIZE);
+	return mad->tid;
+}
+
+static int mock_fd_poll_ready(umad_slot_t *slot) {
+	if (rx_pending(slot))
+		return 1;
+	if (bus_has_in())
+		return 1;
+	if (slot->awaiting_resp && slot->pending_tid &&
+	    bus_has_out_tid(slot->pending_tid))
+		return 1;
+	return 0;
+}
+
+int umad_mock_open(const char *resolved_path) {
+	const char *needle = "/dev/infiniband/umad";
+	const char *p;
+	int idx;
+	int fd;
+	int local_lid;
+
+	p = strstr(resolved_path, needle);
+	if (!p)
+		return -1;
+	p += strlen(needle);
+	idx = (int)strtol(p, NULL, 10);
+	if (idx < 0 || idx > 255)
+		return -1;
+
+	ensure_bus_dirs();
+	local_lid = read_local_lid_for_umad(idx);
+
+	fd = open("/dev/null", O_RDWR | O_CLOEXEC);
+	if (fd < 0)
+		return -1;
+
+	pthread_mutex_lock(&g_table_lock);
+	if (alloc_slot(idx, fd, local_lid) < 0) {
+		pthread_mutex_unlock(&g_table_lock);
+		close(fd);
+		errno = EMFILE;
+		return -1;
+	}
+	pthread_mutex_unlock(&g_table_lock);
+	return fd;
+}
+
+int umad_mock_is_mock_fd(int fd) {
+	return slot_for_fd(fd) != NULL;
+}
+
+int umad_mock_ioctl(int fd, unsigned long request, void *arg) {
+	umad_slot_t *slot = slot_for_fd(fd);
+	struct ib_user_mad_reg_req *req;
+	struct ib_user_mad_reg_req2 *req2;
+
+	if (!slot) {
+		errno = ENOTTY;
+		return -1;
+	}
+
+	pthread_mutex_lock(&slot->lock);
+	if (request == IB_USER_MAD_ENABLE_PKEY) {
+		slot->pkey_enabled = 1;
+		pthread_mutex_unlock(&slot->lock);
+		return 0;
+	}
+	if (request == IB_USER_MAD_REGISTER_AGENT ||
+	    request == IB_USER_MAD_REGISTER_AGENT2) {
+		if (!arg) {
+			pthread_mutex_unlock(&slot->lock);
+			errno = EINVAL;
+			return -1;
+		}
+		if (slot->agent_count >= MAX_AGENTS) {
+			pthread_mutex_unlock(&slot->lock);
+			errno = ENOMEM;
+			return -1;
+		}
+		{
+			uint32_t agent_id = (uint32_t)slot->next_agent_id++;
+			if (request == IB_USER_MAD_REGISTER_AGENT2) {
+				req2 = arg;
+				req2->id = agent_id;
+			} else {
+				req = arg;
+				req->id = agent_id;
+			}
+			slot->agents[slot->agent_count++] = (int)agent_id;
+		}
+		pthread_mutex_unlock(&slot->lock);
+		return 0;
+	}
+	if (request == IB_USER_MAD_UNREGISTER_AGENT) {
+		pthread_mutex_unlock(&slot->lock);
+		return 0;
+	}
+	pthread_mutex_unlock(&slot->lock);
+	errno = ENOTTY;
+	return -1;
+}
+
+ssize_t umad_mock_write(int fd, const void *buf, size_t count) {
+	umad_slot_t *slot = slot_for_fd(fd);
+	uint8_t resp[UMAD_MAX_PKT];
+	int resp_len;
+	int dest_lid;
+	uint64_t tid;
+	const uint8_t *pkt = buf;
+	struct mad_hdr_simple *mad;
+
+	if (!slot || count < UMAD_HDR_SIZE) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	pthread_mutex_lock(&slot->lock);
+
+	if (count >= UMAD_HDR_SIZE + sizeof(struct mad_hdr_simple)) {
+		mad = (struct mad_hdr_simple *)(pkt + UMAD_HDR_SIZE);
+		if (mad->mgmt_class == IB_VENDOR_OPENIB_PING_CLASS &&
+		    mad->method == IB_MAD_METHOD_GET_RESP) {
+			tid = mad->tid;
+			bus_publish_out(tid, pkt, count);
+			pthread_mutex_unlock(&slot->lock);
+			return (ssize_t)count;
+		}
+	}
+
+	dest_lid = dest_lid_from_pkt(pkt);
+	tid = mad_tid_from_pkt(pkt);
+	resp_len = build_ping_response(pkt, count, resp, sizeof(resp));
+
+	if (resp_len > 0 && dest_lid == slot->local_lid) {
+		rx_push(slot, resp, (size_t)resp_len);
+		slot->awaiting_resp = 0;
+		slot->pending_tid = 0;
+	} else if (resp_len > 0) {
+		bus_publish_in(pkt, count);
+		slot->pending_tid = tid;
+		slot->awaiting_resp = 1;
+	}
+
+	pthread_mutex_unlock(&slot->lock);
+	return (ssize_t)count;
+}
+
+ssize_t umad_mock_read(int fd, void *buf, size_t count) {
+	umad_slot_t *slot = slot_for_fd(fd);
+	int n;
+
+	if (!slot) {
+		errno = EBADF;
+		return -1;
+	}
+
+	pthread_mutex_lock(&slot->lock);
+
+	n = rx_pop(slot, buf, count);
+	if (n >= 0) {
+		pthread_mutex_unlock(&slot->lock);
+		return n;
+	}
+
+	if (slot->awaiting_resp && slot->pending_tid) {
+		uint64_t tid = slot->pending_tid;
+		pthread_mutex_unlock(&slot->lock);
+		n = bus_take_out(tid, buf, count);
+		if (n >= 0) {
+			pthread_mutex_lock(&slot->lock);
+			slot->awaiting_resp = 0;
+			slot->pending_tid = 0;
+			pthread_mutex_unlock(&slot->lock);
+			return n;
+		}
+		pthread_mutex_lock(&slot->lock);
+	}
+
+	n = bus_take_in(buf, count);
+	if (n >= 0) {
+		pthread_mutex_unlock(&slot->lock);
+		return n;
+	}
+
+	pthread_mutex_unlock(&slot->lock);
+	errno = EAGAIN;
+	return -1;
+}
+
+int umad_mock_close(int fd) {
+	umad_slot_t *slot = slot_for_fd(fd);
+
+	if (slot) {
+		pthread_mutex_lock(&g_table_lock);
+		slot->active = 0;
+		pthread_mutex_unlock(&g_table_lock);
+		pthread_mutex_destroy(&slot->lock);
+	}
+	return 0;
+}
+
+static int (*real_poll_fn)(struct pollfd *, nfds_t, int);
+
+static int call_real_poll(struct pollfd *fds, nfds_t nfds, int timeout) {
+	if (!real_poll_fn)
+		real_poll_fn = (int (*)(struct pollfd *, nfds_t, int))dlsym(RTLD_NEXT, "poll");
+	if (!real_poll_fn) {
+		errno = ENOSYS;
+		return -1;
+	}
+	return real_poll_fn(fds, nfds, timeout);
+}
+
+int umad_mock_poll(struct pollfd *fds, nfds_t nfds, int timeout) {
+	int ready = 0;
+	struct timespec start, now;
+	long elapsed_ms = 0;
+	struct pollfd real_fds[64];
+	int real_map[64];
+	nfds_t real_n = 0;
+
+	if (nfds > 64)
+		nfds = 64;
+
+	if (!real_poll_fn)
+		real_poll_fn = (int (*)(struct pollfd *, nfds_t, int))dlsym(RTLD_NEXT, "poll");
+
+	clock_gettime(CLOCK_MONOTONIC, &start);
+
+	for (;;) {
+		ready = 0;
+		real_n = 0;
+		for (nfds_t i = 0; i < nfds; i++) {
+			umad_slot_t *slot = slot_for_fd(fds[i].fd);
+			fds[i].revents = 0;
+			if (!slot) {
+				if (real_n < 64) {
+					real_map[real_n] = (int)i;
+					real_fds[real_n] = fds[i];
+					real_n++;
+				}
+				continue;
+			}
+			if (!(fds[i].events & POLLIN))
+				continue;
+			pthread_mutex_lock(&slot->lock);
+			if (mock_fd_poll_ready(slot)) {
+				fds[i].revents = POLLIN;
+				ready++;
+			}
+			pthread_mutex_unlock(&slot->lock);
+		}
+
+		if (real_n > 0) {
+			int rem = timeout;
+			if (timeout > 0) {
+				clock_gettime(CLOCK_MONOTONIC, &now);
+				elapsed_ms = (now.tv_sec - start.tv_sec) * 1000L +
+					     (now.tv_nsec - start.tv_nsec) / 1000000L;
+				rem = timeout - (int)elapsed_ms;
+				if (rem < 0)
+					rem = 0;
+			}
+			int rn = call_real_poll(real_fds, real_n, ready > 0 ? 0 : rem);
+			if (rn > 0) {
+				for (nfds_t j = 0; j < real_n; j++) {
+					if (real_fds[j].revents) {
+						fds[real_map[j]].revents = real_fds[j].revents;
+						ready++;
+					}
+				}
+			}
+		}
+
+		if (ready > 0)
+			return ready;
+		if (timeout == 0)
+			return 0;
+		if (timeout > 0) {
+			clock_gettime(CLOCK_MONOTONIC, &now);
+			elapsed_ms = (now.tv_sec - start.tv_sec) * 1000L +
+				     (now.tv_nsec - start.tv_nsec) / 1000000L;
+			if (elapsed_ms >= timeout)
+				return 0;
+		}
+		usleep(1000);
+	}
+}

--- a/pkg/network/mockibsysfs/umad_mock.h
+++ b/pkg/network/mockibsysfs/umad_mock.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Userspace umad(4) emulation for ibping (OpenIB vendor ping MADs only).
+ * Paired with the sysfs redirector in shim.c.
+ */
+
+#ifndef UMAD_MOCK_H
+#define UMAD_MOCK_H
+
+#include <poll.h>
+#include <stddef.h>
+#include <sys/types.h>
+
+/* After path rewrite, open() calls this instead of the placeholder file. */
+int umad_mock_open(const char *resolved_path);
+
+int umad_mock_is_mock_fd(int fd);
+
+int umad_mock_ioctl(int fd, unsigned long request, void *arg);
+
+ssize_t umad_mock_read(int fd, void *buf, size_t count);
+
+ssize_t umad_mock_write(int fd, const void *buf, size_t count);
+
+int umad_mock_close(int fd);
+
+int umad_mock_poll(struct pollfd *fds, nfds_t nfds, int timeout);
+
+#endif /* UMAD_MOCK_H */

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -11,6 +11,23 @@ They verify:
 - nvml-mock DaemonSet deploys and creates mock device files
 - NVIDIA device plugin discovers mock GPUs and registers `nvidia.com/gpu`
 - DRA driver discovers mock GPUs and publishes ResourceSlices
+- InfiniBand: `validate-ibstat.sh` and `validate-ibping.sh` on nvml-mock pods
+  (skipped for profiles with IB disabled, e.g. `t4`)
+
+### InfiniBand validation scripts
+
+| Script | What it checks |
+|--------|----------------|
+| `validate-ibstat.sh` | `ibstat` / `ibstatus` against rendered sysfs (HCA count) |
+| `validate-ibping.sh` | `ibping` self-ping (LID 1) and cross-HCA ping (LID 2, server on `mlx5_1`) |
+
+```bash
+POD=$(kubectl get pods -l app.kubernetes.io/name=nvml-mock -o jsonpath='{.items[0].metadata.name}')
+./tests/e2e/validate-ibstat.sh "$POD" h100 2
+./tests/e2e/validate-ibping.sh "$POD" h100 2
+```
+
+Requires the pod to have `LD_PRELOAD` and `MOCK_IB_ROOT` set by the chart.
 
 ## Standalone GFD/validator steps (disabled)
 
@@ -68,3 +85,5 @@ Once confirmed that the standalone `nvcr.io` images are publicly accessible:
 | `gpu-operator-values.yaml` | GPU Operator Helm values overlay |
 | `kind-dra-config.yaml` | Kind config with DRA feature gates |
 | `VERSION-MATRIX.md` | Tested component versions |
+| `validate-ibstat.sh` | InfiniBand sysfs mock validation |
+| `validate-ibping.sh` | ibping / umad mock validation |

--- a/tests/e2e/validate-ibping.sh
+++ b/tests/e2e/validate-ibping.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Validate ibping against the mock InfiniBand fabric inside nvml-mock.
+#
+# Usage:
+#   validate-ibping.sh <pod-name> <profile> <expected-hcas>
+#
+# Exercises vendor MAD ping (libibumad) on top of the sysfs mock. Profiles
+# with infiniband.enabled=false are skipped.
+set -euo pipefail
+
+POD="${1:?Usage: $0 <pod-name> <profile> <expected-hcas>}"
+PROFILE="${2:?}"
+EXPECTED="${3:?}"
+
+case "$PROFILE" in
+  l40s|t4)
+    echo "=== ibping validation SKIPPED (IB disabled for $PROFILE) ==="
+    exit 0
+    ;;
+esac
+
+if [ "$EXPECTED" -lt 2 ]; then
+  echo "=== ibping cross-HCA test SKIPPED (need >= 2 HCAs, got $EXPECTED) ==="
+fi
+
+echo "=== Validating ibping on pod=$POD profile=$PROFILE ==="
+
+# Self-ping on mlx5_0 port 1 (LID 1 in the default render layout).
+OUT=$(kubectl exec "$POD" -- ibping -c 1 -C mlx5_0 -P 1 1 2>&1) || {
+  echo "FAIL: ibping self-ping exited non-zero"
+  printf '%s\n' "$OUT"
+  exit 1
+}
+printf '%s\n' "$OUT"
+
+if ! printf '%s\n' "$OUT" | grep -q "Pong from"; then
+  echo "FAIL: ibping self-ping output missing 'Pong from'"
+  exit 1
+fi
+if ! printf '%s\n' "$OUT" | grep -q "1 packets transmitted, 1 received"; then
+  echo "FAIL: ibping self-ping did not report 1/1 packets"
+  exit 1
+fi
+echo "PASS: ibping self-ping on mlx5_0 (LID 1)"
+
+if [ "$EXPECTED" -ge 2 ]; then
+  # Cross-HCA: server on mlx5_1 (LID 2), client on mlx5_0 pinging remote LID 2.
+  # Local LID loopback must not satisfy this path.
+  kubectl exec "$POD" -- sh -c '
+    set -e
+    rm -rf /var/lib/nvml-mock/ib/umad-bus/in/* /var/lib/nvml-mock/ib/umad-bus/out/* 2>/dev/null || true
+    ibping -S -C mlx5_1 -P 1 >/tmp/ibping-server.log 2>&1 &
+    srv=$!
+    sleep 2
+    ibping -c 1 -C mlx5_0 -P 1 2 >/tmp/ibping-client.log 2>&1
+    kill $srv 2>/dev/null || true
+    wait $srv 2>/dev/null || true
+    grep -q "Pong from" /tmp/ibping-client.log
+    ! grep -qiE "iberror|failed: Failed to open|can'\''t serve" /tmp/ibping-server.log
+  '
+  echo "PASS: ibping cross-HCA ping mlx5_0 -> LID 2 (server on mlx5_1)"
+fi
+
+echo "=== ibping validation PASSED ==="


### PR DESCRIPTION
## Summary

- Add `umad_mock.c` to `libibmocksys.so` so **ibping** works on nvml-mock nodes without real `ib_umad` hardware (vendor OpenIB ping MAD class `0x32` only).
- Sysfs mocking (`ibstat`, `ibstatus`, `iblinkinfo`) is unchanged; synthetic umad fds handle `ioctl` / `read` / `write` / `poll`.
- Same-LID pings are answered in-process; cross-HCA / server-client traffic uses a global file bus at `$MOCK_IB_ROOT/umad-bus/{in,out}/` with TID-matched replies.
- Align default `MOCK_IB_ROOT` with the chart (`/var/lib/nvml-mock/ib`), implement `REGISTER_AGENT2`, and fix mixed-fd `poll()` delegation to libc.

## Test plan

- [x] `make -C pkg/network/mockibsysfs` and `go test ./pkg/network/mockibsysfs/...`
- [x] `go test -tags=integration ./pkg/network/mockibsysfs/render/...` (Linux + infiniband-diags)
- [x] Manual: `docker build -f deployments/nvml-mock/Dockerfile` — self-ping and cross-HCA (`mlx5_0` → LID 2, server on `mlx5_1`)
- [ ] CI: `mockib-integration` job
- [ ] CI: `nvml-mock-e2e` — `validate-ibping.sh` on IB-enabled profiles

## Notes

- **Scope:** ibping / vendor ping MADs only — not full libibumad, RDMA, or real InfiniBand.
- Bump `libibmocksys.so` to **1.2.0** (rebuild nvml-mock image for Kind/e2e).