### PR TITLE
fix(demo): replace bash 4 mapfile with portable while-read loop

### DIFF
--- a/docs/demo/standalone/demo.sh
+++ b/docs/demo/standalone/demo.sh
@@ -201,7 +201,14 @@ if [[ "${IB_ENABLED}" == "true" ]]; then
   # before indexing. Reading jsonpath '{.items[1]}' directly would error when
   # only one pod is Running and, under `set -e`, abort the demo right here —
   # before the friendly check below could explain why.
-  mapfile -t IB_PODS < <(kubectl get pods -l app.kubernetes.io/name=nvml-mock \
+  #
+  # Use a `while read` loop rather than `mapfile`/`readarray`: those are
+  # bash 4.0+ builtins and macOS still ships bash 3.2, so `mapfile` aborts
+  # the demo with "command not found" on stock macOS.
+  IB_PODS=()
+  while IFS= read -r ib_pod; do
+    [[ -n "${ib_pod}" ]] && IB_PODS+=("${ib_pod}")
+  done < <(kubectl get pods -l app.kubernetes.io/name=nvml-mock \
     --field-selector=status.phase=Running \
     -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
   if [[ "${#IB_PODS[@]}" -lt 2 ]]; then


### PR DESCRIPTION
## Summary

- The standalone demo (`docs/demo/standalone/demo.sh`) used `mapfile` to collect running `nvml-mock` pods for the cross-node ibping step.
- `mapfile`/`readarray` are bash 4.0+ builtins, but macOS ships bash 3.2, so the demo aborted with `./demo.sh: line 204: mapfile: command not found` on stock macOS.
- Replaced it with a portable `while IFS= read -r` loop that builds the same `IB_PODS` array (skipping empty lines) and runs on bash 3.2.

## Test plan

- [x] `bash -n docs/demo/standalone/demo.sh` passes
- [ ] Run `GPU_PROFILE=gb200 GPU_COUNT=8 ./demo.sh` on macOS (bash 3.2) and confirm it gets past the cross-node ibping step