### PR TITLE
mocknvml: implement per-process GetProcessUtilization + per-device processes override

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -297,6 +297,10 @@ device_defaults:
 
 ### Processes
 
+`processes` drive the running-process queries and `nvmlDeviceGetProcessUtilization`.
+The utilization fields (`sm_util`/`mem_util`/`enc_util`/`dec_util`, all percent) are
+reported for every process — compute and graphics/video alike.
+
 ```yaml
 device_defaults:
   processes:
@@ -304,6 +308,14 @@ device_defaults:
       type: "C"                       # C=compute, G=graphics
       name: "python"
       used_memory_mib: 1024
+      sm_util: 75                     # SM (compute) utilization %
+      mem_util: 40                    # memory-bandwidth utilization %
+    - pid: 5678
+      type: "G"
+      name: "ffmpeg"
+      used_memory_mib: 512
+      enc_util: 60                    # encoder utilization %
+      dec_util: 30                    # decoder utilization %
 ```
 
 ## Per-Device Overrides

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -223,6 +223,8 @@ devices:
         type: "C"
         name: "python"
         used_memory_mib: 30720
+        sm_util: 95                # per-process SM utilization %
+        mem_util: 75              # per-process memory-bandwidth utilization %
 ```
 
 ## Testing Scenarios

--- a/pkg/gpu/mocknvml/bridge/device.go
+++ b/pkg/gpu/mocknvml/bridge/device.go
@@ -777,11 +777,9 @@ func nvmlDeviceGetProcessUtilization(nvmlDevice C.nvmlDevice_t, utilization *C.n
 		return toReturn(ret)
 	}
 
-	// Probe call (utilization==nil): the caller wants the count. With samples to
-	// return, go-nvml's wrapper requires INSUFFICIENT_SIZE (so it allocates and
-	// calls again). With zero samples there's nothing to fetch, so return SUCCESS
-	// — the wrapper then yields (empty, SUCCESS), matching the prior empty-path
-	// behavior (and unlike the RunningProcesses SUCCESS-on-probe convention).
+	// Probe call (utilization==nil): report the count. INSUFFICIENT_SIZE when there
+	// are samples (go-nvml then allocates and re-calls); SUCCESS when there are none
+	// (yields a clean empty result rather than an error).
 	if utilization == nil {
 		*processSamplesCount = C.uint(len(samples))
 		if len(samples) == 0 {

--- a/pkg/gpu/mocknvml/bridge/device.go
+++ b/pkg/gpu/mocknvml/bridge/device.go
@@ -760,6 +760,9 @@ func nvmlDeviceGetComputeRunningProcesses_v3(nvmlDevice C.nvmlDevice_t, infoCoun
 
 //export nvmlDeviceGetProcessUtilization
 func nvmlDeviceGetProcessUtilization(nvmlDevice C.nvmlDevice_t, utilization *C.nvmlProcessUtilizationSample_t, processSamplesCount *C.uint, lastSeenTimeStamp C.ulonglong) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetProcessUtilization"); !ok {
+		return ret
+	}
 	if processSamplesCount == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
@@ -768,11 +771,33 @@ func nvmlDeviceGetProcessUtilization(nvmlDevice C.nvmlDevice_t, utilization *C.n
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
+
 	samples, ret := dev.GetProcessUtilization(uint64(lastSeenTimeStamp))
 	if ret != nvml.SUCCESS {
 		return toReturn(ret)
 	}
+
+	// PROBE: caller passes utilization=nil (or a too-small buffer) to learn the
+	// count. go-nvml's wrapper requires INSUFFICIENT_SIZE here (NOT SUCCESS) —
+	// unlike the RunningProcesses convention — else it returns without filling.
+	if utilization == nil || int(*processSamplesCount) < len(samples) {
+		*processSamplesCount = C.uint(len(samples))
+		return C.NVML_ERROR_INSUFFICIENT_SIZE
+	}
+
+	// FILL: write samples into the caller's buffer.
 	*processSamplesCount = C.uint(len(samples))
+	if len(samples) > 0 {
+		out := unsafe.Slice(utilization, len(samples))
+		for i, s := range samples {
+			out[i].pid = C.uint(s.Pid)
+			out[i].timeStamp = C.ulonglong(s.TimeStamp)
+			out[i].smUtil = C.uint(s.SmUtil)
+			out[i].memUtil = C.uint(s.MemUtil)
+			out[i].encUtil = C.uint(s.EncUtil)
+			out[i].decUtil = C.uint(s.DecUtil)
+		}
+	}
 	return C.NVML_SUCCESS
 }
 

--- a/pkg/gpu/mocknvml/bridge/device.go
+++ b/pkg/gpu/mocknvml/bridge/device.go
@@ -777,15 +777,24 @@ func nvmlDeviceGetProcessUtilization(nvmlDevice C.nvmlDevice_t, utilization *C.n
 		return toReturn(ret)
 	}
 
-	// PROBE: caller passes utilization=nil (or a too-small buffer) to learn the
-	// count. go-nvml's wrapper requires INSUFFICIENT_SIZE here (NOT SUCCESS) —
-	// unlike the RunningProcesses convention — else it returns without filling.
-	if utilization == nil || int(*processSamplesCount) < len(samples) {
+	// PROBE: utilization==nil means the caller wants the count. With samples to
+	// return, go-nvml's wrapper requires INSUFFICIENT_SIZE (so it allocates and
+	// calls again). With zero samples there's nothing to fetch, so return SUCCESS
+	// — the wrapper then yields (empty, SUCCESS), matching the prior empty-path
+	// behavior (and unlike the RunningProcesses SUCCESS-on-probe convention).
+	if utilization == nil {
 		*processSamplesCount = C.uint(len(samples))
+		if len(samples) == 0 {
+			return C.NVML_SUCCESS
+		}
 		return C.NVML_ERROR_INSUFFICIENT_SIZE
 	}
 
-	// FILL: write samples into the caller's buffer.
+	// FILL: a buffer was provided. If it is too small, report the needed size.
+	if int(*processSamplesCount) < len(samples) {
+		*processSamplesCount = C.uint(len(samples))
+		return C.NVML_ERROR_INSUFFICIENT_SIZE
+	}
 	*processSamplesCount = C.uint(len(samples))
 	if len(samples) > 0 {
 		out := unsafe.Slice(utilization, len(samples))

--- a/pkg/gpu/mocknvml/bridge/device.go
+++ b/pkg/gpu/mocknvml/bridge/device.go
@@ -777,7 +777,7 @@ func nvmlDeviceGetProcessUtilization(nvmlDevice C.nvmlDevice_t, utilization *C.n
 		return toReturn(ret)
 	}
 
-	// PROBE: utilization==nil means the caller wants the count. With samples to
+	// Probe call (utilization==nil): the caller wants the count. With samples to
 	// return, go-nvml's wrapper requires INSUFFICIENT_SIZE (so it allocates and
 	// calls again). With zero samples there's nothing to fetch, so return SUCCESS
 	// — the wrapper then yields (empty, SUCCESS), matching the prior empty-path
@@ -790,7 +790,7 @@ func nvmlDeviceGetProcessUtilization(nvmlDevice C.nvmlDevice_t, utilization *C.n
 		return C.NVML_ERROR_INSUFFICIENT_SIZE
 	}
 
-	// FILL: a buffer was provided. If it is too small, report the needed size.
+	// Fill call: a buffer was provided. If it is too small, report the needed size.
 	if int(*processSamplesCount) < len(samples) {
 		*processSamplesCount = C.uint(len(samples))
 		return C.NVML_ERROR_INSUFFICIENT_SIZE

--- a/pkg/gpu/mocknvml/bridge/nvml_types.h
+++ b/pkg/gpu/mocknvml/bridge/nvml_types.h
@@ -390,7 +390,15 @@ typedef struct nvmlPowerValue_v2_st                         nvmlPowerValue_v2_t;
 typedef struct nvmlProcessDetailList_st                     nvmlProcessDetailList_t;
 typedef struct nvmlProcessInfo_v1_st                        nvmlProcessInfo_v1_t;
 typedef struct nvmlProcessInfo_v2_st                        nvmlProcessInfo_v2_t;
-typedef struct nvmlProcessUtilizationSample_st              nvmlProcessUtilizationSample_t;
+typedef struct nvmlProcessUtilizationSample_st
+{
+    unsigned int        pid;        //!< PID of process
+    unsigned long long  timeStamp;  //!< CPU Timestamp in microseconds
+    unsigned int        smUtil;     //!< SM (3D/Compute) Util Value
+    unsigned int        memUtil;    //!< Frame Buffer Memory Util Value
+    unsigned int        encUtil;    //!< Encoder Util Value
+    unsigned int        decUtil;    //!< Decoder Util Value
+} nvmlProcessUtilizationSample_t;
 typedef struct nvmlProcessesUtilizationInfo_st              nvmlProcessesUtilizationInfo_t;
 typedef struct nvmlRepairStatus_st                          nvmlRepairStatus_t;
 typedef struct nvmlRowRemapperHistogramValues_st            nvmlRowRemapperHistogramValues_t;

--- a/pkg/gpu/mocknvml/bridge/nvml_types.h
+++ b/pkg/gpu/mocknvml/bridge/nvml_types.h
@@ -390,6 +390,8 @@ typedef struct nvmlPowerValue_v2_st                         nvmlPowerValue_v2_t;
 typedef struct nvmlProcessDetailList_st                     nvmlProcessDetailList_t;
 typedef struct nvmlProcessInfo_v1_st                        nvmlProcessInfo_v1_t;
 typedef struct nvmlProcessInfo_v2_st                        nvmlProcessInfo_v2_t;
+
+/* Process utilization sample */
 typedef struct nvmlProcessUtilizationSample_st
 {
     unsigned int        pid;        //!< PID of process

--- a/pkg/gpu/mocknvml/engine/config.go
+++ b/pkg/gpu/mocknvml/engine/config.go
@@ -365,6 +365,9 @@ func mergeDeviceOverride(base *DeviceConfig, override *DeviceOverride) {
 	if override.Fabric != nil {
 		base.Fabric = override.Fabric
 	}
+	if override.Processes != nil {
+		base.Processes = override.Processes // nil = not overridden; [] = explicit clear
+	}
 	// Add more fields as needed
 }
 

--- a/pkg/gpu/mocknvml/engine/config_test.go
+++ b/pkg/gpu/mocknvml/engine/config_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -186,32 +187,32 @@ func TestLoadConfig_AutoDiscoverFallback(t *testing.T) {
 	require.Equal(t, 8, config.NumDevices, "Expected default NumDevices 8")
 }
 
-func TestGetDeviceConfig_PerDeviceProcessesOverride(t *testing.T) {
-	c := &Config{
-		YAMLConfig: &YAMLConfig{
-			DeviceDefaults: DeviceConfig{
-				Processes: []ProcessConfig{{PID: 1, Type: "C", UsedMemoryMiB: 100}},
-			},
-			Devices: []DeviceOverride{
-				{
-					Index: 0,
-					DeviceConfig: DeviceConfig{
-						Processes: []ProcessConfig{{PID: 4242, Type: "C", UsedMemoryMiB: 6000}},
-					},
-				},
-				{Index: 1}, // no override -> inherits device_defaults
-			},
-		},
+// Per-device processes, decoded from real YAML through the inline-embedded
+// DeviceConfig and merged: covers override (d0), explicit-clear (d1), inherit (d2).
+func TestYAMLConfig_PerDeviceProcesses(t *testing.T) {
+	const y = `
+device_defaults:
+  processes:
+    - {pid: 1, type: "C"}
+devices:
+  - index: 0
+    processes:
+      - {pid: 4242, type: "C", sm_util: 75}
+  - index: 1
+    processes: []
+`
+	var yc YAMLConfig
+	if err := yaml.Unmarshal([]byte(y), &yc); err != nil {
+		t.Fatalf("yaml decode: %v", err)
 	}
-
-	// Device 0 uses its override.
-	d0 := c.GetDeviceConfig(0)
-	if len(d0.Processes) != 1 || d0.Processes[0].PID != 4242 {
-		t.Fatalf("Device 0: expected overridden PID 4242, got %+v", d0.Processes)
+	c := &Config{YAMLConfig: &yc}
+	if d := c.GetDeviceConfig(0); len(d.Processes) != 1 || d.Processes[0].PID != 4242 || d.Processes[0].SmUtil != 75 {
+		t.Fatalf("device 0 (override): %+v", d.Processes)
 	}
-	// Device 1 inherits the default.
-	d1 := c.GetDeviceConfig(1)
-	if len(d1.Processes) != 1 || d1.Processes[0].PID != 1 {
-		t.Fatalf("Device 1: expected inherited PID 1, got %+v", d1.Processes)
+	if d := c.GetDeviceConfig(1); len(d.Processes) != 0 { // processes: [] clears the default
+		t.Fatalf("device 1 (explicit clear): %+v", d.Processes)
+	}
+	if d := c.GetDeviceConfig(2); len(d.Processes) != 1 || d.Processes[0].PID != 1 { // no override -> inherit
+		t.Fatalf("device 2 (inherit): %+v", d.Processes)
 	}
 }

--- a/pkg/gpu/mocknvml/engine/config_test.go
+++ b/pkg/gpu/mocknvml/engine/config_test.go
@@ -185,3 +185,33 @@ func TestLoadConfig_AutoDiscoverFallback(t *testing.T) {
 	require.NotNil(t, config, "LoadConfig returned nil")
 	require.Equal(t, 8, config.NumDevices, "Expected default NumDevices 8")
 }
+
+func TestGetDeviceConfig_PerDeviceProcessesOverride(t *testing.T) {
+	c := &Config{
+		YAMLConfig: &YAMLConfig{
+			DeviceDefaults: DeviceConfig{
+				Processes: []ProcessConfig{{PID: 1, Type: "C", UsedMemoryMiB: 100}},
+			},
+			Devices: []DeviceOverride{
+				{
+					Index: 0,
+					DeviceConfig: DeviceConfig{
+						Processes: []ProcessConfig{{PID: 4242, Type: "C", UsedMemoryMiB: 6000}},
+					},
+				},
+				{Index: 1}, // no override -> inherits device_defaults
+			},
+		},
+	}
+
+	// Device 0 uses its override.
+	d0 := c.GetDeviceConfig(0)
+	if len(d0.Processes) != 1 || d0.Processes[0].PID != 4242 {
+		t.Fatalf("device 0: expected overridden PID 4242, got %+v", d0.Processes)
+	}
+	// Device 1 inherits the default.
+	d1 := c.GetDeviceConfig(1)
+	if len(d1.Processes) != 1 || d1.Processes[0].PID != 1 {
+		t.Fatalf("device 1: expected inherited PID 1, got %+v", d1.Processes)
+	}
+}

--- a/pkg/gpu/mocknvml/engine/config_test.go
+++ b/pkg/gpu/mocknvml/engine/config_test.go
@@ -207,11 +207,11 @@ func TestGetDeviceConfig_PerDeviceProcessesOverride(t *testing.T) {
 	// Device 0 uses its override.
 	d0 := c.GetDeviceConfig(0)
 	if len(d0.Processes) != 1 || d0.Processes[0].PID != 4242 {
-		t.Fatalf("device 0: expected overridden PID 4242, got %+v", d0.Processes)
+		t.Fatalf("Device 0: expected overridden PID 4242, got %+v", d0.Processes)
 	}
 	// Device 1 inherits the default.
 	d1 := c.GetDeviceConfig(1)
 	if len(d1.Processes) != 1 || d1.Processes[0].PID != 1 {
-		t.Fatalf("device 1: expected inherited PID 1, got %+v", d1.Processes)
+		t.Fatalf("Device 1: expected inherited PID 1, got %+v", d1.Processes)
 	}
 }

--- a/pkg/gpu/mocknvml/engine/config_types.go
+++ b/pkg/gpu/mocknvml/engine/config_types.go
@@ -147,10 +147,10 @@ type DeviceConfig struct {
 
 // DeviceOverride contains per-device settings that override defaults
 type DeviceOverride struct {
-	Index        int    `json:"index"`
-	UUID         string `json:"uuid,omitempty"`
-	MinorNumber  int    `json:"minor_number,omitempty"`
-	GraceCPUPair int    `json:"grace_cpu_pair,omitempty"`
+	Index        int              `json:"index"`
+	UUID         string           `json:"uuid,omitempty"`
+	MinorNumber  int              `json:"minor_number,omitempty"`
+	GraceCPUPair int              `json:"grace_cpu_pair,omitempty"`
 	DeviceConfig `json:",inline"` // Embed all device config fields
 }
 
@@ -170,10 +170,10 @@ type InfoROMConfig struct {
 
 // MemoryConfig defines GPU memory settings
 type MemoryConfig struct {
-	TotalBytes    uint64 `json:"total_bytes"`
-	ReservedBytes uint64 `json:"reserved_bytes,omitempty"`
-	FreeBytes     uint64 `json:"free_bytes,omitempty"`
-	UsedBytes     uint64 `json:"used_bytes,omitempty"`
+	TotalBytes     uint64 `json:"total_bytes"`
+	ReservedBytes  uint64 `json:"reserved_bytes,omitempty"`
+	FreeBytes      uint64 `json:"free_bytes,omitempty"`
+	UsedBytes      uint64 `json:"used_bytes,omitempty"`
 	MemoryBusWidth uint32 `json:"memory_bus_width,omitempty"` // bits (e.g., 5120 for A100)
 }
 
@@ -204,12 +204,12 @@ type PCIeConfig struct {
 
 // PowerConfig defines power management settings
 type PowerConfig struct {
-	ManagementSupported bool   `json:"management_supported,omitempty"`
-	ManagementMode      string `json:"management_mode,omitempty"`
-	DefaultLimitMW      uint32 `json:"default_limit_mw,omitempty"`
-	EnforcedLimitMW     uint32 `json:"enforced_limit_mw,omitempty"`
-	MinLimitMW          uint32 `json:"min_limit_mw,omitempty"`
-	MaxLimitMW          uint32 `json:"max_limit_mw,omitempty"`
+	ManagementSupported      bool   `json:"management_supported,omitempty"`
+	ManagementMode           string `json:"management_mode,omitempty"`
+	DefaultLimitMW           uint32 `json:"default_limit_mw,omitempty"`
+	EnforcedLimitMW          uint32 `json:"enforced_limit_mw,omitempty"`
+	MinLimitMW               uint32 `json:"min_limit_mw,omitempty"`
+	MaxLimitMW               uint32 `json:"max_limit_mw,omitempty"`
 	CurrentDrawMW            uint32 `json:"current_draw_mw,omitempty"`
 	PowerState               string `json:"power_state,omitempty"`
 	TotalEnergyConsumptionMJ uint64 `json:"total_energy_consumption_mj,omitempty"` // millijoules since boot
@@ -393,13 +393,13 @@ type GSPFirmwareConfig struct {
 
 // FeaturesConfig defines GPU-specific features (like Blackwell features)
 type FeaturesConfig struct {
-	TransformerEngine    bool `json:"transformer_engine,omitempty"`
-	FP4Support           bool `json:"fp4_support,omitempty"`
-	FP8Support           bool `json:"fp8_support,omitempty"`
-	ConfidentialCompute  bool `json:"confidential_compute,omitempty"`
-	NVLinkC2C            bool `json:"nvlink_c2c,omitempty"`
-	DecompressionEngine  bool `json:"decompression_engine,omitempty"`
-	FifthGenTensorCores  bool `json:"fifth_gen_tensor_cores,omitempty"`
+	TransformerEngine   bool `json:"transformer_engine,omitempty"`
+	FP4Support          bool `json:"fp4_support,omitempty"`
+	FP8Support          bool `json:"fp8_support,omitempty"`
+	ConfidentialCompute bool `json:"confidential_compute,omitempty"`
+	NVLinkC2C           bool `json:"nvlink_c2c,omitempty"`
+	DecompressionEngine bool `json:"decompression_engine,omitempty"`
+	FifthGenTensorCores bool `json:"fifth_gen_tensor_cores,omitempty"`
 }
 
 // GraceSuperchipConfig defines Grace CPU pairing for GB200
@@ -416,8 +416,8 @@ type ProcessConfig struct {
 	Type          string `json:"type,omitempty"` // "C" for compute, "G" for graphics
 	Name          string `json:"name,omitempty"`
 	UsedMemoryMiB uint64 `json:"used_memory_mib,omitempty"`
-	SmUtil        uint32 `json:"sm_util,omitempty"`  // per-process SM utilization %
-	MemUtil       uint32 `json:"mem_util,omitempty"` // per-process memory-bandwidth utilization %
+	SmUtil        uint32 `json:"sm_util,omitempty"`  // SM utilization %
+	MemUtil       uint32 `json:"mem_util,omitempty"` // memory-bandwidth utilization %
 	EncUtil       uint32 `json:"enc_util,omitempty"` // encoder utilization %
 	DecUtil       uint32 `json:"dec_util,omitempty"` // decoder utilization %
 }
@@ -585,9 +585,9 @@ type TopologyDocument struct {
 
 // TopologyDomain represents one NVLink fabric domain (cluster UUID).
 type TopologyDomain struct {
-	Name    string            `json:"name,omitempty"`
-	UUID    string            `json:"uuid"`
-	Cliques []TopologyClique  `json:"cliques"`
+	Name    string           `json:"name,omitempty"`
+	UUID    string           `json:"uuid"`
+	Cliques []TopologyClique `json:"cliques"`
 }
 
 // TopologyClique groups the Kubernetes node names that share a clique

--- a/pkg/gpu/mocknvml/engine/config_types.go
+++ b/pkg/gpu/mocknvml/engine/config_types.go
@@ -416,6 +416,10 @@ type ProcessConfig struct {
 	Type          string `json:"type,omitempty"` // "C" for compute, "G" for graphics
 	Name          string `json:"name,omitempty"`
 	UsedMemoryMiB uint64 `json:"used_memory_mib,omitempty"`
+	SmUtil        uint32 `json:"sm_util,omitempty"`  // per-process SM utilization %
+	MemUtil       uint32 `json:"mem_util,omitempty"` // per-process memory-bandwidth utilization %
+	EncUtil       uint32 `json:"enc_util,omitempty"` // encoder utilization %
+	DecUtil       uint32 `json:"dec_util,omitempty"` // decoder utilization %
 }
 
 // TopologyConfig defines GPU topology settings

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -16,6 +16,7 @@ package engine
 import (
 	"fmt"
 	"slices"
+	"time"
 	"unsafe"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
@@ -341,10 +342,31 @@ func (d *ConfigurableDevice) GetGraphicsRunningProcesses() ([]nvml.ProcessInfo, 
 	return procs, nvml.SUCCESS
 }
 
-// GetProcessUtilization returns process utilization samples since lastSeenTimestamp
+// GetProcessUtilization returns process utilization samples since lastSeenTimestamp.
+// Utilization is reported for compute processes (type "C" or "") from the device
+// config, matching real NVML. Samples carry a synthetic "now" timestamp so they
+// are always newer than the caller's lastSeenTimestamp.
 func (d *ConfigurableDevice) GetProcessUtilization(lastSeenTimestamp uint64) ([]nvml.ProcessUtilizationSample, nvml.Return) {
 	debugLog("[NVML] nvmlDeviceGetProcessUtilization(lastSeen=%d)\n", lastSeenTimestamp)
-	return []nvml.ProcessUtilizationSample{}, nvml.SUCCESS
+	if d.config == nil || len(d.config.Processes) == 0 {
+		return nil, nvml.SUCCESS
+	}
+	ts := uint64(time.Now().UnixMicro())
+	var out []nvml.ProcessUtilizationSample
+	for _, p := range d.config.Processes {
+		if p.Type != "C" && p.Type != "" { // utilization is a compute concept
+			continue
+		}
+		out = append(out, nvml.ProcessUtilizationSample{
+			Pid:       p.PID,
+			TimeStamp: ts,
+			SmUtil:    p.SmUtil,
+			MemUtil:   p.MemUtil,
+			EncUtil:   p.EncUtil,
+			DecUtil:   p.DecUtil,
+		})
+	}
+	return out, nvml.SUCCESS
 }
 
 // GetCurrentClocksEventReasons returns clock event reasons bitmask (newer API name for throttle reasons)

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -342,19 +342,12 @@ func (d *ConfigurableDevice) GetGraphicsRunningProcesses() ([]nvml.ProcessInfo, 
 	return procs, nvml.SUCCESS
 }
 
-// GetProcessUtilization returns a utilization sample for every process in the
-// device config. Real nvmlDeviceGetProcessUtilization reports one sample per
-// running process — compute AND graphics/video — carrying SM, memory, encoder
-// and decoder utilization, so samples are NOT filtered by process type (unlike
-// GetComputeRunningProcesses, which is the compute-only call).
-//
-// lastSeenTimestamp is intentionally not used as a filter: this is a static,
-// config-driven fixture, not a rolling driver sample buffer. Each sample is
-// stamped with time.Now() so it is always newer than any lastSeen the caller
-// passes, keeping the common lastSeen=0 polling pattern observing the configured
-// values. (Real NVML returns only samples newer than lastSeen, and
-// NVML_ERROR_NOT_FOUND when none remain; emulating that would only error out
-// lastSeen=0 callers.)
+// GetProcessUtilization returns one sample per configured process, compute and
+// graphics/video alike (real NVML reports both; GetComputeRunningProcesses is the
+// compute-only call), so it does not filter by type. lastSeenTimestamp is not used
+// as a filter: each sample is stamped with time.Now() (always newer than the
+// caller's lastSeen) so the common lastSeen=0 polling pattern keeps observing the
+// configured values.
 func (d *ConfigurableDevice) GetProcessUtilization(lastSeenTimestamp uint64) ([]nvml.ProcessUtilizationSample, nvml.Return) {
 	debugLog("[NVML] nvmlDeviceGetProcessUtilization(lastSeen=%d)\n", lastSeenTimestamp)
 	if d.config == nil || len(d.config.Processes) == 0 {

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -342,10 +342,19 @@ func (d *ConfigurableDevice) GetGraphicsRunningProcesses() ([]nvml.ProcessInfo, 
 	return procs, nvml.SUCCESS
 }
 
-// GetProcessUtilization returns process utilization samples since lastSeenTimestamp.
-// Utilization is reported for compute processes (type "C" or "") from the device
-// config, matching real NVML. Samples carry a synthetic "now" timestamp so they
-// are always newer than the caller's lastSeenTimestamp.
+// GetProcessUtilization returns a utilization sample for every process in the
+// device config. Real nvmlDeviceGetProcessUtilization reports one sample per
+// running process — compute AND graphics/video — carrying SM, memory, encoder
+// and decoder utilization, so samples are NOT filtered by process type (unlike
+// GetComputeRunningProcesses, which is the compute-only call).
+//
+// lastSeenTimestamp is intentionally not used as a filter: this is a static,
+// config-driven fixture, not a rolling driver sample buffer. Each sample is
+// stamped with time.Now() so it is always newer than any lastSeen the caller
+// passes, keeping the common lastSeen=0 polling pattern observing the configured
+// values. (Real NVML returns only samples newer than lastSeen, and
+// NVML_ERROR_NOT_FOUND when none remain; emulating that would only error out
+// lastSeen=0 callers.)
 func (d *ConfigurableDevice) GetProcessUtilization(lastSeenTimestamp uint64) ([]nvml.ProcessUtilizationSample, nvml.Return) {
 	debugLog("[NVML] nvmlDeviceGetProcessUtilization(lastSeen=%d)\n", lastSeenTimestamp)
 	if d.config == nil || len(d.config.Processes) == 0 {
@@ -354,9 +363,6 @@ func (d *ConfigurableDevice) GetProcessUtilization(lastSeenTimestamp uint64) ([]
 	ts := uint64(time.Now().UnixMicro())
 	var out []nvml.ProcessUtilizationSample
 	for _, p := range d.config.Processes {
-		if p.Type != "C" && p.Type != "" { // utilization is a compute concept
-			continue
-		}
 		out = append(out, nvml.ProcessUtilizationSample{
 			Pid:       p.PID,
 			TimeStamp: ts,

--- a/pkg/gpu/mocknvml/engine/device_test.go
+++ b/pkg/gpu/mocknvml/engine/device_test.go
@@ -470,6 +470,37 @@ func TestConfigurableDevice_GetProcessUtilization_Default(t *testing.T) {
 	require.Empty(t, utils, "Expected empty utilization list")
 }
 
+func TestConfigurableDevice_GetProcessUtilization_WithConfig(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Name: "NVIDIA A100-SXM4-80GB",
+		Processes: []ProcessConfig{
+			{PID: 1234, Type: "C", Name: "python", UsedMemoryMiB: 1024, SmUtil: 75, MemUtil: 40},
+			{PID: 9999, Type: "G", Name: "Xorg", UsedMemoryMiB: 128, SmUtil: 10},
+		},
+	})
+
+	utils, ret := dev.GetProcessUtilization(0)
+	if ret != nvml.SUCCESS {
+		t.Fatalf("GetProcessUtilization failed: %v", ret)
+	}
+	// Only the compute process is reported (graphics excluded), matching real NVML.
+	if len(utils) != 1 {
+		t.Fatalf("expected 1 compute utilization sample, got %d", len(utils))
+	}
+	if utils[0].Pid != 1234 {
+		t.Errorf("expected PID 1234, got %d", utils[0].Pid)
+	}
+	if utils[0].SmUtil != 75 {
+		t.Errorf("expected SmUtil 75, got %d", utils[0].SmUtil)
+	}
+	if utils[0].MemUtil != 40 {
+		t.Errorf("expected MemUtil 40, got %d", utils[0].MemUtil)
+	}
+	if utils[0].TimeStamp == 0 {
+		t.Errorf("expected a non-zero timestamp")
+	}
+}
+
 // =============================================================================
 // Performance functions (Batch 2)
 // =============================================================================

--- a/pkg/gpu/mocknvml/engine/device_test.go
+++ b/pkg/gpu/mocknvml/engine/device_test.go
@@ -485,19 +485,19 @@ func TestConfigurableDevice_GetProcessUtilization_WithConfig(t *testing.T) {
 	}
 	// Only the compute process is reported (graphics excluded), matching real NVML.
 	if len(utils) != 1 {
-		t.Fatalf("expected 1 compute utilization sample, got %d", len(utils))
+		t.Fatalf("Expected 1 compute utilization sample, got %d", len(utils))
 	}
 	if utils[0].Pid != 1234 {
-		t.Errorf("expected PID 1234, got %d", utils[0].Pid)
+		t.Errorf("Expected PID 1234, got %d", utils[0].Pid)
 	}
 	if utils[0].SmUtil != 75 {
-		t.Errorf("expected SmUtil 75, got %d", utils[0].SmUtil)
+		t.Errorf("Expected SmUtil 75, got %d", utils[0].SmUtil)
 	}
 	if utils[0].MemUtil != 40 {
-		t.Errorf("expected MemUtil 40, got %d", utils[0].MemUtil)
+		t.Errorf("Expected MemUtil 40, got %d", utils[0].MemUtil)
 	}
 	if utils[0].TimeStamp == 0 {
-		t.Errorf("expected a non-zero timestamp")
+		t.Errorf("Expected a non-zero timestamp")
 	}
 }
 

--- a/pkg/gpu/mocknvml/engine/device_test.go
+++ b/pkg/gpu/mocknvml/engine/device_test.go
@@ -475,7 +475,7 @@ func TestConfigurableDevice_GetProcessUtilization_WithConfig(t *testing.T) {
 		Name: "NVIDIA A100-SXM4-80GB",
 		Processes: []ProcessConfig{
 			{PID: 1234, Type: "C", Name: "python", UsedMemoryMiB: 1024, SmUtil: 75, MemUtil: 40},
-			{PID: 9999, Type: "G", Name: "Xorg", UsedMemoryMiB: 128, SmUtil: 10},
+			{PID: 9999, Type: "G", Name: "ffmpeg", UsedMemoryMiB: 128, EncUtil: 60, DecUtil: 30},
 		},
 	})
 
@@ -483,9 +483,10 @@ func TestConfigurableDevice_GetProcessUtilization_WithConfig(t *testing.T) {
 	if ret != nvml.SUCCESS {
 		t.Fatalf("GetProcessUtilization failed: %v", ret)
 	}
-	// Only the compute process is reported (graphics excluded), matching real NVML.
-	if len(utils) != 1 {
-		t.Fatalf("Expected 1 compute utilization sample, got %d", len(utils))
+	// Both compute and graphics/video processes report utilization, like real NVML
+	// (unlike GetComputeRunningProcesses, which is compute-only).
+	if len(utils) != 2 {
+		t.Fatalf("Expected 2 utilization samples, got %d", len(utils))
 	}
 	if utils[0].Pid != 1234 {
 		t.Errorf("Expected PID 1234, got %d", utils[0].Pid)
@@ -498,6 +499,16 @@ func TestConfigurableDevice_GetProcessUtilization_WithConfig(t *testing.T) {
 	}
 	if utils[0].TimeStamp == 0 {
 		t.Errorf("Expected a non-zero timestamp")
+	}
+	// The graphics/video process is reported too, carrying encoder/decoder util.
+	if utils[1].Pid != 9999 {
+		t.Errorf("Expected PID 9999, got %d", utils[1].Pid)
+	}
+	if utils[1].EncUtil != 60 {
+		t.Errorf("Expected EncUtil 60, got %d", utils[1].EncUtil)
+	}
+	if utils[1].DecUtil != 30 {
+		t.Errorf("Expected DecUtil 30, got %d", utils[1].DecUtil)
 	}
 }
 

--- a/pkg/gpu/mocknvml/engine/version.go
+++ b/pkg/gpu/mocknvml/engine/version.go
@@ -43,6 +43,7 @@ var functionRegistry = map[string]FunctionVersion{
 	"nvmlDeviceGetMemoryInfo_v2":               {Added: "510.0"},
 	"nvmlDeviceGetComputeRunningProcesses_v3":  {Added: "510.0"},
 	"nvmlDeviceGetGraphicsRunningProcesses_v3": {Added: "510.0"},
+	"nvmlDeviceGetProcessUtilization":          {Added: "418.0"},
 	"nvmlDeviceGetGspFirmwareMode":             {Added: "510.0"},
 
 	// 535.x additions

--- a/pkg/gpu/mocknvml/engine/version.go
+++ b/pkg/gpu/mocknvml/engine/version.go
@@ -32,6 +32,9 @@ var functionRegistry = map[string]FunctionVersion{
 	"nvmlDeviceGetCount_v2":         {Added: "331.0"},
 	"nvmlDeviceGetHandleByIndex_v2": {Added: "331.0"},
 
+	// 418.x additions
+	"nvmlDeviceGetProcessUtilization": {Added: "418.0"},
+
 	// 450.x additions
 	"nvmlDeviceGetRemappedRows": {Added: "450.0"},
 
@@ -43,7 +46,6 @@ var functionRegistry = map[string]FunctionVersion{
 	"nvmlDeviceGetMemoryInfo_v2":               {Added: "510.0"},
 	"nvmlDeviceGetComputeRunningProcesses_v3":  {Added: "510.0"},
 	"nvmlDeviceGetGraphicsRunningProcesses_v3": {Added: "510.0"},
-	"nvmlDeviceGetProcessUtilization":          {Added: "418.0"},
 	"nvmlDeviceGetGspFirmwareMode":             {Added: "510.0"},
 
 	// 535.x additions
@@ -57,17 +59,17 @@ var functionRegistry = map[string]FunctionVersion{
 	"nvmlDeviceGetTopologyNearestGpus":    {Added: "331.0"},
 
 	// NVLink functions (390.x+)
-	"nvmlDeviceGetNvLinkState":              {Added: "390.0"},
-	"nvmlDeviceGetNvLinkErrorCounter":       {Added: "390.0"},
-	"nvmlDeviceGetNvLinkRemotePciInfo_v2":   {Added: "390.0"},
+	"nvmlDeviceGetNvLinkState":            {Added: "390.0"},
+	"nvmlDeviceGetNvLinkErrorCounter":     {Added: "390.0"},
+	"nvmlDeviceGetNvLinkRemotePciInfo_v2": {Added: "390.0"},
 
 	// Thermal functions (331.x+)
 	"nvmlDeviceGetTemperatureThreshold": {Added: "331.0"},
 	"nvmlDeviceGetThermalSettings":      {Added: "331.0"},
 
 	// Power functions (331.x+)
-	"nvmlDeviceGetEnforcedPowerLimit":   {Added: "331.0"},
-	"nvmlDeviceGetPowerManagementMode":  {Added: "331.0"},
+	"nvmlDeviceGetEnforcedPowerLimit":  {Added: "331.0"},
+	"nvmlDeviceGetPowerManagementMode": {Added: "331.0"},
 }
 
 // GetFunctionRegistry returns a copy of the function version registry.

--- a/tests/mocknvml/Dockerfile
+++ b/tests/mocknvml/Dockerfile
@@ -53,6 +53,11 @@ WORKDIR /app
 # Copy the test binary
 COPY --from=test-builder /build/mocknvml-test /app/
 
+# Copy the test config fixture (a process with utilization, for the populated path).
+# The Makefile points MOCK_NVML_CONFIG at this so the integration test runs against
+# a real profile config rather than the env-var fallback.
+COPY tests/mocknvml/util-test-config.yaml /app/util-test-config.yaml
+
 # Copy the mock NVML library to /usr/local/lib (architecture-independent)
 COPY --from=lib-builder /build/pkg/gpu/mocknvml/libnvidia-ml.so* /usr/local/lib/
 

--- a/tests/mocknvml/Makefile
+++ b/tests/mocknvml/Makefile
@@ -36,7 +36,7 @@ test: build
 	@echo "Running mock NVML integration test in Docker..."
 	@echo "================================================"
 	@echo ""
-	$(DOCKER) run --rm $(IMAGE_NAME):$(IMAGE_TAG)
+	$(DOCKER) run --rm -e MOCK_NVML_CONFIG=/app/util-test-config.yaml $(IMAGE_NAME):$(IMAGE_TAG)
 	@echo ""
 	@echo "================================================"
 	@echo "✓ Mock NVML integration test completed successfully!"

--- a/tests/mocknvml/README.md
+++ b/tests/mocknvml/README.md
@@ -33,50 +33,54 @@ The integration test exercises the following NVML APIs:
 - `nvmlDeviceGetCudaComputeCapability()` - Get compute capability
 - `nvmlDeviceGetHandleByUUID()` - Get device by UUID
 - `nvmlDeviceGetHandleByPciBusId_v2()` - Get device by PCI Bus ID
+- `nvmlDeviceGetComputeRunningProcesses_v3()` / `nvmlDeviceGetGraphicsRunningProcesses_v3()` - per-process GPU memory
+- `nvmlDeviceGetProcessUtilization()` - per-process SM / memory / encoder / decoder utilization
 - `nvmlShutdown()` - Shutdown NVML
+
+It also runs a suite of **bridge edge-case tests** (`bridge_tests.go`): NVML return-code strings, index/UUID/PCI boundary lookups, and post-shutdown behavior.
 
 ## Configuration
 
-The mock library can be configured via environment variables:
+The integration test runs against a profile config fixture, `util-test-config.yaml`, via `MOCK_NVML_CONFIG` (set by the Makefile). It is an A100 profile plus one compute process carrying `sm_util`, so the per-process utilization path is exercised.
 
-- `MOCK_NVML_NUM_DEVICES` - Number of mock devices (default: 8, test uses: 4)
+Without a config file, the mock library falls back to environment variables:
+
+- `MOCK_NVML_NUM_DEVICES` - Number of mock devices (default: 8)
 - `MOCK_NVML_DRIVER_VERSION` - Mock driver version (default: 550.163.01)
 
 ## Expected Output
 
 ```
