### PR TITLE
chore(deps): consolidate Dependabot updates (merge train 2026-06-08)

### DIFF
--- a/.github/workflows/code_scanning.yaml
+++ b/.github/workflows/code_scanning.yaml
@@ -40,7 +40,7 @@ jobs:
           go-version: ${{ inputs.golang_version }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           languages: go
 
@@ -48,6 +48,6 @@ jobs:
         run: go mod download
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           category: "/language:go"

--- a/.github/workflows/nvml-mock-publish.yaml
+++ b/.github/workflows/nvml-mock-publish.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/nvml-mock-publish.yaml
+++ b/.github/workflows/nvml-mock-publish.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4

--- a/.github/workflows/nvml-mock-publish.yaml
+++ b/.github/workflows/nvml-mock-publish.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/nvml-mock-publish.yaml
+++ b/.github/workflows/nvml-mock-publish.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -33,6 +33,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           sarif_file: results.sarif

--- a/deployments/devel/Dockerfile
+++ b/deployments/devel/Dockerfile
@@ -14,4 +14,4 @@
 
 # This Dockerfile is also used to define the golang version used in this project
 # This allows dependabot to manage this version in addition to other images.
-FROM golang:1.26.3
+FROM golang:1.26.4


### PR DESCRIPTION
## Problem

Six open Dependabot PRs are pending review. Merging them one at a time risks
sequential rebases and per-PR CI churn. This consolidates all six into a single
branch so conflicts are resolved once and CI runs once.

## Approach

Cherry-picked each Dependabot commit (provenance preserved via `-x`; original
`dependabot[bot]` authorship retained) onto a branch off `main`. No merge
commits. Each pinned SHA was verified to resolve to its claimed version tag.

Consolidates:
- #362 — docker/setup-buildx-action 4.0.0 → 4.1.0
- #363 — github/codeql-action 4.35.5 → 4.36.0
- #364 — docker/metadata-action 6.0.0 → 6.1.0
- #365 — docker/login-action 4.1.0 → 4.2.0
- #369 — docker/setup-qemu-action 4.0.0 → 4.1.0
- #379 — golang 1.26.3 → 1.26.4 (`/deployments/devel`)

## Testing done

- `actionlint` on all three touched workflows — no new findings (2 pre-existing
  SC2046 warnings on `main` are unrelated to these `uses:` SHA bumps)
- Verified every action SHA resolves to its claimed version tag via the GitHub API
- Confirmed `golang:1.26.4` exists on Docker Hub
- Combined diff equals the exact union of all six source PRs

## Breaking changes

None. SHA-pin and base-image patch bumps only.

The six source PRs will be closed in favor of this one once CI is green.