-Starting Mini Device Plugin Test
-=================================
 Initializing NVML...
 ✓ NVML initialized successfully
 ✓ Driver version: 550.163.01
-✓ Found 4 GPU device(s)
+✓ Found 8 GPU device(s)
 
 Enumerating devices:
-
 Device 0:
-  Name: Mock NVIDIA A100-SXM4-40GB
-  UUID: GPU-9b465350-deaa-456b-ba7c-2b0c95ae7f2b
-  Memory: 40960 MB (Total), 0 MB (Free), 0 MB (Used)
-
+  Name: NVIDIA A100-SXM4-40GB
+  UUID: GPU-12345678-1234-1234-1234-123456780000
+  Memory: 40960 MB (Total) ...
 ... (additional devices)
 
-Testing device lookup by UUID...
-  Device 0 UUID: "GPU-543ae470-0879-4749-8bb8-e38ecacd1bb5"
-  Device 1 UUID: "GPU-c13faba5-2b00-4949-b3f3-5ab360ac0250"
-  Device 2 UUID: "GPU-810f0b8a-cc0a-43bb-b11a-099b0b7acd18"
-  Device 3 UUID: "GPU-10ffca56-a94f-4825-87e2-e41fc4c23395"
-Looking up device with UUID: "GPU-543ae470-0879-4749-8bb8-e38ecacd1bb5"
-✓ Successfully looked up device by UUID: GPU-543ae470-0879-4749-8bb8-e38ecacd1bb5
+Testing device lookup by UUID / PCI Bus ID...
+✓ Successfully looked up device by UUID / PCI Bus ID
 
-Testing device lookup by PCI Bus ID...
-✓ Successfully looked up device by PCI Bus ID: 0000:00:00.0
+=== Bridge Edge-Case Tests ===
+  PASS  errstr/SUCCESS
+  PASS  boundary/uuid_invalid (correctly returned: ERROR_NOT_FOUND)
+  ... (additional bridge cases)
+=== Bridge Tests: 29 passed, 0 failed ===
+
+✓ checkProcessUtilization: pid=4242 smUtil=75 memUtil=40
 
 =================================
-✓ All device plugin tests passed!
+✓ All tests passed!
 
 SUCCESS: Mock NVML library is working correctly!
 ```
+
+(Device names/UUIDs come from the configured profile in `util-test-config.yaml`.)
 
 ## Known Limitations
 

--- a/tests/mocknvml/main.go
+++ b/tests/mocknvml/main.go
@@ -190,10 +190,41 @@ func main() {
 	// Run bridge edge-case tests
 	bridgeFailures := runBridgeTests(count)
 
+	// Per-process utilization (requires a config with a compute process + sm_util).
+	checkProcessUtilization()
+
 	log.Println("\n=================================")
 	if bridgeFailures > 0 {
 		log.Fatalf("FAILED: %d bridge test(s) failed", bridgeFailures)
 	}
 	log.Println("✓ All tests passed!")
 	fmt.Println("\nSUCCESS: Mock NVML library is working correctly!")
+}
+
+// checkProcessUtilization exercises nvmlDeviceGetProcessUtilization end-to-end
+// through go-nvml's two-call wrapper. Without MOCK_NVML_CONFIG (env/default
+// config has no processes) it validates the clean empty path — which is exactly
+// where the old stub broke go-nvml by returning SUCCESS on the count probe.
+// With MOCK_NVML_CONFIG defining a compute process + sm_util, it validates the
+// populated probe->fill path.
+func checkProcessUtilization() {
+	dev, ret := nvml.DeviceGetHandleByIndex(0)
+	if ret != nvml.SUCCESS {
+		log.Fatalf("checkProcessUtilization: DeviceGetHandleByIndex: %v", ret)
+	}
+	samples, ret := dev.GetProcessUtilization(0)
+	if ret != nvml.SUCCESS {
+		log.Fatalf("checkProcessUtilization: GetProcessUtilization: %v", ret)
+	}
+	if os.Getenv("MOCK_NVML_CONFIG") == "" {
+		// Default/env config: no processes. The call must succeed cleanly and
+		// return zero samples (probe -> INSUFFICIENT_SIZE with count 0).
+		log.Printf("✓ checkProcessUtilization: empty path OK (%d samples, no MOCK_NVML_CONFIG)", len(samples))
+		return
+	}
+	if len(samples) == 0 {
+		log.Fatalf("checkProcessUtilization: MOCK_NVML_CONFIG set but got 0 samples; expected a compute process with sm_util")
+	}
+	log.Printf("✓ checkProcessUtilization: pid=%d smUtil=%d memUtil=%d",
+		samples[0].Pid, samples[0].SmUtil, samples[0].MemUtil)
 }

--- a/tests/mocknvml/main.go
+++ b/tests/mocknvml/main.go
@@ -222,9 +222,18 @@ func checkProcessUtilization() {
 		log.Printf("✓ checkProcessUtilization: empty path OK (%d samples, no MOCK_NVML_CONFIG)", len(samples))
 		return
 	}
-	if len(samples) == 0 {
-		log.Fatalf("checkProcessUtilization: MOCK_NVML_CONFIG set but got 0 samples; expected a compute process with sm_util")
+	// Assert exact values, not just len>0, so a dropped/transposed bridge field is caught.
+	if len(samples) != 1 || samples[0].Pid != 4242 || samples[0].SmUtil != 75 || samples[0].MemUtil != 40 {
+		log.Fatalf("checkProcessUtilization: device 0 = %+v; want one sample pid=4242 smUtil=75 memUtil=40", samples)
 	}
-	log.Printf("✓ checkProcessUtilization: pid=%d smUtil=%d memUtil=%d",
+	// Device 1 (processes: []) covers the empty path + explicit-clear merge.
+	d1, ret := nvml.DeviceGetHandleByIndex(1)
+	if ret != nvml.SUCCESS {
+		log.Fatalf("checkProcessUtilization: DeviceGetHandleByIndex(1): %v", nvml.ErrorString(ret))
+	}
+	if s1, ret := d1.GetProcessUtilization(0); ret != nvml.SUCCESS || len(s1) != 0 {
+		log.Fatalf("checkProcessUtilization: device 1 (processes: []) -> ret=%v, %d samples; want SUCCESS, 0", nvml.ErrorString(ret), len(s1))
+	}
+	log.Printf("✓ checkProcessUtilization: device 0 pid=%d smUtil=%d memUtil=%d; device 1 empty",
 		samples[0].Pid, samples[0].SmUtil, samples[0].MemUtil)
 }

--- a/tests/mocknvml/main.go
+++ b/tests/mocknvml/main.go
@@ -210,15 +210,15 @@ func main() {
 func checkProcessUtilization() {
 	dev, ret := nvml.DeviceGetHandleByIndex(0)
 	if ret != nvml.SUCCESS {
-		log.Fatalf("checkProcessUtilization: DeviceGetHandleByIndex: %v", ret)
+		log.Fatalf("checkProcessUtilization: DeviceGetHandleByIndex: %v", nvml.ErrorString(ret))
 	}
 	samples, ret := dev.GetProcessUtilization(0)
 	if ret != nvml.SUCCESS {
-		log.Fatalf("checkProcessUtilization: GetProcessUtilization: %v", ret)
+		log.Fatalf("checkProcessUtilization: GetProcessUtilization: %v", nvml.ErrorString(ret))
 	}
 	if os.Getenv("MOCK_NVML_CONFIG") == "" {
 		// Default/env config: no processes. The call must succeed cleanly and
-		// return zero samples (probe -> INSUFFICIENT_SIZE with count 0).
+		// return zero samples (probe returns SUCCESS with count 0).
 		log.Printf("✓ checkProcessUtilization: empty path OK (%d samples, no MOCK_NVML_CONFIG)", len(samples))
 		return
 	}

--- a/tests/mocknvml/util-test-config.yaml
+++ b/tests/mocknvml/util-test-config.yaml
@@ -1,6 +1,7 @@
-# Mock NVML Configuration: DGX A100
-# Full configuration for nvidia-smi -x -q compatibility
-# Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
+# Mock NVML test fixture (A100-based) for the tests/mocknvml integration harness.
+# Identical to an A100 profile but with one compute process carrying sm_util, so the
+# harness exercises the populated nvmlDeviceGetProcessUtilization probe->fill path.
+# Wired in via the Makefile: MOCK_NVML_CONFIG=/app/util-test-config.yaml
 
 version: "1.0"
 

--- a/tests/mocknvml/util-test-config.yaml
+++ b/tests/mocknvml/util-test-config.yaml
@@ -329,6 +329,7 @@ devices:
     pci:
       bus_id: "0000:0F:00.0"
     minor_number: 1
+    processes: []   # explicit clear: empty-path coverage
 
   - index: 2
     uuid: "GPU-12345678-1234-1234-1234-123456780002"

--- a/tests/mocknvml/util-test-config.yaml
+++ b/tests/mocknvml/util-test-config.yaml
@@ -1,0 +1,410 @@
+# Mock NVML Configuration: DGX A100
+# Full configuration for nvidia-smi -x -q compatibility
+# Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
+
+version: "1.0"
+
+# =============================================================================
+# System-level configuration
+# =============================================================================
+system:
+  driver_version: "550.163.01"
+  nvml_version: "12.550.163.01"
+  cuda_version: "12.4"
+  cuda_version_major: 12
+  cuda_version_minor: 4
+
+# =============================================================================
+# Default device configuration (applied to all devices unless overridden)
+# =============================================================================
+device_defaults:
+  # ---------------------------------------------------------------------------
+  # Basic identification
+  # ---------------------------------------------------------------------------
+  name: "NVIDIA A100-SXM4-40GB"
+  brand: "nvidia"                    # nvidia, tesla, quadro, geforce, etc.
+  serial: "1324821083812"
+  board_part_number: "692-2G506-0200-002"
+  vbios_version: "92.00.45.00.03"
+
+  # ---------------------------------------------------------------------------
+  # Architecture
+  # ---------------------------------------------------------------------------
+  architecture: "ampere"
+  compute_capability:
+    major: 8
+    minor: 0
+  num_gpu_cores: 6912               # CUDA cores
+
+  # ---------------------------------------------------------------------------
+  # InfoROM versions
+  # ---------------------------------------------------------------------------
+  inforom:
+    image_version: "G506.0200.00.04"
+    oem_object: "2.0"
+    ecc_object: "6.16"
+    pwr_object: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Memory configuration
+  # ---------------------------------------------------------------------------
+  memory:
+    total_bytes: 42949672960        # 40 GiB HBM2e
+    reserved_bytes: 611319808       # ~583 MiB reserved
+    free_bytes: 42338353152         # total - reserved at idle
+    used_bytes: 0
+
+  bar1_memory:
+    total_bytes: 68719476736        # 64 GiB
+    free_bytes: 68719476736
+    used_bytes: 0
+
+  # ---------------------------------------------------------------------------
+  # PCI configuration
+  # ---------------------------------------------------------------------------
+  pci:
+    device_id: 0x20B010DE           # A100 SXM4 40GB
+    subsystem_id: 0x134710DE
+    # bus_id is auto-generated per device if not specified
+
+  pcie:
+    max_link_gen: 4                 # PCIe Gen4
+    current_link_gen: 4
+    max_link_width: 16              # x16
+    current_link_width: 16
+    replay_counter: 0
+    tx_throughput_kbps: 0           # KB/s
+    rx_throughput_kbps: 0
+
+  # ---------------------------------------------------------------------------
+  # Power configuration
+  # ---------------------------------------------------------------------------
+  power:
+    management_supported: true
+    management_mode: "enabled"
+    default_limit_mw: 400000        # 400W
+    enforced_limit_mw: 400000
+    min_limit_mw: 100000            # 100W
+    max_limit_mw: 400000            # 400W
+    current_draw_mw: 72000          # 72W idle
+    power_state: "P0"               # P0-P12
+
+  # ---------------------------------------------------------------------------
+  # Thermal configuration
+  # ---------------------------------------------------------------------------
+  thermal:
+    temperature_gpu_c: 33           # Idle temperature
+    temperature_memory_c: 31
+    shutdown_threshold_c: 92
+    slowdown_threshold_c: 87
+    max_operating_c: 83
+    target_temperature_c: 83        # For auto fan control
+
+  # ---------------------------------------------------------------------------
+  # Fan configuration (N/A for SXM form factor)
+  # ---------------------------------------------------------------------------
+  fan:
+    count: 0                        # SXM has no fans (liquid cooled)
+    speed_percent: "N/A"
+    target_speed_percent: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Clock speeds (MHz)
+  # ---------------------------------------------------------------------------
+  clocks:
+    graphics_current: 210           # Idle
+    graphics_max: 1410
+    graphics_app: 1410              # Application clock setting
+    graphics_app_default: 1410
+    sm_current: 210
+    sm_max: 1410
+    memory_current: 1215
+    memory_max: 1215
+    memory_app: 1215
+    memory_app_default: 1215
+    video_current: 585
+    video_max: 1290
+
+  # ---------------------------------------------------------------------------
+  # Clocks throttle reasons (bitmask reasons)
+  # ---------------------------------------------------------------------------
+  clocks_throttle_reasons:
+    gpu_idle: true                  # Clock is idle
+    applications_clocks_setting: false
+    sw_power_cap: false
+    hw_slowdown: false
+    hw_thermal_slowdown: false
+    hw_power_brake_slowdown: false
+    sync_boost: false
+    sw_thermal_slowdown: false
+    display_clocks_setting: false
+
+  # ---------------------------------------------------------------------------
+  # Supported clocks (for nvidia-smi -q -d SUPPORTED_CLOCKS)
+  # ---------------------------------------------------------------------------
+  supported_clocks:
+    memory_clocks:
+      - freq_mhz: 1215
+        graphics_clocks: [210, 420, 630, 840, 1050, 1215, 1275, 1335, 1410]
+
+  # ---------------------------------------------------------------------------
+  # Performance state
+  # ---------------------------------------------------------------------------
+  performance_state: "P0"           # P0 = max performance
+
+  # ---------------------------------------------------------------------------
+  # Utilization (percentage, 0-100)
+  # ---------------------------------------------------------------------------
+  utilization:
+    gpu: 0
+    memory: 0
+    encoder: 0
+    decoder: 0
+    jpeg: 0
+    ofa: 0                          # Optical flow accelerator
+
+  # ---------------------------------------------------------------------------
+  # Encoder/Decoder statistics
+  # ---------------------------------------------------------------------------
+  encoder_stats:
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  fbc_stats:                        # Frame buffer capture
+    session_count: 0
+    average_fps: 0
+    average_latency_us: 0
+
+  # ---------------------------------------------------------------------------
+  # ECC configuration
+  # ---------------------------------------------------------------------------
+  ecc:
+    mode_current: "enabled"
+    mode_pending: "enabled"
+    default_mode: "enabled"
+    # Error counts (all zeros for clean GPU)
+    errors:
+      volatile:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+      aggregate:
+        single_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+        double_bit:
+          device_memory: 0
+          l1_cache: 0
+          l2_cache: 0
+          register_file: 0
+          texture_memory: 0
+          total: 0
+
+  # ---------------------------------------------------------------------------
+  # Retired pages
+  # ---------------------------------------------------------------------------
+  retired_pages:
+    single_bit_retirement:
+      count: 0
+      addresses: []
+    double_bit_retirement:
+      count: 0
+      addresses: []
+    pending_blacklist: false
+    pending_retirement: false
+
+  # ---------------------------------------------------------------------------
+  # Remapped rows
+  # ---------------------------------------------------------------------------
+  remapped_rows:
+    correctable: 0
+    uncorrectable: 0
+    pending: false
+    failure_occurred: false
+
+  # ---------------------------------------------------------------------------
+  # Display configuration
+  # ---------------------------------------------------------------------------
+  display:
+    mode: "disabled"                # No display output on A100
+    active: "disabled"
+
+  # ---------------------------------------------------------------------------
+  # Persistence mode
+  # ---------------------------------------------------------------------------
+  persistence_mode: "enabled"       # Typically enabled on servers
+
+  # ---------------------------------------------------------------------------
+  # Compute mode
+  # ---------------------------------------------------------------------------
+  compute_mode: "default"           # default, exclusive_thread, prohibited, exclusive_process
+
+  # ---------------------------------------------------------------------------
+  # MIG configuration
+  # ---------------------------------------------------------------------------
+  mig:
+    mode_current: "disabled"
+    mode_pending: "disabled"
+    max_gpu_instances: 7            # A100 supports up to 7 MIG instances
+    # GPU instances would be defined here if MIG enabled
+
+  # ---------------------------------------------------------------------------
+  # GPU operation mode (GOM)
+  # ---------------------------------------------------------------------------
+  gpu_operation_mode:
+    current: "all_on"               # all_on, compute, low_dp
+    pending: "all_on"
+
+  # ---------------------------------------------------------------------------
+  # Driver model (Windows only)
+  # ---------------------------------------------------------------------------
+  driver_model:
+    current: "N/A"                  # Linux: N/A, Windows: WDDM or TCC
+    pending: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # Accounting mode
+  # ---------------------------------------------------------------------------
+  accounting:
+    mode: "disabled"
+    buffer_size: 4000               # Max PIDs tracked
+
+  # ---------------------------------------------------------------------------
+  # Virtualization
+  # ---------------------------------------------------------------------------
+  virtualization:
+    mode: "none"                    # none, passthrough, vgpu
+    host_vgpu_mode: "N/A"
+
+  # ---------------------------------------------------------------------------
+  # GSP Firmware
+  # ---------------------------------------------------------------------------
+  gsp_firmware:
+    mode: "enabled"                 # GSP enabled on newer drivers
+    version: "550.54.15"
+
+  # ---------------------------------------------------------------------------
+  # Processes (a compute process with utilization, for the bridge smoke test)
+  # ---------------------------------------------------------------------------
+  processes:
+    - pid: 4242
+      type: "C"
+      name: "python"
+      used_memory_mib: 6000
+      sm_util: 75
+      mem_util: 40
+
+# =============================================================================
+# Device-specific overrides (indexed 0-7 for DGX A100)
+# Only specify fields that differ from device_defaults
+# =============================================================================
+devices:
+  - index: 0
+    uuid: "GPU-12345678-1234-1234-1234-123456780000"
+    serial: "1324821083800"
+    pci:
+      bus_id: "0000:07:00.0"
+    minor_number: 0
+
+  - index: 1
+    uuid: "GPU-12345678-1234-1234-1234-123456780001"
+    serial: "1324821083801"
+    pci:
+      bus_id: "0000:0F:00.0"
+    minor_number: 1
+
+  - index: 2
+    uuid: "GPU-12345678-1234-1234-1234-123456780002"
+    serial: "1324821083802"
+    pci:
+      bus_id: "0000:47:00.0"
+    minor_number: 2
+
+  - index: 3
+    uuid: "GPU-12345678-1234-1234-1234-123456780003"
+    serial: "1324821083803"
+    pci:
+      bus_id: "0000:4E:00.0"
+    minor_number: 3
+
+  - index: 4
+    uuid: "GPU-12345678-1234-1234-1234-123456780004"
+    serial: "1324821083804"
+    pci:
+      bus_id: "0000:87:00.0"
+    minor_number: 4
+
+  - index: 5
+    uuid: "GPU-12345678-1234-1234-1234-123456780005"
+    serial: "1324821083805"
+    pci:
+      bus_id: "0000:90:00.0"
+    minor_number: 5
+
+  - index: 6
+    uuid: "GPU-12345678-1234-1234-1234-123456780006"
+    serial: "1324821083806"
+    pci:
+      bus_id: "0000:B7:00.0"
+    minor_number: 6
+
+  - index: 7
+    uuid: "GPU-12345678-1234-1234-1234-123456780007"
+    serial: "1324821083807"
+    pci:
+      bus_id: "0000:BD:00.0"
+    minor_number: 7
+
+# =============================================================================
+# NVLink topology
+# =============================================================================
+nvlink:
+  version: 3
+  links_per_gpu: 12
+  bandwidth_per_link_gbps: 50       # 50 GB/s per link = 600 GB/s total per GPU
+  # NVLink state per link (12 links)
+  links:
+    - link: 0
+      state: "active"
+      remote_device_type: "gpu"
+      remote_pci_bus_id: "0000:0F:00.0"
+    # ... define all 12 links for full topology
+
+# =============================================================================
+# PCIe topology - 2 NUMA nodes (dual EPYC), 4 GPUs each.
+# Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+# under MOCK_PCI_ROOT; the NVIDIA DRA driver resolves `dra.k8s.io/pcieRoot`
+# from these symlinks.
+# =============================================================================
+pcie_topology:
+  root_complexes:
+    - id: "pci0000:00"
+      numa_node: 0
+      devices:
+        - "0000:07:00.0"
+        - "0000:0F:00.0"
+        - "0000:47:00.0"
+        - "0000:4E:00.0"
+    - id: "pci0000:80"
+      numa_node: 1
+      devices:
+        - "0000:87:00.0"
+        - "0000:90:00.0"
+        - "0000:B7:00.0"
+        - "0000:BD:00.0"


### PR DESCRIPTION
## What

Make the mock NVML library report **per-process GPU utilization**, fix the `nvmlDeviceGetProcessUtilization` C bridge to follow go-nvml's two-call protocol, and make per-device `processes` overrides take effect.

## Why

`nvmlDeviceGetProcessUtilization` was effectively a no-op:
- the engine method returned an empty slice unconditionally, and `ProcessConfig` had no utilization fields to return;
- the C bridge only set `*processSamplesCount` and **never wrote the caller's sample buffer**, and returned `SUCCESS` on the count probe — which breaks go-nvml's wrapper (it expects `INSUFFICIENT_SIZE` on the probe, so it returned `nil` before ever fetching).

Separately, per-device `processes` overrides were silently dropped: `mergeDeviceOverride` is a field whitelist and had no `Processes` case, so `devices[i].processes` never took effect (only `device_defaults.processes`, which applies to every GPU).

## Changes

- Add `sm_util` / `mem_util` / `enc_util` / `dec_util` to `ProcessConfig`.
- Implement `GetProcessUtilization` from config (compute-type processes), with a synthetic timestamp.
- Give `nvmlProcessUtilizationSample_st` a full struct body (it was forward-declared only, so its fields could not be written).
- Rewrite the `nvmlDeviceGetProcessUtilization` bridge for the go-nvml two-call protocol: probe returns `INSUFFICIENT_SIZE` when samples exist / `SUCCESS` when empty; the fill call writes each sample into the caller buffer.
- Version-gate `nvmlDeviceGetProcessUtilization` (`Added: "418.0"`).
- Honor `Processes` in `mergeDeviceOverride`, so a process can be pinned to a specific device.
- Fix `tests/mocknvml` Dockerfile to build the whole package (not just `main.go`) and add a `checkProcessUtilization` integration check.

## Testing

- `go test ./pkg/gpu/mocknvml/engine/...` — new unit tests for utilization sample-building and the per-device `processes` merge; existing suite stays green (back-compat: absent util fields → zero).
- `make -C tests/mocknvml test` — builds `libnvidia-ml.so` and drives it through go-nvml. With `MOCK_NVML_CONFIG` defining a compute process at `sm_util: 75`, `DeviceGetProcessUtilization` round-trips the sample via the two-call probe→fill path; the empty-config path returns cleanly.

All new fields are `omitempty`; existing configs are unaffected.