### PR TITLE
test: standardize test suite on testify/require

### DIFF
--- a/cmd/fake-imex/ctl/peers_test.go
+++ b/cmd/fake-imex/ctl/peers_test.go
@@ -14,8 +14,9 @@
 package main
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestExpectedPeers locks in the contract used by main()'s readiness
@@ -56,9 +57,7 @@ func TestExpectedPeers(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := ExpectedPeers(tc.peers, tc.ownIP)
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("ExpectedPeers(%v, %q) = %v, want %v", tc.peers, tc.ownIP, got, tc.want)
-			}
+			require.Equal(t, tc.want, got, "ExpectedPeers(%v, %q)", tc.peers, tc.ownIP)
 		})
 	}
 }

--- a/cmd/fake-imex/integration_test.go
+++ b/cmd/fake-imex/integration_test.go
@@ -23,6 +23,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 // build compiles a fake-imex sub-command into the given output path and
@@ -38,24 +40,21 @@ func build(t *testing.T, pkg, out string) string {
 	}
 	cmd := exec.Command("go", "build", "-mod=vendor", "-o", out, pkg)
 	cmd.Dir = repoRoot(t)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("build %s: %v\n%s", pkg, err, output)
-	}
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "build %s: %s", pkg, output)
 	return out
 }
 
 func repoRoot(t *testing.T) string {
 	t.Helper()
 	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	for cur := wd; cur != "/"; cur = filepath.Dir(cur) {
 		if _, err := os.Stat(filepath.Join(cur, "go.mod")); err == nil {
 			return cur
 		}
 	}
-	t.Fatal("could not locate repo root")
+	require.FailNow(t, "could not locate repo root")
 	return ""
 }
 
@@ -65,13 +64,9 @@ func repoRoot(t *testing.T) string {
 func TestFakeImex_HappyPath_ReadyTransitions(t *testing.T) {
 	tmp := t.TempDir()
 	stateDir := filepath.Join(tmp, "state")
-	if err := os.MkdirAll(stateDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(stateDir, 0o755))
 	nodesCfg := filepath.Join(tmp, "nodes.cfg")
-	if err := os.WriteFile(nodesCfg, []byte("10.0.0.1\n10.0.0.2\n10.0.0.3\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(nodesCfg, []byte("10.0.0.1\n10.0.0.2\n10.0.0.3\n"), 0o644))
 
 	daemonBin := build(t, "./cmd/fake-imex/daemon", filepath.Join(tmp, "nvidia-imex"))
 	ctlBin := build(t, "./cmd/fake-imex/ctl", filepath.Join(tmp, "nvidia-imex-ctl"))
@@ -88,7 +83,7 @@ func TestFakeImex_HappyPath_ReadyTransitions(t *testing.T) {
 		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		if err := cmd.Start(); err != nil {
 			cancel()
-			t.Fatalf("start daemon %s: %v", ip, err)
+			require.NoError(t, err, "start daemon %s", ip)
 		}
 		t.Cleanup(func() {
 			cancel()
@@ -105,7 +100,7 @@ func TestFakeImex_HappyPath_ReadyTransitions(t *testing.T) {
 			if ee, ok := err.(*exec.ExitError); ok {
 				return string(out), ee.ExitCode()
 			}
-			t.Fatalf("ctl unexpected error: %v", err)
+			require.NoError(t, err, "ctl unexpected error")
 		}
 		return string(out), 0
 	}
@@ -116,23 +111,20 @@ func TestFakeImex_HappyPath_ReadyTransitions(t *testing.T) {
 	// Only 2 of 3 markers exist → ctl exits 1.
 	waitForMarker(t, stateDir, "10.0.0.1")
 	waitForMarker(t, stateDir, "10.0.0.2")
-	if _, code := runCtl(); code != 1 {
-		t.Fatalf("ctl with 2/3 markers: want exit 1, got %d", code)
-	}
+	_, code := runCtl()
+	require.Equal(t, 1, code, "ctl with 2/3 markers: want exit 1")
 
 	startDaemon("10.0.0.3")
 	waitForMarker(t, stateDir, "10.0.0.3")
 	out, code := runCtl()
-	if code != 0 || !strings.HasPrefix(out, "READY") {
-		t.Fatalf("ctl with 3/3: want READY exit 0, got %q exit %d", out, code)
-	}
+	require.Equal(t, 0, code, "ctl with 3/3: want exit 0, got %q", out)
+	require.True(t, strings.HasPrefix(out, "READY"), "ctl with 3/3: want READY prefix, got %q", out)
 
 	// Kill d1 cleanly so it removes its marker; ctl should fail again.
 	_ = d1.Process.Signal(syscall.SIGTERM)
 	waitForNoMarker(t, stateDir, "10.0.0.1")
-	if _, code := runCtl(); code != 1 {
-		t.Fatalf("ctl after d1 SIGTERM: want exit 1, got %d", code)
-	}
+	_, code = runCtl()
+	require.Equal(t, 1, code, "ctl after d1 SIGTERM: want exit 1")
 }
 
 func waitForMarker(t *testing.T, dir, ip string) {
@@ -144,7 +136,7 @@ func waitForMarker(t *testing.T, dir, ip string) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	t.Fatalf("marker %s did not appear within deadline", ip)
+	require.FailNowf(t, "marker did not appear", "marker %s did not appear within deadline", ip)
 }
 
 // TestFakeImex_DaemonReassertsMarker verifies the 2s tick re-creates
@@ -154,13 +146,9 @@ func waitForMarker(t *testing.T, dir, ip string) {
 func TestFakeImex_DaemonReassertsMarker(t *testing.T) {
 	tmp := t.TempDir()
 	stateDir := filepath.Join(tmp, "state")
-	if err := os.MkdirAll(stateDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(stateDir, 0o755))
 	nodesCfg := filepath.Join(tmp, "nodes.cfg")
-	if err := os.WriteFile(nodesCfg, []byte("10.0.0.99\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(nodesCfg, []byte("10.0.0.99\n"), 0o644))
 
 	daemonBin := build(t, "./cmd/fake-imex/daemon", filepath.Join(tmp, "nvidia-imex"))
 
@@ -174,7 +162,7 @@ func TestFakeImex_DaemonReassertsMarker(t *testing.T) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := cmd.Start(); err != nil {
 		cancel()
-		t.Fatalf("start daemon: %v", err)
+		require.NoError(t, err, "start daemon")
 	}
 	t.Cleanup(func() {
 		cancel()
@@ -185,9 +173,7 @@ func TestFakeImex_DaemonReassertsMarker(t *testing.T) {
 	waitForMarker(t, stateDir, "10.0.0.99")
 
 	// Wipe it externally.
-	if err := os.Remove(filepath.Join(stateDir, "10.0.0.99")); err != nil {
-		t.Fatalf("remove marker: %v", err)
-	}
+	require.NoError(t, os.Remove(filepath.Join(stateDir, "10.0.0.99")), "remove marker")
 	waitForNoMarker(t, stateDir, "10.0.0.99")
 
 	// The daemon's 2s tick must re-create the marker. waitForMarker has
@@ -205,5 +191,5 @@ func waitForNoMarker(t *testing.T, dir, ip string) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	t.Fatalf("marker %s did not disappear within deadline", ip)
+	require.FailNowf(t, "marker did not disappear", "marker %s did not disappear within deadline", ip)
 }

--- a/cmd/generate-bridge/main_test.go
+++ b/cmd/generate-bridge/main_test.go
@@ -18,6 +18,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseNVMLPrototypes(t *testing.T) {
@@ -33,9 +35,7 @@ nvmlReturn_t DECLDIR nvmlDeviceCreateGpuInstance(nvmlDevice_t device, unsigned i
 DEPRECATED(13.0) nvmlReturn_t DECLDIR nvmlDeviceGetHandleBySerial(const char *serial, nvmlDevice_t *device);
 `
 	protos, err := parseNVMLPrototypes(strings.NewReader(header))
-	if err != nil {
-		t.Fatalf("parseNVMLPrototypes: %v", err)
-	}
+	require.NoError(t, err, "parseNVMLPrototypes")
 
 	tests := []struct {
 		name       string
@@ -98,19 +98,12 @@ DEPRECATED(13.0) nvmlReturn_t DECLDIR nvmlDeviceGetHandleBySerial(const char *se
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			proto, ok := protos[tt.name]
-			if !ok {
-				t.Fatalf("function %s not found in parsed prototypes", tt.name)
-			}
-			if len(proto.Params) != len(tt.wantParams) {
-				t.Fatalf("param count: got %d, want %d\n  got:  %+v\n  want: %+v",
-					len(proto.Params), len(tt.wantParams), proto.Params, tt.wantParams)
-			}
+			require.True(t, ok, "function %s not found in parsed prototypes", tt.name)
+			require.Len(t, proto.Params, len(tt.wantParams),
+				"param count\n  got:  %+v\n  want: %+v", proto.Params, tt.wantParams)
 			for i, want := range tt.wantParams {
 				got := proto.Params[i]
-				if got.CType != want.CType || got.Name != want.Name {
-					t.Errorf("param[%d]: got {%q, %q}, want {%q, %q}",
-						i, got.CType, got.Name, want.CType, want.Name)
-				}
+				require.Equal(t, want, got, "param[%d]", i)
 			}
 		})
 	}
@@ -144,9 +137,7 @@ func TestCTypeToGo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.cType, func(t *testing.T) {
 			got := cTypeToGo(tt.cType)
-			if got != tt.goType {
-				t.Errorf("cTypeToGo(%q) = %q, want %q", tt.cType, got, tt.goType)
-			}
+			require.Equal(t, tt.goType, got, "cTypeToGo(%q)", tt.cType)
 		})
 	}
 }
@@ -164,17 +155,11 @@ func TestGenerateStubWithSignature(t *testing.T) {
 	stub := generateStubWithSignature(proto)
 
 	// Should contain //export directive
-	if !strings.Contains(stub, "//export nvmlDeviceGetTemperature") {
-		t.Error("missing //export directive")
-	}
+	require.Contains(t, stub, "//export nvmlDeviceGetTemperature", "missing //export directive")
 	// Should contain correct Go function signature
-	if !strings.Contains(stub, "func nvmlDeviceGetTemperature(device C.nvmlDevice_t, sensorType C.nvmlTemperatureSensors_t, temp *C.uint)") {
-		t.Errorf("incorrect function signature in:\n%s", stub)
-	}
+	require.Contains(t, stub, "func nvmlDeviceGetTemperature(device C.nvmlDevice_t, sensorType C.nvmlTemperatureSensors_t, temp *C.uint)", "incorrect function signature in:\n%s", stub)
 	// Should return stubReturn
-	if !strings.Contains(stub, `return stubReturn("nvmlDeviceGetTemperature")`) {
-		t.Error("missing stubReturn call")
-	}
+	require.Contains(t, stub, `return stubReturn("nvmlDeviceGetTemperature")`, "missing stubReturn call")
 }
 
 func TestGenerateStubWithSignatureVoid(t *testing.T) {
@@ -185,9 +170,7 @@ func TestGenerateStubWithSignatureVoid(t *testing.T) {
 
 	stub := generateStubWithSignature(proto)
 
-	if !strings.Contains(stub, "func nvmlInit_v2() C.nvmlReturn_t") {
-		t.Errorf("incorrect void function signature in:\n%s", stub)
-	}
+	require.Contains(t, stub, "func nvmlInit_v2() C.nvmlReturn_t", "incorrect void function signature in:\n%s", stub)
 }
 
 func TestGenerateStubWithSignaturePointerParam(t *testing.T) {
@@ -200,9 +183,7 @@ func TestGenerateStubWithSignaturePointerParam(t *testing.T) {
 
 	stub := generateStubWithSignature(proto)
 
-	if !strings.Contains(stub, "func nvmlDeviceGetCount_v2(deviceCount *C.uint)") {
-		t.Errorf("incorrect pointer param signature in:\n%s", stub)
-	}
+	require.Contains(t, stub, "func nvmlDeviceGetCount_v2(deviceCount *C.uint)", "incorrect pointer param signature in:\n%s", stub)
 }
 
 func TestScanBridgeExports(t *testing.T) {
@@ -216,18 +197,14 @@ func nvmlDeviceGetCount_v2() {}
 //export nvmlDeviceGetName
 func nvmlDeviceGetName() {}
 `
-	if err := os.WriteFile(filepath.Join(dir, "device.go"), []byte(deviceGo), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "device.go"), []byte(deviceGo), 0644))
 
 	initGo := `package main
 
 //export nvmlInit_v2
 func nvmlInit_v2() {}
 `
-	if err := os.WriteFile(filepath.Join(dir, "init.go"), []byte(initGo), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "init.go"), []byte(initGo), 0644))
 
 	// stubs_generated.go should be SKIPPED
 	stubsGo := `package main
@@ -235,41 +212,27 @@ func nvmlInit_v2() {}
 //export nvmlStubFunction
 func nvmlStubFunction() {}
 `
-	if err := os.WriteFile(filepath.Join(dir, "stubs_generated.go"), []byte(stubsGo), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "stubs_generated.go"), []byte(stubsGo), 0644))
 
 	exports, err := scanBridgeExports(dir)
-	if err != nil {
-		t.Fatalf("scanBridgeExports: %v", err)
-	}
+	require.NoError(t, err, "scanBridgeExports")
 
-	if len(exports) != 3 {
-		t.Fatalf("expected 3 exports, got %d: %v", len(exports), exports)
-	}
+	require.Len(t, exports, 3, "exports: %v", exports)
 
 	for _, fn := range []string{"nvmlDeviceGetCount_v2", "nvmlDeviceGetName", "nvmlInit_v2"} {
-		if !exports[fn] {
-			t.Errorf("expected export %q not found", fn)
-		}
+		require.True(t, exports[fn], "expected export %q not found", fn)
 	}
 
-	if exports["nvmlStubFunction"] {
-		t.Error("stubs_generated.go should be skipped but nvmlStubFunction was found")
-	}
+	require.False(t, exports["nvmlStubFunction"], "stubs_generated.go should be skipped but nvmlStubFunction was found")
 }
 
 func TestScanBridgeExportsEmptyDir(t *testing.T) {
 	dir := t.TempDir()
 
 	exports, err := scanBridgeExports(dir)
-	if err != nil {
-		t.Fatalf("scanBridgeExports: %v", err)
-	}
+	require.NoError(t, err, "scanBridgeExports")
 
-	if len(exports) != 0 {
-		t.Fatalf("expected 0 exports from empty dir, got %d", len(exports))
-	}
+	require.Empty(t, exports, "expected 0 exports from empty dir")
 }
 
 func TestFindMissing(t *testing.T) {
@@ -281,12 +244,9 @@ func TestFindMissing(t *testing.T) {
 
 	missing := findMissing(all, existing)
 
-	if len(missing) != 2 {
-		t.Fatalf("expected 2 missing, got %d: %v", len(missing), missing)
-	}
-	if missing[0] != "nvmlDeviceGetCount_v2" || missing[1] != "nvmlDeviceGetName" {
-		t.Errorf("unexpected missing functions: %v", missing)
-	}
+	require.Len(t, missing, 2, "missing: %v", missing)
+	require.Equal(t, "nvmlDeviceGetCount_v2", missing[0], "unexpected missing functions: %v", missing)
+	require.Equal(t, "nvmlDeviceGetName", missing[1], "unexpected missing functions: %v", missing)
 }
 
 func TestFindMissingNoneImplemented(t *testing.T) {
@@ -294,9 +254,7 @@ func TestFindMissingNoneImplemented(t *testing.T) {
 	existing := map[string]bool{}
 
 	missing := findMissing(all, existing)
-	if len(missing) != 3 {
-		t.Fatalf("expected 3 missing, got %d", len(missing))
-	}
+	require.Len(t, missing, 3)
 }
 
 func TestFindMissingAllImplemented(t *testing.T) {
@@ -304,9 +262,7 @@ func TestFindMissingAllImplemented(t *testing.T) {
 	existing := map[string]bool{"a": true, "b": true}
 
 	missing := findMissing(all, existing)
-	if len(missing) != 0 {
-		t.Fatalf("expected 0 missing, got %d", len(missing))
-	}
+	require.Empty(t, missing)
 }
 
 func TestLookupProtoDirectMatch(t *testing.T) {
@@ -315,12 +271,8 @@ func TestLookupProtoDirectMatch(t *testing.T) {
 	}
 
 	proto, ok := lookupProto("nvmlInit_v2", protos)
-	if !ok {
-		t.Fatal("expected direct match")
-	}
-	if proto.Name != "nvmlInit_v2" {
-		t.Errorf("got name %q, want nvmlInit_v2", proto.Name)
-	}
+	require.True(t, ok, "expected direct match")
+	require.Equal(t, "nvmlInit_v2", proto.Name)
 }
 
 func TestLookupProtoVersionFallback(t *testing.T) {
@@ -332,21 +284,15 @@ func TestLookupProtoVersionFallback(t *testing.T) {
 	}
 
 	proto, ok := lookupProto("nvmlDeviceGetCount_v2", protos)
-	if !ok {
-		t.Fatal("expected fallback match for _v2 → unversioned")
-	}
-	if len(proto.Params) != 1 {
-		t.Errorf("expected 1 param, got %d", len(proto.Params))
-	}
+	require.True(t, ok, "expected fallback match for _v2 → unversioned")
+	require.Len(t, proto.Params, 1, "expected 1 param")
 }
 
 func TestLookupProtoNoMatch(t *testing.T) {
 	protos := map[string]FuncProto{}
 
 	_, ok := lookupProto("nvmlNonexistent", protos)
-	if ok {
-		t.Fatal("expected no match for nonexistent function")
-	}
+	require.False(t, ok, "expected no match for nonexistent function")
 }
 
 func TestPrintStats(t *testing.T) {
@@ -360,18 +306,14 @@ func nvmlDeviceGetCount_v2() {}
 //export nvmlDeviceGetName
 func nvmlDeviceGetName() {}
 `
-	if err := os.WriteFile(filepath.Join(dir, "device.go"), []byte(deviceGo), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "device.go"), []byte(deviceGo), 0644))
 
 	initGo := `package main
 
 //export nvmlInit_v2
 func nvmlInit_v2() {}
 `
-	if err := os.WriteFile(filepath.Join(dir, "init.go"), []byte(initGo), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "init.go"), []byte(initGo), 0644))
 
 	allFunctions := []string{"nvmlDeviceGetCount_v2", "nvmlDeviceGetName", "nvmlInit_v2", "nvmlShutdown", "nvmlFoo"}
 
@@ -379,15 +321,9 @@ func nvmlInit_v2() {}
 	printStats(&buf, allFunctions, dir)
 	output := buf.String()
 
-	if !strings.Contains(output, "Total functions") {
-		t.Errorf("expected 'Total functions' in output:\n%s", output)
-	}
-	if !strings.Contains(output, "5") {
-		t.Errorf("expected total count 5 in output:\n%s", output)
-	}
-	if !strings.Contains(output, "device.go") {
-		t.Errorf("expected 'device.go' in per-file breakdown:\n%s", output)
-	}
+	require.Contains(t, output, "Total functions", "expected 'Total functions' in output:\n%s", output)
+	require.Contains(t, output, "5", "expected total count 5 in output:\n%s", output)
+	require.Contains(t, output, "device.go", "expected 'device.go' in per-file breakdown:\n%s", output)
 }
 
 func TestValidateSignatures(t *testing.T) {
@@ -401,9 +337,7 @@ func nvmlDeviceGetCount_v2(deviceCount *C.uint) C.nvmlReturn_t {
 	return 0
 }
 `
-	if err := os.WriteFile(filepath.Join(dir, "correct.go"), []byte(correctGo), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "correct.go"), []byte(correctGo), 0644))
 
 	// Wrong: 0 params but prototype says 3
 	wrongGo := `package main
@@ -413,9 +347,7 @@ func nvmlDeviceGetName() C.nvmlReturn_t {
 	return 0
 }
 `
-	if err := os.WriteFile(filepath.Join(dir, "wrong.go"), []byte(wrongGo), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "wrong.go"), []byte(wrongGo), 0644))
 
 	protos := map[string]FuncProto{
 		"nvmlDeviceGetCount_v2": {
@@ -433,14 +365,8 @@ func nvmlDeviceGetName() C.nvmlReturn_t {
 	}
 
 	mismatches, err := validateSignatures(dir, protos)
-	if err != nil {
-		t.Fatalf("validateSignatures: %v", err)
-	}
+	require.NoError(t, err, "validateSignatures")
 
-	if len(mismatches) != 1 {
-		t.Fatalf("expected 1 mismatch, got %d: %v", len(mismatches), mismatches)
-	}
-	if !strings.Contains(mismatches[0], "nvmlDeviceGetName") {
-		t.Errorf("expected mismatch for nvmlDeviceGetName, got: %s", mismatches[0])
-	}
+	require.Len(t, mismatches, 1, "mismatches: %v", mismatches)
+	require.Contains(t, mismatches[0], "nvmlDeviceGetName", "expected mismatch for nvmlDeviceGetName, got: %s", mismatches[0])
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/NVIDIA/go-nvml v0.13.0-1
 	github.com/onsi/ginkgo/v2 v2.29.0
 	github.com/onsi/gomega v1.41.0
+	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.36.1
 	k8s.io/apiextensions-apiserver v0.36.1
 	k8s.io/apimachinery v0.36.1
@@ -36,6 +37,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/pkg/gpu/mockcuda/engine/cuda_test.go
+++ b/pkg/gpu/mockcuda/engine/cuda_test.go
@@ -15,6 +15,8 @@ package engine
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func newTestEngine() *Engine {
@@ -23,47 +25,29 @@ func newTestEngine() *Engine {
 
 func TestInit(t *testing.T) {
 	e := newTestEngine()
-	if err := e.Init(0); err != CudaSuccess {
-		t.Fatalf("Init(0) = %d, want %d", err, CudaSuccess)
-	}
+	require.Equal(t, CudaSuccess, e.Init(0), "Init(0)")
 }
 
 func TestDriverGetVersion(t *testing.T) {
 	e := newTestEngine()
 	ver, err := e.DriverGetVersion()
-	if err != CudaSuccess {
-		t.Fatalf("DriverGetVersion() error = %d", err)
-	}
-	if ver != DefaultDriverVersion {
-		t.Fatalf("DriverGetVersion() = %d, want %d", ver, DefaultDriverVersion)
-	}
+	require.Equal(t, CudaSuccess, err, "DriverGetVersion() error")
+	require.Equal(t, DefaultDriverVersion, ver, "DriverGetVersion()")
 }
 
 func TestGetDeviceCount(t *testing.T) {
 	e := newTestEngine()
 	count, err := e.GetDeviceCount()
-	if err != CudaSuccess {
-		t.Fatalf("GetDeviceCount() error = %d", err)
-	}
-	if count != DefaultDeviceCount {
-		t.Fatalf("GetDeviceCount() = %d, want %d", count, DefaultDeviceCount)
-	}
+	require.Equal(t, CudaSuccess, err, "GetDeviceCount() error")
+	require.Equal(t, DefaultDeviceCount, count, "GetDeviceCount()")
 }
 
 func TestSetDevice(t *testing.T) {
 	e := newTestEngine()
-	if err := e.SetDevice(0); err != CudaSuccess {
-		t.Fatalf("SetDevice(0) = %d, want SUCCESS", err)
-	}
-	if err := e.SetDevice(7); err != CudaSuccess {
-		t.Fatalf("SetDevice(7) = %d, want SUCCESS", err)
-	}
-	if err := e.SetDevice(8); err != CudaErrorInvalidDevice {
-		t.Fatalf("SetDevice(8) = %d, want CudaErrorInvalidDevice", err)
-	}
-	if err := e.SetDevice(-1); err != CudaErrorInvalidDevice {
-		t.Fatalf("SetDevice(-1) = %d, want CudaErrorInvalidDevice", err)
-	}
+	require.Equal(t, CudaSuccess, e.SetDevice(0), "SetDevice(0)")
+	require.Equal(t, CudaSuccess, e.SetDevice(7), "SetDevice(7)")
+	require.Equal(t, CudaErrorInvalidDevice, e.SetDevice(8), "SetDevice(8)")
+	require.Equal(t, CudaErrorInvalidDevice, e.SetDevice(-1), "SetDevice(-1)")
 }
 
 func TestMallocFreeLifecycle(t *testing.T) {
@@ -71,50 +55,30 @@ func TestMallocFreeLifecycle(t *testing.T) {
 
 	// Allocate
 	ptr, err := e.Malloc(1024)
-	if err != CudaSuccess {
-		t.Fatalf("Malloc(1024) error = %d", err)
-	}
-	if ptr == 0 {
-		t.Fatal("Malloc returned nil pointer")
-	}
-	if e.AllocationCount() != 1 {
-		t.Fatalf("AllocationCount = %d, want 1", e.AllocationCount())
-	}
+	require.Equal(t, CudaSuccess, err, "Malloc(1024) error")
+	require.NotZero(t, ptr, "Malloc returned nil pointer")
+	require.Equal(t, 1, e.AllocationCount(), "AllocationCount")
 
 	// Verify allocation info
 	info, ok := e.GetAllocation(ptr)
-	if !ok {
-		t.Fatal("GetAllocation returned false for allocated pointer")
-	}
-	if info.Size != 1024 {
-		t.Fatalf("AllocationInfo.Size = %d, want 1024", info.Size)
-	}
+	require.True(t, ok, "GetAllocation returned false for allocated pointer")
+	require.Equal(t, uint64(1024), info.Size, "AllocationInfo.Size")
 
 	// Free
-	if err := e.Free(ptr); err != CudaSuccess {
-		t.Fatalf("Free() = %d, want SUCCESS", err)
-	}
-	if e.AllocationCount() != 0 {
-		t.Fatalf("AllocationCount after free = %d, want 0", e.AllocationCount())
-	}
+	require.Equal(t, CudaSuccess, e.Free(ptr), "Free()")
+	require.Equal(t, 0, e.AllocationCount(), "AllocationCount after free")
 
 	// Double free should fail
-	if err := e.Free(ptr); err != CudaErrorInvalidValue {
-		t.Fatalf("Double Free() = %d, want CudaErrorInvalidValue", err)
-	}
+	require.Equal(t, CudaErrorInvalidValue, e.Free(ptr), "Double Free()")
 
 	// Free(NULL) is no-op
-	if err := e.Free(0); err != CudaSuccess {
-		t.Fatalf("Free(0) = %d, want SUCCESS", err)
-	}
+	require.Equal(t, CudaSuccess, e.Free(0), "Free(0)")
 }
 
 func TestMallocZeroSize(t *testing.T) {
 	e := newTestEngine()
 	_, err := e.Malloc(0)
-	if err != CudaErrorInvalidValue {
-		t.Fatalf("Malloc(0) = %d, want CudaErrorInvalidValue", err)
-	}
+	require.Equal(t, CudaErrorInvalidValue, err, "Malloc(0)")
 }
 
 func TestMultipleAllocations(t *testing.T) {
@@ -122,60 +86,40 @@ func TestMultipleAllocations(t *testing.T) {
 	ptrs := make([]uintptr, 5)
 	for i := range ptrs {
 		ptr, err := e.Malloc(uint64(1024 * (i + 1)))
-		if err != CudaSuccess {
-			t.Fatalf("Malloc(%d) error = %d", 1024*(i+1), err)
-		}
+		require.Equal(t, CudaSuccess, err, "Malloc(%d) error", 1024*(i+1))
 		ptrs[i] = ptr
 	}
-	if e.AllocationCount() != 5 {
-		t.Fatalf("AllocationCount = %d, want 5", e.AllocationCount())
-	}
+	require.Equal(t, 5, e.AllocationCount(), "AllocationCount")
 
 	// All pointers should be unique
 	seen := make(map[uintptr]bool)
 	for _, ptr := range ptrs {
-		if seen[ptr] {
-			t.Fatal("Duplicate pointer returned from Malloc")
-		}
+		require.False(t, seen[ptr], "Duplicate pointer returned from Malloc")
 		seen[ptr] = true
 	}
 
 	// Free all
 	for _, ptr := range ptrs {
-		if err := e.Free(ptr); err != CudaSuccess {
-			t.Fatalf("Free(0x%x) = %d", ptr, err)
-		}
+		require.Equal(t, CudaSuccess, e.Free(ptr), "Free(0x%x)", ptr)
 	}
-	if e.AllocationCount() != 0 {
-		t.Fatalf("AllocationCount after freeing all = %d, want 0", e.AllocationCount())
-	}
+	require.Equal(t, 0, e.AllocationCount(), "AllocationCount after freeing all")
 }
 
 func TestMemcpy(t *testing.T) {
 	e := newTestEngine()
-	if err := e.Memcpy(CudaMemcpyHostToHost); err != CudaSuccess {
-		t.Fatalf("Memcpy(HostToHost) = %d", err)
-	}
-	if err := e.Memcpy(CudaMemcpyHostToDevice); err != CudaSuccess {
-		t.Fatalf("Memcpy(HostToDevice) = %d", err)
-	}
-	if err := e.Memcpy(CudaMemcpyDeviceToHost); err != CudaSuccess {
-		t.Fatalf("Memcpy(DeviceToHost) = %d", err)
-	}
+	require.Equal(t, CudaSuccess, e.Memcpy(CudaMemcpyHostToHost), "Memcpy(HostToHost)")
+	require.Equal(t, CudaSuccess, e.Memcpy(CudaMemcpyHostToDevice), "Memcpy(HostToDevice)")
+	require.Equal(t, CudaSuccess, e.Memcpy(CudaMemcpyDeviceToHost), "Memcpy(DeviceToHost)")
 }
 
 func TestLaunchKernel(t *testing.T) {
 	e := newTestEngine()
-	if err := e.LaunchKernel(); err != CudaSuccess {
-		t.Fatalf("LaunchKernel() = %d", err)
-	}
+	require.Equal(t, CudaSuccess, e.LaunchKernel(), "LaunchKernel()")
 }
 
 func TestDeviceSynchronize(t *testing.T) {
 	e := newTestEngine()
-	if err := e.DeviceSynchronize(); err != CudaSuccess {
-		t.Fatalf("DeviceSynchronize() = %d", err)
-	}
+	require.Equal(t, CudaSuccess, e.DeviceSynchronize(), "DeviceSynchronize()")
 }
 
 func TestGetErrorString(t *testing.T) {
@@ -192,9 +136,7 @@ func TestGetErrorString(t *testing.T) {
 	}
 	for _, tc := range tests {
 		got := e.GetErrorString(tc.err)
-		if got != tc.want {
-			t.Errorf("GetErrorString(%d) = %q, want %q", tc.err, got, tc.want)
-		}
+		require.Equal(t, tc.want, got, "GetErrorString(%d)", tc.err)
 	}
 }
 
@@ -203,19 +145,11 @@ func TestSetDeviceTracksCurrent(t *testing.T) {
 	e.SetDevice(3)
 	ptr, _ := e.Malloc(512)
 	info, ok := e.GetAllocation(ptr)
-	if !ok {
-		t.Fatal("allocation not found")
-	}
-	if info.DeviceID != 3 {
-		t.Fatalf("allocation device = %d, want 3", info.DeviceID)
-	}
+	require.True(t, ok, "allocation not found")
+	require.Equal(t, 3, info.DeviceID, "allocation device")
 }
 
 func TestErrorStringFunction(t *testing.T) {
-	if s := ErrorString(CudaSuccess); s != "no error" {
-		t.Fatalf("ErrorString(0) = %q, want 'no error'", s)
-	}
-	if s := ErrorString(CudaError(99999)); s != "unknown error" {
-		t.Fatalf("ErrorString(99999) = %q, want 'unknown error'", s)
-	}
+	require.Equal(t, "no error", ErrorString(CudaSuccess), "ErrorString(0)")
+	require.Equal(t, "unknown error", ErrorString(CudaError(99999)), "ErrorString(99999)")
 }

--- a/pkg/gpu/mocknvml/bridge/fabric_dispatch_test.go
+++ b/pkg/gpu/mocknvml/bridge/fabric_dispatch_test.go
@@ -18,6 +18,7 @@ import (
 	"unsafe"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
 )
 
 // TestClassifyFabricVersion locks in the strict dispatch contract used
@@ -53,10 +54,9 @@ func TestClassifyFabricVersion(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := ClassifyFabricVersion(tc.requested, v2Tag, v3Tag)
-			if got != tc.want {
-				t.Errorf("ClassifyFabricVersion(0x%x, v2=0x%x, v3=0x%x) = %d, want %d",
-					tc.requested, v2Tag, v3Tag, got, tc.want)
-			}
+			require.Equal(t, tc.want, got,
+				"ClassifyFabricVersion(0x%x, v2=0x%x, v3=0x%x)",
+				tc.requested, v2Tag, v3Tag)
 		})
 	}
 }

--- a/pkg/gpu/mocknvml/bridge/fabric_layout_test.go
+++ b/pkg/gpu/mocknvml/bridge/fabric_layout_test.go
@@ -36,6 +36,7 @@ import (
 	"unsafe"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
 )
 
 // Expected byte sizes derived from nvml_types.h field-by-field. Update
@@ -65,10 +66,9 @@ func TestFabricStructLayouts(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.goSize != tc.expected {
-				t.Errorf("%s: go-nvml = %d bytes, C layout expects %d bytes — ABI drift; update either go-nvml vendor or nvml_types.h",
-					tc.name, tc.goSize, tc.expected)
-			}
+			require.Equal(t, tc.expected, tc.goSize,
+				"%s: go-nvml = %d bytes, C layout expects %d bytes — ABI drift; update either go-nvml vendor or nvml_types.h",
+				tc.name, tc.goSize, tc.expected)
 		})
 	}
 }
@@ -101,10 +101,9 @@ func TestFabricStructVersion_MatchesGoNvml(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.ours != tc.theirs {
-				t.Errorf("%s: bridge encoded 0x%x, go-nvml encoded 0x%x — version-tag mismatch",
-					tc.name, tc.ours, tc.theirs)
-			}
+			require.Equal(t, tc.theirs, tc.ours,
+				"%s: bridge encoded 0x%x, go-nvml encoded 0x%x — version-tag mismatch",
+				tc.name, tc.ours, tc.theirs)
 		})
 	}
 }

--- a/pkg/gpu/mocknvml/engine/config_profiles_test.go
+++ b/pkg/gpu/mocknvml/engine/config_profiles_test.go
@@ -17,6 +17,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // testdataDir returns the absolute path to the profiles directory.
@@ -29,225 +31,137 @@ func TestLoadConfig_L40SProfile(t *testing.T) {
 	profilePath := filepath.Join(testdataDir(), "l40s.yaml")
 
 	yamlCfg, err := LoadYAMLConfig(profilePath)
-	if err != nil {
-		t.Fatalf("Failed to load L40S profile: %v", err)
-	}
+	require.NoError(t, err, "Failed to load L40S profile")
 
 	// Verify device count: L40S typically 8 GPUs in a server
-	if got := len(yamlCfg.Devices); got != 8 {
-		t.Errorf("L40S device count: got %d, want 8", got)
-	}
+	require.Len(t, yamlCfg.Devices, 8, "L40S device count")
 
 	// Verify architecture
-	if got := yamlCfg.DeviceDefaults.Architecture; got != "ada_lovelace" {
-		t.Errorf("L40S architecture: got %q, want %q", got, "ada_lovelace")
-	}
+	require.Equal(t, "ada_lovelace", yamlCfg.DeviceDefaults.Architecture, "L40S architecture")
 
 	// Verify compute capability 8.9
 	cc := yamlCfg.DeviceDefaults.ComputeCapability
-	if cc == nil {
-		t.Fatal("L40S compute_capability is nil")
-	}
-	if cc.Major != 8 || cc.Minor != 9 {
-		t.Errorf("L40S compute capability: got %d.%d, want 8.9", cc.Major, cc.Minor)
-	}
+	require.NotNil(t, cc, "L40S compute_capability is nil")
+	require.Equal(t, 8, cc.Major, "L40S compute capability major")
+	require.Equal(t, 9, cc.Minor, "L40S compute capability minor")
 
 	// Verify memory: 48 GiB = 51539607552 bytes
 	mem := yamlCfg.DeviceDefaults.Memory
-	if mem == nil {
-		t.Fatal("L40S memory config is nil")
-	}
+	require.NotNil(t, mem, "L40S memory config is nil")
 	expectedMemBytes := uint64(51539607552) // 48 GiB
-	if mem.TotalBytes != expectedMemBytes {
-		t.Errorf("L40S memory total_bytes: got %d, want %d", mem.TotalBytes, expectedMemBytes)
-	}
+	require.Equal(t, expectedMemBytes, mem.TotalBytes, "L40S memory total_bytes")
 
 	// Verify PCI device ID: 0x26B510DE
 	pci := yamlCfg.DeviceDefaults.PCI
-	if pci == nil {
-		t.Fatal("L40S PCI config is nil")
-	}
+	require.NotNil(t, pci, "L40S PCI config is nil")
 	expectedDeviceID := uint32(0x26B510DE)
-	if pci.DeviceID != expectedDeviceID {
-		t.Errorf("L40S PCI device_id: got 0x%08X, want 0x%08X", pci.DeviceID, expectedDeviceID)
-	}
+	require.Equal(t, expectedDeviceID, pci.DeviceID, "L40S PCI device_id")
 
 	// Verify GPU name
-	if got := yamlCfg.DeviceDefaults.Name; got != "NVIDIA L40S" {
-		t.Errorf("L40S name: got %q, want %q", got, "NVIDIA L40S")
-	}
+	require.Equal(t, "NVIDIA L40S", yamlCfg.DeviceDefaults.Name, "L40S name")
 
 	// Verify no NVLink (L40S is PCIe only)
-	if yamlCfg.NVLink != nil {
-		t.Error("L40S should not have NVLink configuration")
-	}
+	require.Nil(t, yamlCfg.NVLink, "L40S should not have NVLink configuration")
 
 	// Verify PCIe Gen4
 	pcie := yamlCfg.DeviceDefaults.PCIe
-	if pcie == nil {
-		t.Fatal("L40S PCIe config is nil")
-	}
-	if pcie.MaxLinkGen != 4 {
-		t.Errorf("L40S PCIe max_link_gen: got %d, want 4", pcie.MaxLinkGen)
-	}
+	require.NotNil(t, pcie, "L40S PCIe config is nil")
+	require.Equal(t, 4, pcie.MaxLinkGen, "L40S PCIe max_link_gen")
 
 	// Verify power: 350W TDP
 	power := yamlCfg.DeviceDefaults.Power
-	if power == nil {
-		t.Fatal("L40S power config is nil")
-	}
-	if power.DefaultLimitMW != 350000 {
-		t.Errorf("L40S power default_limit_mw: got %d, want 350000", power.DefaultLimitMW)
-	}
+	require.NotNil(t, power, "L40S power config is nil")
+	require.Equal(t, uint32(350000), power.DefaultLimitMW, "L40S power default_limit_mw")
 }
 
 func TestLoadConfig_T4Profile(t *testing.T) {
 	profilePath := filepath.Join(testdataDir(), "t4.yaml")
 
 	yamlCfg, err := LoadYAMLConfig(profilePath)
-	if err != nil {
-		t.Fatalf("Failed to load T4 profile: %v", err)
-	}
+	require.NoError(t, err, "Failed to load T4 profile")
 
 	// Verify device count: T4 typically 4 GPUs
-	if got := len(yamlCfg.Devices); got != 4 {
-		t.Errorf("T4 device count: got %d, want 4", got)
-	}
+	require.Len(t, yamlCfg.Devices, 4, "T4 device count")
 
 	// Verify architecture
-	if got := yamlCfg.DeviceDefaults.Architecture; got != "turing" {
-		t.Errorf("T4 architecture: got %q, want %q", got, "turing")
-	}
+	require.Equal(t, "turing", yamlCfg.DeviceDefaults.Architecture, "T4 architecture")
 
 	// Verify compute capability 7.5
 	cc := yamlCfg.DeviceDefaults.ComputeCapability
-	if cc == nil {
-		t.Fatal("T4 compute_capability is nil")
-	}
-	if cc.Major != 7 || cc.Minor != 5 {
-		t.Errorf("T4 compute capability: got %d.%d, want 7.5", cc.Major, cc.Minor)
-	}
+	require.NotNil(t, cc, "T4 compute_capability is nil")
+	require.Equal(t, 7, cc.Major, "T4 compute capability major")
+	require.Equal(t, 5, cc.Minor, "T4 compute capability minor")
 
 	// Verify memory: 16 GiB = 17179869184 bytes
 	mem := yamlCfg.DeviceDefaults.Memory
-	if mem == nil {
-		t.Fatal("T4 memory config is nil")
-	}
+	require.NotNil(t, mem, "T4 memory config is nil")
 	expectedMemBytes := uint64(17179869184) // 16 GiB
-	if mem.TotalBytes != expectedMemBytes {
-		t.Errorf("T4 memory total_bytes: got %d, want %d", mem.TotalBytes, expectedMemBytes)
-	}
+	require.Equal(t, expectedMemBytes, mem.TotalBytes, "T4 memory total_bytes")
 
 	// Verify PCI device ID: 0x1EB810DE
 	pci := yamlCfg.DeviceDefaults.PCI
-	if pci == nil {
-		t.Fatal("T4 PCI config is nil")
-	}
+	require.NotNil(t, pci, "T4 PCI config is nil")
 	expectedDeviceID := uint32(0x1EB810DE)
-	if pci.DeviceID != expectedDeviceID {
-		t.Errorf("T4 PCI device_id: got 0x%08X, want 0x%08X", pci.DeviceID, expectedDeviceID)
-	}
+	require.Equal(t, expectedDeviceID, pci.DeviceID, "T4 PCI device_id")
 
 	// Verify GPU name
-	if got := yamlCfg.DeviceDefaults.Name; got != "NVIDIA T4" {
-		t.Errorf("T4 name: got %q, want %q", got, "NVIDIA T4")
-	}
+	require.Equal(t, "NVIDIA T4", yamlCfg.DeviceDefaults.Name, "T4 name")
 
 	// Verify no NVLink (T4 is PCIe only)
-	if yamlCfg.NVLink != nil {
-		t.Error("T4 should not have NVLink configuration")
-	}
+	require.Nil(t, yamlCfg.NVLink, "T4 should not have NVLink configuration")
 
 	// Verify PCIe Gen3
 	pcie := yamlCfg.DeviceDefaults.PCIe
-	if pcie == nil {
-		t.Fatal("T4 PCIe config is nil")
-	}
-	if pcie.MaxLinkGen != 3 {
-		t.Errorf("T4 PCIe max_link_gen: got %d, want 3", pcie.MaxLinkGen)
-	}
+	require.NotNil(t, pcie, "T4 PCIe config is nil")
+	require.Equal(t, 3, pcie.MaxLinkGen, "T4 PCIe max_link_gen")
 
 	// Verify power: 70W TDP
 	power := yamlCfg.DeviceDefaults.Power
-	if power == nil {
-		t.Fatal("T4 power config is nil")
-	}
-	if power.DefaultLimitMW != 70000 {
-		t.Errorf("T4 power default_limit_mw: got %d, want 70000", power.DefaultLimitMW)
-	}
+	require.NotNil(t, power, "T4 power config is nil")
+	require.Equal(t, uint32(70000), power.DefaultLimitMW, "T4 power default_limit_mw")
 }
 
 func TestLoadConfig_GB300Profile(t *testing.T) {
 	profilePath := filepath.Join(testdataDir(), "gb300.yaml")
 
 	yamlCfg, err := LoadYAMLConfig(profilePath)
-	if err != nil {
-		t.Fatalf("Failed to load GB300 profile: %v", err)
-	}
+	require.NoError(t, err, "Failed to load GB300 profile")
 
 	// 8 GPUs: 4 Grace-Blackwell Ultra superchips × 2 B300 GPUs each.
-	if got := len(yamlCfg.Devices); got != 8 {
-		t.Errorf("GB300 device count: got %d, want 8", got)
-	}
+	require.Len(t, yamlCfg.Devices, 8, "GB300 device count")
 
-	if got := yamlCfg.DeviceDefaults.Name; got != "NVIDIA GB300 NVL" {
-		t.Errorf("GB300 name: got %q, want %q", got, "NVIDIA GB300 NVL")
-	}
+	require.Equal(t, "NVIDIA GB300 NVL", yamlCfg.DeviceDefaults.Name, "GB300 name")
 
 	// 288 GiB HBM3e per GPU is the headline GB300 vs. GB200 delta — make
 	// sure a regression in the YAML can never quietly drop us back to 192.
 	mem := yamlCfg.DeviceDefaults.Memory
-	if mem == nil {
-		t.Fatal("GB300 memory config is nil")
-	}
+	require.NotNil(t, mem, "GB300 memory config is nil")
 	expectedMemBytes := uint64(288) * 1024 * 1024 * 1024
-	if mem.TotalBytes != expectedMemBytes {
-		t.Errorf("GB300 memory total_bytes: got %d, want %d (288 GiB)", mem.TotalBytes, expectedMemBytes)
-	}
+	require.Equal(t, expectedMemBytes, mem.TotalBytes, "GB300 memory total_bytes (288 GiB)")
 
 	// Blackwell Ultra uses the 570.x driver line; the chart's
 	// driverVersion helper relies on this value being consistent.
-	if got := yamlCfg.System.DriverVersion; got != "570.124.06" {
-		t.Errorf("GB300 driver_version: got %q, want %q", got, "570.124.06")
-	}
+	require.Equal(t, "570.124.06", yamlCfg.System.DriverVersion, "GB300 driver_version")
 
 	// PCIe Gen6 (or NVLink-C2C to Grace).
 	pcie := yamlCfg.DeviceDefaults.PCIe
-	if pcie == nil {
-		t.Fatal("GB300 PCIe config is nil")
-	}
-	if pcie.MaxLinkGen != 6 {
-		t.Errorf("GB300 PCIe max_link_gen: got %d, want 6", pcie.MaxLinkGen)
-	}
+	require.NotNil(t, pcie, "GB300 PCIe config is nil")
+	require.Equal(t, 6, pcie.MaxLinkGen, "GB300 PCIe max_link_gen")
 
 	// 1400W default TDP (vs. GB200's 1000W).
 	power := yamlCfg.DeviceDefaults.Power
-	if power == nil {
-		t.Fatal("GB300 power config is nil")
-	}
-	if power.DefaultLimitMW != 1400000 {
-		t.Errorf("GB300 power default_limit_mw: got %d, want 1400000", power.DefaultLimitMW)
-	}
+	require.NotNil(t, power, "GB300 power config is nil")
+	require.Equal(t, uint32(1400000), power.DefaultLimitMW, "GB300 power default_limit_mw")
 
 	// Grace pairing must be wired up — GB300 is a superchip part.
 	grace := yamlCfg.DeviceDefaults.GraceSuperchip
-	if grace == nil {
-		t.Fatal("GB300 grace_superchip config is nil")
-	}
-	if !grace.Enabled {
-		t.Error("GB300 grace_superchip.enabled: got false, want true")
-	}
+	require.NotNil(t, grace, "GB300 grace_superchip config is nil")
+	require.True(t, grace.Enabled, "GB300 grace_superchip.enabled: got false, want true")
 
 	// NVLink v5, 18 links @ 100 GB/s (same fabric as GB200).
-	if yamlCfg.NVLink == nil {
-		t.Fatal("GB300 NVLink config is nil")
-	}
-	if yamlCfg.NVLink.Version != 5 {
-		t.Errorf("GB300 nvlink.version: got %d, want 5", yamlCfg.NVLink.Version)
-	}
-	if yamlCfg.NVLink.LinksPerGPU != 18 {
-		t.Errorf("GB300 nvlink.links_per_gpu: got %d, want 18", yamlCfg.NVLink.LinksPerGPU)
-	}
+	require.NotNil(t, yamlCfg.NVLink, "GB300 NVLink config is nil")
+	require.Equal(t, 5, yamlCfg.NVLink.Version, "GB300 nvlink.version")
+	require.Equal(t, 18, yamlCfg.NVLink.LinksPerGPU, "GB300 nvlink.links_per_gpu")
 }
 
 func TestLoadConfig_AllProfilesConsistent(t *testing.T) {
@@ -273,38 +187,23 @@ func TestLoadConfig_AllProfilesConsistent(t *testing.T) {
 		t.Run(p.name, func(t *testing.T) {
 			profilePath := filepath.Join(testdataDir(), p.file)
 			yamlCfg, err := LoadYAMLConfig(profilePath)
-			if err != nil {
-				t.Fatalf("Failed to load %s profile: %v", p.name, err)
-			}
+			require.NoError(t, err, "Failed to load %s profile", p.name)
 
-			if yamlCfg.DeviceDefaults.Architecture != p.architecture {
-				t.Errorf("%s architecture: got %q, want %q", p.name, yamlCfg.DeviceDefaults.Architecture, p.architecture)
-			}
+			require.Equal(t, p.architecture, yamlCfg.DeviceDefaults.Architecture, "%s architecture", p.name)
 
 			cc := yamlCfg.DeviceDefaults.ComputeCapability
-			if cc == nil {
-				t.Fatalf("%s compute_capability is nil", p.name)
-			}
-			if cc.Major != p.ccMajor || cc.Minor != p.ccMinor {
-				t.Errorf("%s compute capability: got %d.%d, want %d.%d", p.name, cc.Major, cc.Minor, p.ccMajor, p.ccMinor)
-			}
+			require.NotNil(t, cc, "%s compute_capability is nil", p.name)
+			require.Equal(t, p.ccMajor, cc.Major, "%s compute capability major", p.name)
+			require.Equal(t, p.ccMinor, cc.Minor, "%s compute capability minor", p.name)
 
 			mem := yamlCfg.DeviceDefaults.Memory
-			if mem == nil {
-				t.Fatalf("%s memory config is nil", p.name)
-			}
+			require.NotNil(t, mem, "%s memory config is nil", p.name)
 			expectedBytes := p.memGiB * 1024 * 1024 * 1024
-			if mem.TotalBytes != expectedBytes {
-				t.Errorf("%s memory: got %d bytes, want %d bytes (%d GiB)", p.name, mem.TotalBytes, expectedBytes, p.memGiB)
-			}
+			require.Equal(t, expectedBytes, mem.TotalBytes, "%s memory (%d GiB)", p.name, p.memGiB)
 
-			if len(yamlCfg.Devices) != p.deviceCount {
-				t.Errorf("%s device count: got %d, want %d", p.name, len(yamlCfg.Devices), p.deviceCount)
-			}
+			require.Len(t, yamlCfg.Devices, p.deviceCount, "%s device count", p.name)
 
-			if yamlCfg.System.DriverVersion == "" {
-				t.Errorf("%s driver_version is empty", p.name)
-			}
+			require.NotEmpty(t, yamlCfg.System.DriverVersion, "%s driver_version is empty", p.name)
 		})
 	}
 }

--- a/pkg/gpu/mocknvml/engine/config_test.go
+++ b/pkg/gpu/mocknvml/engine/config_test.go
@@ -18,19 +18,15 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultConfig(t *testing.T) {
 	config := DefaultConfig()
-	if config == nil {
-		t.Fatal("DefaultConfig returned nil")
-	}
-	if config.NumDevices != 8 {
-		t.Errorf("Expected default NumDevices 8, got %d", config.NumDevices)
-	}
-	if config.DriverVersion != "550.163.01" {
-		t.Errorf("Expected default DriverVersion 550.163.01, got %s", config.DriverVersion)
-	}
+	require.NotNil(t, config, "DefaultConfig returned nil")
+	require.Equal(t, 8, config.NumDevices, "Expected default NumDevices 8")
+	require.Equal(t, "550.163.01", config.DriverVersion, "Expected default DriverVersion 550.163.01")
 }
 
 func TestLoadConfig_Defaults(t *testing.T) {
@@ -38,15 +34,9 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	ClearConfigCache()
 
 	config := LoadConfig()
-	if config == nil {
-		t.Fatal("LoadConfig returned nil")
-	}
-	if config.NumDevices != 8 {
-		t.Errorf("Expected default NumDevices 8, got %d", config.NumDevices)
-	}
-	if config.DriverVersion != "550.163.01" {
-		t.Errorf("Expected default DriverVersion, got %s", config.DriverVersion)
-	}
+	require.NotNil(t, config, "LoadConfig returned nil")
+	require.Equal(t, 8, config.NumDevices, "Expected default NumDevices 8")
+	require.Equal(t, "550.163.01", config.DriverVersion, "Expected default DriverVersion")
 }
 
 func TestLoadConfig_NumDevices(t *testing.T) {
@@ -74,9 +64,7 @@ func TestLoadConfig_NumDevices(t *testing.T) {
 			}
 
 			config := LoadConfig()
-			if config.NumDevices != tt.expected {
-				t.Errorf("Expected NumDevices %d, got %d", tt.expected, config.NumDevices)
-			}
+			require.Equal(t, tt.expected, config.NumDevices, "Expected NumDevices %d", tt.expected)
 		})
 	}
 }
@@ -89,9 +77,7 @@ func TestLoadConfig_DriverVersion(t *testing.T) {
 	t.Setenv("MOCK_NVML_DRIVER_VERSION", customVersion)
 
 	config := LoadConfig()
-	if config.DriverVersion != customVersion {
-		t.Errorf("Expected DriverVersion %s, got %s", customVersion, config.DriverVersion)
-	}
+	require.Equal(t, customVersion, config.DriverVersion, "Expected DriverVersion %s", customVersion)
 }
 
 func TestLoadConfig_AllEnvVars(t *testing.T) {
@@ -102,12 +88,8 @@ func TestLoadConfig_AllEnvVars(t *testing.T) {
 	t.Setenv("MOCK_NVML_DRIVER_VERSION", "600.00.00")
 
 	config := LoadConfig()
-	if config.NumDevices != 6 {
-		t.Errorf("NumDevices not set correctly: %d", config.NumDevices)
-	}
-	if config.DriverVersion != "600.00.00" {
-		t.Errorf("DriverVersion not set correctly: %s", config.DriverVersion)
-	}
+	require.Equal(t, 6, config.NumDevices, "NumDevices not set correctly")
+	require.Equal(t, "600.00.00", config.DriverVersion, "DriverVersion not set correctly")
 }
 
 func TestLoadConfig_EmptyEnvVars(t *testing.T) {
@@ -119,12 +101,8 @@ func TestLoadConfig_EmptyEnvVars(t *testing.T) {
 
 	config := LoadConfig()
 	// Empty strings should result in defaults
-	if config.NumDevices != 8 {
-		t.Errorf("Expected default NumDevices 8, got %d", config.NumDevices)
-	}
-	if config.DriverVersion != "550.163.01" {
-		t.Errorf("Expected default DriverVersion, got %s", config.DriverVersion)
-	}
+	require.Equal(t, 8, config.NumDevices, "Expected default NumDevices 8")
+	require.Equal(t, "550.163.01", config.DriverVersion, "Expected default DriverVersion")
 }
 
 func TestLoadConfig_YAMLNumDevices(t *testing.T) {
@@ -145,17 +123,13 @@ devices:
   - index: 1
     uuid: "GPU-bbbb"
 `
-	if err := os.WriteFile(configPath, []byte(yamlContent), 0644); err != nil {
-		t.Fatalf("Failed to write config file: %v", err)
-	}
+	require.NoError(t, os.WriteFile(configPath, []byte(yamlContent), 0644), "Failed to write config file")
 
 	ClearConfigCache()
 	t.Setenv("MOCK_NVML_CONFIG", configPath)
 
 	config := LoadConfig()
-	if config.NumDevices != 4 {
-		t.Errorf("Expected NumDevices=4 from system.num_devices, got %d", config.NumDevices)
-	}
+	require.Equal(t, 4, config.NumDevices, "Expected NumDevices=4 from system.num_devices")
 }
 
 func TestLoadConfig_YAMLNumDevicesZero(t *testing.T) {
@@ -176,17 +150,13 @@ devices:
   - index: 2
     uuid: "GPU-cccc"
 `
-	if err := os.WriteFile(configPath, []byte(yamlContent), 0644); err != nil {
-		t.Fatalf("Failed to write config file: %v", err)
-	}
+	require.NoError(t, os.WriteFile(configPath, []byte(yamlContent), 0644), "Failed to write config file")
 
 	ClearConfigCache()
 	t.Setenv("MOCK_NVML_CONFIG", configPath)
 
 	config := LoadConfig()
-	if config.NumDevices != 3 {
-		t.Errorf("Expected NumDevices=3 from device list, got %d", config.NumDevices)
-	}
+	require.Equal(t, 3, config.NumDevices, "Expected NumDevices=3 from device list")
 }
 
 func TestDiscoverConfigPath_NonLinux(t *testing.T) {
@@ -194,9 +164,7 @@ func TestDiscoverConfigPath_NonLinux(t *testing.T) {
 		t.Skip("Test only applies to non-Linux platforms")
 	}
 	result := discoverConfigPath()
-	if result != "" {
-		t.Errorf("Expected empty string on non-Linux, got %q", result)
-	}
+	require.Empty(t, result, "Expected empty string on non-Linux")
 }
 
 func TestDiscoverConfigPath_Linux(t *testing.T) {
@@ -205,9 +173,7 @@ func TestDiscoverConfigPath_Linux(t *testing.T) {
 	}
 	// On Linux without a mock .so loaded, should return empty
 	result := discoverConfigPath()
-	if result != "" {
-		t.Errorf("Expected empty string when no libnvidia-ml.so is mapped, got %q", result)
-	}
+	require.Empty(t, result, "Expected empty string when no libnvidia-ml.so is mapped")
 }
 
 func TestLoadConfig_AutoDiscoverFallback(t *testing.T) {
@@ -216,10 +182,6 @@ func TestLoadConfig_AutoDiscoverFallback(t *testing.T) {
 	ClearConfigCache()
 
 	config := LoadConfig()
-	if config == nil {
-		t.Fatal("LoadConfig returned nil")
-	}
-	if config.NumDevices != 8 {
-		t.Errorf("Expected default NumDevices 8, got %d", config.NumDevices)
-	}
+	require.NotNil(t, config, "LoadConfig returned nil")
+	require.Equal(t, 8, config.NumDevices, "Expected default NumDevices 8")
 }

--- a/pkg/gpu/mocknvml/engine/device_test.go
+++ b/pkg/gpu/mocknvml/engine/device_test.go
@@ -18,6 +18,7 @@ import (
 	"unsafe"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfigurableDevice_GetBAR1MemoryInfo(t *testing.T) {
@@ -29,25 +30,15 @@ func TestConfigurableDevice_GetBAR1MemoryInfo(t *testing.T) {
 	dev := e.LookupDevice(handle)
 
 	enhanced, ok := dev.(*ConfigurableDevice)
-	if !ok {
-		t.Fatal("Expected ConfigurableDevice type")
-	}
+	require.True(t, ok, "Expected ConfigurableDevice type")
 
 	bar1, ret := enhanced.GetBAR1MemoryInfo()
-	if ret != nvml.SUCCESS {
-		t.Errorf("GetBAR1MemoryInfo failed: %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetBAR1MemoryInfo failed")
 
 	expectedBytes := uint64(DefaultBAR1SizeMB * 1024 * 1024)
-	if bar1.Bar1Total != expectedBytes {
-		t.Errorf("Expected BAR1 total %d, got %d", expectedBytes, bar1.Bar1Total)
-	}
-	if bar1.Bar1Free != expectedBytes {
-		t.Errorf("Expected BAR1 free %d, got %d", expectedBytes, bar1.Bar1Free)
-	}
-	if bar1.Bar1Used != 0 {
-		t.Errorf("Expected BAR1 used 0, got %d", bar1.Bar1Used)
-	}
+	require.Equal(t, expectedBytes, bar1.Bar1Total, "Expected BAR1 total")
+	require.Equal(t, expectedBytes, bar1.Bar1Free, "Expected BAR1 free")
+	require.Zero(t, bar1.Bar1Used, "Expected BAR1 used 0")
 }
 
 func TestConfigurableDevice_GetComputeRunningProcesses(t *testing.T) {
@@ -59,18 +50,12 @@ func TestConfigurableDevice_GetComputeRunningProcesses(t *testing.T) {
 	dev := e.LookupDevice(handle)
 
 	enhanced, ok := dev.(*ConfigurableDevice)
-	if !ok {
-		t.Fatal("Expected ConfigurableDevice type")
-	}
+	require.True(t, ok, "Expected ConfigurableDevice type")
 
 	processes, ret := enhanced.GetComputeRunningProcesses()
-	if ret != nvml.SUCCESS {
-		t.Errorf("GetComputeRunningProcesses failed: %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetComputeRunningProcesses failed")
 	// Mock returns empty list
-	if len(processes) != 0 {
-		t.Errorf("Expected empty process list, got %d processes", len(processes))
-	}
+	require.Empty(t, processes, "Expected empty process list")
 }
 
 func TestConfigurableDevice_GetGraphicsRunningProcesses(t *testing.T) {
@@ -82,18 +67,12 @@ func TestConfigurableDevice_GetGraphicsRunningProcesses(t *testing.T) {
 	dev := e.LookupDevice(handle)
 
 	enhanced, ok := dev.(*ConfigurableDevice)
-	if !ok {
-		t.Fatal("Expected ConfigurableDevice type")
-	}
+	require.True(t, ok, "Expected ConfigurableDevice type")
 
 	processes, ret := enhanced.GetGraphicsRunningProcesses()
-	if ret != nvml.SUCCESS {
-		t.Errorf("GetGraphicsRunningProcesses failed: %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetGraphicsRunningProcesses failed")
 	// Mock returns empty list
-	if len(processes) != 0 {
-		t.Errorf("Expected empty process list, got %d processes", len(processes))
-	}
+	require.Empty(t, processes, "Expected empty process list")
 }
 
 func TestConfigurableDevice_GetPciInfo(t *testing.T) {
@@ -105,19 +84,13 @@ func TestConfigurableDevice_GetPciInfo(t *testing.T) {
 	dev := e.LookupDevice(handle)
 
 	enhanced, ok := dev.(*ConfigurableDevice)
-	if !ok {
-		t.Fatal("Expected ConfigurableDevice type")
-	}
+	require.True(t, ok, "Expected ConfigurableDevice type")
 
 	pciInfo, ret := enhanced.GetPciInfo()
-	if ret != nvml.SUCCESS {
-		t.Errorf("GetPciInfo failed: %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetPciInfo failed")
 
 	// Verify PCI device ID is set (A100)
-	if pciInfo.PciDeviceId != 0x20B010DE {
-		t.Errorf("Expected A100 PCI device ID, got 0x%X", pciInfo.PciDeviceId)
-	}
+	require.Equal(t, uint32(0x20B010DE), pciInfo.PciDeviceId, "Expected A100 PCI device ID")
 }
 
 // =============================================================================
@@ -139,18 +112,12 @@ func TestConfigurableDevice_GetTopologyCommonAncestor(t *testing.T) {
 	dev2 := e.LookupDevice(handle2)
 
 	cd1, ok := dev1.(*ConfigurableDevice)
-	if !ok {
-		t.Fatal("Expected ConfigurableDevice type")
-	}
+	require.True(t, ok, "Expected ConfigurableDevice type")
 
 	// Default: devices on same node should return TOPOLOGY_SINGLE
 	level, ret := cd1.GetTopologyCommonAncestor(dev2)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetTopologyCommonAncestor failed: %v", ret)
-	}
-	if level != nvml.TOPOLOGY_SINGLE {
-		t.Errorf("Expected TOPOLOGY_SINGLE (%d), got %d", nvml.TOPOLOGY_SINGLE, level)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetTopologyCommonAncestor failed")
+	require.Equal(t, nvml.TOPOLOGY_SINGLE, level, "Expected TOPOLOGY_SINGLE")
 }
 
 func TestConfigurableDevice_GetTopologyCommonAncestor_WithConfig(t *testing.T) {
@@ -180,17 +147,11 @@ func TestConfigurableDevice_GetTopologyCommonAncestor_WithConfig(t *testing.T) {
 	dev2 := e.LookupDevice(handle2)
 
 	cd1, ok := dev1.(*ConfigurableDevice)
-	if !ok {
-		t.Fatal("Expected ConfigurableDevice type")
-	}
+	require.True(t, ok, "Expected ConfigurableDevice type")
 
 	level, ret := cd1.GetTopologyCommonAncestor(dev2)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetTopologyCommonAncestor failed: %v", ret)
-	}
-	if level != nvml.TOPOLOGY_SYSTEM {
-		t.Errorf("Expected TOPOLOGY_SYSTEM (%d), got %d", nvml.TOPOLOGY_SYSTEM, level)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetTopologyCommonAncestor failed")
+	require.Equal(t, nvml.TOPOLOGY_SYSTEM, level, "Expected TOPOLOGY_SYSTEM")
 }
 
 // =============================================================================
@@ -224,27 +185,17 @@ func TestConfigurableDevice_GetNvLinkState_WithConfig(t *testing.T) {
 	dev := e.LookupDevice(handle)
 
 	cd, ok := dev.(*ConfigurableDevice)
-	if !ok {
-		t.Fatal("Expected ConfigurableDevice type")
-	}
+	require.True(t, ok, "Expected ConfigurableDevice type")
 
 	// Link 0 should be active
 	state, ret := cd.GetNvLinkState(0)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetNvLinkState(0) failed: %v", ret)
-	}
-	if state != nvml.FEATURE_ENABLED {
-		t.Errorf("Expected link 0 ENABLED, got %d", state)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetNvLinkState(0) failed")
+	require.Equal(t, nvml.FEATURE_ENABLED, state, "Expected link 0 ENABLED")
 
 	// Link 1 should be inactive
 	state, ret = cd.GetNvLinkState(1)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetNvLinkState(1) failed: %v", ret)
-	}
-	if state != nvml.FEATURE_DISABLED {
-		t.Errorf("Expected link 1 DISABLED, got %d", state)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetNvLinkState(1) failed")
+	require.Equal(t, nvml.FEATURE_DISABLED, state, "Expected link 1 DISABLED")
 }
 
 func TestConfigurableDevice_GetNvLinkErrorCounter(t *testing.T) {
@@ -256,18 +207,12 @@ func TestConfigurableDevice_GetNvLinkErrorCounter(t *testing.T) {
 	dev := e.LookupDevice(handle)
 
 	cd, ok := dev.(*ConfigurableDevice)
-	if !ok {
-		t.Fatal("Expected ConfigurableDevice type")
-	}
+	require.True(t, ok, "Expected ConfigurableDevice type")
 
 	// Error counter should always return 0
 	val, ret := cd.GetNvLinkErrorCounter(0, 0)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetNvLinkErrorCounter failed: %v", ret)
-	}
-	if val != 0 {
-		t.Errorf("Expected 0, got %d", val)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetNvLinkErrorCounter failed")
+	require.Zero(t, val, "Expected 0")
 }
 
 func TestConfigurableDevice_GetNvLinkRemotePciInfo(t *testing.T) {
@@ -296,17 +241,11 @@ func TestConfigurableDevice_GetNvLinkRemotePciInfo(t *testing.T) {
 	dev := e.LookupDevice(handle)
 
 	cd, ok := dev.(*ConfigurableDevice)
-	if !ok {
-		t.Fatal("Expected ConfigurableDevice type")
-	}
+	require.True(t, ok, "Expected ConfigurableDevice type")
 
 	pci, ret := cd.GetNvLinkRemotePciInfo(0)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetNvLinkRemotePciInfo failed: %v", ret)
-	}
-	if pci.Bus != 0x3B {
-		t.Errorf("Expected bus 0x3B, got 0x%X", pci.Bus)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetNvLinkRemotePciInfo failed")
+	require.Equal(t, uint32(0x3B), pci.Bus, "Expected bus 0x3B")
 }
 
 // =============================================================================
@@ -340,25 +279,15 @@ func TestConfigurableDevice_GetTemperatureThreshold_WithConfig(t *testing.T) {
 	dev := e.LookupDevice(handle)
 
 	cd, ok := dev.(*ConfigurableDevice)
-	if !ok {
-		t.Fatal("Expected ConfigurableDevice type")
-	}
+	require.True(t, ok, "Expected ConfigurableDevice type")
 
 	temp, ret := cd.GetTemperatureThreshold(nvml.TEMPERATURE_THRESHOLD_SHUTDOWN)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetTemperatureThreshold(SHUTDOWN) failed: %v", ret)
-	}
-	if temp != 95 {
-		t.Errorf("Expected 95, got %d", temp)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetTemperatureThreshold(SHUTDOWN) failed")
+	require.Equal(t, uint32(95), temp, "Expected 95")
 
 	temp, ret = cd.GetTemperatureThreshold(nvml.TEMPERATURE_THRESHOLD_SLOWDOWN)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetTemperatureThreshold(SLOWDOWN) failed: %v", ret)
-	}
-	if temp != 90 {
-		t.Errorf("Expected 90, got %d", temp)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetTemperatureThreshold(SLOWDOWN) failed")
+	require.Equal(t, uint32(90), temp, "Expected 90")
 }
 
 func TestConfigurableDevice_GetThermalSettings(t *testing.T) {
@@ -387,17 +316,11 @@ func TestConfigurableDevice_GetThermalSettings(t *testing.T) {
 	dev := e.LookupDevice(handle)
 
 	cd, ok := dev.(*ConfigurableDevice)
-	if !ok {
-		t.Fatal("Expected ConfigurableDevice type")
-	}
+	require.True(t, ok, "Expected ConfigurableDevice type")
 
 	settings, ret := cd.GetThermalSettings(0)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetThermalSettings failed: %v", ret)
-	}
-	if settings.Count != 1 {
-		t.Errorf("Expected 1 sensor, got %d", settings.Count)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetThermalSettings failed")
+	require.Equal(t, uint32(1), settings.Count, "Expected 1 sensor")
 }
 
 // =============================================================================
@@ -429,17 +352,11 @@ func TestConfigurableDevice_GetEnforcedPowerLimit_WithConfig(t *testing.T) {
 	dev := e.LookupDevice(handle)
 
 	cd, ok := dev.(*ConfigurableDevice)
-	if !ok {
-		t.Fatal("Expected ConfigurableDevice type")
-	}
+	require.True(t, ok, "Expected ConfigurableDevice type")
 
 	limit, ret := cd.GetEnforcedPowerLimit()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetEnforcedPowerLimit failed: %v", ret)
-	}
-	if limit != 300000 {
-		t.Errorf("Expected 300000, got %d", limit)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetEnforcedPowerLimit failed")
+	require.Equal(t, uint32(300000), limit, "Expected 300000")
 }
 
 func TestConfigurableDevice_GetPowerManagementMode(t *testing.T) {
@@ -467,17 +384,11 @@ func TestConfigurableDevice_GetPowerManagementMode(t *testing.T) {
 	dev := e.LookupDevice(handle)
 
 	cd, ok := dev.(*ConfigurableDevice)
-	if !ok {
-		t.Fatal("Expected ConfigurableDevice type")
-	}
+	require.True(t, ok, "Expected ConfigurableDevice type")
 
 	mode, ret := cd.GetPowerManagementMode()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetPowerManagementMode failed: %v", ret)
-	}
-	if mode != nvml.FEATURE_ENABLED {
-		t.Errorf("Expected FEATURE_ENABLED, got %d", mode)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetPowerManagementMode failed")
+	require.Equal(t, nvml.FEATURE_ENABLED, mode, "Expected FEATURE_ENABLED")
 }
 
 func TestConfigurableDevice_GetPowerManagementMode_Default(t *testing.T) {
@@ -489,17 +400,11 @@ func TestConfigurableDevice_GetPowerManagementMode_Default(t *testing.T) {
 	dev := e.LookupDevice(handle)
 
 	cd, ok := dev.(*ConfigurableDevice)
-	if !ok {
-		t.Fatal("Expected ConfigurableDevice type")
-	}
+	require.True(t, ok, "Expected ConfigurableDevice type")
 
 	mode, ret := cd.GetPowerManagementMode()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetPowerManagementMode failed: %v", ret)
-	}
-	if mode != nvml.FEATURE_DISABLED {
-		t.Errorf("Expected FEATURE_DISABLED, got %d", mode)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetPowerManagementMode failed")
+	require.Equal(t, nvml.FEATURE_DISABLED, mode, "Expected FEATURE_DISABLED")
 }
 
 // =============================================================================
@@ -529,9 +434,7 @@ func newTestDeviceWithConfig(t *testing.T, deviceCfg *DeviceConfig) *Configurabl
 	handle, _ := e.DeviceGetHandleByIndex(0)
 	dev := e.LookupDevice(handle)
 	cd, ok := dev.(*ConfigurableDevice)
-	if !ok {
-		t.Fatal("Expected ConfigurableDevice type")
-	}
+	require.True(t, ok, "Expected ConfigurableDevice type")
 	return cd
 }
 
@@ -550,21 +453,11 @@ func TestConfigurableDevice_GetComputeRunningProcesses_WithConfig(t *testing.T) 
 	})
 
 	procs, ret := dev.GetComputeRunningProcesses()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetComputeRunningProcesses failed: %v", ret)
-	}
-	if len(procs) != 2 {
-		t.Fatalf("Expected 2 compute processes, got %d", len(procs))
-	}
-	if procs[0].Pid != 1234 {
-		t.Errorf("Expected PID 1234, got %d", procs[0].Pid)
-	}
-	if procs[0].UsedGpuMemory != 1024*1024*1024 {
-		t.Errorf("Expected 1 GiB memory, got %d", procs[0].UsedGpuMemory)
-	}
-	if procs[1].Pid != 5678 {
-		t.Errorf("Expected PID 5678, got %d", procs[1].Pid)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetComputeRunningProcesses failed")
+	require.Len(t, procs, 2, "Expected 2 compute processes")
+	require.Equal(t, uint32(1234), procs[0].Pid, "Expected PID 1234")
+	require.Equal(t, uint64(1024*1024*1024), procs[0].UsedGpuMemory, "Expected 1 GiB memory")
+	require.Equal(t, uint32(5678), procs[1].Pid, "Expected PID 5678")
 }
 
 func TestConfigurableDevice_GetProcessUtilization_Default(t *testing.T) {
@@ -573,12 +466,8 @@ func TestConfigurableDevice_GetProcessUtilization_Default(t *testing.T) {
 	})
 
 	utils, ret := dev.GetProcessUtilization(0)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetProcessUtilization failed: %v", ret)
-	}
-	if len(utils) != 0 {
-		t.Errorf("Expected empty utilization list, got %d", len(utils))
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetProcessUtilization failed")
+	require.Empty(t, utils, "Expected empty utilization list")
 }
 
 // =============================================================================
@@ -591,12 +480,8 @@ func TestConfigurableDevice_GetPerformanceState_Default(t *testing.T) {
 	})
 
 	pstate, ret := dev.GetPerformanceState()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetPerformanceState failed: %v", ret)
-	}
-	if pstate != nvml.PSTATE_0 {
-		t.Errorf("Expected P0 default, got %d", pstate)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetPerformanceState failed")
+	require.Equal(t, nvml.PSTATE_0, pstate, "Expected P0 default")
 }
 
 func TestConfigurableDevice_GetPerformanceState_Configured(t *testing.T) {
@@ -606,12 +491,8 @@ func TestConfigurableDevice_GetPerformanceState_Configured(t *testing.T) {
 	})
 
 	pstate, ret := dev.GetPerformanceState()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetPerformanceState failed: %v", ret)
-	}
-	if pstate != nvml.PSTATE_8 {
-		t.Errorf("Expected P8, got %d", pstate)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetPerformanceState failed")
+	require.Equal(t, nvml.PSTATE_8, pstate, "Expected P8")
 }
 
 func TestConfigurableDevice_GetCurrentClocksEventReasons_Default(t *testing.T) {
@@ -620,12 +501,8 @@ func TestConfigurableDevice_GetCurrentClocksEventReasons_Default(t *testing.T) {
 	})
 
 	reasons, ret := dev.GetCurrentClocksEventReasons()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetCurrentClocksEventReasons failed: %v", ret)
-	}
-	if reasons != 0 {
-		t.Errorf("Expected 0 (no throttling), got 0x%x", reasons)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetCurrentClocksEventReasons failed")
+	require.Zero(t, reasons, "Expected 0 (no throttling)")
 }
 
 // =============================================================================
@@ -638,12 +515,8 @@ func TestConfigurableDevice_GetPersistenceMode_Default(t *testing.T) {
 	})
 
 	mode, ret := dev.GetPersistenceMode()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetPersistenceMode failed: %v", ret)
-	}
-	if mode != nvml.FEATURE_DISABLED {
-		t.Errorf("Expected DISABLED default, got %d", mode)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetPersistenceMode failed")
+	require.Equal(t, nvml.FEATURE_DISABLED, mode, "Expected DISABLED default")
 }
 
 func TestConfigurableDevice_GetPersistenceMode_Configured(t *testing.T) {
@@ -653,12 +526,8 @@ func TestConfigurableDevice_GetPersistenceMode_Configured(t *testing.T) {
 	})
 
 	mode, ret := dev.GetPersistenceMode()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetPersistenceMode failed: %v", ret)
-	}
-	if mode != nvml.FEATURE_ENABLED {
-		t.Errorf("Expected ENABLED, got %d", mode)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetPersistenceMode failed")
+	require.Equal(t, nvml.FEATURE_ENABLED, mode, "Expected ENABLED")
 }
 
 func TestConfigurableDevice_SetPersistenceMode(t *testing.T) {
@@ -668,41 +537,25 @@ func TestConfigurableDevice_SetPersistenceMode(t *testing.T) {
 
 	// Initially disabled
 	mode, ret := dev.GetPersistenceMode()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetPersistenceMode failed: %v", ret)
-	}
-	if mode != nvml.FEATURE_DISABLED {
-		t.Errorf("Expected DISABLED initially, got %d", mode)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetPersistenceMode failed")
+	require.Equal(t, nvml.FEATURE_DISABLED, mode, "Expected DISABLED initially")
 
 	// Set to enabled
 	ret = dev.SetPersistenceMode(nvml.FEATURE_ENABLED)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("SetPersistenceMode failed: %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "SetPersistenceMode failed")
 
 	// Now should be enabled
 	mode, ret = dev.GetPersistenceMode()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetPersistenceMode failed: %v", ret)
-	}
-	if mode != nvml.FEATURE_ENABLED {
-		t.Errorf("Expected ENABLED after set, got %d", mode)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetPersistenceMode failed")
+	require.Equal(t, nvml.FEATURE_ENABLED, mode, "Expected ENABLED after set")
 
 	// Set back to disabled
 	ret = dev.SetPersistenceMode(nvml.FEATURE_DISABLED)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("SetPersistenceMode failed: %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "SetPersistenceMode failed")
 
 	mode, ret = dev.GetPersistenceMode()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetPersistenceMode failed: %v", ret)
-	}
-	if mode != nvml.FEATURE_DISABLED {
-		t.Errorf("Expected DISABLED after unset, got %d", mode)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetPersistenceMode failed")
+	require.Equal(t, nvml.FEATURE_DISABLED, mode, "Expected DISABLED after unset")
 }
 
 // =============================================================================
@@ -715,15 +568,11 @@ func TestConfigurableDevice_GetRemappedRows_Default(t *testing.T) {
 	})
 
 	corrRows, uncRows, isPending, failureOccurred, ret := dev.GetRemappedRows()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetRemappedRows failed: %v", ret)
-	}
-	if corrRows != 0 || uncRows != 0 {
-		t.Errorf("Expected 0 rows, got corr=%d unc=%d", corrRows, uncRows)
-	}
-	if isPending || failureOccurred {
-		t.Errorf("Expected no pending/failure, got pending=%v failure=%v", isPending, failureOccurred)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetRemappedRows failed")
+	require.Zero(t, corrRows, "Expected 0 correctable rows")
+	require.Zero(t, uncRows, "Expected 0 uncorrectable rows")
+	require.False(t, isPending, "Expected no pending")
+	require.False(t, failureOccurred, "Expected no failure")
 }
 
 func TestConfigurableDevice_GetRemappedRows_Configured(t *testing.T) {
@@ -738,21 +587,11 @@ func TestConfigurableDevice_GetRemappedRows_Configured(t *testing.T) {
 	})
 
 	corrRows, uncRows, isPending, failureOccurred, ret := dev.GetRemappedRows()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetRemappedRows failed: %v", ret)
-	}
-	if corrRows != 2 {
-		t.Errorf("Expected 2 correctable rows, got %d", corrRows)
-	}
-	if uncRows != 1 {
-		t.Errorf("Expected 1 uncorrectable row, got %d", uncRows)
-	}
-	if !isPending {
-		t.Errorf("Expected pending=true")
-	}
-	if failureOccurred {
-		t.Errorf("Expected failure=false")
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetRemappedRows failed")
+	require.Equal(t, 2, corrRows, "Expected 2 correctable rows")
+	require.Equal(t, 1, uncRows, "Expected 1 uncorrectable row")
+	require.True(t, isPending, "Expected pending=true")
+	require.False(t, failureOccurred, "Expected failure=false")
 }
 
 func TestConfigurableDevice_GetGspFirmwareMode_Default(t *testing.T) {
@@ -761,16 +600,10 @@ func TestConfigurableDevice_GetGspFirmwareMode_Default(t *testing.T) {
 	})
 
 	isEnabled, defaultMode, ret := dev.GetGspFirmwareMode()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetGspFirmwareMode failed: %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetGspFirmwareMode failed")
 	// Default: disabled
-	if isEnabled {
-		t.Errorf("Expected GSP disabled by default")
-	}
-	if defaultMode {
-		t.Errorf("Expected GSP default mode disabled by default")
-	}
+	require.False(t, isEnabled, "Expected GSP disabled by default")
+	require.False(t, defaultMode, "Expected GSP default mode disabled by default")
 }
 
 func TestConfigurableDevice_GetGspFirmwareMode_Enabled(t *testing.T) {
@@ -782,12 +615,8 @@ func TestConfigurableDevice_GetGspFirmwareMode_Enabled(t *testing.T) {
 	})
 
 	isEnabled, _, ret := dev.GetGspFirmwareMode()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetGspFirmwareMode failed: %v", ret)
-	}
-	if !isEnabled {
-		t.Errorf("Expected GSP enabled")
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetGspFirmwareMode failed")
+	require.True(t, isEnabled, "Expected GSP enabled")
 }
 
 func TestConfigurableDevice_GetDisplayActive_Default(t *testing.T) {
@@ -796,12 +625,8 @@ func TestConfigurableDevice_GetDisplayActive_Default(t *testing.T) {
 	})
 
 	active, ret := dev.GetDisplayActive()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetDisplayActive failed: %v", ret)
-	}
-	if active != nvml.FEATURE_DISABLED {
-		t.Errorf("Expected DISABLED default, got %d", active)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetDisplayActive failed")
+	require.Equal(t, nvml.FEATURE_DISABLED, active, "Expected DISABLED default")
 }
 
 func TestConfigurableDevice_GetDisplayActive_Enabled(t *testing.T) {
@@ -813,12 +638,8 @@ func TestConfigurableDevice_GetDisplayActive_Enabled(t *testing.T) {
 	})
 
 	active, ret := dev.GetDisplayActive()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetDisplayActive failed: %v", ret)
-	}
-	if active != nvml.FEATURE_ENABLED {
-		t.Errorf("Expected ENABLED, got %d", active)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetDisplayActive failed")
+	require.Equal(t, nvml.FEATURE_ENABLED, active, "Expected ENABLED")
 }
 
 // =============================================================================
@@ -831,13 +652,9 @@ func TestConfigurableDevice_GetMaxMigDeviceCount_Default(t *testing.T) {
 	})
 
 	count, ret := dev.GetMaxMigDeviceCount()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetMaxMigDeviceCount failed: %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetMaxMigDeviceCount failed")
 	// Default: MIG disabled, count = 0
-	if count != 0 {
-		t.Errorf("Expected 0 (MIG disabled), got %d", count)
-	}
+	require.Zero(t, count, "Expected 0 (MIG disabled)")
 }
 
 func TestConfigurableDevice_GetMaxMigDeviceCount_Configured(t *testing.T) {
@@ -850,12 +667,8 @@ func TestConfigurableDevice_GetMaxMigDeviceCount_Configured(t *testing.T) {
 	})
 
 	count, ret := dev.GetMaxMigDeviceCount()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetMaxMigDeviceCount failed: %v", ret)
-	}
-	if count != 7 {
-		t.Errorf("Expected 7, got %d", count)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetMaxMigDeviceCount failed")
+	require.Equal(t, 7, count, "Expected 7")
 }
 
 func TestConfigurableDevice_GetMigMode_WithConfig(t *testing.T) {
@@ -868,15 +681,9 @@ func TestConfigurableDevice_GetMigMode_WithConfig(t *testing.T) {
 	})
 
 	current, pending, ret := dev.GetMigMode()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetMigMode failed: %v", ret)
-	}
-	if current != 1 {
-		t.Errorf("Expected current=1 (enabled), got %d", current)
-	}
-	if pending != 0 {
-		t.Errorf("Expected pending=0 (disabled), got %d", pending)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetMigMode failed")
+	require.Equal(t, 1, current, "Expected current=1 (enabled)")
+	require.Zero(t, pending, "Expected pending=0 (disabled)")
 }
 
 func TestConfigurableDevice_GetMigDeviceHandleByIndex_MIGDisabled(t *testing.T) {
@@ -887,9 +694,7 @@ func TestConfigurableDevice_GetMigDeviceHandleByIndex_MIGDisabled(t *testing.T) 
 	// NOT_FOUND (not NOT_SUPPORTED) signals "no device at this index" which
 	// callers like nvidia-device-plugin treat as end-of-iteration, not error.
 	_, ret := dev.GetMigDeviceHandleByIndex(0)
-	if ret != nvml.ERROR_NOT_FOUND {
-		t.Errorf("Expected NOT_FOUND when MIG disabled, got %v", ret)
-	}
+	require.Equal(t, nvml.ERROR_NOT_FOUND, ret, "Expected NOT_FOUND when MIG disabled")
 }
 
 // =============================================================================
@@ -910,12 +715,8 @@ func TestConfigurableDevice_GetMemoryBusWidth_Configured(t *testing.T) {
 	})
 
 	width, ret := dev.GetMemoryBusWidth()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetMemoryBusWidth failed: %v", ret)
-	}
-	if width != 5120 {
-		t.Errorf("Expected 5120, got %d", width)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetMemoryBusWidth failed")
+	require.Equal(t, uint32(5120), width, "Expected 5120")
 }
 
 func TestConfigurableDevice_GetMemoryBusWidth_NotConfigured(t *testing.T) {
@@ -924,9 +725,7 @@ func TestConfigurableDevice_GetMemoryBusWidth_NotConfigured(t *testing.T) {
 	})
 
 	_, ret := dev.GetMemoryBusWidth()
-	if ret != nvml.ERROR_NOT_SUPPORTED {
-		t.Errorf("Expected NOT_SUPPORTED when no memory config, got %v", ret)
-	}
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret, "Expected NOT_SUPPORTED when no memory config")
 }
 
 func TestConfigurableDevice_GetDefaultEccMode_Enabled(t *testing.T) {
@@ -938,12 +737,8 @@ func TestConfigurableDevice_GetDefaultEccMode_Enabled(t *testing.T) {
 	})
 
 	mode, ret := dev.GetDefaultEccMode()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetDefaultEccMode failed: %v", ret)
-	}
-	if mode != nvml.FEATURE_ENABLED {
-		t.Errorf("Expected ENABLED, got %d", mode)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetDefaultEccMode failed")
+	require.Equal(t, nvml.FEATURE_ENABLED, mode, "Expected ENABLED")
 }
 
 func TestConfigurableDevice_GetDefaultEccMode_NoConfig(t *testing.T) {
@@ -952,12 +747,8 @@ func TestConfigurableDevice_GetDefaultEccMode_NoConfig(t *testing.T) {
 	})
 
 	mode, ret := dev.GetDefaultEccMode()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetDefaultEccMode failed: %v", ret)
-	}
-	if mode != nvml.FEATURE_DISABLED {
-		t.Errorf("Expected DISABLED when no ECC config, got %d", mode)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetDefaultEccMode failed")
+	require.Equal(t, nvml.FEATURE_DISABLED, mode, "Expected DISABLED when no ECC config")
 }
 
 func TestConfigurableDevice_GetSupportedClocksThrottleReasons(t *testing.T) {
@@ -966,12 +757,8 @@ func TestConfigurableDevice_GetSupportedClocksThrottleReasons(t *testing.T) {
 	})
 
 	reasons, ret := dev.GetSupportedClocksThrottleReasons()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetSupportedClocksThrottleReasons failed: %v", ret)
-	}
-	if reasons != uint64(nvml.ClocksThrottleReasonAll) {
-		t.Errorf("Expected 0x%x, got 0x%x", nvml.ClocksThrottleReasonAll, reasons)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetSupportedClocksThrottleReasons failed")
+	require.Equal(t, uint64(nvml.ClocksThrottleReasonAll), reasons, "Expected ClocksThrottleReasonAll")
 }
 
 func TestConfigurableDevice_GetAutoBoostedClocksEnabled(t *testing.T) {
@@ -980,9 +767,7 @@ func TestConfigurableDevice_GetAutoBoostedClocksEnabled(t *testing.T) {
 	})
 
 	_, _, ret := dev.GetAutoBoostedClocksEnabled()
-	if ret != nvml.ERROR_NOT_SUPPORTED {
-		t.Errorf("Expected NOT_SUPPORTED for datacenter GPU, got %v", ret)
-	}
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret, "Expected NOT_SUPPORTED for datacenter GPU")
 }
 
 func TestConfigurableDevice_GetGspFirmwareVersion_Configured(t *testing.T) {
@@ -994,12 +779,8 @@ func TestConfigurableDevice_GetGspFirmwareVersion_Configured(t *testing.T) {
 	})
 
 	version, ret := dev.GetGspFirmwareVersion()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetGspFirmwareVersion failed: %v", ret)
-	}
-	if version != "550.54.15" {
-		t.Errorf("Expected '550.54.15', got '%s'", version)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetGspFirmwareVersion failed")
+	require.Equal(t, "550.54.15", version, "Expected '550.54.15'")
 }
 
 func TestConfigurableDevice_GetGspFirmwareVersion_NoConfig(t *testing.T) {
@@ -1008,9 +789,7 @@ func TestConfigurableDevice_GetGspFirmwareVersion_NoConfig(t *testing.T) {
 	})
 
 	_, ret := dev.GetGspFirmwareVersion()
-	if ret != nvml.ERROR_NOT_SUPPORTED {
-		t.Errorf("Expected NOT_SUPPORTED when no GSP config, got %v", ret)
-	}
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret, "Expected NOT_SUPPORTED when no GSP config")
 }
 
 func TestConfigurableDevice_GetTotalEnergyConsumption_Configured(t *testing.T) {
@@ -1022,12 +801,8 @@ func TestConfigurableDevice_GetTotalEnergyConsumption_Configured(t *testing.T) {
 	})
 
 	energy, ret := dev.GetTotalEnergyConsumption()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetTotalEnergyConsumption failed: %v", ret)
-	}
-	if energy != 500000 {
-		t.Errorf("Expected 500000, got %d", energy)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetTotalEnergyConsumption failed")
+	require.Equal(t, uint64(500000), energy, "Expected 500000")
 }
 
 func TestConfigurableDevice_GetTotalEnergyConsumption_Zero(t *testing.T) {
@@ -1039,12 +814,8 @@ func TestConfigurableDevice_GetTotalEnergyConsumption_Zero(t *testing.T) {
 	})
 
 	energy, ret := dev.GetTotalEnergyConsumption()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetTotalEnergyConsumption failed: %v", ret)
-	}
-	if energy != 0 {
-		t.Errorf("Expected 0 (valid zero), got %d", energy)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetTotalEnergyConsumption failed")
+	require.Zero(t, energy, "Expected 0 (valid zero)")
 }
 
 func TestConfigurableDevice_GetTotalEnergyConsumption_NoPowerConfig(t *testing.T) {
@@ -1053,9 +824,7 @@ func TestConfigurableDevice_GetTotalEnergyConsumption_NoPowerConfig(t *testing.T
 	})
 
 	_, ret := dev.GetTotalEnergyConsumption()
-	if ret != nvml.ERROR_NOT_SUPPORTED {
-		t.Errorf("Expected NOT_SUPPORTED when no power config, got %v", ret)
-	}
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret, "Expected NOT_SUPPORTED when no power config")
 }
 
 func TestConfigurableDevice_GetDetailedEccErrors_Default(t *testing.T) {
@@ -1064,13 +833,11 @@ func TestConfigurableDevice_GetDetailedEccErrors_Default(t *testing.T) {
 	})
 
 	counts, ret := dev.GetDetailedEccErrors(nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.VOLATILE_ECC)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetDetailedEccErrors failed: %v", ret)
-	}
-	if counts.L1Cache != 0 || counts.L2Cache != 0 || counts.DeviceMemory != 0 || counts.RegisterFile != 0 {
-		t.Errorf("Expected all zeros, got l1=%d l2=%d mem=%d reg=%d",
-			counts.L1Cache, counts.L2Cache, counts.DeviceMemory, counts.RegisterFile)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetDetailedEccErrors failed")
+	require.Zero(t, counts.L1Cache, "Expected L1Cache zero")
+	require.Zero(t, counts.L2Cache, "Expected L2Cache zero")
+	require.Zero(t, counts.DeviceMemory, "Expected DeviceMemory zero")
+	require.Zero(t, counts.RegisterFile, "Expected RegisterFile zero")
 }
 
 func TestConfigurableDevice_GetGpmSupport_Default(t *testing.T) {
@@ -1079,13 +846,9 @@ func TestConfigurableDevice_GetGpmSupport_Default(t *testing.T) {
 	})
 
 	supported, ret := dev.GetGpmSupport()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetGpmSupport failed: %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetGpmSupport failed")
 	// Default: not supported
-	if supported != 0 {
-		t.Errorf("Expected 0 (not supported), got %d", supported)
-	}
+	require.Zero(t, supported, "Expected 0 (not supported)")
 }
 
 func TestParseArchitecture(t *testing.T) {
@@ -1109,9 +872,7 @@ func TestParseArchitecture(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			got := parseArchitecture(tt.input)
-			if got != tt.expected {
-				t.Errorf("parseArchitecture(%q) = %d, want %d", tt.input, got, tt.expected)
-			}
+			require.Equal(t, tt.expected, got, "parseArchitecture(%q)", tt.input)
 		})
 	}
 }
@@ -1129,16 +890,12 @@ func TestConfigurableDevice_GetMemoryInfo_v2_VersionEncoding(t *testing.T) {
 	})
 
 	mem, ret := dev.GetMemoryInfo_v2()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetMemoryInfo_v2 failed: %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetMemoryInfo_v2 failed")
 
 	// NVML_STRUCT_VERSION(Memory, 2) = sizeof(nvmlMemory_v2_t) | (2 << 24)
 	expectedVersion := uint32(unsafe.Sizeof(nvml.Memory_v2{})) | (2 << 24)
-	if mem.Version != expectedVersion {
-		t.Errorf("Expected Version=0x%X (sizeof=%d | 2<<24), got 0x%X",
-			expectedVersion, unsafe.Sizeof(nvml.Memory_v2{}), mem.Version)
-	}
+	require.Equal(t, expectedVersion, mem.Version, "Expected Version 0x%X (sizeof=%d | 2<<24)",
+		expectedVersion, unsafe.Sizeof(nvml.Memory_v2{}))
 }
 
 // =============================================================================
@@ -1154,12 +911,8 @@ func TestConfigurableDevice_GetTemperature_ZeroIsValid(t *testing.T) {
 	})
 
 	temp, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU)
-	if ret != nvml.SUCCESS {
-		t.Errorf("Expected SUCCESS when Thermal config exists with temp=0, got %v", ret)
-	}
-	if temp != 0 {
-		t.Errorf("Expected 0, got %d", temp)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "Expected SUCCESS when Thermal config exists with temp=0")
+	require.Zero(t, temp, "Expected 0")
 }
 
 func TestConfigurableDevice_GetTemperature_NilConfigReturnsNotSupported(t *testing.T) {
@@ -1168,9 +921,7 @@ func TestConfigurableDevice_GetTemperature_NilConfigReturnsNotSupported(t *testi
 	})
 
 	_, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU)
-	if ret != nvml.ERROR_NOT_SUPPORTED {
-		t.Errorf("Expected NOT_SUPPORTED when no Thermal config, got %v", ret)
-	}
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret, "Expected NOT_SUPPORTED when no Thermal config")
 }
 
 func TestConfigurableDevice_GetPowerUsage_ZeroIsValid(t *testing.T) {
@@ -1182,12 +933,8 @@ func TestConfigurableDevice_GetPowerUsage_ZeroIsValid(t *testing.T) {
 	})
 
 	power, ret := dev.GetPowerUsage()
-	if ret != nvml.SUCCESS {
-		t.Errorf("Expected SUCCESS when Power config exists with draw=0, got %v", ret)
-	}
-	if power != 0 {
-		t.Errorf("Expected 0, got %d", power)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "Expected SUCCESS when Power config exists with draw=0")
+	require.Zero(t, power, "Expected 0")
 }
 
 func TestConfigurableDevice_GetClockInfo_ZeroIsValid(t *testing.T) {
@@ -1199,10 +946,6 @@ func TestConfigurableDevice_GetClockInfo_ZeroIsValid(t *testing.T) {
 	})
 
 	clock, ret := dev.GetClockInfo(nvml.CLOCK_GRAPHICS)
-	if ret != nvml.SUCCESS {
-		t.Errorf("Expected SUCCESS when Clocks config exists with graphics=0, got %v", ret)
-	}
-	if clock != 0 {
-		t.Errorf("Expected 0, got %d", clock)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "Expected SUCCESS when Clocks config exists with graphics=0")
+	require.Zero(t, clock, "Expected 0")
 }

--- a/pkg/gpu/mocknvml/engine/dynamic_metrics_test.go
+++ b/pkg/gpu/mocknvml/engine/dynamic_metrics_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
 )
 
 // =============================================================================
@@ -53,9 +54,7 @@ func staticConfig() *DeviceConfig {
 func newSimulator(t *testing.T, cfg *DynamicMetricsConfig) (*dynamicMetricsSimulator, *time.Time) {
 	t.Helper()
 	s := newDynamicMetricsSimulator(cfg)
-	if s == nil {
-		t.Fatal("newDynamicMetricsSimulator returned nil for non-nil config")
-	}
+	require.NotNil(t, s, "newDynamicMetricsSimulator returned nil for non-nil config")
 	// Anchor the virtual clock to the simulator's start so elapsed() == 0
 	// at the first call, then let tests advance it explicitly.
 	now := s.start
@@ -103,16 +102,18 @@ func TestDynamicMetrics_AbsentPreservesStaticBehavior(t *testing.T) {
 	dev := newTestDeviceWithConfig(t, staticConfig())
 
 	for i := 0; i < 20; i++ {
-		if temp, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU); ret != nvml.SUCCESS || temp != 33 {
-			t.Fatalf("call %d: expected (33, SUCCESS), got (%d, %v)", i, temp, ret)
-		}
-		if power, ret := dev.GetPowerUsage(); ret != nvml.SUCCESS || power != 72000 {
-			t.Fatalf("call %d: expected (72000, SUCCESS), got (%d, %v)", i, power, ret)
-		}
+		temp, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU)
+		require.Equal(t, nvml.SUCCESS, ret, "call %d", i)
+		require.Equal(t, uint32(33), temp, "call %d", i)
+
+		power, ret := dev.GetPowerUsage()
+		require.Equal(t, nvml.SUCCESS, ret, "call %d", i)
+		require.Equal(t, uint32(72000), power, "call %d", i)
+
 		util, ret := dev.GetUtilizationRates()
-		if ret != nvml.SUCCESS || util.Gpu != 0 || util.Memory != 0 {
-			t.Fatalf("call %d: expected (0,0,SUCCESS), got (%d,%d,%v)", i, util.Gpu, util.Memory, ret)
-		}
+		require.Equal(t, nvml.SUCCESS, ret, "call %d", i)
+		require.Zero(t, util.Gpu, "call %d", i)
+		require.Zero(t, util.Memory, "call %d", i)
 	}
 }
 
@@ -126,17 +127,16 @@ func TestDynamicMetrics_SubConfigsAreIndependentlyOptIn(t *testing.T) {
 	dev := newTestDeviceWithConfig(t, cfg)
 
 	for i := 0; i < 20; i++ {
-		if temp, _ := dev.GetTemperature(nvml.TEMPERATURE_GPU); temp != 33 {
-			t.Fatalf("temperature must stay static, got %d", temp)
-		}
-		if util, _ := dev.GetUtilizationRates(); util.Gpu != 0 || util.Memory != 0 {
-			t.Fatalf("utilization must stay static, got %d/%d", util.Gpu, util.Memory)
-		}
+		temp, _ := dev.GetTemperature(nvml.TEMPERATURE_GPU)
+		require.Equal(t, uint32(33), temp, "temperature must stay static")
+
+		util, _ := dev.GetUtilizationRates()
+		require.Zero(t, util.Gpu, "utilization must stay static")
+		require.Zero(t, util.Memory, "utilization must stay static")
+
 		// Power is dynamic, so we only assert it's within [149000, 151000].
 		power, _ := dev.GetPowerUsage()
-		if power < 149000 || power > 151000 {
-			t.Fatalf("power %d outside [149000,151000]", power)
-		}
+		require.True(t, power >= 149000 && power <= 151000, "power %d outside [149000,151000]", power)
 	}
 }
 
@@ -179,9 +179,8 @@ func TestDynamicMetrics_Temperature_ZeroVarianceReturnsBase(t *testing.T) {
 		Temperature: &DynamicTemperatureConfig{BaseC: 50},
 	})
 	for i := 0; i < 50; i++ {
-		if got := s.Temperature(0, 0); got != 50 {
-			t.Fatalf("call %d: expected deterministic 50 when variance=0, got %d", i, got)
-		}
+		got := s.Temperature(0, 0)
+		require.Equal(t, uint32(50), got, "call %d: expected deterministic 50 when variance=0", i)
 	}
 }
 
@@ -192,20 +191,13 @@ func TestDynamicMetrics_Temperature_VarianceTightBounds(t *testing.T) {
 	})
 	samples := samplesN(2000, func() uint32 { return s.Temperature(0, 0) })
 	lo, hi := minMaxU32(samples)
-	if lo < 45 || hi > 55 {
-		t.Fatalf("samples out of [45,55]: observed [%d,%d]", lo, hi)
-	}
+	require.True(t, lo >= 45 && hi <= 55, "samples out of [45,55]: observed [%d,%d]", lo, hi)
 	// Uniform noise in [-5,5] should realistically hit both extremes at n=2000.
-	if lo > 46 {
-		t.Errorf("lower tail weak: min=%d, expected <=46", lo)
-	}
-	if hi < 54 {
-		t.Errorf("upper tail weak: max=%d, expected >=54", hi)
-	}
+	require.LessOrEqual(t, lo, uint32(46), "lower tail weak: min=%d, expected <=46", lo)
+	require.GreaterOrEqual(t, hi, uint32(54), "upper tail weak: max=%d, expected >=54", hi)
 	// Mean should be close to base (50) for uniform noise. Allow 0.5c tolerance.
-	if got := meanU32(samples); math.Abs(got-50.0) > 0.5 {
-		t.Errorf("mean=%.2f too far from base=50", got)
-	}
+	got := meanU32(samples)
+	require.LessOrEqual(t, math.Abs(got-50.0), 0.5, "mean=%.2f too far from base=50", got)
 }
 
 func TestDynamicMetrics_Temperature_RampOscillatesOverPeriod(t *testing.T) {
@@ -234,9 +226,8 @@ func TestDynamicMetrics_Temperature_RampOscillatesOverPeriod(t *testing.T) {
 	}
 	for _, tc := range cases {
 		*now = s.start.Add(tc.offset)
-		if got := s.Temperature(0, 0); got != tc.want {
-			t.Errorf("t=%s: got %d, want %d", tc.offset, got, tc.want)
-		}
+		got := s.Temperature(0, 0)
+		require.Equal(t, tc.want, got, "t=%s", tc.offset)
 	}
 }
 
@@ -247,9 +238,8 @@ func TestDynamicMetrics_Temperature_ClampedByShutdownThreshold(t *testing.T) {
 		Temperature: &DynamicTemperatureConfig{BaseC: 200, VarianceC: 10},
 	})
 	for i := 0; i < 200; i++ {
-		if got := s.Temperature(0, 80); got > 80 {
-			t.Fatalf("call %d: got %d, must be <=80 (shutdown clamp)", i, got)
-		}
+		got := s.Temperature(0, 80)
+		require.LessOrEqual(t, got, uint32(80), "call %d: got %d, must be <=80 (shutdown clamp)", i, got)
 	}
 }
 
@@ -262,9 +252,7 @@ func TestDynamicMetrics_Temperature_NeverNegative(t *testing.T) {
 	for i := 0; i < 500; i++ {
 		got := s.Temperature(0, 0)
 		// uint32 can't be negative; assert it's also <=max(base+variance)=51.
-		if got > 51 {
-			t.Fatalf("call %d: got %d above base+variance", i, got)
-		}
+		require.LessOrEqual(t, got, uint32(51), "call %d: got %d above base+variance", i, got)
 	}
 }
 
@@ -276,9 +264,8 @@ func TestDynamicMetrics_Temperature_NilConfigFallsThroughToStatic(t *testing.T) 
 		Power: &DynamicPowerConfig{BaseMW: 100},
 	})
 	for i := 0; i < 10; i++ {
-		if got := s.Temperature(77, 0); got != 77 {
-			t.Fatalf("expected static 77, got %d", got)
-		}
+		got := s.Temperature(77, 0)
+		require.Equal(t, uint32(77), got, "expected static 77")
 	}
 }
 
@@ -292,9 +279,8 @@ func TestDynamicMetrics_Power_ZeroVarianceReturnsBase(t *testing.T) {
 		Power: &DynamicPowerConfig{BaseMW: 250_000},
 	})
 	for i := 0; i < 50; i++ {
-		if got := s.Power(0, 0, 0); got != 250_000 {
-			t.Fatalf("call %d: expected 250000, got %d", i, got)
-		}
+		got := s.Power(0, 0, 0)
+		require.Equal(t, uint32(250_000), got, "call %d", i)
 	}
 }
 
@@ -305,19 +291,12 @@ func TestDynamicMetrics_Power_VarianceTightBounds(t *testing.T) {
 	})
 	samples := samplesN(2000, func() uint32 { return s.Power(0, 0, 0) })
 	lo, hi := minMaxU32(samples)
-	if lo < 225_000 || hi > 275_000 {
-		t.Fatalf("samples out of [225000, 275000]: observed [%d, %d]", lo, hi)
-	}
+	require.True(t, lo >= 225_000 && hi <= 275_000, "samples out of [225000, 275000]: observed [%d, %d]", lo, hi)
 	// Tails should be visited with n=2000, variance=25000 (~0.01% chance of missing).
-	if lo > 226_000 {
-		t.Errorf("lower tail weak: min=%d", lo)
-	}
-	if hi < 274_000 {
-		t.Errorf("upper tail weak: max=%d", hi)
-	}
-	if got := meanU32(samples); math.Abs(got-250_000) > 1_000 {
-		t.Errorf("mean=%.0f too far from base=250000", got)
-	}
+	require.LessOrEqual(t, lo, uint32(226_000), "lower tail weak: min=%d", lo)
+	require.GreaterOrEqual(t, hi, uint32(274_000), "upper tail weak: max=%d", hi)
+	got := meanU32(samples)
+	require.LessOrEqual(t, math.Abs(got-250_000), 1000.0, "mean=%.0f too far from base=250000", got)
 }
 
 func TestDynamicMetrics_Power_ClampedToConfiguredMinMax(t *testing.T) {
@@ -328,9 +307,7 @@ func TestDynamicMetrics_Power_ClampedToConfiguredMinMax(t *testing.T) {
 	})
 	for i := 0; i < 500; i++ {
 		got := s.Power(0, 100_000, 400_000)
-		if got < 100_000 || got > 400_000 {
-			t.Fatalf("call %d: %d outside [100000, 400000]", i, got)
-		}
+		require.True(t, got >= 100_000 && got <= 400_000, "call %d: %d outside [100000, 400000]", i, got)
 	}
 }
 
@@ -342,9 +319,7 @@ func TestDynamicMetrics_Power_ZeroBoundsDisabledClamp(t *testing.T) {
 	})
 	samples := samplesN(500, func() uint32 { return s.Power(0, 0, 0) })
 	lo, hi := minMaxU32(samples)
-	if lo < 50 || hi > 150 {
-		t.Fatalf("samples %d..%d outside [50,150]", lo, hi)
-	}
+	require.True(t, lo >= 50 && hi <= 150, "samples %d..%d outside [50,150]", lo, hi)
 }
 
 func TestDynamicMetrics_Power_NilConfigFallsThroughToStatic(t *testing.T) {
@@ -353,9 +328,8 @@ func TestDynamicMetrics_Power_NilConfigFallsThroughToStatic(t *testing.T) {
 		Temperature: &DynamicTemperatureConfig{BaseC: 40},
 	})
 	for i := 0; i < 10; i++ {
-		if got := s.Power(72_000, 0, 0); got != 72_000 {
-			t.Fatalf("expected static 72000, got %d", got)
-		}
+		got := s.Power(72_000, 0, 0)
+		require.Equal(t, uint32(72_000), got, "expected static 72000")
 	}
 }
 
@@ -369,12 +343,12 @@ func TestDynamicMetrics_Utilization_Patterns_Bounds(t *testing.T) {
 	//   busy : [75, 100]
 	//   steady / unknown : [0, 100]
 	cases := []struct {
-		name       string
-		pattern    string
-		wantLoLE   uint32 // observed min must be <= this
-		wantHiGE   uint32 // observed max must be >= this
-		hardLo     uint32 // observed min must be >= this
-		hardHi     uint32 // observed max must be <= this
+		name     string
+		pattern  string
+		wantLoLE uint32 // observed min must be <= this
+		wantHiGE uint32 // observed max must be >= this
+		hardLo   uint32 // observed min must be >= this
+		hardHi   uint32 // observed max must be <= this
 	}{
 		{"idle", "idle", 3, 22, 0, 25},
 		{"busy", "busy", 78, 97, 75, 100},
@@ -400,16 +374,10 @@ func TestDynamicMetrics_Utilization_Patterns_Bounds(t *testing.T) {
 			}
 			for _, xs := range [][]uint32{gpuSamples, memSamples} {
 				lo, hi := minMaxU32(xs)
-				if lo < tc.hardLo || hi > tc.hardHi {
-					t.Fatalf("out of range [%d,%d]: observed [%d,%d]",
-						tc.hardLo, tc.hardHi, lo, hi)
-				}
-				if lo > tc.wantLoLE {
-					t.Errorf("lower tail weak: min=%d expected <=%d", lo, tc.wantLoLE)
-				}
-				if hi < tc.wantHiGE {
-					t.Errorf("upper tail weak: max=%d expected >=%d", hi, tc.wantHiGE)
-				}
+				require.True(t, lo >= tc.hardLo && hi <= tc.hardHi, "out of range [%d,%d]: observed [%d,%d]",
+					tc.hardLo, tc.hardHi, lo, hi)
+				require.LessOrEqual(t, lo, tc.wantLoLE, "lower tail weak: min=%d expected <=%d", lo, tc.wantLoLE)
+				require.GreaterOrEqual(t, hi, tc.wantHiGE, "upper tail weak: max=%d expected >=%d", hi, tc.wantHiGE)
 			}
 		})
 	}
@@ -435,23 +403,21 @@ func TestDynamicMetrics_Utilization_BurstAlternatesWithTime(t *testing.T) {
 	// Sample multiple times within each phase to be robust to RNG.
 	inIdle := func(offset time.Duration) {
 		for i := 0; i < 20; i++ {
-			if got := sampleAt(offset + time.Duration(i)*time.Second/10); got > 25 {
-				t.Fatalf("burst idle phase at %s iter %d: got %d, want <=25", offset, i, got)
-			}
+			got := sampleAt(offset + time.Duration(i)*time.Second/10)
+			require.LessOrEqual(t, got, uint32(25), "burst idle phase at %s iter %d: got %d, want <=25", offset, i, got)
 		}
 	}
 	inBusy := func(offset time.Duration) {
 		for i := 0; i < 20; i++ {
-			if got := sampleAt(offset + time.Duration(i)*time.Second/10); got < 75 {
-				t.Fatalf("burst busy phase at %s iter %d: got %d, want >=75", offset, i, got)
-			}
+			got := sampleAt(offset + time.Duration(i)*time.Second/10)
+			require.GreaterOrEqual(t, got, uint32(75), "burst busy phase at %s iter %d: got %d, want >=75", offset, i, got)
 		}
 	}
 
-	inIdle(1 * time.Second)   // phase 0
-	inBusy(11 * time.Second)  // phase 1
-	inIdle(21 * time.Second)  // phase 2
-	inBusy(31 * time.Second)  // phase 3
+	inIdle(1 * time.Second)  // phase 0
+	inBusy(11 * time.Second) // phase 1
+	inIdle(21 * time.Second) // phase 2
+	inBusy(31 * time.Second) // phase 3
 }
 
 func TestDynamicMetrics_Utilization_GPUAndMemoryUseIndependentRanges(t *testing.T) {
@@ -465,12 +431,8 @@ func TestDynamicMetrics_Utilization_GPUAndMemoryUseIndependentRanges(t *testing.
 	})
 	for i := 0; i < 500; i++ {
 		g, m := s.Utilization(0, 0)
-		if g < 60 || g > 80 {
-			t.Fatalf("call %d: gpu=%d outside [60,80]", i, g)
-		}
-		if m < 10 || m > 20 {
-			t.Fatalf("call %d: mem=%d outside [10,20]", i, m)
-		}
+		require.True(t, g >= 60 && g <= 80, "call %d: gpu=%d outside [60,80]", i, g)
+		require.True(t, m >= 10 && m <= 20, "call %d: mem=%d outside [10,20]", i, m)
 	}
 }
 
@@ -485,9 +447,8 @@ func TestDynamicMetrics_Utilization_MinEqualsMaxPinsToSingleValue(t *testing.T) 
 	})
 	for i := 0; i < 50; i++ {
 		g, m := s.Utilization(0, 0)
-		if g != 42 || m != 7 {
-			t.Fatalf("call %d: got (%d,%d), want (42,7)", i, g, m)
-		}
+		require.Equal(t, uint32(42), g, "call %d", i)
+		require.Equal(t, uint32(7), m, "call %d", i)
 	}
 }
 
@@ -503,9 +464,7 @@ func TestDynamicMetrics_Utilization_ClampedTo0_100(t *testing.T) {
 	})
 	for i := 0; i < 200; i++ {
 		g, m := s.Utilization(0, 0)
-		if g > 100 || m > 100 {
-			t.Fatalf("call %d: got (%d,%d) with value >100", i, g, m)
-		}
+		require.True(t, g <= 100 && m <= 100, "call %d: got (%d,%d) with value >100", i, g, m)
 	}
 }
 
@@ -516,9 +475,8 @@ func TestDynamicMetrics_Utilization_NilConfigFallsThroughToStatic(t *testing.T) 
 	})
 	for i := 0; i < 10; i++ {
 		g, m := s.Utilization(11, 22)
-		if g != 11 || m != 22 {
-			t.Fatalf("expected static (11,22), got (%d,%d)", g, m)
-		}
+		require.Equal(t, uint32(11), g, "expected static gpu 11")
+		require.Equal(t, uint32(22), m, "expected static mem 22")
 	}
 }
 
@@ -544,19 +502,14 @@ func TestDynamicMetrics_SameSeedIsReproducible(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		at := a.Temperature(0, 0)
 		bt := b.Temperature(0, 0)
-		if at != bt {
-			t.Fatalf("call %d: temperature diverged %d vs %d", i, at, bt)
-		}
+		require.Equal(t, at, bt, "call %d: temperature diverged", i)
 		ap := a.Power(0, 0, 0)
 		bp := b.Power(0, 0, 0)
-		if ap != bp {
-			t.Fatalf("call %d: power diverged %d vs %d", i, ap, bp)
-		}
+		require.Equal(t, ap, bp, "call %d: power diverged", i)
 		ag, am := a.Utilization(0, 0)
 		bg, bm := b.Utilization(0, 0)
-		if ag != bg || am != bm {
-			t.Fatalf("call %d: utilization diverged (%d,%d) vs (%d,%d)", i, ag, am, bg, bm)
-		}
+		require.Equal(t, ag, bg, "call %d: utilization gpu diverged", i)
+		require.Equal(t, am, bm, "call %d: utilization mem diverged", i)
 	}
 }
 
@@ -578,9 +531,7 @@ func TestDynamicMetrics_DifferentSeedsProduceDifferentSequences(t *testing.T) {
 	// With uniform noise over 11 values (base 50, variance 5), expected
 	// collisions ~= 50/11 ~= 4.5. Failing only if essentially everything
 	// collided would mean seeds weren't actually independent.
-	if same >= 40 {
-		t.Fatalf("expected divergent sequences, but %d/50 matched", same)
-	}
+	require.Less(t, same, 40, "expected divergent sequences, but %d/50 matched", same)
 }
 
 // =============================================================================
@@ -605,12 +556,8 @@ func TestDynamicMetrics_DeviceLevel_TemperatureWorksWithoutStaticThermal(t *test
 
 	for i := 0; i < 50; i++ {
 		temp, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU)
-		if ret != nvml.SUCCESS {
-			t.Fatalf("call %d: expected SUCCESS without static thermal, got %v", i, ret)
-		}
-		if temp < 52 || temp > 58 {
-			t.Fatalf("call %d: temp %d outside [52,58]", i, temp)
-		}
+		require.Equal(t, nvml.SUCCESS, ret, "call %d: expected SUCCESS without static thermal", i)
+		require.True(t, temp >= 52 && temp <= 58, "call %d: temp %d outside [52,58]", i, temp)
 	}
 }
 
@@ -626,12 +573,8 @@ func TestDynamicMetrics_DeviceLevel_PowerWorksWithoutStaticPower(t *testing.T) {
 
 	for i := 0; i < 50; i++ {
 		power, ret := dev.GetPowerUsage()
-		if ret != nvml.SUCCESS {
-			t.Fatalf("call %d: expected SUCCESS without static power, got %v", i, ret)
-		}
-		if power < 225_000 || power > 275_000 {
-			t.Fatalf("call %d: power %d outside [225000, 275000]", i, power)
-		}
+		require.Equal(t, nvml.SUCCESS, ret, "call %d: expected SUCCESS without static power", i)
+		require.True(t, power >= 225_000 && power <= 275_000, "call %d: power %d outside [225000, 275000]", i, power)
 	}
 }
 
@@ -648,12 +591,10 @@ func TestDynamicMetrics_DeviceLevel_NotSupportedWhenNeitherSectionPresent(t *tes
 			Utilization: &DynamicUtilizationConfig{Pattern: "steady"},
 		},
 	})
-	if _, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU); ret != nvml.ERROR_NOT_SUPPORTED {
-		t.Errorf("expected ERROR_NOT_SUPPORTED for temperature, got %v", ret)
-	}
-	if _, ret := dev.GetPowerUsage(); ret != nvml.ERROR_NOT_SUPPORTED {
-		t.Errorf("expected ERROR_NOT_SUPPORTED for power, got %v", ret)
-	}
+	_, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU)
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret, "expected ERROR_NOT_SUPPORTED for temperature")
+	_, ret = dev.GetPowerUsage()
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret, "expected ERROR_NOT_SUPPORTED for power")
 }
 
 // =============================================================================
@@ -663,13 +604,9 @@ func TestDynamicMetrics_DeviceLevel_NotSupportedWhenNeitherSectionPresent(t *tes
 func TestDynamicMetrics_NilSimulatorReturnsStatic(t *testing.T) {
 	// Exercises the `s == nil` guards on every public method.
 	var s *dynamicMetricsSimulator // nil
-	if got := s.Temperature(42, 100); got != 42 {
-		t.Errorf("nil sim Temperature: got %d, want 42", got)
-	}
-	if got := s.Power(123, 0, 200); got != 123 {
-		t.Errorf("nil sim Power: got %d, want 123", got)
-	}
-	if g, m := s.Utilization(10, 20); g != 10 || m != 20 {
-		t.Errorf("nil sim Utilization: got (%d,%d), want (10,20)", g, m)
-	}
+	require.Equal(t, uint32(42), s.Temperature(42, 100), "nil sim Temperature")
+	require.Equal(t, uint32(123), s.Power(123, 0, 200), "nil sim Power")
+	g, m := s.Utilization(10, 20)
+	require.Equal(t, uint32(10), g, "nil sim Utilization gpu")
+	require.Equal(t, uint32(20), m, "nil sim Utilization mem")
 }

--- a/pkg/gpu/mocknvml/engine/engine_test.go
+++ b/pkg/gpu/mocknvml/engine/engine_test.go
@@ -19,15 +19,14 @@ import (
 	"testing"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEngine_Singleton(t *testing.T) {
 	e1 := GetEngine()
 	e2 := GetEngine()
 
-	if e1 != e2 {
-		t.Error("GetEngine should return same instance")
-	}
+	require.Same(t, e1, e2, "GetEngine should return same instance")
 }
 
 func TestEngine_NewEngine(t *testing.T) {
@@ -37,29 +36,17 @@ func TestEngine_NewEngine(t *testing.T) {
 	}
 
 	e := NewEngine(config)
-	if e == nil {
-		t.Fatal("NewEngine returned nil")
-	}
-	if e.config.NumDevices != 4 {
-		t.Errorf("Expected NumDevices 4, got %d", e.config.NumDevices)
-	}
-	if e.handles == nil {
-		t.Error("HandleTable not initialized")
-	}
+	require.NotNil(t, e, "NewEngine returned nil")
+	require.Equal(t, 4, e.config.NumDevices, "Expected NumDevices 4")
+	require.NotNil(t, e.handles, "HandleTable not initialized")
 }
 
 func TestEngine_NewEngineDefaultConfig(t *testing.T) {
 	e := NewEngine(nil)
-	if e == nil {
-		t.Fatal("NewEngine returned nil")
-	}
-	if e.config == nil {
-		t.Fatal("Config not initialized")
-	}
+	require.NotNil(t, e, "NewEngine returned nil")
+	require.NotNil(t, e.config, "Config not initialized")
 	// Should use default config
-	if e.config.NumDevices != 8 {
-		t.Errorf("Expected default NumDevices 8, got %d", e.config.NumDevices)
-	}
+	require.Equal(t, 8, e.config.NumDevices, "Expected default NumDevices 8")
 }
 
 func TestEngine_InitShutdown(t *testing.T) {
@@ -71,27 +58,15 @@ func TestEngine_InitShutdown(t *testing.T) {
 
 	// Init
 	ret := e.Init()
-	if ret != nvml.SUCCESS {
-		t.Errorf("Init failed with %v", ret)
-	}
-	if e.server == nil {
-		t.Error("Server not initialized")
-	}
-	if e.initCount != 1 {
-		t.Errorf("Expected initCount 1, got %d", e.initCount)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "Init failed")
+	require.NotNil(t, e.server, "Server not initialized")
+	require.Equal(t, 1, e.initCount, "Expected initCount 1")
 
 	// Shutdown
 	ret = e.Shutdown()
-	if ret != nvml.SUCCESS {
-		t.Errorf("Shutdown failed with %v", ret)
-	}
-	if e.server != nil {
-		t.Error("Server should be nil after shutdown")
-	}
-	if e.initCount != 0 {
-		t.Errorf("Expected initCount 0, got %d", e.initCount)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "Shutdown failed")
+	require.Nil(t, e.server, "Server should be nil after shutdown")
+	require.Equal(t, 0, e.initCount, "Expected initCount 0")
 }
 
 func TestEngine_MultipleInit(t *testing.T) {
@@ -103,60 +78,38 @@ func TestEngine_MultipleInit(t *testing.T) {
 
 	// First init
 	ret := e.Init()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("First init failed: %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "First init failed")
 
 	// Second init (should succeed and increment counter)
 	ret = e.Init()
-	if ret != nvml.SUCCESS {
-		t.Errorf("Second init failed: %v", ret)
-	}
-	if e.initCount != 2 {
-		t.Errorf("Expected initCount 2, got %d", e.initCount)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "Second init failed")
+	require.Equal(t, 2, e.initCount, "Expected initCount 2")
 
 	// First shutdown (should not uninitialize)
 	ret = e.Shutdown()
-	if ret != nvml.SUCCESS {
-		t.Errorf("First shutdown failed: %v", ret)
-	}
-	if e.server == nil {
-		t.Error("Server should still be initialized after first shutdown")
-	}
-	if e.initCount != 1 {
-		t.Errorf("Expected initCount 1, got %d", e.initCount)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "First shutdown failed")
+	require.NotNil(t, e.server, "Server should still be initialized after first shutdown")
+	require.Equal(t, 1, e.initCount, "Expected initCount 1")
 
 	// Second shutdown (should uninitialize)
 	ret = e.Shutdown()
-	if ret != nvml.SUCCESS {
-		t.Errorf("Second shutdown failed: %v", ret)
-	}
-	if e.server != nil {
-		t.Error("Server should be nil after final shutdown")
-	}
-	if e.initCount != 0 {
-		t.Errorf("Expected initCount 0, got %d", e.initCount)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "Second shutdown failed")
+	require.Nil(t, e.server, "Server should be nil after final shutdown")
+	require.Equal(t, 0, e.initCount, "Expected initCount 0")
 }
 
 func TestEngine_ShutdownWithoutInit(t *testing.T) {
 	e := NewEngine(nil)
 
 	ret := e.Shutdown()
-	if ret != nvml.ERROR_UNINITIALIZED {
-		t.Errorf("Expected ERROR_UNINITIALIZED, got %v", ret)
-	}
+	require.Equal(t, nvml.ERROR_UNINITIALIZED, ret, "Expected ERROR_UNINITIALIZED")
 }
 
 func TestEngine_DeviceGetCountBeforeInit(t *testing.T) {
 	e := NewEngine(nil)
 
 	_, ret := e.DeviceGetCount()
-	if ret != nvml.ERROR_UNINITIALIZED {
-		t.Errorf("Expected ERROR_UNINITIALIZED, got %v", ret)
-	}
+	require.Equal(t, nvml.ERROR_UNINITIALIZED, ret, "Expected ERROR_UNINITIALIZED")
 }
 
 func TestEngine_DeviceGetCount(t *testing.T) {
@@ -169,12 +122,8 @@ func TestEngine_DeviceGetCount(t *testing.T) {
 	defer func() { _ = e.Shutdown() }()
 
 	count, ret := e.DeviceGetCount()
-	if ret != nvml.SUCCESS {
-		t.Errorf("DeviceGetCount failed: %v", ret)
-	}
-	if count != 4 {
-		t.Errorf("Expected count 4, got %d", count)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "DeviceGetCount failed")
+	require.Equal(t, 4, count, "Expected count 4")
 }
 
 func TestEngine_DeviceGetCountDefault(t *testing.T) {
@@ -183,12 +132,8 @@ func TestEngine_DeviceGetCountDefault(t *testing.T) {
 	defer func() { _ = e.Shutdown() }()
 
 	count, ret := e.DeviceGetCount()
-	if ret != nvml.SUCCESS {
-		t.Errorf("DeviceGetCount failed: %v", ret)
-	}
-	if count != 8 {
-		t.Errorf("Expected default count 8, got %d", count)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "DeviceGetCount failed")
+	require.Equal(t, 8, count, "Expected default count 8")
 }
 
 func TestEngine_DeviceGetHandleByIndex(t *testing.T) {
@@ -202,21 +147,13 @@ func TestEngine_DeviceGetHandleByIndex(t *testing.T) {
 
 	// Valid index
 	handle, ret := e.DeviceGetHandleByIndex(0)
-	if ret != nvml.SUCCESS {
-		t.Errorf("DeviceGetHandleByIndex failed: %v", ret)
-	}
-	if handle == 0 {
-		t.Error("Expected non-zero handle")
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "DeviceGetHandleByIndex failed")
+	require.NotZero(t, handle, "Expected non-zero handle")
 
 	// Same index should return same handle
 	handle2, ret := e.DeviceGetHandleByIndex(0)
-	if ret != nvml.SUCCESS {
-		t.Errorf("Second DeviceGetHandleByIndex failed: %v", ret)
-	}
-	if handle != handle2 {
-		t.Error("Expected same handle for same index")
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "Second DeviceGetHandleByIndex failed")
+	require.Equal(t, handle, handle2, "Expected same handle for same index")
 }
 
 func TestEngine_DeviceGetHandleByIndexInvalid(t *testing.T) {
@@ -230,9 +167,7 @@ func TestEngine_DeviceGetHandleByIndexInvalid(t *testing.T) {
 
 	// Invalid index (out of range)
 	_, ret := e.DeviceGetHandleByIndex(10)
-	if ret == nvml.SUCCESS {
-		t.Error("Expected error for invalid index")
-	}
+	require.NotEqual(t, nvml.SUCCESS, ret, "Expected error for invalid index")
 }
 
 func TestEngine_LookupDevice(t *testing.T) {
@@ -246,38 +181,26 @@ func TestEngine_LookupDevice(t *testing.T) {
 
 	handle, _ := e.DeviceGetHandleByIndex(0)
 	dev := e.LookupDevice(handle)
-	if dev == nil {
-		t.Error("LookupDevice returned nil for valid handle")
-	}
+	require.NotNil(t, dev, "LookupDevice returned nil for valid handle")
 
 	// Invalid handle - returns InvalidDeviceInstance (null-object pattern)
 	invalidDev := e.LookupDevice(999)
-	if invalidDev != InvalidDeviceInstance {
-		t.Error("Expected InvalidDeviceInstance for invalid handle")
-	}
+	require.Equal(t, InvalidDeviceInstance, invalidDev, "Expected InvalidDeviceInstance for invalid handle")
 }
 
 func TestEngine_LookupDeviceBeforeInit(t *testing.T) {
 	e := NewEngine(nil)
 	dev := e.LookupDevice(1)
-	if dev == nil {
-		t.Fatal("LookupDevice on uninitialized engine returned nil, expected InvalidDeviceInstance")
-	}
-	if dev != InvalidDeviceInstance {
-		t.Errorf("Expected InvalidDeviceInstance, got %T", dev)
-	}
+	require.NotNil(t, dev, "LookupDevice on uninitialized engine returned nil, expected InvalidDeviceInstance")
+	require.Equal(t, InvalidDeviceInstance, dev, "Expected InvalidDeviceInstance")
 	_, ret := dev.GetName()
-	if ret != nvml.ERROR_INVALID_ARGUMENT {
-		t.Errorf("Expected ERROR_INVALID_ARGUMENT from InvalidDeviceInstance, got %v", ret)
-	}
+	require.Equal(t, nvml.ERROR_INVALID_ARGUMENT, ret, "Expected ERROR_INVALID_ARGUMENT from InvalidDeviceInstance")
 }
 
 func TestEngine_LookupConfigurableDevice_UninitializedReturnsNil(t *testing.T) {
 	e := NewEngine(nil)
 	dev := e.LookupConfigurableDevice(0x1234)
-	if dev != nil {
-		t.Error("LookupConfigurableDevice on uninitialized engine should return nil")
-	}
+	require.Nil(t, dev, "LookupConfigurableDevice on uninitialized engine should return nil")
 }
 
 func TestEngine_DriverVersionOverride(t *testing.T) {
@@ -291,12 +214,8 @@ func TestEngine_DriverVersionOverride(t *testing.T) {
 	defer func() { _ = e.Shutdown() }()
 
 	version, ret := e.server.SystemGetDriverVersion()
-	if ret != nvml.SUCCESS {
-		t.Errorf("SystemGetDriverVersion failed: %v", ret)
-	}
-	if version != customVersion {
-		t.Errorf("Expected driver version %s, got %s", customVersion, version)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "SystemGetDriverVersion failed")
+	require.Equal(t, customVersion, version, "Expected driver version %s", customVersion)
 }
 
 func TestEngine_HandleTableCleanupOnShutdown(t *testing.T) {
@@ -311,15 +230,11 @@ func TestEngine_HandleTableCleanupOnShutdown(t *testing.T) {
 	_, _ = e.DeviceGetHandleByIndex(0)
 	_, _ = e.DeviceGetHandleByIndex(1)
 
-	if e.handles.Count() == 0 {
-		t.Error("Expected handles to be registered")
-	}
+	require.NotZero(t, e.handles.Count(), "Expected handles to be registered")
 
 	_ = e.Shutdown()
 
-	if e.handles.Count() != 0 {
-		t.Error("Expected handles to be cleared on shutdown")
-	}
+	require.Zero(t, e.handles.Count(), "Expected handles to be cleared on shutdown")
 }
 
 func TestEngine_ConfigFromEnvironment(t *testing.T) {
@@ -330,12 +245,8 @@ func TestEngine_ConfigFromEnvironment(t *testing.T) {
 	t.Setenv("MOCK_NVML_DRIVER_VERSION", "600.00.00")
 
 	e := NewEngine(nil) // Should load from env
-	if e.config.NumDevices != 6 {
-		t.Errorf("Expected NumDevices 6 from env, got %d", e.config.NumDevices)
-	}
-	if e.config.DriverVersion != "600.00.00" {
-		t.Errorf("Expected DriverVersion from env, got %s", e.config.DriverVersion)
-	}
+	require.Equal(t, 6, e.config.NumDevices, "Expected NumDevices 6 from env")
+	require.Equal(t, "600.00.00", e.config.DriverVersion, "Expected DriverVersion from env")
 }
 
 func TestEngine_DeviceGetHandleByUUID(t *testing.T) {
@@ -350,12 +261,8 @@ func TestEngine_DeviceGetHandleByUUID(t *testing.T) {
 
 	// Lookup by UUID
 	handleByUUID, ret := e.DeviceGetHandleByUUID(uuid)
-	if ret != nvml.SUCCESS {
-		t.Errorf("DeviceGetHandleByUUID failed: %v", ret)
-	}
-	if handleByUUID != handle {
-		t.Error("Expected same handle for same device")
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "DeviceGetHandleByUUID failed")
+	require.Equal(t, handle, handleByUUID, "Expected same handle for same device")
 }
 
 func TestEngine_DeviceGetHandleByUUIDInvalid(t *testing.T) {
@@ -364,9 +271,7 @@ func TestEngine_DeviceGetHandleByUUIDInvalid(t *testing.T) {
 	defer func() { _ = e.Shutdown() }()
 
 	_, ret := e.DeviceGetHandleByUUID("invalid-uuid-12345")
-	if ret == nvml.SUCCESS {
-		t.Error("Expected error for invalid UUID")
-	}
+	require.NotEqual(t, nvml.SUCCESS, ret, "Expected error for invalid UUID")
 }
 
 func TestEngine_DeviceGetHandleByPciBusId(t *testing.T) {
@@ -378,9 +283,7 @@ func TestEngine_DeviceGetHandleByPciBusId(t *testing.T) {
 	handle, _ := e.DeviceGetHandleByIndex(0)
 	dev := e.LookupDevice(handle)
 	pciInfo, ret := dev.GetPciInfo()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetPciInfo failed: %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetPciInfo failed")
 
 	// Convert BusId to string (trim null bytes)
 	var busId string
@@ -393,12 +296,8 @@ func TestEngine_DeviceGetHandleByPciBusId(t *testing.T) {
 
 	// Lookup by PCI bus ID
 	handleByPCI, ret := e.DeviceGetHandleByPciBusId(busId)
-	if ret != nvml.SUCCESS {
-		t.Errorf("DeviceGetHandleByPciBusId failed: %v", ret)
-	}
-	if handleByPCI != handle {
-		t.Error("Expected same handle for same device")
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "DeviceGetHandleByPciBusId failed")
+	require.Equal(t, handle, handleByPCI, "Expected same handle for same device")
 }
 
 func TestEngine_DeviceGetHandleByPciBusIdInvalid(t *testing.T) {
@@ -407,9 +306,7 @@ func TestEngine_DeviceGetHandleByPciBusIdInvalid(t *testing.T) {
 	defer func() { _ = e.Shutdown() }()
 
 	_, ret := e.DeviceGetHandleByPciBusId("0000:FF:FF.0")
-	if ret == nvml.SUCCESS {
-		t.Error("Expected error for invalid PCI bus ID")
-	}
+	require.NotEqual(t, nvml.SUCCESS, ret, "Expected error for invalid PCI bus ID")
 }
 
 // --- Visibility filtering tests ---
@@ -420,9 +317,7 @@ func TestDetectVisibleDevices_NonePresent(t *testing.T) {
 	dir := t.TempDir()
 	// No files created – simulates no /dev/nvidia* nodes
 	result := detectVisibleDevicesAt(dir+"/nvidia%d", 4)
-	if result != nil {
-		t.Errorf("Expected nil (no filtering) when no nodes exist, got %v", result)
-	}
+	require.Nil(t, result, "Expected nil (no filtering) when no nodes exist")
 }
 
 // TestDetectVisibleDevices_AllPresent verifies nil is returned when every
@@ -431,18 +326,12 @@ func TestDetectVisibleDevices_AllPresent(t *testing.T) {
 	dir := t.TempDir()
 	for i := 0; i < 4; i++ {
 		f, err := os.Create(fmt.Sprintf("%s/nvidia%d", dir, i))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := f.Close(); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
 	}
 
 	result := detectVisibleDevicesAt(dir+"/nvidia%d", 4)
-	if result != nil {
-		t.Errorf("Expected nil (no filtering) when all nodes exist, got %v", result)
-	}
+	require.Nil(t, result, "Expected nil (no filtering) when all nodes exist")
 }
 
 // TestDetectVisibleDevices_Subset verifies correct filtering when only some
@@ -452,21 +341,13 @@ func TestDetectVisibleDevices_Subset(t *testing.T) {
 	// Create only nodes 0 and 2 out of 4
 	for _, idx := range []int{0, 2} {
 		f, err := os.Create(fmt.Sprintf("%s/nvidia%d", dir, idx))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := f.Close(); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
 	}
 
 	result := detectVisibleDevicesAt(dir+"/nvidia%d", 4)
-	if len(result) != 2 {
-		t.Fatalf("Expected 2 visible devices, got %d: %v", len(result), result)
-	}
-	if result[0] != 0 || result[1] != 2 {
-		t.Errorf("Expected visible devices [0 2], got %v", result)
-	}
+	require.Len(t, result, 2, "Expected 2 visible devices")
+	require.Equal(t, []int{0, 2}, result, "Expected visible devices [0 2]")
 }
 
 // TestVisibility_DeviceGetCount verifies that DeviceGetCount returns the
@@ -478,32 +359,20 @@ func TestVisibility_DeviceGetCount(t *testing.T) {
 
 	// Before filtering: should see all 4
 	count, ret := e.DeviceGetCount()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("DeviceGetCount failed: %v", ret)
-	}
-	if count != 4 {
-		t.Errorf("Expected 4, got %d", count)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "DeviceGetCount failed")
+	require.Equal(t, 4, count, "Expected 4")
 
 	// Activate filtering: only devices 1 and 3 visible
 	e.SetVisibleDevicesForTesting([]int{1, 3})
 	count, ret = e.DeviceGetCount()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("DeviceGetCount failed: %v", ret)
-	}
-	if count != 2 {
-		t.Errorf("Expected 2 visible devices, got %d", count)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "DeviceGetCount failed")
+	require.Equal(t, 2, count, "Expected 2 visible devices")
 
 	// Disable filtering
 	e.SetVisibleDevicesForTesting(nil)
 	count, ret = e.DeviceGetCount()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("DeviceGetCount failed: %v", ret)
-	}
-	if count != 4 {
-		t.Errorf("Expected 4 after disabling filter, got %d", count)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "DeviceGetCount failed")
+	require.Equal(t, 4, count, "Expected 4 after disabling filter")
 }
 
 // TestVisibility_DeviceGetHandleByIndex verifies index remapping through the
@@ -515,27 +384,19 @@ func TestVisibility_DeviceGetHandleByIndex(t *testing.T) {
 
 	// Get the actual device at index 2 before filtering
 	handleDev2, ret := e.DeviceGetHandleByIndex(2)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("DeviceGetHandleByIndex(2) failed: %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "DeviceGetHandleByIndex(2) failed")
 
 	// Activate filtering: visible = [2, 3] (device 2 becomes visible index 0)
 	e.SetVisibleDevicesForTesting([]int{2, 3})
 
 	// Visible index 0 should map to actual device 2
 	handle, ret := e.DeviceGetHandleByIndex(0)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("DeviceGetHandleByIndex(0) with visibility failed: %v", ret)
-	}
-	if handle != handleDev2 {
-		t.Error("Visible index 0 should map to actual device 2")
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "DeviceGetHandleByIndex(0) with visibility failed")
+	require.Equal(t, handleDev2, handle, "Visible index 0 should map to actual device 2")
 
 	// Visible index 2 should be out of range (only 2 visible)
 	_, ret = e.DeviceGetHandleByIndex(2)
-	if ret != nvml.ERROR_INVALID_ARGUMENT {
-		t.Errorf("Expected ERROR_INVALID_ARGUMENT for out-of-range visible index, got %v", ret)
-	}
+	require.Equal(t, nvml.ERROR_INVALID_ARGUMENT, ret, "Expected ERROR_INVALID_ARGUMENT for out-of-range visible index")
 }
 
 // TestVisibility_DeviceGetHandleByUUID verifies that UUID lookups respect
@@ -556,15 +417,11 @@ func TestVisibility_DeviceGetHandleByUUID(t *testing.T) {
 
 	// Device 0's UUID should resolve
 	_, ret := e.DeviceGetHandleByUUID(uuid0)
-	if ret != nvml.SUCCESS {
-		t.Errorf("Expected SUCCESS for visible device UUID, got %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "Expected SUCCESS for visible device UUID")
 
 	// Device 1's UUID should NOT resolve
 	_, ret = e.DeviceGetHandleByUUID(uuid1)
-	if ret != nvml.ERROR_NOT_FOUND {
-		t.Errorf("Expected ERROR_NOT_FOUND for non-visible device UUID, got %v", ret)
-	}
+	require.Equal(t, nvml.ERROR_NOT_FOUND, ret, "Expected ERROR_NOT_FOUND for non-visible device UUID")
 }
 
 // TestVisibility_DeviceGetHandleByPciBusId verifies that PCI bus ID lookups
@@ -588,15 +445,11 @@ func TestVisibility_DeviceGetHandleByPciBusId(t *testing.T) {
 
 	// Device 0's PCI bus ID should resolve
 	_, ret := e.DeviceGetHandleByPciBusId(busId0)
-	if ret != nvml.SUCCESS {
-		t.Errorf("Expected SUCCESS for visible device PCI bus ID, got %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "Expected SUCCESS for visible device PCI bus ID")
 
 	// Device 1's PCI bus ID should NOT resolve
 	_, ret = e.DeviceGetHandleByPciBusId(busId1)
-	if ret != nvml.ERROR_NOT_FOUND {
-		t.Errorf("Expected ERROR_NOT_FOUND for non-visible device PCI bus ID, got %v", ret)
-	}
+	require.Equal(t, nvml.ERROR_NOT_FOUND, ret, "Expected ERROR_NOT_FOUND for non-visible device PCI bus ID")
 }
 
 // pciInfoBusIdString extracts a Go string from the null-terminated BusId array.

--- a/pkg/gpu/mocknvml/engine/fabric_test.go
+++ b/pkg/gpu/mocknvml/engine/fabric_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock/dgxa100"
+	"github.com/stretchr/testify/require"
 )
 
 func makeFabricDevice(t *testing.T, fabric *FabricConfig) *ConfigurableDevice {
@@ -33,13 +34,9 @@ func makeFabricDevice(t *testing.T, fabric *FabricConfig) *ConfigurableDevice {
 func TestGetMockFabricInfo_NotSupportedWhenNil(t *testing.T) {
 	dev := makeFabricDevice(t, nil)
 	_, ret := dev.GetMockFabricInfo()
-	if ret != nvml.ERROR_NOT_SUPPORTED {
-		t.Fatalf("nil fabric: want ERROR_NOT_SUPPORTED, got %v", ret)
-	}
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret, "nil fabric")
 	_, ret = dev.GetMockFabricInfoV()
-	if ret != nvml.ERROR_NOT_SUPPORTED {
-		t.Fatalf("nil fabric V: want ERROR_NOT_SUPPORTED, got %v", ret)
-	}
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret, "nil fabric V")
 }
 
 func TestGetMockFabricInfo_PopulatesFields(t *testing.T) {
@@ -50,26 +47,14 @@ func TestGetMockFabricInfo_PopulatesFields(t *testing.T) {
 		HealthMask:  0x42,
 	})
 	info, ret := dev.GetMockFabricInfo()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("v1: %v", ret)
-	}
-	if info.CliqueID != 7 {
-		t.Errorf("CliqueID: want 7, got %d", info.CliqueID)
-	}
-	if info.State != FabricStateCompleted {
-		t.Errorf("State: want completed (%d), got %d", FabricStateCompleted, info.State)
-	}
-	if info.ClusterUUID[15] != 0xab {
-		t.Errorf("ClusterUUID last byte: want 0xab, got 0x%x", info.ClusterUUID[15])
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "v1")
+	require.Equal(t, uint32(7), info.CliqueID, "CliqueID")
+	require.Equal(t, FabricStateCompleted, info.State, "State")
+	require.Equal(t, byte(0xab), info.ClusterUUID[15], "ClusterUUID last byte")
 
 	v, ret := dev.GetMockFabricInfoV()
-	if ret != nvml.SUCCESS {
-		t.Fatalf("V: %v", ret)
-	}
-	if v.HealthMask != 0x42 {
-		t.Errorf("V: healthMask=%d", v.HealthMask)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "V")
+	require.Equal(t, uint32(0x42), v.HealthMask, "V healthMask")
 }
 
 func TestParseFabricState(t *testing.T) {
@@ -83,28 +68,23 @@ func TestParseFabricState(t *testing.T) {
 		"garbage":      FabricStateCompleted,
 	}
 	for in, want := range cases {
-		if got := parseFabricState(in); got != want {
-			t.Errorf("parseFabricState(%q) = %d, want %d", in, got, want)
-		}
+		require.Equal(t, want, parseFabricState(in), "parseFabricState(%q)", in)
 	}
 }
 
 func TestParseClusterUUID(t *testing.T) {
 	out := parseClusterUUID("00000000-0000-0000-0000-000000000001")
-	if out[15] != 0x01 {
-		t.Errorf("last byte: want 0x01, got 0x%x", out[15])
-	}
+	require.Equal(t, byte(0x01), out[15], "last byte")
 	// short input is zero-padded
 	short := parseClusterUUID("ff")
-	if short[0] != 0xff || short[15] != 0x00 {
-		t.Errorf("short: want [ff..00], got %x", short)
-	}
+	require.Equal(t, byte(0xff), short[0], "short first byte")
+	require.Equal(t, byte(0x00), short[15], "short last byte")
 }
 
 func TestTopologyOverlay(t *testing.T) {
 	dir := t.TempDir()
 	topoPath := filepath.Join(dir, "topology.yaml")
-	if err := os.WriteFile(topoPath, []byte(`
+	err := os.WriteFile(topoPath, []byte(`
 version: 1
 domains:
   - name: dom1
@@ -114,9 +94,8 @@ domains:
         nodes: [nodeA, nodeB]
       - id: 9
         nodes: [nodeC]
-`), 0o644); err != nil {
-		t.Fatal(err)
-	}
+`), 0o644)
+	require.NoError(t, err)
 	t.Setenv("NODE_NAME", "nodeB")
 	t.Setenv("MOCK_TOPOLOGY_CONFIG", topoPath)
 
@@ -127,12 +106,8 @@ domains:
 		}},
 	}
 	applyTopologyOverlay(cfg)
-	if cfg.DeviceDefaults.Fabric.CliqueID != 5 {
-		t.Errorf("CliqueID: want 5, got %d", cfg.DeviceDefaults.Fabric.CliqueID)
-	}
-	if cfg.DeviceDefaults.Fabric.ClusterUUID != "00000000-0000-0000-0000-0000000000ab" {
-		t.Errorf("ClusterUUID: got %q", cfg.DeviceDefaults.Fabric.ClusterUUID)
-	}
+	require.Equal(t, uint32(5), cfg.DeviceDefaults.Fabric.CliqueID, "CliqueID")
+	require.Equal(t, "00000000-0000-0000-0000-0000000000ab", cfg.DeviceDefaults.Fabric.ClusterUUID, "ClusterUUID")
 }
 
 func TestTopologyOverlay_NoFabricDefaults_NoOp(t *testing.T) {
@@ -155,9 +130,7 @@ domains:
 
 	cfg := &YAMLConfig{DeviceDefaults: DeviceConfig{}}
 	applyTopologyOverlay(cfg)
-	if cfg.DeviceDefaults.Fabric != nil {
-		t.Errorf("non-fabric profile: want Fabric=nil after overlay, got %+v", cfg.DeviceDefaults.Fabric)
-	}
+	require.Nil(t, cfg.DeviceDefaults.Fabric, "non-fabric profile: want Fabric=nil after overlay")
 }
 
 func TestTopologyOverlay_NodeNotPresent_NoChange(t *testing.T) {
@@ -181,9 +154,8 @@ domains:
 		}},
 	}
 	applyTopologyOverlay(cfg)
-	if cfg.DeviceDefaults.Fabric.CliqueID != 77 || cfg.DeviceDefaults.Fabric.ClusterUUID != "ORIG" {
-		t.Errorf("unexpected mutation: %+v", cfg.DeviceDefaults.Fabric)
-	}
+	require.Equal(t, uint32(77), cfg.DeviceDefaults.Fabric.CliqueID, "unexpected mutation")
+	require.Equal(t, "ORIG", cfg.DeviceDefaults.Fabric.ClusterUUID, "unexpected mutation")
 }
 
 // TestTopologyOverlay_MissingFile_NoChange exercises the os.Stat
@@ -202,12 +174,9 @@ func TestTopologyOverlay_MissingFile_NoChange(t *testing.T) {
 		}},
 	}
 	applyTopologyOverlay(cfg)
-	if cfg.DeviceDefaults.Fabric == nil {
-		t.Fatal("Fabric reset to nil; want sentinel values preserved")
-	}
-	if cfg.DeviceDefaults.Fabric.ClusterUUID != "ORIG-UUID" || cfg.DeviceDefaults.Fabric.CliqueID != 42 {
-		t.Errorf("Fabric mutated by missing-file path: %+v", cfg.DeviceDefaults.Fabric)
-	}
+	require.NotNil(t, cfg.DeviceDefaults.Fabric, "Fabric reset to nil; want sentinel values preserved")
+	require.Equal(t, "ORIG-UUID", cfg.DeviceDefaults.Fabric.ClusterUUID, "Fabric mutated by missing-file path")
+	require.Equal(t, uint32(42), cfg.DeviceDefaults.Fabric.CliqueID, "Fabric mutated by missing-file path")
 }
 
 // TestTopologyOverlay_MalformedYAML_NoChange exercises the yaml.Unmarshal
@@ -216,9 +185,7 @@ func TestTopologyOverlay_MissingFile_NoChange(t *testing.T) {
 func TestTopologyOverlay_MalformedYAML_NoChange(t *testing.T) {
 	dir := t.TempDir()
 	topoPath := filepath.Join(dir, "topology.yaml")
-	if err := os.WriteFile(topoPath, []byte("this: is: not: valid: yaml\n  - mismatched indent\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(topoPath, []byte("this: is: not: valid: yaml\n  - mismatched indent\n"), 0o644))
 	t.Setenv("NODE_NAME", "nodeA")
 	t.Setenv("MOCK_TOPOLOGY_CONFIG", topoPath)
 
@@ -229,12 +196,9 @@ func TestTopologyOverlay_MalformedYAML_NoChange(t *testing.T) {
 		}},
 	}
 	applyTopologyOverlay(cfg)
-	if cfg.DeviceDefaults.Fabric == nil {
-		t.Fatal("Fabric reset to nil; want sentinel values preserved")
-	}
-	if cfg.DeviceDefaults.Fabric.ClusterUUID != "ORIG-UUID" || cfg.DeviceDefaults.Fabric.CliqueID != 42 {
-		t.Errorf("Fabric mutated by malformed-YAML path: %+v", cfg.DeviceDefaults.Fabric)
-	}
+	require.NotNil(t, cfg.DeviceDefaults.Fabric, "Fabric reset to nil; want sentinel values preserved")
+	require.Equal(t, "ORIG-UUID", cfg.DeviceDefaults.Fabric.ClusterUUID, "Fabric mutated by malformed-YAML path")
+	require.Equal(t, uint32(42), cfg.DeviceDefaults.Fabric.CliqueID, "Fabric mutated by malformed-YAML path")
 }
 
 // TestTopologyOverlay_UnreadableFile_NoChange exercises the os.ReadFile
@@ -253,10 +217,7 @@ func TestTopologyOverlay_UnreadableFile_NoChange(t *testing.T) {
 		}},
 	}
 	applyTopologyOverlay(cfg)
-	if cfg.DeviceDefaults.Fabric == nil {
-		t.Fatal("Fabric reset to nil; want sentinel values preserved")
-	}
-	if cfg.DeviceDefaults.Fabric.ClusterUUID != "ORIG-UUID" || cfg.DeviceDefaults.Fabric.CliqueID != 42 {
-		t.Errorf("Fabric mutated by unreadable-file path: %+v", cfg.DeviceDefaults.Fabric)
-	}
+	require.NotNil(t, cfg.DeviceDefaults.Fabric, "Fabric reset to nil; want sentinel values preserved")
+	require.Equal(t, "ORIG-UUID", cfg.DeviceDefaults.Fabric.ClusterUUID, "Fabric mutated by unreadable-file path")
+	require.Equal(t, uint32(42), cfg.DeviceDefaults.Fabric.CliqueID, "Fabric mutated by unreadable-file path")
 }

--- a/pkg/gpu/mocknvml/engine/failure_injector_test.go
+++ b/pkg/gpu/mocknvml/engine/failure_injector_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
 )
 
 // =============================================================================
@@ -55,36 +56,24 @@ func withFailure(f *FailureInjectionConfig) *DeviceConfig {
 // =============================================================================
 
 func TestFailureInjector_NilConfigYieldsNilInjector(t *testing.T) {
-	if got := newFailureInjector(nil); got != nil {
-		t.Fatalf("expected nil injector for nil cfg, got %#v", got)
-	}
+	got := newFailureInjector(nil)
+	require.Nil(t, got, "expected nil injector for nil cfg")
 }
 
 func TestFailureInjector_HealthyModeYieldsNilInjector(t *testing.T) {
 	for _, mode := range []string{"", "healthy", "not-a-real-mode"} {
-		if got := newFailureInjector(&FailureInjectionConfig{Mode: mode}); got != nil {
-			t.Fatalf("mode %q: expected nil injector for healthy/unknown mode, got %#v", mode, got)
-		}
+		got := newFailureInjector(&FailureInjectionConfig{Mode: mode})
+		require.Nil(t, got, "mode %q: expected nil injector for healthy/unknown mode", mode)
 	}
 }
 
 func TestFailureInjector_ModeWithoutTriggersFailsOnFirstTick(t *testing.T) {
 	f := newFailureInjector(&FailureInjectionConfig{Mode: FailureModeLost})
-	if f == nil {
-		t.Fatal("expected non-nil injector for lost mode")
-	}
-	if f.Triggered() {
-		t.Fatal("injector must not be tripped before any Tick()")
-	}
-	if !f.Tick() {
-		t.Fatal("expected first Tick() to trip a mode-only injector")
-	}
-	if !f.Triggered() {
-		t.Fatal("Triggered() must report true after Tick() trips")
-	}
-	if got, want := f.ErrorReturn(), nvml.ERROR_GPU_IS_LOST; got != want {
-		t.Fatalf("ErrorReturn = %v, want %v", got, want)
-	}
+	require.NotNil(t, f, "expected non-nil injector for lost mode")
+	require.False(t, f.Triggered(), "injector must not be tripped before any Tick()")
+	require.True(t, f.Tick(), "expected first Tick() to trip a mode-only injector")
+	require.True(t, f.Triggered(), "Triggered() must report true after Tick() trips")
+	require.Equal(t, nvml.ERROR_GPU_IS_LOST, f.ErrorReturn(), "ErrorReturn")
 }
 
 func TestFailureInjector_AfterCallsIsDeterministic(t *testing.T) {
@@ -95,18 +84,12 @@ func TestFailureInjector_AfterCallsIsDeterministic(t *testing.T) {
 	})
 
 	for i := 1; i < N; i++ {
-		if f.Tick() {
-			t.Fatalf("call %d: tripped before AfterCalls=%d", i, N)
-		}
+		require.False(t, f.Tick(), "call %d: tripped before AfterCalls=%d", i, N)
 	}
-	if !f.Tick() {
-		t.Fatalf("call %d: expected trip at AfterCalls=%d", N, N)
-	}
+	require.True(t, f.Tick(), "call %d: expected trip at AfterCalls=%d", N, N)
 	// And it stays tripped afterwards.
 	for i := 0; i < 3; i++ {
-		if !f.Tick() {
-			t.Fatalf("post-trip call %d: expected sticky trip", i)
-		}
+		require.True(t, f.Tick(), "post-trip call %d: expected sticky trip", i)
 	}
 }
 
@@ -118,9 +101,7 @@ func TestFailureInjector_ProbabilityZeroNeverTripsOnItsOwn(t *testing.T) {
 		Seed:        42,
 	})
 	for i := 0; i < 10_000; i++ {
-		if f.Tick() {
-			t.Fatalf("call %d: probability=0 must not trip", i)
-		}
+		require.False(t, f.Tick(), "call %d: probability=0 must not trip", i)
 	}
 }
 
@@ -131,9 +112,7 @@ func TestFailureInjector_ProbabilityOneTripsOnFirstTick(t *testing.T) {
 		AfterCalls:  1_000_000, // ensure trip is from probability, not AfterCalls
 		Seed:        42,
 	})
-	if !f.Tick() {
-		t.Fatal("probability=1 must trip immediately")
-	}
+	require.True(t, f.Tick(), "probability=1 must trip immediately")
 }
 
 func TestFailureInjector_SeedReproducibility(t *testing.T) {
@@ -157,12 +136,8 @@ func TestFailureInjector_SeedReproducibility(t *testing.T) {
 
 	a := tripAt(mk())
 	b := tripAt(mk())
-	if a != b {
-		t.Fatalf("same seed must trip at the same call: a=%d b=%d", a, b)
-	}
-	if a < 1 || a > 10_000 {
-		t.Fatalf("expected trip within 10k calls (Probability=0.05 makes p(no-trip) effectively 0), got %d", a)
-	}
+	require.Equal(t, a, b, "same seed must trip at the same call: a=%d b=%d", a, b)
+	require.True(t, a >= 1 && a <= 10_000, "expected trip within 10k calls (Probability=0.05 makes p(no-trip) effectively 0), got %d", a)
 }
 
 func TestFailureInjector_DifferentSeedsDiverge(t *testing.T) {
@@ -183,9 +158,7 @@ func TestFailureInjector_DifferentSeedsDiverge(t *testing.T) {
 		return -1
 	}
 
-	if tripAt(mk(1)) == tripAt(mk(2)) {
-		t.Fatal("different seeds should not trip at the exact same call (with high probability)")
-	}
+	require.NotEqual(t, tripAt(mk(1)), tripAt(mk(2)), "different seeds should not trip at the exact same call (with high probability)")
 }
 
 func TestFailureInjector_ConcurrentTickSafety(t *testing.T) {
@@ -211,9 +184,7 @@ func TestFailureInjector_ConcurrentTickSafety(t *testing.T) {
 
 	// Only assertion we make is the call count is correct; -race covers
 	// the rest of the synchronization properties.
-	if got, want := f.CallCount(), int64(goroutines*iters); got != want {
-		t.Fatalf("CallCount = %d, want %d", got, want)
-	}
+	require.Equal(t, int64(goroutines*iters), f.CallCount(), "CallCount")
 }
 
 func TestFailureInjector_XidRequiresTrip(t *testing.T) {
@@ -222,18 +193,12 @@ func TestFailureInjector_XidRequiresTrip(t *testing.T) {
 		AfterCalls: 5,
 		Xid:        &XidErrorConfig{Code: 79},
 	})
-	if got := f.Xid(); got != 0 {
-		t.Fatalf("Xid() before trip must be 0, got %d", got)
-	}
+	require.Zero(t, f.Xid(), "Xid() before trip must be 0")
 	for i := 0; i < 5; i++ {
 		f.Tick()
 	}
-	if !f.Triggered() {
-		t.Fatal("expected trip after AfterCalls")
-	}
-	if got, want := f.Xid(), uint64(79); got != want {
-		t.Fatalf("Xid() after trip = %d, want %d", got, want)
-	}
+	require.True(t, f.Triggered(), "expected trip after AfterCalls")
+	require.Equal(t, uint64(79), f.Xid(), "Xid() after trip")
 }
 
 // =============================================================================
@@ -247,27 +212,22 @@ func TestFailureInjection_DeviceLevel_LostTripsAfterCalls(t *testing.T) {
 	}))
 
 	for i := 1; i <= 2; i++ {
-		if temp, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU); ret != nvml.SUCCESS || temp != 33 {
-			t.Fatalf("call %d before trip: expected (33, SUCCESS), got (%d, %v)", i, temp, ret)
-		}
+		temp, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU)
+		require.Equal(t, nvml.SUCCESS, ret, "call %d before trip", i)
+		require.Equal(t, uint32(33), temp, "call %d before trip", i)
 	}
 	// Third call trips and immediately surfaces ERROR_GPU_IS_LOST.
-	if _, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU); ret != nvml.ERROR_GPU_IS_LOST {
-		t.Fatalf("trip call: expected ERROR_GPU_IS_LOST, got %v", ret)
-	}
+	_, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU)
+	require.Equal(t, nvml.ERROR_GPU_IS_LOST, ret, "trip call")
 	// All subsequent guarded calls keep failing.
-	if _, ret := dev.GetPowerUsage(); ret != nvml.ERROR_GPU_IS_LOST {
-		t.Fatalf("post-trip GetPowerUsage: expected ERROR_GPU_IS_LOST, got %v", ret)
-	}
-	if _, ret := dev.GetUtilizationRates(); ret != nvml.ERROR_GPU_IS_LOST {
-		t.Fatalf("post-trip GetUtilizationRates: expected ERROR_GPU_IS_LOST, got %v", ret)
-	}
-	if _, ret := dev.GetMemoryInfo(); ret != nvml.ERROR_GPU_IS_LOST {
-		t.Fatalf("post-trip GetMemoryInfo: expected ERROR_GPU_IS_LOST, got %v", ret)
-	}
-	if _, ret := dev.GetClockInfo(nvml.CLOCK_SM); ret != nvml.ERROR_GPU_IS_LOST {
-		t.Fatalf("post-trip GetClockInfo: expected ERROR_GPU_IS_LOST, got %v", ret)
-	}
+	_, ret = dev.GetPowerUsage()
+	require.Equal(t, nvml.ERROR_GPU_IS_LOST, ret, "post-trip GetPowerUsage")
+	_, ret = dev.GetUtilizationRates()
+	require.Equal(t, nvml.ERROR_GPU_IS_LOST, ret, "post-trip GetUtilizationRates")
+	_, ret = dev.GetMemoryInfo()
+	require.Equal(t, nvml.ERROR_GPU_IS_LOST, ret, "post-trip GetMemoryInfo")
+	_, ret = dev.GetClockInfo(nvml.CLOCK_SM)
+	require.Equal(t, nvml.ERROR_GPU_IS_LOST, ret, "post-trip GetClockInfo")
 }
 
 func TestFailureInjection_DeviceLevel_FallenOffBusBehavesLikeLost(t *testing.T) {
@@ -275,9 +235,8 @@ func TestFailureInjection_DeviceLevel_FallenOffBusBehavesLikeLost(t *testing.T) 
 		Mode: FailureModeFallenOffBus,
 	}))
 	// Mode without triggers ⇒ trips on first call.
-	if _, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU); ret != nvml.ERROR_GPU_IS_LOST {
-		t.Fatalf("expected ERROR_GPU_IS_LOST, got %v", ret)
-	}
+	_, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU)
+	require.Equal(t, nvml.ERROR_GPU_IS_LOST, ret, "expected ERROR_GPU_IS_LOST")
 }
 
 func TestFailureInjection_HandleLookupFailsAfterTrip(t *testing.T) {
@@ -298,35 +257,29 @@ func TestFailureInjection_HandleLookupFailsAfterTrip(t *testing.T) {
 		},
 	}
 	e := NewEngine(cfg)
-	if ret := e.Init(); ret != nvml.SUCCESS {
-		t.Fatalf("engine init failed: %v", ret)
-	}
+	ret := e.Init()
+	require.Equal(t, nvml.SUCCESS, ret, "engine init failed")
 	t.Cleanup(func() { _ = e.Shutdown() })
 
 	// Pre-trip handle lookup must succeed (else newTestDeviceWithConfig
 	// itself wouldn't be able to drive the failure). This documents that
 	// a fresh boot sees the GPU before guarded API calls trip it.
 	handle, ret := e.DeviceGetHandleByIndex(0)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("pre-trip handle lookup: expected SUCCESS, got %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "pre-trip handle lookup")
 	dev := e.LookupDevice(handle).(*ConfigurableDevice)
 
 	// One guarded call trips the device.
-	if _, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU); ret != nvml.ERROR_GPU_IS_LOST {
-		t.Fatalf("expected first guarded call to trip, got %v", ret)
-	}
+	_, ret = dev.GetTemperature(nvml.TEMPERATURE_GPU)
+	require.Equal(t, nvml.ERROR_GPU_IS_LOST, ret, "expected first guarded call to trip")
 
 	// Re-lookups now report the GPU as lost (real NVML returns the same
 	// error from handle lookups when the kernel driver has marked the
 	// device as gone).
-	if _, ret := e.DeviceGetHandleByIndex(0); ret != nvml.ERROR_GPU_IS_LOST {
-		t.Fatalf("post-trip DeviceGetHandleByIndex: expected ERROR_GPU_IS_LOST, got %v", ret)
-	}
+	_, ret = e.DeviceGetHandleByIndex(0)
+	require.Equal(t, nvml.ERROR_GPU_IS_LOST, ret, "post-trip DeviceGetHandleByIndex")
 	if dev.UUID != "" {
-		if _, ret := e.DeviceGetHandleByUUID(dev.UUID); ret != nvml.ERROR_GPU_IS_LOST {
-			t.Fatalf("post-trip DeviceGetHandleByUUID: expected ERROR_GPU_IS_LOST, got %v", ret)
-		}
+		_, ret = e.DeviceGetHandleByUUID(dev.UUID)
+		require.Equal(t, nvml.ERROR_GPU_IS_LOST, ret, "post-trip DeviceGetHandleByUUID")
 	}
 }
 
@@ -342,43 +295,31 @@ func TestFailureInjection_ECC_NonZeroAfterTrip(t *testing.T) {
 
 	// Pre-trip: counters report zero.
 	count, ret := dev.GetTotalEccErrors(nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.AGGREGATE_ECC)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("pre-trip GetTotalEccErrors ret: %v", ret)
-	}
-	if count != 1 {
-		// Reasoning: the call above was the AfterCalls=1 trigger; the
-		// counter therefore reports 1 (the running call count) on this
-		// very call. Subsequent calls report strictly larger values.
-		t.Fatalf("first ECC poll: expected 1 (call count), got %d", count)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "pre-trip GetTotalEccErrors ret")
+	// Reasoning: the call above was the AfterCalls=1 trigger; the
+	// counter therefore reports 1 (the running call count) on this
+	// very call. Subsequent calls report strictly larger values.
+	require.Equal(t, uint64(1), count, "first ECC poll: expected 1 (call count)")
 
 	count2, _ := dev.GetTotalEccErrors(nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.AGGREGATE_ECC)
-	if count2 <= count {
-		t.Fatalf("expected ECC count to grow with subsequent polls: %d -> %d", count, count2)
-	}
+	require.Greater(t, count2, count, "expected ECC count to grow with subsequent polls")
 
 	// Corrected counter stays zero — the failure is uncorrectable only.
-	if c, _ := dev.GetTotalEccErrors(nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.AGGREGATE_ECC); c != 0 {
-		t.Fatalf("corrected counter must stay zero, got %d", c)
-	}
+	c, _ := dev.GetTotalEccErrors(nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.AGGREGATE_ECC)
+	require.Zero(t, c, "corrected counter must stay zero")
 
 	// Per-location counter agrees on device memory.
 	loc, _ := dev.GetMemoryErrorCounter(nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_DEVICE_MEMORY)
-	if loc == 0 {
-		t.Fatalf("device-memory uncorrected counter must be > 0 after trip, got 0")
-	}
+	require.NotZero(t, loc, "device-memory uncorrected counter must be > 0 after trip")
 
 	// L1 cache (different location) stays at zero.
 	l1, _ := dev.GetMemoryErrorCounter(nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_L1_CACHE)
-	if l1 != 0 {
-		t.Fatalf("L1 cache counter must stay zero (we only inject device-memory errors), got %d", l1)
-	}
+	require.Zero(t, l1, "L1 cache counter must stay zero (we only inject device-memory errors)")
 
 	// Remapped rows surface the failure.
 	_, unc, _, failureOccurred, _ := dev.GetRemappedRows()
-	if unc == 0 || !failureOccurred {
-		t.Fatalf("expected non-zero uncorrectable rows + failure flag, got unc=%d failure=%v", unc, failureOccurred)
-	}
+	require.NotZero(t, unc, "expected non-zero uncorrectable rows")
+	require.True(t, failureOccurred, "expected failure flag")
 }
 
 func TestFailureInjection_ECC_DoesNotBlockHandleLookup(t *testing.T) {
@@ -407,13 +348,11 @@ func TestFailureInjection_ECC_DoesNotBlockHandleLookup(t *testing.T) {
 	_, _ = dev.GetTemperature(nvml.TEMPERATURE_GPU)
 
 	// Handle lookup MUST keep working — ecc_uncorrectable ≠ lost.
-	if _, ret := e.DeviceGetHandleByIndex(0); ret != nvml.SUCCESS {
-		t.Fatalf("ecc_uncorrectable must not affect handle lookup, got %v", ret)
-	}
+	_, ret := e.DeviceGetHandleByIndex(0)
+	require.Equal(t, nvml.SUCCESS, ret, "ecc_uncorrectable must not affect handle lookup")
 	// And so must other API calls.
-	if _, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU); ret != nvml.SUCCESS {
-		t.Fatalf("ecc_uncorrectable must not block GetTemperature, got %v", ret)
-	}
+	_, ret = dev.GetTemperature(nvml.TEMPERATURE_GPU)
+	require.Equal(t, nvml.SUCCESS, ret, "ecc_uncorrectable must not block GetTemperature")
 }
 
 // =============================================================================
@@ -423,12 +362,9 @@ func TestFailureInjection_ECC_DoesNotBlockHandleLookup(t *testing.T) {
 func TestFailureInjection_GetViolationStatus_HealthyReportsNoViolation(t *testing.T) {
 	dev := newTestDeviceWithConfig(t, healthyConfig())
 	vt, ret := dev.GetViolationStatus(nvml.PERF_POLICY_POWER)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("expected SUCCESS, got %v", ret)
-	}
-	if vt.ViolationTime != 0 || vt.ReferenceTime != 0 {
-		t.Fatalf("healthy device must report empty ViolationTime, got %+v", vt)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "expected SUCCESS")
+	require.Zero(t, vt.ViolationTime, "healthy device must report empty ViolationTime")
+	require.Zero(t, vt.ReferenceTime, "healthy device must report empty ReferenceTime")
 }
 
 func TestFailureInjection_GetViolationStatus_StaysSpecCompliantAfterTrip(t *testing.T) {
@@ -447,24 +383,17 @@ func TestFailureInjection_GetViolationStatus_StaysSpecCompliantAfterTrip(t *test
 	}))
 
 	// Trip the device with one guarded call.
-	if _, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU); ret != nvml.SUCCESS {
-		t.Fatalf("setup call 1: expected SUCCESS, got %v", ret)
-	}
+	_, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU)
+	require.Equal(t, nvml.SUCCESS, ret, "setup call 1")
 
 	// At this point the device has just tripped (AfterCalls=2 met by the
 	// SECOND tick, which is GetViolationStatus itself). It must NOT
 	// stuff the Xid into the violation_time field; both fields stay
 	// at their healthy zero values.
 	vt, ret := dev.GetViolationStatus(nvml.PERF_POLICY_POWER)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("expected SUCCESS, got %v", ret)
-	}
-	if vt.ViolationTime != 0 {
-		t.Fatalf("ViolationTime must be 0 ns post-trip (Xid no longer overloaded), got %d", vt.ViolationTime)
-	}
-	if vt.ReferenceTime != 0 {
-		t.Fatalf("ReferenceTime must be 0 ns post-trip, got %d", vt.ReferenceTime)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "expected SUCCESS")
+	require.Zero(t, vt.ViolationTime, "ViolationTime must be 0 ns post-trip (Xid no longer overloaded)")
+	require.Zero(t, vt.ReferenceTime, "ReferenceTime must be 0 ns post-trip")
 }
 
 func TestFailureInjection_GetViolationStatus_LostModeReturnsError(t *testing.T) {
@@ -475,9 +404,8 @@ func TestFailureInjection_GetViolationStatus_LostModeReturnsError(t *testing.T) 
 	// Mode without triggers ⇒ trips on first Tick(). GetViolationStatus
 	// is guarded, so the very first call returns the error code (we
 	// never get to populate the Xid in the response).
-	if _, ret := dev.GetViolationStatus(nvml.PERF_POLICY_POWER); ret != nvml.ERROR_GPU_IS_LOST {
-		t.Fatalf("expected ERROR_GPU_IS_LOST, got %v", ret)
-	}
+	_, ret := dev.GetViolationStatus(nvml.PERF_POLICY_POWER)
+	require.Equal(t, nvml.ERROR_GPU_IS_LOST, ret, "expected ERROR_GPU_IS_LOST")
 }
 
 // =============================================================================
@@ -499,14 +427,12 @@ func TestEngine_PendingXidEvent_NoneWhenHealthy(t *testing.T) {
 		},
 	}
 	e := NewEngine(cfg)
-	if ret := e.Init(); ret != nvml.SUCCESS {
-		t.Fatalf("engine init failed: %v", ret)
-	}
+	ret := e.Init()
+	require.Equal(t, nvml.SUCCESS, ret, "engine init failed")
 	t.Cleanup(func() { _ = e.Shutdown() })
 
-	if h, x, ok := e.PendingXidEvent(); ok {
-		t.Fatalf("healthy engine must not have pending Xid events, got handle=%v xid=%d", h, x)
-	}
+	_, _, ok := e.PendingXidEvent()
+	require.False(t, ok, "healthy engine must not have pending Xid events")
 }
 
 func TestEngine_PendingXidEvent_DeliveredOnceAfterTrip(t *testing.T) {
@@ -531,44 +457,32 @@ func TestEngine_PendingXidEvent_DeliveredOnceAfterTrip(t *testing.T) {
 		},
 	}
 	e := NewEngine(cfg)
-	if ret := e.Init(); ret != nvml.SUCCESS {
-		t.Fatalf("engine init failed: %v", ret)
-	}
+	ret := e.Init()
+	require.Equal(t, nvml.SUCCESS, ret, "engine init failed")
 	t.Cleanup(func() { _ = e.Shutdown() })
 
 	// Before any guarded call trips the device, no event is queued —
 	// PendingXidEvent must not synthesize one out of mere config.
-	if _, _, ok := e.PendingXidEvent(); ok {
-		t.Fatalf("pre-trip: PendingXidEvent must report no event")
-	}
+	_, _, ok := e.PendingXidEvent()
+	require.False(t, ok, "pre-trip: PendingXidEvent must report no event")
 
 	// Trip device 0 with a single guarded call (AfterCalls=1).
 	h0, _ := e.DeviceGetHandleByIndex(0)
 	dev0 := e.LookupDevice(h0).(*ConfigurableDevice)
-	if _, ret := dev0.GetTemperature(nvml.TEMPERATURE_GPU); ret != nvml.SUCCESS {
-		t.Fatalf("trip call: expected SUCCESS (ecc_uncorrectable doesn't error), got %v", ret)
-	}
+	_, ret = dev0.GetTemperature(nvml.TEMPERATURE_GPU)
+	require.Equal(t, nvml.SUCCESS, ret, "trip call: expected SUCCESS (ecc_uncorrectable doesn't error)")
 
 	// First wait delivers the Xid event with the right device handle.
 	gotHandle, gotXid, ok := e.PendingXidEvent()
-	if !ok {
-		t.Fatalf("post-trip: expected pending Xid event, got none")
-	}
-	if gotXid != 79 {
-		t.Fatalf("Xid: expected 79, got %d", gotXid)
-	}
-	if gotHandle == 0 {
-		t.Fatalf("expected non-zero device handle, got 0")
-	}
-	if gotHandle != h0 {
-		t.Fatalf("expected device handle for index 0 (%v), got %v", h0, gotHandle)
-	}
+	require.True(t, ok, "post-trip: expected pending Xid event, got none")
+	require.Equal(t, uint64(79), gotXid, "Xid")
+	require.NotZero(t, gotHandle, "expected non-zero device handle")
+	require.Equal(t, h0, gotHandle, "expected device handle for index 0")
 
 	// Second wait must NOT redeliver the same Xid (matches real NVML
 	// where each critical Xid fires exactly once per occurrence).
-	if _, _, ok := e.PendingXidEvent(); ok {
-		t.Fatalf("Xid must be delivered at most once; got duplicate event")
-	}
+	_, _, ok = e.PendingXidEvent()
+	require.False(t, ok, "Xid must be delivered at most once; got duplicate event")
 }
 
 func TestEngine_PendingXidEvent_NoEventWithoutXidConfig(t *testing.T) {
@@ -593,20 +507,17 @@ func TestEngine_PendingXidEvent_NoEventWithoutXidConfig(t *testing.T) {
 		},
 	}
 	e := NewEngine(cfg)
-	if ret := e.Init(); ret != nvml.SUCCESS {
-		t.Fatalf("engine init failed: %v", ret)
-	}
+	ret := e.Init()
+	require.Equal(t, nvml.SUCCESS, ret, "engine init failed")
 	t.Cleanup(func() { _ = e.Shutdown() })
 
 	h, _ := e.DeviceGetHandleByIndex(0)
 	dev := e.LookupDevice(h).(*ConfigurableDevice)
-	if _, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU); ret != nvml.SUCCESS {
-		t.Fatalf("trip call: %v", ret)
-	}
+	_, ret = dev.GetTemperature(nvml.TEMPERATURE_GPU)
+	require.Equal(t, nvml.SUCCESS, ret, "trip call")
 
-	if _, _, ok := e.PendingXidEvent(); ok {
-		t.Fatalf("Xid-less config must produce no event")
-	}
+	_, _, ok := e.PendingXidEvent()
+	require.False(t, ok, "Xid-less config must produce no event")
 }
 
 // =============================================================================
@@ -631,9 +542,8 @@ func TestFailureInjection_IdentityGettersFailWhenLost(t *testing.T) {
 		},
 	}
 	e := NewEngine(cfg)
-	if ret := e.Init(); ret != nvml.SUCCESS {
-		t.Fatalf("engine init failed: %v", ret)
-	}
+	ret := e.Init()
+	require.Equal(t, nvml.SUCCESS, ret, "engine init failed")
 	t.Cleanup(func() { _ = e.Shutdown() })
 
 	h, _ := e.DeviceGetHandleByIndex(0)
@@ -641,24 +551,18 @@ func TestFailureInjection_IdentityGettersFailWhenLost(t *testing.T) {
 
 	// Pre-trip: identity getters succeed (real NVML answers from the
 	// PCI subsystem before the kernel marks the device gone).
-	if _, ret := dev.GetUUID(); ret != nvml.SUCCESS {
-		t.Fatalf("pre-trip GetUUID: expected SUCCESS, got %v", ret)
-	}
-	if _, ret := dev.GetName(); ret != nvml.SUCCESS {
-		t.Fatalf("pre-trip GetName: expected SUCCESS, got %v", ret)
-	}
-	if _, ret := dev.GetIndex(); ret != nvml.SUCCESS {
-		t.Fatalf("pre-trip GetIndex: expected SUCCESS, got %v", ret)
-	}
-	if _, ret := dev.GetMinorNumber(); ret != nvml.SUCCESS {
-		t.Fatalf("pre-trip GetMinorNumber: expected SUCCESS, got %v", ret)
-	}
-	if _, ret := dev.GetPciInfo(); ret != nvml.SUCCESS {
-		t.Fatalf("pre-trip GetPciInfo: expected SUCCESS, got %v", ret)
-	}
-	if _, ret := dev.GetBrand(); ret != nvml.SUCCESS {
-		t.Fatalf("pre-trip GetBrand: expected SUCCESS, got %v", ret)
-	}
+	_, ret = dev.GetUUID()
+	require.Equal(t, nvml.SUCCESS, ret, "pre-trip GetUUID")
+	_, ret = dev.GetName()
+	require.Equal(t, nvml.SUCCESS, ret, "pre-trip GetName")
+	_, ret = dev.GetIndex()
+	require.Equal(t, nvml.SUCCESS, ret, "pre-trip GetIndex")
+	_, ret = dev.GetMinorNumber()
+	require.Equal(t, nvml.SUCCESS, ret, "pre-trip GetMinorNumber")
+	_, ret = dev.GetPciInfo()
+	require.Equal(t, nvml.SUCCESS, ret, "pre-trip GetPciInfo")
+	_, ret = dev.GetBrand()
+	require.Equal(t, nvml.SUCCESS, ret, "pre-trip GetBrand")
 
 	// Trip the device with two guarded calls.
 	for i := 1; i <= 2; i++ {
@@ -680,9 +584,7 @@ func TestFailureInjection_IdentityGettersFailWhenLost(t *testing.T) {
 		{"GetBrand", func() nvml.Return { _, r := dev.GetBrand(); return r }},
 	}
 	for _, tc := range tests {
-		if got := tc.fn(); got != nvml.ERROR_GPU_IS_LOST {
-			t.Errorf("post-trip %s: expected ERROR_GPU_IS_LOST, got %v", tc.name, got)
-		}
+		require.Equal(t, nvml.ERROR_GPU_IS_LOST, tc.fn(), "post-trip %s", tc.name)
 	}
 }
 
@@ -707,15 +609,11 @@ func TestFailureInjection_MergeDeviceOverride(t *testing.T) {
 
 	mergeDeviceOverride(&base, override)
 
-	if base.Failure == nil || base.Failure.Mode != FailureModeLost {
-		t.Fatalf("expected override to replace base.Failure with lost mode, got %+v", base.Failure)
-	}
-	if base.Failure.AfterCalls != 5 {
-		t.Fatalf("AfterCalls not propagated: got %d", base.Failure.AfterCalls)
-	}
-	if base.Failure.Xid == nil || base.Failure.Xid.Code != 79 {
-		t.Fatalf("Xid not propagated: %+v", base.Failure.Xid)
-	}
+	require.NotNil(t, base.Failure, "expected override to replace base.Failure")
+	require.Equal(t, FailureModeLost, base.Failure.Mode, "expected override to replace base.Failure with lost mode")
+	require.Equal(t, int64(5), base.Failure.AfterCalls, "AfterCalls not propagated")
+	require.NotNil(t, base.Failure.Xid, "Xid not propagated")
+	require.Equal(t, uint64(79), base.Failure.Xid.Code, "Xid not propagated")
 }
 
 // =============================================================================
@@ -726,12 +624,10 @@ func TestFailureInjection_HealthyConfigIsNoOp(t *testing.T) {
 	dev := newTestDeviceWithConfig(t, withFailure(&FailureInjectionConfig{
 		Mode: FailureModeHealthy,
 	}))
-	if dev.failure != nil {
-		t.Fatalf("healthy mode must not allocate a failureInjector, got %#v", dev.failure)
-	}
+	require.Nil(t, dev.failure, "healthy mode must not allocate a failureInjector")
 	for i := 0; i < 50; i++ {
-		if temp, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU); ret != nvml.SUCCESS || temp != 33 {
-			t.Fatalf("call %d: expected (33, SUCCESS), got (%d, %v)", i, temp, ret)
-		}
+		temp, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU)
+		require.Equal(t, nvml.SUCCESS, ret, "call %d", i)
+		require.Equal(t, uint32(33), temp, "call %d", i)
 	}
 }

--- a/pkg/gpu/mocknvml/engine/fuzz_test.go
+++ b/pkg/gpu/mocknvml/engine/fuzz_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func FuzzLoadYAMLConfig(f *testing.F) {
@@ -30,9 +32,7 @@ total_memory_mib: 40960
 		// Write fuzzed data to a temp file
 		dir := t.TempDir()
 		path := filepath.Join(dir, "config.yaml")
-		if err := os.WriteFile(path, data, 0644); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(path, data, 0644))
 		// LoadYAMLConfig should never panic on any input
 		_, _ = LoadYAMLConfig(path)
 	})

--- a/pkg/gpu/mocknvml/engine/handles_test.go
+++ b/pkg/gpu/mocknvml/engine/handles_test.go
@@ -20,16 +20,13 @@ import (
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock/dgxa100"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHandleTable_NewHandleTable(t *testing.T) {
 	ht := NewHandleTable()
-	if ht == nil {
-		t.Fatal("NewHandleTable returned nil")
-	}
-	if ht.Count() != 0 {
-		t.Errorf("Expected empty table, got count %d", ht.Count())
-	}
+	require.NotNil(t, ht, "NewHandleTable returned nil")
+	require.Equal(t, 0, ht.Count(), "Expected empty table")
 }
 
 func TestHandleTable_Register(t *testing.T) {
@@ -38,32 +35,20 @@ func TestHandleTable_Register(t *testing.T) {
 
 	// Register device
 	handle := ht.Register(dev)
-	if handle == 0 {
-		t.Error("Expected non-zero handle")
-	}
-	if ht.Count() != 1 {
-		t.Errorf("Expected count 1, got %d", ht.Count())
-	}
+	require.NotZero(t, handle, "Expected non-zero handle")
+	require.Equal(t, 1, ht.Count(), "Expected count 1")
 
 	// Register same device again - should return same handle
 	handle2 := ht.Register(dev)
-	if handle != handle2 {
-		t.Errorf("Expected same handle for same device, got %d and %d", handle, handle2)
-	}
-	if ht.Count() != 1 {
-		t.Errorf("Expected count to remain 1, got %d", ht.Count())
-	}
+	require.Equal(t, handle, handle2, "Expected same handle for same device")
+	require.Equal(t, 1, ht.Count(), "Expected count to remain 1")
 }
 
 func TestHandleTable_RegisterNil(t *testing.T) {
 	ht := NewHandleTable()
 	handle := ht.Register(nil)
-	if handle != 0 {
-		t.Errorf("Expected 0 handle for nil device, got %d", handle)
-	}
-	if ht.Count() != 0 {
-		t.Errorf("Expected count 0, got %d", ht.Count())
-	}
+	require.Zero(t, handle, "Expected 0 handle for nil device")
+	require.Equal(t, 0, ht.Count(), "Expected count 0")
 }
 
 func TestHandleTable_Lookup(t *testing.T) {
@@ -73,21 +58,15 @@ func TestHandleTable_Lookup(t *testing.T) {
 	// Register and lookup
 	handle := ht.Register(dev)
 	retrieved := ht.Lookup(handle)
-	if retrieved != dev {
-		t.Error("Lookup returned different device")
-	}
+	require.Equal(t, dev, retrieved, "Lookup returned different device")
 
 	// Lookup invalid handle - returns InvalidDeviceInstance (null-object pattern)
 	invalid := ht.Lookup(999)
-	if invalid != InvalidDeviceInstance {
-		t.Error("Expected InvalidDeviceInstance for invalid handle")
-	}
+	require.Equal(t, InvalidDeviceInstance, invalid, "Expected InvalidDeviceInstance for invalid handle")
 
 	// Lookup zero handle - returns InvalidDeviceInstance
 	zero := ht.Lookup(0)
-	if zero != InvalidDeviceInstance {
-		t.Error("Expected InvalidDeviceInstance for zero handle")
-	}
+	require.Equal(t, InvalidDeviceInstance, zero, "Expected InvalidDeviceInstance for zero handle")
 }
 
 func TestHandleTable_Clear(t *testing.T) {
@@ -98,23 +77,15 @@ func TestHandleTable_Clear(t *testing.T) {
 	handle1 := ht.Register(dev1)
 	handle2 := ht.Register(dev2)
 
-	if ht.Count() != 2 {
-		t.Errorf("Expected count 2, got %d", ht.Count())
-	}
+	require.Equal(t, 2, ht.Count(), "Expected count 2")
 
 	ht.Clear()
 
-	if ht.Count() != 0 {
-		t.Errorf("Expected count 0 after clear, got %d", ht.Count())
-	}
+	require.Equal(t, 0, ht.Count(), "Expected count 0 after clear")
 
 	// Lookup should return InvalidDeviceInstance after clear (null-object pattern)
-	if ht.Lookup(handle1) != InvalidDeviceInstance {
-		t.Error("Expected InvalidDeviceInstance after clear")
-	}
-	if ht.Lookup(handle2) != InvalidDeviceInstance {
-		t.Error("Expected InvalidDeviceInstance after clear")
-	}
+	require.Equal(t, InvalidDeviceInstance, ht.Lookup(handle1), "Expected InvalidDeviceInstance after clear")
+	require.Equal(t, InvalidDeviceInstance, ht.Lookup(handle2), "Expected InvalidDeviceInstance after clear")
 }
 
 func TestHandleTable_MultipleDevices(t *testing.T) {
@@ -129,25 +100,19 @@ func TestHandleTable_MultipleDevices(t *testing.T) {
 		handles[i] = ht.Register(devices[i])
 	}
 
-	if ht.Count() != MaxDevices {
-		t.Errorf("Expected count %d, got %d", MaxDevices, ht.Count())
-	}
+	require.Equal(t, MaxDevices, ht.Count(), "Expected count %d", MaxDevices)
 
 	// Verify all handles are unique
 	seen := make(map[uintptr]bool)
 	for _, h := range handles {
-		if seen[h] {
-			t.Errorf("Duplicate handle detected: %d", h)
-		}
+		require.False(t, seen[h], "Duplicate handle detected: %d", h)
 		seen[h] = true
 	}
 
 	// Verify all lookups work
 	for i, h := range handles {
 		retrieved := ht.Lookup(h)
-		if retrieved != devices[i] {
-			t.Errorf("Lookup failed for device %d", i)
-		}
+		require.Equal(t, devices[i], retrieved, "Lookup failed for device %d", i)
 	}
 }
 
@@ -173,13 +138,9 @@ func TestHandleTable_ConcurrentAccess(t *testing.T) {
 	wg.Wait()
 
 	// Due to MaxDevices limit, only MaxDevices registrations should succeed
-	if successCount != int32(MaxDevices) {
-		t.Errorf("Expected %d successful registrations, got %d", MaxDevices, successCount)
-	}
+	require.Equal(t, int32(MaxDevices), successCount, "Expected %d successful registrations", MaxDevices)
 
-	if ht.Count() != MaxDevices {
-		t.Errorf("Expected count %d, got %d", MaxDevices, ht.Count())
-	}
+	require.Equal(t, MaxDevices, ht.Count(), "Expected count %d", MaxDevices)
 }
 
 func TestHandleTable_ConcurrentRegisterAndLookup(t *testing.T) {
@@ -213,9 +174,7 @@ func TestHandleTable_ConcurrentRegisterAndLookup(t *testing.T) {
 	}
 	wg.Wait()
 
-	if lookupNilCount > 0 {
-		t.Errorf("Lookup returned nil %d times for valid handles", lookupNilCount)
-	}
+	require.Zero(t, lookupNilCount, "Lookup returned nil %d times for valid handles", lookupNilCount)
 }
 
 func TestHandleTable_ConcurrentClear(t *testing.T) {

--- a/pkg/gpu/mocknvml/engine/version_test.go
+++ b/pkg/gpu/mocknvml/engine/version_test.go
@@ -13,7 +13,11 @@
 
 package engine
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestCompareDriverVersions(t *testing.T) {
 	tests := []struct {
@@ -56,9 +60,7 @@ func TestCompareDriverVersions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := CompareDriverVersions(tt.a, tt.b)
-			if got != tt.want {
-				t.Errorf("CompareDriverVersions(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
-			}
+			require.Equal(t, tt.want, got, "CompareDriverVersions(%q, %q)", tt.a, tt.b)
 		})
 	}
 }
@@ -97,9 +99,7 @@ func TestFunctionAvailable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := FunctionAvailable(tt.funcName, tt.driverVersion)
-			if got != tt.want {
-				t.Errorf("FunctionAvailable(%q, %q) = %v, want %v", tt.funcName, tt.driverVersion, got, tt.want)
-			}
+			require.Equal(t, tt.want, got, "FunctionAvailable(%q, %q)", tt.funcName, tt.driverVersion)
 		})
 	}
 }
@@ -123,8 +123,7 @@ func TestFunctionRegistry_Coverage(t *testing.T) {
 
 	registry := GetFunctionRegistry()
 	for _, name := range expectedFunctions {
-		if _, ok := registry[name]; !ok {
-			t.Errorf("expected function %q not found in registry", name)
-		}
+		_, ok := registry[name]
+		require.True(t, ok, "expected function %q not found in registry", name)
 	}
 }

--- a/pkg/imexcoord/coord_test.go
+++ b/pkg/imexcoord/coord_test.go
@@ -18,45 +18,40 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestAllPeersReady_HappyPath(t *testing.T) {
 	dir := t.TempDir()
 	for _, ip := range []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"} {
-		if err := WriteMarker(dir, ip); err != nil {
-			t.Fatal(err)
-		}
+		err := WriteMarker(dir, ip)
+		require.NoError(t, err)
 	}
 	ok, missing := AllPeersReady(dir, []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"})
-	if !ok {
-		t.Fatalf("expected ready, got missing=%s", missing)
-	}
+	require.True(t, ok, "expected ready, got missing=%s", missing)
 }
 
 func TestAllPeersReady_MissingPeer(t *testing.T) {
 	dir := t.TempDir()
 	_ = WriteMarker(dir, "10.0.0.1")
 	ok, missing := AllPeersReady(dir, []string{"10.0.0.1", "10.0.0.99"})
-	if ok || missing != "10.0.0.99" {
-		t.Fatalf("expected missing=10.0.0.99 not-ready, got ok=%v missing=%q", ok, missing)
-	}
+	require.False(t, ok, "expected missing=10.0.0.99 not-ready, got ok=%v missing=%q", ok, missing)
+	require.Equal(t, "10.0.0.99", missing, "expected missing=10.0.0.99 not-ready, got ok=%v missing=%q", ok, missing)
 }
 
 func TestAllPeersReady_EmptyPeersTreatedAsReady(t *testing.T) {
-	if ok, _ := AllPeersReady(t.TempDir(), nil); !ok {
-		t.Fatal("empty peers should be ready")
-	}
+	ok, _ := AllPeersReady(t.TempDir(), nil)
+	require.True(t, ok, "empty peers should be ready")
 }
 
 func TestRemoveMarker_IsIdempotent(t *testing.T) {
 	dir := t.TempDir()
-	if err := RemoveMarker(dir, "10.0.0.1"); err != nil {
-		t.Fatalf("remove missing: %v", err)
-	}
+	err := RemoveMarker(dir, "10.0.0.1")
+	require.NoError(t, err, "remove missing")
 	_ = WriteMarker(dir, "10.0.0.1")
-	if err := RemoveMarker(dir, "10.0.0.1"); err != nil {
-		t.Fatalf("remove existing: %v", err)
-	}
+	err = RemoveMarker(dir, "10.0.0.1")
+	require.NoError(t, err, "remove existing")
 }
 
 func TestReadPeers_SkipsCommentsBlanksAndPort(t *testing.T) {
@@ -64,12 +59,10 @@ func TestReadPeers_SkipsCommentsBlanksAndPort(t *testing.T) {
 	path := filepath.Join(dir, "nodes.cfg")
 	_ = os.WriteFile(path, []byte("# header\n\n10.0.0.1\n10.0.0.2 50051\n  \n"), 0o644)
 	peers, err := ReadPeers(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(peers) != 2 || peers[0] != "10.0.0.1" || peers[1] != "10.0.0.2" {
-		t.Fatalf("unexpected peers: %v", peers)
-	}
+	require.NoError(t, err)
+	require.Len(t, peers, 2, "unexpected peers: %v", peers)
+	require.Equal(t, "10.0.0.1", peers[0], "unexpected peers: %v", peers)
+	require.Equal(t, "10.0.0.2", peers[1], "unexpected peers: %v", peers)
 }
 
 // TestWriteMarker_RejectsInvalidIP guards against path traversal via
@@ -92,12 +85,9 @@ func TestWriteMarker_RejectsInvalidIP(t *testing.T) {
 	for _, bad := range cases {
 		t.Run(bad, func(t *testing.T) {
 			err := WriteMarker(dir, bad)
-			if err == nil {
-				t.Fatalf("WriteMarker(%q) = nil, want validation error", bad)
-			}
-			if !strings.Contains(err.Error(), "invalid") && !strings.Contains(err.Error(), "empty") {
-				t.Errorf("WriteMarker(%q) error %q lacks 'invalid'/'empty' tag — looks like incidental filesystem failure rather than a validation reject", bad, err)
-			}
+			require.Error(t, err, "WriteMarker(%q) = nil, want validation error", bad)
+			require.True(t, strings.Contains(err.Error(), "invalid") || strings.Contains(err.Error(), "empty"),
+				"WriteMarker(%q) error %q lacks 'invalid'/'empty' tag — looks like incidental filesystem failure rather than a validation reject", bad, err)
 		})
 	}
 }
@@ -109,14 +99,9 @@ func TestWriteMarker_RejectsInvalidIP(t *testing.T) {
 // unintended path).
 func TestAllPeersReady_TreatsInvalidIPAsMissing(t *testing.T) {
 	dir := t.TempDir()
-	if err := WriteMarker(dir, "10.0.0.1"); err != nil {
-		t.Fatal(err)
-	}
+	err := WriteMarker(dir, "10.0.0.1")
+	require.NoError(t, err)
 	ok, missing := AllPeersReady(dir, []string{"10.0.0.1", "../etc/passwd"})
-	if ok {
-		t.Fatal("AllPeersReady with invalid peer returned ready=true")
-	}
-	if missing != "../etc/passwd" {
-		t.Errorf("missing = %q, want %q (the invalid peer)", missing, "../etc/passwd")
-	}
+	require.False(t, ok, "AllPeersReady with invalid peer returned ready=true")
+	require.Equal(t, "../etc/passwd", missing, "missing = %q, want %q (the invalid peer)", missing, "../etc/passwd")
 }

--- a/pkg/network/mockib/daemon/destlid_test.go
+++ b/pkg/network/mockib/daemon/destlid_test.go
@@ -6,6 +6,8 @@ package daemon
 import (
 	"encoding/base64"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // Captured from `ibping -c 1 3520` (dest LID 0x0dc0) via libibmockumad → mock-ib send RPC.
@@ -13,14 +15,8 @@ const ibpingLID3520MAD = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAEAAA3AAAAAAAAAAAAAAA
 
 func TestDestLID_RealIbpingSend(t *testing.T) {
 	mad, err := base64.StdEncoding.DecodeString(ibpingLID3520MAD)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	lid, ok := destLID(mad)
-	if !ok {
-		t.Fatal("destLID: not found")
-	}
-	if lid != 0x0dc0 {
-		t.Fatalf("destLID: got 0x%04x want 0x0dc0", lid)
-	}
+	require.True(t, ok, "destLID: not found")
+	require.Equal(t, uint16(0x0dc0), lid)
 }

--- a/pkg/network/mockib/daemon/discover_test.go
+++ b/pkg/network/mockib/daemon/discover_test.go
@@ -3,12 +3,14 @@
 
 package daemon
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestDiscoverPeerIPs_FiltersSelf(t *testing.T) {
 	// Unit test uses empty host; integration uses real DNS in cluster.
 	got := DiscoverPeerIPs("", "10.0.0.1")
-	if len(got) != 0 {
-		t.Fatalf("want empty, got %v", got)
-	}
+	require.Empty(t, got)
 }

--- a/pkg/network/mockib/daemon/env_test.go
+++ b/pkg/network/mockib/daemon/env_test.go
@@ -6,71 +6,46 @@ package daemon
 import (
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestEnvOr(t *testing.T) {
 	const key = "MOCK_IB_TEST_ENV_OR"
 	t.Setenv(key, "")
-	if got := EnvOr(key, "def"); got != "def" {
-		t.Fatalf("unset: got %q want def", got)
-	}
+	require.Equal(t, "def", EnvOr(key, "def"), "unset")
 	t.Setenv(key, "val")
-	if got := EnvOr(key, "def"); got != "val" {
-		t.Fatalf("set: got %q want val", got)
-	}
+	require.Equal(t, "val", EnvOr(key, "def"), "set")
 }
 
 func TestEnvIntOr(t *testing.T) {
 	const key = "MOCK_IB_TEST_ENV_INT"
 	t.Setenv(key, "")
-	if got := EnvIntOr(key, 42); got != 42 {
-		t.Fatalf("unset: got %d want 42", got)
-	}
+	require.Equal(t, 42, EnvIntOr(key, 42), "unset")
 	t.Setenv(key, "99")
-	if got := EnvIntOr(key, 42); got != 99 {
-		t.Fatalf("set: got %d want 99", got)
-	}
+	require.Equal(t, 99, EnvIntOr(key, 42), "set")
 	t.Setenv(key, "nope")
-	if got := EnvIntOr(key, 42); got != 42 {
-		t.Fatalf("invalid: got %d want 42", got)
-	}
+	require.Equal(t, 42, EnvIntOr(key, 42), "invalid")
 }
 
 func TestEnvBoolOr(t *testing.T) {
 	const key = "MOCK_IB_TEST_ENV_BOOL"
 	t.Setenv(key, "")
-	if got := EnvBoolOr(key, true); !got {
-		t.Fatal("unset default true: want true")
-	}
-	if got := EnvBoolOr(key, false); got {
-		t.Fatal("unset default false: want false")
-	}
+	require.True(t, EnvBoolOr(key, true), "unset default true: want true")
+	require.False(t, EnvBoolOr(key, false), "unset default false: want false")
 	for _, v := range []string{"1", "true", "TRUE"} {
 		t.Setenv(key, v)
-		if !EnvBoolOr(key, false) {
-			t.Fatalf("%q: want true", v)
-		}
+		require.True(t, EnvBoolOr(key, false), "%q: want true", v)
 	}
 	t.Setenv(key, "0")
-	if EnvBoolOr(key, true) {
-		t.Fatal("0: want false")
-	}
+	require.False(t, EnvBoolOr(key, true), "0: want false")
 }
 
 func TestParsePeerList(t *testing.T) {
-	if got := ParsePeerList(""); got != nil {
-		t.Fatalf("empty: got %v want nil", got)
-	}
+	require.Nil(t, ParsePeerList(""), "empty")
 	got := ParsePeerList(" 10.0.0.1 , , 10.0.0.2 ")
 	want := []string{"10.0.0.1", "10.0.0.2"}
-	if len(got) != len(want) {
-		t.Fatalf("got %v want %v", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("got %v want %v", got, want)
-		}
-	}
+	require.Equal(t, want, got)
 }
 
 func TestEnvOr_readsProcessEnv(t *testing.T) {
@@ -78,7 +53,5 @@ func TestEnvOr_readsProcessEnv(t *testing.T) {
 	if os.Getenv("PATH") == "" {
 		t.Skip("PATH unset in test environment")
 	}
-	if EnvOr("PATH", "") == "" {
-		t.Fatal("expected non-empty PATH")
-	}
+	require.NotEmpty(t, EnvOr("PATH", ""), "expected non-empty PATH")
 }

--- a/pkg/network/mockib/daemon/fabric_register_test.go
+++ b/pkg/network/mockib/daemon/fabric_register_test.go
@@ -13,33 +13,24 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/config"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/protocol"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/render"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServer_sendRegister(t *testing.T) {
 	dir := t.TempDir()
-	if err := render.Render(render.Options{
+	require.NoError(t, render.Render(render.Options{
 		IB: config.Infiniband{Enabled: true}, GPUCount: 1, NodeName: "node-a", Output: dir,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}))
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = ln.Close() }()
 	_, portStr, err := net.SplitHostPort(ln.Addr().String())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	tcpPort, err := strconv.Atoi(portStr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	srv, err := NewServer(Config{IBRoot: dir, TCPPort: tcpPort, Fabric: true}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go srv.acceptFabric(ctx, ln)
@@ -51,9 +42,7 @@ func TestServer_sendRegister(t *testing.T) {
 			{PortGUID: "a088:c203:00ab:2001", LID: 0x0300, CAName: "mlx5_0", Port: 1},
 		},
 	}
-	if err := srv.sendRegister("127.0.0.1", body); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, srv.sendRegister("127.0.0.1", body))
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
@@ -62,5 +51,5 @@ func TestServer_sendRegister(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatal("peer not registered")
+	require.Fail(t, "peer not registered")
 }

--- a/pkg/network/mockib/daemon/fabric_test.go
+++ b/pkg/network/mockib/daemon/fabric_test.go
@@ -17,19 +17,16 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/registry"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/render"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/sysfs"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFabric_RegisterAndPingHandler(t *testing.T) {
 	dir := t.TempDir()
-	if err := render.Render(render.Options{
+	require.NoError(t, render.Render(render.Options{
 		IB: config.Infiniband{Enabled: true}, GPUCount: 2, NodeName: "node-a", Output: dir,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}))
 	ports, err := sysfs.Scan(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	srv := &Server{
 		cfg:        Config{TCPPort: 0, Fabric: true},
@@ -45,9 +42,7 @@ func TestFabric_RegisterAndPingHandler(t *testing.T) {
 	defer func() { _ = ln.Close() }()
 
 	conn, err := net.Dial("tcp", ln.Addr().String())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = conn.Close() }()
 
 	remotePorts := []protocol.PortAdvert{{
@@ -56,63 +51,42 @@ func TestFabric_RegisterAndPingHandler(t *testing.T) {
 		Port:     1,
 		LID:      0x0200,
 	}}
-	if err := protocol.WriteMessage(conn, protocol.TypeRegister, protocol.RegisterBody{
+	require.NoError(t, protocol.WriteMessage(conn, protocol.TypeRegister, protocol.RegisterBody{
 		NodeName: "node-b",
 		PodIP:    "10.0.0.2",
 		Ports:    remotePorts,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}))
 
-	if err := protocol.WriteMessage(conn, protocol.TypePing, protocol.PingBody{
+	require.NoError(t, protocol.WriteMessage(conn, protocol.TypePing, protocol.PingBody{
 		DstPortGUID: ports[0].PortGUID,
 		Seq:         42,
 		ClientTS:    time.Now().UnixNano(),
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}))
 	var env protocol.Envelope
-	if err := protocol.ReadEnvelope(conn, &env); err != nil {
-		t.Fatal(err)
-	}
-	if env.Type != protocol.TypePong {
-		t.Fatalf("type: got %q want %q", env.Type, protocol.TypePong)
-	}
+	require.NoError(t, protocol.ReadEnvelope(conn, &env))
+	require.Equal(t, protocol.TypePong, env.Type, "type")
 	var pong protocol.PongBody
-	if err := protocol.DecodeBody(env, &pong); err != nil {
-		t.Fatal(err)
-	}
-	if pong.Seq != 42 {
-		t.Fatalf("pong seq: got %d want 42", pong.Seq)
-	}
+	require.NoError(t, protocol.DecodeBody(env, &pong))
+	require.Equal(t, uint32(42), pong.Seq, "pong seq")
 
 	peer, ok := srv.registry.Lookup("a088:c203:00ab:00ff")
-	if !ok || peer.PodIP != "10.0.0.2" {
-		t.Fatalf("register lookup failed: %+v ok=%v", peer, ok)
-	}
+	require.True(t, ok, "register lookup failed: %+v", peer)
+	require.Equal(t, "10.0.0.2", peer.PodIP, "register lookup failed: %+v", peer)
 }
 
 func TestFabric_RemoteSendForwardsPing(t *testing.T) {
 	dirA := t.TempDir()
 	dirB := t.TempDir()
-	if err := render.Render(render.Options{
+	require.NoError(t, render.Render(render.Options{
 		IB: config.Infiniband{Enabled: true}, GPUCount: 2, NodeName: "node-a", Output: dirA,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if err := render.Render(render.Options{
+	}))
+	require.NoError(t, render.Render(render.Options{
 		IB: config.Infiniband{Enabled: true}, GPUCount: 2, NodeName: "node-b", Output: dirB,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}))
 	portsA, err := sysfs.Scan(dirA)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	portsB, err := sysfs.Scan(dirB)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	server := &Server{
 		cfg:        Config{TCPPort: 0, Fabric: true},
@@ -147,31 +121,19 @@ func TestFabric_RemoteSendForwardsPing(t *testing.T) {
 
 	h := &portHandle{caName: portsB[0].CAName, port: portsB[0].Port}
 	sendMad := madtest.PingMAD(portsA[0])
-	if !client.tryFabricSend(h, sendMad) {
-		t.Fatal("tryFabricSend: expected remote ping success")
-	}
-	if len(h.recvQ) != 1 {
-		t.Fatalf("recvQ len: got %d want 1", len(h.recvQ))
-	}
-	if h.recvQ[0][umadMADOffset+ibMADMethodOff]&0x80 == 0 {
-		t.Fatal("expected response method bit set on synthesized MAD")
-	}
+	require.True(t, client.tryFabricSend(h, sendMad), "tryFabricSend: expected remote ping success")
+	require.Len(t, h.recvQ, 1, "recvQ len")
+	require.NotZero(t, h.recvQ[0][umadMADOffset+ibMADMethodOff]&0x80, "expected response method bit set on synthesized MAD")
 }
 
 func startTestFabricListener(t *testing.T, srv *Server) net.Listener {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, portStr, err := net.SplitHostPort(ln.Addr().String())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	srv.cfg.TCPPort = port
 	go srv.acceptFabric(context.Background(), ln)
 	return ln

--- a/pkg/network/mockib/daemon/loopback_test.go
+++ b/pkg/network/mockib/daemon/loopback_test.go
@@ -11,46 +11,33 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/daemon/madtest"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/render"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/sysfs"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoopback_ShouldQueueRecv_LocalGUID(t *testing.T) {
 	dir := t.TempDir()
 	ib := config.Infiniband{Enabled: true}
-	if err := render.Render(render.Options{IB: ib, GPUCount: 2, NodeName: "node-a", Output: dir}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, render.Render(render.Options{IB: ib, GPUCount: 2, NodeName: "node-a", Output: dir}))
 	ports, err := sysfs.Scan(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	lb := NewLoopback(ports)
 	mad := madtest.PingMAD(ports[0])
-	if !lb.ShouldQueueRecv(mad) {
-		t.Fatalf("want queue for local ping; port=%+v", ports[0])
-	}
+	require.True(t, lb.ShouldQueueRecv(mad), "want queue for local ping; port=%+v", ports[0])
 }
 
 func TestLoopback_ShouldNotQueueRecv_RemoteLID(t *testing.T) {
 	dir := t.TempDir()
 	ib := config.Infiniband{Enabled: true}
-	if err := render.Render(render.Options{IB: ib, GPUCount: 2, NodeName: "node-a", Output: dir}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, render.Render(render.Options{IB: ib, GPUCount: 2, NodeName: "node-a", Output: dir}))
 	ports, err := sysfs.Scan(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	lb := NewLoopback(ports)
 	remote := make([]byte, 72)
 	binary.BigEndian.PutUint16(remote[umadLIDOffset:], ports[0].LID+0x100)
-	if lb.ShouldQueueRecv(remote) {
-		t.Fatal("should not loopback echo for non-local destination LID")
-	}
+	require.False(t, lb.ShouldQueueRecv(remote), "should not loopback echo for non-local destination LID")
 }
 
 func TestLoopback_umadMADOffsetMatchesShim(t *testing.T) {
 	const want = 56 // libibumad umad_get_mad() offset; see c/umad_shim.c MOCK_UMAD_HDR_SZ
-	if umadMADOffset != want {
-		t.Fatalf("umadMADOffset = %d, want %d (libibumad header size)", umadMADOffset, want)
-	}
+	require.Equal(t, want, umadMADOffset, "umadMADOffset (libibumad header size)")
 }

--- a/pkg/network/mockib/daemon/render_sysfs_test.go
+++ b/pkg/network/mockib/daemon/render_sysfs_test.go
@@ -7,47 +7,39 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestRenderSysfsFromConfig_disabled(t *testing.T) {
 	dir := t.TempDir()
 	cfg := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(cfg, []byte("infiniband:\n  enabled: false\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(cfg, []byte("infiniband:\n  enabled: false\n"), 0o644))
 	out := filepath.Join(dir, "ib")
-	if err := RenderSysfsFromConfig(RenderSysfsOptions{
+	require.NoError(t, RenderSysfsFromConfig(RenderSysfsOptions{
 		ConfigPath: cfg,
 		OutputDir:  out,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := os.Stat(filepath.Join(out, "sys/class/infiniband")); err == nil {
-		t.Fatal("expected no sysfs tree when infiniband.enabled=false")
-	}
+	}))
+	_, err := os.Stat(filepath.Join(out, "sys/class/infiniband"))
+	require.Error(t, err, "expected no sysfs tree when infiniband.enabled=false")
 }
 
 func TestRenderSysfsFromConfig_enabled(t *testing.T) {
 	dir := t.TempDir()
 	cfg := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(cfg, []byte(`
+	require.NoError(t, os.WriteFile(cfg, []byte(`
 infiniband:
   enabled: true
   hca_count: 1
-`), 0o644); err != nil {
-		t.Fatal(err)
-	}
+`), 0o644))
 	out := filepath.Join(dir, "ib")
-	if err := RenderSysfsFromConfig(RenderSysfsOptions{
+	require.NoError(t, RenderSysfsFromConfig(RenderSysfsOptions{
 		ConfigPath: cfg,
 		GPUCount:   2,
 		NodeName:   "node-a",
 		OutputDir:  out,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}))
 	lidPath := filepath.Join(out, "sys/class/infiniband/mlx5_0/ports/1/lid")
-	if _, err := os.Stat(lidPath); err != nil {
-		t.Fatalf("missing rendered lid: %v", err)
-	}
+	_, err := os.Stat(lidPath)
+	require.NoError(t, err, "missing rendered lid")
 }

--- a/pkg/network/mockib/daemon/sa_capture_test.go
+++ b/pkg/network/mockib/daemon/sa_capture_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/registry"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/render"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/sysfs"
+	"github.com/stretchr/testify/require"
 )
 
 // Built from ibping -G LIBIBMAD_DEBUG_LEVEL=3 xdump (MAD payload rows at umad offset 64).
@@ -35,19 +36,13 @@ const ibpingSAPathSendHex = "" +
 
 func TestSAPathQuery_IbpingCapture(t *testing.T) {
 	madPayload, err := hex.DecodeString(ibpingSAPathSendHex)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(madPayload) != 256 {
-		t.Fatalf("payload len: got %d want 256", len(madPayload))
-	}
+	require.NoError(t, err)
+	require.Len(t, madPayload, 256, "payload len")
 	umad := make([]byte, umadMADOffset+len(madPayload))
 	copy(umad[umadMADOffset:], madPayload)
 	binary.BigEndian.PutUint16(umad[umadLIDOffset:], 0x0001)
 
-	if !isSAPathRecordGet(umad) {
-		t.Fatal("isSAPathRecordGet: want true for captured ibping SA GET")
-	}
+	require.True(t, isSAPathRecordGet(umad), "isSAPathRecordGet: want true for captured ibping SA GET")
 
 	// The recorded SA GET targets port GUID a088:c203:00ab:2001 (the DGID in
 	// the hex above). Register that exact GUID so the test pins SA PathRecord
@@ -58,11 +53,9 @@ func TestSAPathQuery_IbpingCapture(t *testing.T) {
 	const capturedTargetLID uint16 = 0x0201
 
 	dirB := t.TempDir()
-	if err := render.Render(render.Options{
+	require.NoError(t, render.Render(render.Options{
 		IB: config.Infiniband{Enabled: true}, GPUCount: 2, NodeName: "nvml-mock-demo-worker2", Output: dirB,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}))
 	portsB, _ := sysfs.Scan(dirB)
 
 	client := &Server{
@@ -75,22 +68,12 @@ func TestSAPathQuery_IbpingCapture(t *testing.T) {
 	})
 
 	h := &portHandle{}
-	if !client.trySAPathQuery(h, umad) {
-		t.Fatal("trySAPathQuery: want true")
-	}
-	if len(h.recvQ) != 1 {
-		t.Fatalf("recvQ len: got %d want 1", len(h.recvQ))
-	}
+	require.True(t, client.trySAPathQuery(h, umad), "trySAPathQuery: want true")
+	require.Len(t, h.recvQ, 1, "recvQ len")
 	dlidOff, _ := pathRecordDLIDOffset(h.recvQ[0][umadMADOffset:])
 	gotLID := binary.BigEndian.Uint16(h.recvQ[0][umadMADOffset+dlidOff:])
-	if gotLID != capturedTargetLID {
-		t.Fatalf("dlid: got 0x%04x want 0x%04x", gotLID, capturedTargetLID)
-	}
+	require.Equal(t, capturedTargetLID, gotLID, "dlid")
 	mad := h.recvQ[0][umadMADOffset:]
-	if got, want := mad[8:16], umad[umadMADOffset+8:umadMADOffset+16]; string(got) != string(want) {
-		t.Fatalf("TRID bytes 8-15: got %x want %x", got, want)
-	}
-	if !saMethodResponseSet(mad) {
-		t.Fatal("expected GET response bit on SA method byte")
-	}
+	require.Equal(t, umad[umadMADOffset+8:umadMADOffset+16], mad[8:16], "TRID bytes 8-15")
+	require.True(t, saMethodResponseSet(mad), "expected GET response bit on SA method byte")
 }

--- a/pkg/network/mockib/daemon/sa_method_test.go
+++ b/pkg/network/mockib/daemon/sa_method_test.go
@@ -6,15 +6,16 @@ package daemon
 import (
 	"encoding/binary"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestPathRecordAttrOffset(t *testing.T) {
 	mad := make([]byte, 128)
 	binary.BigEndian.PutUint16(mad[24:26], ibSAAttrPathRecord)
 	off, ok := pathRecordAttrOffset(mad)
-	if !ok || off != 24 {
-		t.Fatalf("got off=%d ok=%v", off, ok)
-	}
+	require.True(t, ok, "got off=%d ok=%v", off, ok)
+	require.Equal(t, 24, off, "got off=%d ok=%v", off, ok)
 }
 
 func TestPathRecordDGIDOffset_RMPP(t *testing.T) {
@@ -22,18 +23,16 @@ func TestPathRecordDGIDOffset_RMPP(t *testing.T) {
 	binary.BigEndian.PutUint16(mad[24:26], ibSAAttrPathRecord)
 	copy(mad[72:74], []byte{0xfe, 0x80})
 	off, ok := pathRecordDGIDOffset(mad)
-	if !ok || off != 72 {
-		t.Fatalf("got off=%d ok=%v", off, ok)
-	}
+	require.True(t, ok, "got off=%d ok=%v", off, ok)
+	require.Equal(t, 72, off, "got off=%d ok=%v", off, ok)
 }
 
 func TestPathRecordDGIDOffset_Fixed(t *testing.T) {
 	mad := make([]byte, ibPathRecDGIDOff+16)
 	copy(mad[ibPathRecDGIDOff:ibPathRecDGIDOff+2], []byte{0xfe, 0x80})
 	off, ok := pathRecordDGIDOffset(mad)
-	if !ok || off != ibPathRecDGIDOff {
-		t.Fatalf("got off=%d ok=%v", off, ok)
-	}
+	require.True(t, ok, "got off=%d ok=%v", off, ok)
+	require.Equal(t, ibPathRecDGIDOff, off, "got off=%d ok=%v", off, ok)
 }
 
 func TestSetSAMethodResponse(t *testing.T) {
@@ -81,9 +80,7 @@ func TestSetSAMethodResponse(t *testing.T) {
 			mad := make([]byte, 128)
 			tc.setup(mad)
 			setSAMethodResponse(mad)
-			if !tc.check(mad) {
-				t.Fatalf("check failed for %x", mad[:32])
-			}
+			require.True(t, tc.check(mad), "check failed for %x", mad[:32])
 		})
 	}
 }
@@ -93,7 +90,5 @@ func TestSynthesizeSAPathRecordResp_PreservesTRID(t *testing.T) {
 	copy(send[umadMADOffset+8:umadMADOffset+16], []byte{1, 2, 3, 4, 5, 6, 7, 8})
 	resp := synthesizeSAPathRecordResp(send, 0x0300)
 	mad := resp[umadMADOffset:]
-	if got, want := mad[8:16], send[umadMADOffset+8:umadMADOffset+16]; string(got) != string(want) {
-		t.Fatalf("TRID: got %x want %x", got, want)
-	}
+	require.Equal(t, send[umadMADOffset+8:umadMADOffset+16], mad[8:16], "TRID")
 }

--- a/pkg/network/mockib/daemon/sa_test.go
+++ b/pkg/network/mockib/daemon/sa_test.go
@@ -13,19 +13,16 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/registry"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/render"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/sysfs"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSAPathQuery_LocalPort(t *testing.T) {
 	dir := t.TempDir()
-	if err := render.Render(render.Options{
+	require.NoError(t, render.Render(render.Options{
 		IB: config.Infiniband{Enabled: true}, GPUCount: 2, NodeName: "node-a", Output: dir,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}))
 	ports, err := sysfs.Scan(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	srv := &Server{
 		localPorts: ports,
 		loopback:   NewLoopback(ports),
@@ -34,40 +31,26 @@ func TestSAPathQuery_LocalPort(t *testing.T) {
 	dgid := gidBytesForPort(t, ports[0].DefaultGID)
 	send := madtest.SAPathQueryMAD(dgid)
 	h := &portHandle{}
-	if !srv.trySAPathQuery(h, send) {
-		t.Fatal("expected SA path query handled")
-	}
-	if len(h.recvQ) != 1 {
-		t.Fatalf("recvQ len: got %d want 1", len(h.recvQ))
-	}
+	require.True(t, srv.trySAPathQuery(h, send), "expected SA path query handled")
+	require.Len(t, h.recvQ, 1, "recvQ len")
 	dlidOff, _ := pathRecordDLIDOffset(h.recvQ[0][umadMADOffset:])
 	gotLID := binary.BigEndian.Uint16(h.recvQ[0][umadMADOffset+dlidOff:])
-	if gotLID != ports[0].LID {
-		t.Fatalf("dlid: got 0x%04x want 0x%04x", gotLID, ports[0].LID)
-	}
+	require.Equal(t, ports[0].LID, gotLID, "dlid")
 	resp := h.recvQ[0][umadMADOffset:]
-	if resp[20]&0x80 == 0 {
-		t.Fatalf("SA GET response bit not set on method byte: 0x%02x", resp[20])
-	}
+	require.NotZero(t, resp[20]&0x80, "SA GET response bit not set on method byte: 0x%02x", resp[20])
 	// libibmad _do_madrpc matches TRID at MAD bytes 8-15; must not be corrupted by method scan.
-	if got, want := resp[8:16], send[umadMADOffset+8:umadMADOffset+16]; string(got) != string(want) {
-		t.Fatalf("TRID bytes 8-15: got %x want %x", got, want)
-	}
+	require.Equal(t, send[umadMADOffset+8:umadMADOffset+16], resp[8:16], "TRID bytes 8-15")
 }
 
 func TestSAPathQuery_RemoteViaRegistry(t *testing.T) {
 	dirA := t.TempDir()
 	dirB := t.TempDir()
-	if err := render.Render(render.Options{
+	require.NoError(t, render.Render(render.Options{
 		IB: config.Infiniband{Enabled: true}, GPUCount: 2, NodeName: "node-a", Output: dirA,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if err := render.Render(render.Options{
+	}))
+	require.NoError(t, render.Render(render.Options{
 		IB: config.Infiniband{Enabled: true}, GPUCount: 2, NodeName: "node-b", Output: dirB,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}))
 	portsA, _ := sysfs.Scan(dirA)
 	portsB, _ := sysfs.Scan(dirB)
 
@@ -83,14 +66,10 @@ func TestSAPathQuery_RemoteViaRegistry(t *testing.T) {
 	dgid := gidBytesForPort(t, portsA[0].DefaultGID)
 	send := madtest.SAPathQueryMAD(dgid)
 	h := &portHandle{}
-	if !client.trySAPathQuery(h, send) {
-		t.Fatal("expected remote SA path query handled")
-	}
+	require.True(t, client.trySAPathQuery(h, send), "expected remote SA path query handled")
 	dlidOff, _ := pathRecordDLIDOffset(h.recvQ[0][umadMADOffset:])
 	gotLID := binary.BigEndian.Uint16(h.recvQ[0][umadMADOffset+dlidOff:])
-	if gotLID != portsA[0].LID {
-		t.Fatalf("dlid: got 0x%04x want 0x%04x", gotLID, portsA[0].LID)
-	}
+	require.Equal(t, portsA[0].LID, gotLID, "dlid")
 }
 
 func gidBytesForPort(t *testing.T, gidStr string) []byte {

--- a/pkg/network/mockib/daemon/server_smp_test.go
+++ b/pkg/network/mockib/daemon/server_smp_test.go
@@ -16,23 +16,20 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/protocol"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/render"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/subnet"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServer_SMPPortInfoSelfResolveShort(t *testing.T) {
 	dir := t.TempDir()
-	if err := render.Render(render.Options{
+	require.NoError(t, render.Render(render.Options{
 		IB: config.Infiniband{Enabled: true}, GPUCount: 2, NodeName: "node-a", Output: dir,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}))
 	safe := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
 	sock := filepath.Join(os.TempDir(), "mock-ib-"+safe+".sock")
 	t.Cleanup(func() { _ = os.Remove(sock) })
 
 	srv, err := NewServer(Config{SocketPath: sock, IBRoot: dir, Fabric: true}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)
@@ -40,25 +37,15 @@ func TestServer_SMPPortInfoSelfResolveShort(t *testing.T) {
 	waitForSocket(t, sock, errCh)
 
 	conn, err := net.Dial("unix", sock)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = conn.Close() }()
 
-	if err := protocol.WriteMessage(conn, protocol.TypeOpen, protocol.OpenReq{CAName: "mlx5_0", Port: 1}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, protocol.WriteMessage(conn, protocol.TypeOpen, protocol.OpenReq{CAName: "mlx5_0", Port: 1}))
 	var env protocol.Envelope
-	if err := protocol.ReadEnvelope(conn, &env); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, protocol.ReadEnvelope(conn, &env))
 	var openResp protocol.OpenResp
-	if err := protocol.DecodeBody(env, &openResp); err != nil {
-		t.Fatal(err)
-	}
-	if openResp.Handle == 0 {
-		t.Fatalf("open: %+v", openResp)
-	}
+	require.NoError(t, protocol.DecodeBody(env, &openResp))
+	require.NotZero(t, openResp.Handle, "open: %+v", openResp)
 
 	send := make([]byte, umadMADOffset+64)
 	mad := send[umadMADOffset:]
@@ -71,64 +58,41 @@ func TestServer_SMPPortInfoSelfResolveShort(t *testing.T) {
 	binary.BigEndian.PutUint16(mad[16:18], 0x0015)
 	subnet.SetField(mad, 32, 8, 0)
 
-	if err := protocol.WriteMessage(conn, protocol.TypeSend, protocol.SendReq{
+	require.NoError(t, protocol.WriteMessage(conn, protocol.TypeSend, protocol.SendReq{
 		Handle: openResp.Handle,
 		MAD:    send,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if err := protocol.ReadEnvelope(conn, &env); err != nil {
-		t.Fatal(err)
-	}
+	}))
+	require.NoError(t, protocol.ReadEnvelope(conn, &env))
 	var sendResp protocol.SendResp
-	if err := protocol.DecodeBody(env, &sendResp); err != nil {
-		t.Fatal(err)
-	}
-	if !sendResp.OK {
-		t.Fatalf("send: %+v", sendResp)
-	}
+	require.NoError(t, protocol.DecodeBody(env, &sendResp))
+	require.True(t, sendResp.OK, "send: %+v", sendResp)
 
-	if err := protocol.WriteMessage(conn, protocol.TypeRecv, protocol.RecvReq{
+	require.NoError(t, protocol.WriteMessage(conn, protocol.TypeRecv, protocol.RecvReq{
 		Handle: openResp.Handle, TimeoutMS: 500,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if err := protocol.ReadEnvelope(conn, &env); err != nil {
-		t.Fatal(err)
-	}
+	}))
+	require.NoError(t, protocol.ReadEnvelope(conn, &env))
 	var recvResp protocol.RecvResp
-	if err := protocol.DecodeBody(env, &recvResp); err != nil {
-		t.Fatal(err)
-	}
-	if recvResp.Timeout || len(recvResp.MAD) < umadMADOffset+128 {
-		t.Fatalf("recv: timeout=%v len=%d", recvResp.Timeout, len(recvResp.MAD))
-	}
+	require.NoError(t, protocol.DecodeBody(env, &recvResp))
+	require.False(t, recvResp.Timeout, "recv: timeout=%v len=%d", recvResp.Timeout, len(recvResp.MAD))
+	require.GreaterOrEqual(t, len(recvResp.MAD), umadMADOffset+128, "recv: timeout=%v len=%d", recvResp.Timeout, len(recvResp.MAD))
 	pl := recvResp.MAD[umadMADOffset+64:]
 	lid := subnet.GetFieldSpec(pl, 128, 16)
 	phys := subnet.GetFieldSpec(pl, 264, 4)
-	if lid == 0 || lid == 1 {
-		t.Fatalf("base lid: got %#x (likely echo/SMLid, not synthesized)", lid)
-	}
-	if phys != 5 {
-		t.Fatalf("phys state: got %d want 5 (LINKUP)", phys)
-	}
+	require.NotContains(t, []uint32{0, 1}, lid, "base lid: got %#x (likely echo/SMLid, not synthesized)", lid)
+	require.Equal(t, uint32(5), phys, "phys state: want 5 (LINKUP)")
 }
 
 func TestServer_SMPNodeInfoThenPortInfo(t *testing.T) {
 	dir := t.TempDir()
-	if err := render.Render(render.Options{
+	require.NoError(t, render.Render(render.Options{
 		IB: config.Infiniband{Enabled: true}, GPUCount: 2, NodeName: "node-a", Output: dir,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}))
 	safe := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
 	sock := filepath.Join(os.TempDir(), "mock-ib-"+safe+".sock")
 	t.Cleanup(func() { _ = os.Remove(sock) })
 
 	srv, err := NewServer(Config{SocketPath: sock, IBRoot: dir, Fabric: true}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)
@@ -136,22 +100,15 @@ func TestServer_SMPNodeInfoThenPortInfo(t *testing.T) {
 	waitForSocket(t, sock, errCh)
 
 	conn, err := net.Dial("unix", sock)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = conn.Close() }()
 
 	var env protocol.Envelope
-	if err := protocol.WriteMessage(conn, protocol.TypeOpen, protocol.OpenReq{CAName: "mlx5_0", Port: 1}); err != nil {
-		t.Fatal(err)
-	}
-	if err := protocol.ReadEnvelope(conn, &env); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, protocol.WriteMessage(conn, protocol.TypeOpen, protocol.OpenReq{CAName: "mlx5_0", Port: 1}))
+	require.NoError(t, protocol.ReadEnvelope(conn, &env))
 	var openResp protocol.OpenResp
-	if err := protocol.DecodeBody(env, &openResp); err != nil || openResp.Handle == 0 {
-		t.Fatalf("open: %+v err=%v", openResp, err)
-	}
+	require.NoError(t, protocol.DecodeBody(env, &openResp))
+	require.NotZero(t, openResp.Handle, "open: %+v", openResp)
 	handle := openResp.Handle
 
 	smpSendRecv := func(attr uint16) []byte {
@@ -165,39 +122,23 @@ func TestServer_SMPNodeInfoThenPortInfo(t *testing.T) {
 		mad[2] = 0x01 // ClassVersion
 		mad[3] = 0x01 // Method = Get
 		binary.BigEndian.PutUint16(mad[16:18], attr)
-		if err := protocol.WriteMessage(conn, protocol.TypeSend, protocol.SendReq{Handle: handle, MAD: send}); err != nil {
-			t.Fatal(err)
-		}
-		if err := protocol.ReadEnvelope(conn, &env); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, protocol.WriteMessage(conn, protocol.TypeSend, protocol.SendReq{Handle: handle, MAD: send}))
+		require.NoError(t, protocol.ReadEnvelope(conn, &env))
 		var sendResp protocol.SendResp
-		if err := protocol.DecodeBody(env, &sendResp); err != nil || !sendResp.OK {
-			t.Fatalf("send: %+v", sendResp)
-		}
-		if err := protocol.WriteMessage(conn, protocol.TypeRecv, protocol.RecvReq{Handle: handle, TimeoutMS: 500}); err != nil {
-			t.Fatal(err)
-		}
-		if err := protocol.ReadEnvelope(conn, &env); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, protocol.DecodeBody(env, &sendResp))
+		require.True(t, sendResp.OK, "send: %+v", sendResp)
+		require.NoError(t, protocol.WriteMessage(conn, protocol.TypeRecv, protocol.RecvReq{Handle: handle, TimeoutMS: 500}))
+		require.NoError(t, protocol.ReadEnvelope(conn, &env))
 		var recvResp protocol.RecvResp
-		if err := protocol.DecodeBody(env, &recvResp); err != nil {
-			t.Fatal(err)
-		}
-		if recvResp.Timeout || len(recvResp.MAD) == 0 {
-			t.Fatalf("recv: %+v", recvResp)
-		}
+		require.NoError(t, protocol.DecodeBody(env, &recvResp))
+		require.False(t, recvResp.Timeout, "recv: %+v", recvResp)
+		require.NotZero(t, len(recvResp.MAD), "recv: %+v", recvResp)
 		return recvResp.MAD
 	}
 
 	_ = smpSendRecv(0x0011)
 	port := smpSendRecv(0x0015)
 	pl := port[umadMADOffset+64:]
-	if got := subnet.GetFieldSpec(pl, 264, 4); got != 5 {
-		t.Fatalf("PORT_INFO phys: got %d want 5", got)
-	}
-	if got := subnet.GetFieldSpec(pl, 128, 16); got == 0 || got == 1 {
-		t.Fatalf("PORT_INFO lid: got %#x", got)
-	}
+	require.Equal(t, uint32(5), subnet.GetFieldSpec(pl, 264, 4), "PORT_INFO phys: want 5")
+	require.NotContains(t, []uint32{0, 1}, subnet.GetFieldSpec(pl, 128, 16), "PORT_INFO lid")
 }

--- a/pkg/network/mockib/daemon/server_test.go
+++ b/pkg/network/mockib/daemon/server_test.go
@@ -19,23 +19,20 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/protocol"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/render"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/sysfs"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServer_LoopbackOpenSendRecv(t *testing.T) {
 	dir := t.TempDir()
 	ib := config.Infiniband{Enabled: true}
-	if err := render.Render(render.Options{IB: ib, GPUCount: 2, NodeName: "node-a", Output: dir}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, render.Render(render.Options{IB: ib, GPUCount: 2, NodeName: "node-a", Output: dir}))
 	// Short path under /tmp: macOS limits unix socket paths; sandbox may block $TMPDIR binds.
 	safe := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
 	sock := filepath.Join(os.TempDir(), "mock-ib-"+safe+".sock")
 	t.Cleanup(func() { _ = os.Remove(sock) })
 
 	srv, err := NewServer(Config{SocketPath: sock, IBRoot: dir}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)
@@ -43,30 +40,19 @@ func TestServer_LoopbackOpenSendRecv(t *testing.T) {
 	waitForSocket(t, sock, errCh)
 
 	conn, err := net.Dial("unix", sock)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = conn.Close() }()
 
-	if err := protocol.WriteMessage(conn, protocol.TypeOpen, protocol.OpenReq{CAName: "mlx5_0", Port: 1}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, protocol.WriteMessage(conn, protocol.TypeOpen, protocol.OpenReq{CAName: "mlx5_0", Port: 1}))
 	var env protocol.Envelope
-	if err := protocol.ReadEnvelope(conn, &env); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, protocol.ReadEnvelope(conn, &env))
 	var openResp protocol.OpenResp
-	if err := protocol.DecodeBody(env, &openResp); err != nil {
-		t.Fatal(err)
-	}
-	if openResp.Handle == 0 || openResp.Error != "" {
-		t.Fatalf("open: %+v", openResp)
-	}
+	require.NoError(t, protocol.DecodeBody(env, &openResp))
+	require.NotZero(t, openResp.Handle, "open: %+v", openResp)
+	require.Empty(t, openResp.Error, "open: %+v", openResp)
 
 	ports, err := sysfs.Scan(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	var advert protocol.PortAdvert
 	for _, p := range ports {
 		if p.CAName == "mlx5_0" {
@@ -74,77 +60,46 @@ func TestServer_LoopbackOpenSendRecv(t *testing.T) {
 			break
 		}
 	}
-	if advert.CAName == "" {
-		t.Fatalf("mlx5_0 not in %+v", ports)
-	}
+	require.NotEmpty(t, advert.CAName, "mlx5_0 not in %+v", ports)
 	sendMad := madtest.PingMAD(advert)
-	if err := protocol.WriteMessage(conn, protocol.TypeSend, protocol.SendReq{
+	require.NoError(t, protocol.WriteMessage(conn, protocol.TypeSend, protocol.SendReq{
 		Handle: openResp.Handle,
 		MAD:    sendMad,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if err := protocol.ReadEnvelope(conn, &env); err != nil {
-		t.Fatal(err)
-	}
+	}))
+	require.NoError(t, protocol.ReadEnvelope(conn, &env))
 	var sendResp protocol.SendResp
-	if err := protocol.DecodeBody(env, &sendResp); err != nil {
-		t.Fatal(err)
-	}
-	if !sendResp.OK {
-		t.Fatalf("send: %+v", sendResp)
-	}
+	require.NoError(t, protocol.DecodeBody(env, &sendResp))
+	require.True(t, sendResp.OK, "send: %+v", sendResp)
 
-	if err := protocol.WriteMessage(conn, protocol.TypeRecv, protocol.RecvReq{
+	require.NoError(t, protocol.WriteMessage(conn, protocol.TypeRecv, protocol.RecvReq{
 		Handle:    openResp.Handle,
 		TimeoutMS: 500,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if err := protocol.ReadEnvelope(conn, &env); err != nil {
-		t.Fatal(err)
-	}
+	}))
+	require.NoError(t, protocol.ReadEnvelope(conn, &env))
 	var recvResp protocol.RecvResp
-	if err := protocol.DecodeBody(env, &recvResp); err != nil {
-		t.Fatal(err)
-	}
-	if recvResp.Timeout || len(recvResp.MAD) == 0 {
-		t.Fatalf("recv: %+v", recvResp)
-	}
-	if recvResp.MAD[umadMADOffset+ibMADMethodOff]&0x80 == 0 {
-		t.Fatal("expected response method bit set on echoed MAD")
-	}
+	require.NoError(t, protocol.DecodeBody(env, &recvResp))
+	require.False(t, recvResp.Timeout, "recv: %+v", recvResp)
+	require.NotZero(t, len(recvResp.MAD), "recv: %+v", recvResp)
+	require.NotZero(t, recvResp.MAD[umadMADOffset+ibMADMethodOff]&0x80, "expected response method bit set on echoed MAD")
 
-	if err := protocol.WriteMessage(conn, protocol.TypeClose, protocol.CloseReq{Handle: openResp.Handle}); err != nil {
-		t.Fatal(err)
-	}
-	if err := protocol.ReadEnvelope(conn, &env); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, protocol.WriteMessage(conn, protocol.TypeClose, protocol.CloseReq{Handle: openResp.Handle}))
+	require.NoError(t, protocol.ReadEnvelope(conn, &env))
 	var closeResp protocol.CloseResp
-	if err := protocol.DecodeBody(env, &closeResp); err != nil {
-		t.Fatal(err)
-	}
-	if !closeResp.OK {
-		t.Fatalf("close: %+v", closeResp)
-	}
+	require.NoError(t, protocol.DecodeBody(env, &closeResp))
+	require.True(t, closeResp.OK, "close: %+v", closeResp)
 
 	cancel()
 }
 
 func TestServer_handleSend_shortMADNoPanic(t *testing.T) {
 	dir := t.TempDir()
-	if err := render.Render(render.Options{
+	require.NoError(t, render.Render(render.Options{
 		IB: config.Infiniband{Enabled: true}, GPUCount: 1, NodeName: "n", Output: dir,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}))
 	sock := filepath.Join(os.TempDir(), fmt.Sprintf("mock-ib-%d-short.sock", os.Getpid()))
 	t.Cleanup(func() { _ = os.Remove(sock) })
 	srv, err := NewServer(Config{SocketPath: sock, IBRoot: dir}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)
@@ -152,69 +107,44 @@ func TestServer_handleSend_shortMADNoPanic(t *testing.T) {
 	waitForSocket(t, sock, errCh)
 
 	conn, err := net.Dial("unix", sock)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = conn.Close() }()
 
-	if err := protocol.WriteMessage(conn, protocol.TypeOpen, protocol.OpenReq{CAName: "mlx5_0", Port: 1}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, protocol.WriteMessage(conn, protocol.TypeOpen, protocol.OpenReq{CAName: "mlx5_0", Port: 1}))
 	var env protocol.Envelope
-	if err := protocol.ReadEnvelope(conn, &env); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, protocol.ReadEnvelope(conn, &env))
 	var openResp protocol.OpenResp
-	if err := protocol.DecodeBody(env, &openResp); err != nil {
-		t.Fatal(err)
-	}
-	if openResp.Handle == 0 {
-		t.Fatalf("open: %+v", openResp)
-	}
+	require.NoError(t, protocol.DecodeBody(env, &openResp))
+	require.NotZero(t, openResp.Handle, "open: %+v", openResp)
 
 	// A truncated umad buffer (shorter than the 56-byte header) used to slice
 	// umad[umadMADOffset:] out of range and panic the serveConn goroutine.
 	// Now it must come back as an error and leave the daemon serving.
-	if err := protocol.WriteMessage(conn, protocol.TypeSend, protocol.SendReq{
+	require.NoError(t, protocol.WriteMessage(conn, protocol.TypeSend, protocol.SendReq{
 		Handle: openResp.Handle,
 		MAD:    make([]byte, 10),
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if err := protocol.ReadEnvelope(conn, &env); err != nil {
-		t.Fatal(err)
-	}
+	}))
+	require.NoError(t, protocol.ReadEnvelope(conn, &env))
 	var sendResp protocol.SendResp
-	if err := protocol.DecodeBody(env, &sendResp); err != nil {
-		t.Fatal(err)
-	}
-	if sendResp.OK || !strings.Contains(sendResp.Error, "too short") {
-		t.Fatalf("short send: got %+v, want error containing \"too short\"", sendResp)
-	}
+	require.NoError(t, protocol.DecodeBody(env, &sendResp))
+	require.False(t, sendResp.OK, "short send: got %+v, want error containing \"too short\"", sendResp)
+	require.Contains(t, sendResp.Error, "too short", "short send: got %+v", sendResp)
 
 	// The daemon must still answer on the same connection (goroutine survived).
-	if err := protocol.WriteMessage(conn, protocol.TypeClose, protocol.CloseReq{Handle: openResp.Handle}); err != nil {
-		t.Fatal(err)
-	}
-	if err := protocol.ReadEnvelope(conn, &env); err != nil {
-		t.Fatalf("daemon stopped serving after short MAD: %v", err)
-	}
+	require.NoError(t, protocol.WriteMessage(conn, protocol.TypeClose, protocol.CloseReq{Handle: openResp.Handle}))
+	require.NoError(t, protocol.ReadEnvelope(conn, &env), "daemon stopped serving after short MAD")
 	cancel()
 }
 
 func TestServer_handleClose_unknownHandle(t *testing.T) {
 	dir := t.TempDir()
-	if err := render.Render(render.Options{
+	require.NoError(t, render.Render(render.Options{
 		IB: config.Infiniband{Enabled: true}, GPUCount: 1, NodeName: "n", Output: dir,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	}))
 	sock := filepath.Join(os.TempDir(), fmt.Sprintf("mock-ib-%d-close.sock", os.Getpid()))
 	t.Cleanup(func() { _ = os.Remove(sock) })
 	srv, err := NewServer(Config{SocketPath: sock, IBRoot: dir}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)
@@ -222,25 +152,15 @@ func TestServer_handleClose_unknownHandle(t *testing.T) {
 	waitForSocket(t, sock, errCh)
 
 	conn, err := net.Dial("unix", sock)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = conn.Close() }()
 
-	if err := protocol.WriteMessage(conn, protocol.TypeClose, protocol.CloseReq{Handle: 9999}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, protocol.WriteMessage(conn, protocol.TypeClose, protocol.CloseReq{Handle: 9999}))
 	var env protocol.Envelope
-	if err := protocol.ReadEnvelope(conn, &env); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, protocol.ReadEnvelope(conn, &env))
 	var closeResp protocol.CloseResp
-	if err := protocol.DecodeBody(env, &closeResp); err != nil {
-		t.Fatal(err)
-	}
-	if closeResp.OK {
-		t.Fatalf("expected close error, got %+v", closeResp)
-	}
+	require.NoError(t, protocol.DecodeBody(env, &closeResp))
+	require.False(t, closeResp.OK, "expected close error, got %+v", closeResp)
 	cancel()
 }
 
@@ -250,9 +170,7 @@ func waitForSocket(t *testing.T, path string, errCh <-chan error) {
 	for time.Now().Before(deadline) {
 		select {
 		case err := <-errCh:
-			if err != nil && !errors.Is(err, context.Canceled) {
-				t.Fatalf("server exited early: %v", err)
-			}
+			require.True(t, err == nil || errors.Is(err, context.Canceled), "server exited early: %v", err)
 		default:
 		}
 		c, err := net.Dial("unix", path)
@@ -262,5 +180,5 @@ func waitForSocket(t *testing.T, path string, errCh <-chan error) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	t.Fatalf("socket %s not ready", path)
+	require.Failf(t, "socket not ready", "socket %s not ready", path)
 }

--- a/pkg/network/mockib/daemon/smp_fabric_test.go
+++ b/pkg/network/mockib/daemon/smp_fabric_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/protocol"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/registry"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/subnet"
+	"github.com/stretchr/testify/require"
 )
 
 // SMP GETs to a peer LID must be answered by subnet synthesis, not fabric ping
@@ -64,26 +65,16 @@ func TestTryFabricSend_SkipsSubnetMAD(t *testing.T) {
 	binary.BigEndian.PutUint16(send[28:30], 0x102)
 
 	h := &portHandle{caName: "mlx5_0", port: 1}
-	if !subnet.IsSMPSend(send) {
-		t.Fatalf("wire-format SMI-direct MAD (mad[1]=0x%02x) must be SMP", mad[1])
-	}
-	if srv.tryFabricSend(h, send) {
-		t.Fatal("tryFabricSend must reject subnet SMP MADs (defense-in-depth)")
-	}
+	require.True(t, subnet.IsSMPSend(send), "wire-format SMI-direct MAD (mad[1]=0x%02x) must be SMP", mad[1])
+	require.False(t, srv.tryFabricSend(h, send), "tryFabricSend must reject subnet SMP MADs (defense-in-depth)")
 
 	srv.graphMu.RLock()
 	g := srv.graph
 	srv.graphMu.RUnlock()
 	resp, ok := subnet.TrySynthesize(send, g, h.caName)
-	if !ok {
-		t.Fatal("TrySynthesize: expected peer PORT_INFO")
-	}
+	require.True(t, ok, "TrySynthesize: expected peer PORT_INFO")
 	pl := resp[umadMADOffset+64:]
-	if got := subnet.GetFieldSpec(pl, 264, 4); got != 5 {
-		t.Fatalf("peer phys: got %d want 5 (link up)", got)
-	}
-	if got := subnet.GetFieldSpec(pl, 128, 16); got != 0x102 {
-		t.Fatalf("peer lid: got %#x want 0x102", got)
-	}
+	require.Equal(t, uint32(5), subnet.GetFieldSpec(pl, 264, 4), "peer phys: want 5 (link up)")
+	require.Equal(t, uint32(0x102), subnet.GetFieldSpec(pl, 128, 16), "peer lid: want 0x102")
 	_ = fabric.Port{}
 }

--- a/pkg/network/mockib/daemon/synthesize_test.go
+++ b/pkg/network/mockib/daemon/synthesize_test.go
@@ -6,6 +6,8 @@ package daemon
 import (
 	"encoding/base64"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // Real ibping send buffer (see destlid_test.go).
@@ -13,20 +15,12 @@ const ibpingSendMAD = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAEAAA3AAAAAAAAAAAAAAAAAA
 
 func TestSynthesizeRecv_PreservesTrid(t *testing.T) {
 	send, err := base64.StdEncoding.DecodeString(ibpingSendMAD)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	lb := NewLoopback(nil)
 	recv := lb.SynthesizeRecv(send)
-	if len(recv) < umadMADOffset+8 {
-		t.Fatal("short recv buffer")
-	}
+	require.GreaterOrEqual(t, len(recv), umadMADOffset+8, "short recv buffer")
 	sendMAD := send[umadMADOffset : umadMADOffset+16]
 	recvMAD := recv[umadMADOffset : umadMADOffset+16]
-	if sendMAD[4] != recvMAD[4] || sendMAD[5] != recvMAD[5] || sendMAD[6] != recvMAD[6] || sendMAD[7] != recvMAD[7] {
-		t.Fatalf("TRID bytes 4-7 changed: send %x recv %x", sendMAD[4:8], recvMAD[4:8])
-	}
-	if recvMAD[ibMADMethodOff]&0x80 == 0 {
-		t.Fatal("expected response method bit set")
-	}
+	require.Equal(t, sendMAD[4:8], recvMAD[4:8], "TRID bytes 4-7 changed")
+	require.NotZero(t, recvMAD[ibMADMethodOff]&0x80, "expected response method bit set")
 }

--- a/pkg/network/mockib/daemon/umad_test.go
+++ b/pkg/network/mockib/daemon/umad_test.go
@@ -8,15 +8,15 @@ import (
 	"testing"
 
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/gid"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDestLID(t *testing.T) {
 	umad := make([]byte, 64)
 	binary.BigEndian.PutUint16(umad[umadLIDOffset:], 0x0300)
 	lid, ok := destLID(umad)
-	if !ok || lid != 0x0300 {
-		t.Fatalf("got 0x%04x ok=%v", lid, ok)
-	}
+	require.True(t, ok, "got 0x%04x ok=%v", lid, ok)
+	require.Equal(t, uint16(0x0300), lid, "got 0x%04x ok=%v", lid, ok)
 }
 
 func TestDestGID_and_PortGUID(t *testing.T) {
@@ -24,11 +24,9 @@ func TestDestGID_and_PortGUID(t *testing.T) {
 	binary.LittleEndian.PutUint32(umad[umadGRHPresent:], 1)
 	gid.ParseInto(umad[umadGIDOffset:umadGIDOffset+16], "fe80:0000:0000:0000:a088:c203:00ab:2001")
 	g, ok := destGID(umad)
-	if !ok || g == "" {
-		t.Fatal("destGID")
-	}
+	require.True(t, ok, "destGID")
+	require.NotEmpty(t, g, "destGID")
 	pg, ok := destPortGUID(umad)
-	if !ok || pg != "a088:c203:00ab:2001" {
-		t.Fatalf("destPortGUID: got %q ok=%v", pg, ok)
-	}
+	require.True(t, ok, "destPortGUID: got %q ok=%v", pg, ok)
+	require.Equal(t, "a088:c203:00ab:2001", pg, "destPortGUID: got %q ok=%v", pg, ok)
 }

--- a/pkg/network/mockib/daemon/verbs_test.go
+++ b/pkg/network/mockib/daemon/verbs_test.go
@@ -9,30 +9,24 @@ import (
 
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/config"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/render"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSynthesizeVerbsWrite_QueryDevice(t *testing.T) {
 	root := t.TempDir()
-	if err := render.Render(render.Options{
+	require.NoError(t, render.Render(render.Options{
 		IB:       config.Infiniband{Enabled: true},
 		GPUCount: 1,
 		NodeName: "n1",
 		Output:   root,
-	}); err != nil {
-		t.Fatalf("render: %v", err)
-	}
+	}), "render")
 	srv, err := NewServer(Config{IBRoot: root}, nil)
-	if err != nil {
-		t.Fatalf("server: %v", err)
-	}
+	require.NoError(t, err, "server")
 	h := &verbsHandle{caName: "mlx5_0"}
 	cmd := make([]byte, 16)
 	binary.LittleEndian.PutUint32(cmd[0:4], ibUVCmdQueryDevice)
 	resp, err := srv.synthesizeVerbsWrite(h, cmd)
-	if err != nil {
-		t.Fatalf("synthesize: %v", err)
-	}
-	if len(resp) < 132 || resp[131] != 1 {
-		t.Fatalf("phys_port_cnt: len=%d byte=%d", len(resp), resp[131])
-	}
+	require.NoError(t, err, "synthesize")
+	require.GreaterOrEqual(t, len(resp), 132, "phys_port_cnt: len=%d", len(resp))
+	require.Equal(t, byte(1), resp[131], "phys_port_cnt")
 }

--- a/pkg/network/mockib/fabric/drpath_test.go
+++ b/pkg/network/mockib/fabric/drpath_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/protocol"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/registry"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPeerAtOutbound_FirstHopRemote(t *testing.T) {
@@ -21,13 +22,11 @@ func TestPeerAtOutbound_FirstHopRemote(t *testing.T) {
 	}
 	g := Build(local, peers)
 	from, ok := g.ByCAName("mlx5_0")
-	if !ok {
-		t.Fatal("local port")
-	}
+	require.True(t, ok, "local port")
 	peer, ok := g.PeerAtOutbound(from, 1, 0)
-	if !ok || peer.Local || peer.PortGUID != "a088:c203:00ab:0002" {
-		t.Fatalf("peer: %+v ok=%v", peer, ok)
-	}
+	require.True(t, ok, "peer: %+v ok=%v", peer, ok)
+	require.False(t, peer.Local, "peer: %+v ok=%v", peer, ok)
+	require.Equal(t, "a088:c203:00ab:0002", peer.PortGUID, "peer: %+v ok=%v", peer, ok)
 }
 
 func TestPeerAtOutbound_SecondHopDifferentPod(t *testing.T) {
@@ -41,17 +40,9 @@ func TestPeerAtOutbound_SecondHopDifferentPod(t *testing.T) {
 	g := Build(local, peers)
 	from, _ := g.ByCAName("mlx5_0")
 	first, ok := g.PeerAtOutbound(from, 1, 0)
-	if !ok {
-		t.Fatal("first hop")
-	}
+	require.True(t, ok, "first hop")
 	second, ok := g.PeerAtOutbound(first, 1, 1)
-	if !ok {
-		t.Fatal("second hop")
-	}
-	if second.PortGUID == first.PortGUID {
-		t.Fatalf("second hop must be a different port, got %s", second.PortGUID)
-	}
-	if second.PodIP == first.PodIP {
-		t.Fatalf("second hop must be a different pod")
-	}
+	require.True(t, ok, "second hop")
+	require.NotEqual(t, first.PortGUID, second.PortGUID, "second hop must be a different port, got %s", second.PortGUID)
+	require.NotEqual(t, first.PodIP, second.PodIP, "second hop must be a different pod")
 }

--- a/pkg/network/mockib/fabric/graph_test.go
+++ b/pkg/network/mockib/fabric/graph_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/protocol"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/registry"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGraph_BuildAndLookup(t *testing.T) {
@@ -19,11 +20,8 @@ func TestGraph_BuildAndLookup(t *testing.T) {
 		"a088:c203:00ab:0003": {LID: 0x103, CAName: "mlx5_1", PodIP: "10.0.0.2"},
 	}
 	g := Build(local, peers)
-	if len(g.Ports()) != 3 {
-		t.Fatalf("ports: got %d want 3", len(g.Ports()))
-	}
+	require.Len(t, g.Ports(), 3, "ports")
 	remote, ok := g.ByLID(0x102)
-	if !ok || remote.PodIP != "10.0.0.2" {
-		t.Fatalf("ByLID: %+v ok=%v", remote, ok)
-	}
+	require.True(t, ok, "ByLID: %+v ok=%v", remote, ok)
+	require.Equal(t, "10.0.0.2", remote.PodIP, "ByLID: %+v ok=%v", remote, ok)
 }

--- a/pkg/network/mockib/gid/gid_test.go
+++ b/pkg/network/mockib/gid/gid_test.go
@@ -5,12 +5,13 @@ package gid
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNormalize(t *testing.T) {
-	if got := Normalize(" FE80::1 "); got != "fe80::1" {
-		t.Fatalf("got %q", got)
-	}
+	got := Normalize(" FE80::1 ")
+	require.Equal(t, "fe80::1", got)
 }
 
 func TestPortGUIDFromBytes(t *testing.T) {
@@ -18,15 +19,11 @@ func TestPortGUIDFromBytes(t *testing.T) {
 	copy(b[8:], []byte{0xa0, 0x88, 0xc2, 0x03, 0x00, 0xab, 0x20, 0x01})
 	got := PortGUIDFromBytes(b[:])
 	want := "a088:c203:00ab:2001"
-	if got != want {
-		t.Fatalf("got %q want %q", got, want)
-	}
+	require.Equal(t, want, got)
 }
 
 func TestParseInto(t *testing.T) {
 	var dst [16]byte
 	ParseInto(dst[:], "fe80:0000:0000:0000:a088:c203:00ab:2001")
-	if Format(dst[:]) != "fe80:0000:0000:0000:a088:c203:00ab:2001" {
-		t.Fatalf("round-trip: %s", Format(dst[:]))
-	}
+	require.Equal(t, "fe80:0000:0000:0000:a088:c203:00ab:2001", Format(dst[:]), "round-trip")
 }

--- a/pkg/network/mockib/protocol/wire_test.go
+++ b/pkg/network/mockib/protocol/wire_test.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"encoding/binary"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestWriteReadEnvelope_Register(t *testing.T) {
@@ -21,61 +23,44 @@ func TestWriteReadEnvelope_Register(t *testing.T) {
 			LID:      0x0100,
 		}},
 	}
-	if err := WriteMessage(&buf, TypeRegister, body); err != nil {
-		t.Fatal(err)
-	}
+	err := WriteMessage(&buf, TypeRegister, body)
+	require.NoError(t, err)
 	var env Envelope
-	if err := ReadEnvelope(&buf, &env); err != nil {
-		t.Fatal(err)
-	}
-	if env.Type != TypeRegister {
-		t.Fatalf("type: got %q want %q", env.Type, TypeRegister)
-	}
+	err = ReadEnvelope(&buf, &env)
+	require.NoError(t, err)
+	require.Equal(t, TypeRegister, env.Type, "type")
 	var got RegisterBody
-	if err := DecodeBody(env, &got); err != nil {
-		t.Fatal(err)
-	}
-	if got.NodeName != body.NodeName || got.PodIP != body.PodIP || len(got.Ports) != 1 {
-		t.Fatalf("register body mismatch: %+v", got)
-	}
-	if got.Ports[0].PortGUID != body.Ports[0].PortGUID {
-		t.Fatalf("port_guid: got %q want %q", got.Ports[0].PortGUID, body.Ports[0].PortGUID)
-	}
+	err = DecodeBody(env, &got)
+	require.NoError(t, err)
+	require.Equal(t, body.NodeName, got.NodeName, "register body mismatch: %+v", got)
+	require.Equal(t, body.PodIP, got.PodIP, "register body mismatch: %+v", got)
+	require.Len(t, got.Ports, 1, "register body mismatch: %+v", got)
+	require.Equal(t, body.Ports[0].PortGUID, got.Ports[0].PortGUID, "port_guid")
 }
 
 func TestWriteReadEnvelope_PingPong(t *testing.T) {
 	var buf bytes.Buffer
 	ping := PingBody{DstPortGUID: "a088:c203:00ab:0001", Seq: 7, ClientTS: 100}
-	if err := WriteMessage(&buf, TypePing, ping); err != nil {
-		t.Fatal(err)
-	}
+	err := WriteMessage(&buf, TypePing, ping)
+	require.NoError(t, err)
 	var env Envelope
-	if err := ReadEnvelope(&buf, &env); err != nil {
-		t.Fatal(err)
-	}
+	err = ReadEnvelope(&buf, &env)
+	require.NoError(t, err)
 	var got PingBody
-	if err := DecodeBody(env, &got); err != nil {
-		t.Fatal(err)
-	}
-	if got != ping {
-		t.Fatalf("ping: got %+v want %+v", got, ping)
-	}
+	err = DecodeBody(env, &got)
+	require.NoError(t, err)
+	require.Equal(t, ping, got, "ping")
 
 	buf.Reset()
 	pong := PongBody{Seq: 7, ServerTS: 200}
-	if err := WriteMessage(&buf, TypePong, pong); err != nil {
-		t.Fatal(err)
-	}
-	if err := ReadEnvelope(&buf, &env); err != nil {
-		t.Fatal(err)
-	}
+	err = WriteMessage(&buf, TypePong, pong)
+	require.NoError(t, err)
+	err = ReadEnvelope(&buf, &env)
+	require.NoError(t, err)
 	var gotPong PongBody
-	if err := DecodeBody(env, &gotPong); err != nil {
-		t.Fatal(err)
-	}
-	if gotPong != pong {
-		t.Fatalf("pong: got %+v want %+v", gotPong, pong)
-	}
+	err = DecodeBody(env, &gotPong)
+	require.NoError(t, err)
+	require.Equal(t, pong, gotPong, "pong")
 }
 
 func TestReadFrame_RejectsOversize(t *testing.T) {
@@ -84,7 +69,5 @@ func TestReadFrame_RejectsOversize(t *testing.T) {
 	binary.BigEndian.PutUint32(hdr[:], MaxFrameSize+1)
 	buf.Write(hdr[:])
 	_, err := ReadFrame(&buf)
-	if err == nil {
-		t.Fatal("expected error for oversize frame")
-	}
+	require.Error(t, err, "expected error for oversize frame")
 }

--- a/pkg/network/mockib/registry/registry_test.go
+++ b/pkg/network/mockib/registry/registry_test.go
@@ -3,15 +3,18 @@
 
 package registry
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestRegistry_RegisterAndLookup(t *testing.T) {
 	r := New()
 	r.Register("a088:c203:00ab:0001", Peer{PodIP: "10.0.0.2", NodeName: "w1"})
 	p, ok := r.Lookup("a088:c203:00ab:0001")
-	if !ok || p.PodIP != "10.0.0.2" {
-		t.Fatalf("lookup failed: %+v %v", p, ok)
-	}
+	require.True(t, ok, "lookup failed: %+v %v", p, ok)
+	require.Equal(t, "10.0.0.2", p.PodIP, "lookup failed: %+v %v", p, ok)
 }
 
 func TestRegistry_DuplicateGUIDPrefersLowerIP(t *testing.T) {
@@ -19,9 +22,7 @@ func TestRegistry_DuplicateGUIDPrefersLowerIP(t *testing.T) {
 	r.Register("a088:c203:00ab:0001", Peer{PodIP: "10.0.0.9", NodeName: "node-a"})
 	r.Register("a088:c203:00ab:0001", Peer{PodIP: "10.0.0.2", NodeName: "node-b"})
 	p, _ := r.Lookup("a088:c203:00ab:0001")
-	if p.PodIP != "10.0.0.2" {
-		t.Fatalf("want lower IP, got %s", p.PodIP)
-	}
+	require.Equal(t, "10.0.0.2", p.PodIP, "want lower IP")
 }
 
 func TestRegistry_SameNodeRefreshesPodIP(t *testing.T) {
@@ -29,25 +30,22 @@ func TestRegistry_SameNodeRefreshesPodIP(t *testing.T) {
 	r.Register("a088:c203:00ab:0001", Peer{PodIP: "10.244.0.5", NodeName: "node-a"})
 	r.Register("a088:c203:00ab:0001", Peer{PodIP: "10.244.0.6", NodeName: "node-a"})
 	p, _ := r.Lookup("a088:c203:00ab:0001")
-	if p.PodIP != "10.244.0.6" {
-		t.Fatalf("want refreshed PodIP after restart, got %s", p.PodIP)
-	}
+	require.Equal(t, "10.244.0.6", p.PodIP, "want refreshed PodIP after restart")
 }
 
 func TestRegistry_NormalizesGUIDKey(t *testing.T) {
 	r := New()
 	r.Register("A088C20300AB0001", Peer{PodIP: "10.0.0.2"})
 	p, ok := r.Lookup("a088:c203:00ab:0001")
-	if !ok || p.PodIP != "10.0.0.2" {
-		t.Fatalf("lookup with normalized key failed: %+v %v", p, ok)
-	}
+	require.True(t, ok, "lookup with normalized key failed: %+v %v", p, ok)
+	require.Equal(t, "10.0.0.2", p.PodIP, "lookup with normalized key failed: %+v %v", p, ok)
 }
 
 func TestRegistry_LookupByLID(t *testing.T) {
 	r := New()
 	r.Register("a088:c203:00ab:0001", Peer{PodIP: "10.0.0.2", LID: 0x0200})
 	p, guid, ok := r.LookupByLID(0x0200)
-	if !ok || p.PodIP != "10.0.0.2" || guid != "a088:c203:00ab:0001" {
-		t.Fatalf("lookup by lid failed: %+v %q %v", p, guid, ok)
-	}
+	require.True(t, ok, "lookup by lid failed: %+v %q %v", p, guid, ok)
+	require.Equal(t, "10.0.0.2", p.PodIP, "lookup by lid failed: %+v %q %v", p, guid, ok)
+	require.Equal(t, "a088:c203:00ab:0001", guid, "lookup by lid failed: %+v %q %v", p, guid, ok)
 }

--- a/pkg/network/mockib/render/format_test.go
+++ b/pkg/network/mockib/render/format_test.go
@@ -3,7 +3,11 @@
 
 package render
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestFormatPortState(t *testing.T) {
 	tests := []struct {
@@ -19,9 +23,8 @@ func TestFormatPortState(t *testing.T) {
 		{"unknown", "4: ACTIVE\n"},
 	}
 	for _, tc := range tests {
-		if got := formatPortState(tc.in); got != tc.want {
-			t.Errorf("formatPortState(%q) = %q want %q", tc.in, got, tc.want)
-		}
+		got := formatPortState(tc.in)
+		require.Equal(t, tc.want, got, "formatPortState(%q)", tc.in)
 	}
 }
 
@@ -40,8 +43,7 @@ func TestFormatPhysState(t *testing.T) {
 		{"other", "5: LinkUp\n"},
 	}
 	for _, tc := range tests {
-		if got := formatPhysState(tc.in); got != tc.want {
-			t.Errorf("formatPhysState(%q) = %q want %q", tc.in, got, tc.want)
-		}
+		got := formatPhysState(tc.in)
+		require.Equal(t, tc.want, got, "formatPhysState(%q)", tc.in)
 	}
 }

--- a/pkg/network/mockib/render/integration_test.go
+++ b/pkg/network/mockib/render/integration_test.go
@@ -19,10 +19,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/config"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIbstat_Integration(t *testing.T) {
@@ -34,16 +34,14 @@ func TestIbstat_Integration(t *testing.T) {
 		t.Skip("ibstat not installed (apt-get install infiniband-diags)")
 	}
 	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
+	require.NoError(t, err, "getwd")
 	shim := filepath.Join(wd, "..", "libibmocksys.so")
 	if _, err := os.Stat(shim); err != nil {
 		t.Skipf("shim not built: %v (run `make -C pkg/network/mockib`)", err)
 	}
 
 	root := t.TempDir()
-	if err := Render(Options{
+	err = Render(Options{
 		IB: config.Infiniband{
 			Enabled:   true,
 			HCAType:   "MT4129",
@@ -53,9 +51,8 @@ func TestIbstat_Integration(t *testing.T) {
 		GPUCount: 2,
 		NodeName: "test-node",
 		Output:   root,
-	}); err != nil {
-		t.Fatalf("Render: %v", err)
-	}
+	})
+	require.NoError(t, err, "Render")
 
 	cmd := exec.Command(ibstat)
 	cmd.Env = append(os.Environ(),
@@ -64,9 +61,7 @@ func TestIbstat_Integration(t *testing.T) {
 		"MOCK_IB_ROOT="+root,
 	)
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("ibstat failed: %v\noutput:\n%s", err, out)
-	}
+	require.NoError(t, err, "ibstat failed\noutput:\n%s", out)
 	want := []string{
 		"CA 'mlx5_0'",
 		"CA 'mlx5_1'",
@@ -79,9 +74,7 @@ func TestIbstat_Integration(t *testing.T) {
 	}
 	got := string(out)
 	for _, s := range want {
-		if !strings.Contains(got, s) {
-			t.Errorf("ibstat output missing %q\nfull output:\n%s", s, got)
-		}
+		require.Contains(t, got, s, "ibstat output missing %q\nfull output:\n%s", s, got)
 	}
 
 	// Spot-check end-to-end that branches not exercised by `ibstat` are
@@ -93,9 +86,8 @@ func TestIbstat_Integration(t *testing.T) {
 		"sys/class/infiniband/mlx5_1/ports/1/counters/port_xmit_packets",
 		"sys/class/infiniband_mad/abi_version",
 	} {
-		if _, err := os.Stat(filepath.Join(root, rel)); err != nil {
-			t.Errorf("expected rendered file %s: %v", rel, err)
-		}
+		_, err := os.Stat(filepath.Join(root, rel))
+		require.NoError(t, err, "expected rendered file %s", rel)
 	}
 }
 
@@ -108,16 +100,14 @@ func TestIbvDevinfo_List_Integration(t *testing.T) {
 		t.Skip("ibv_devinfo not installed (apt-get install rdma-core)")
 	}
 	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
+	require.NoError(t, err, "getwd")
 	shim := filepath.Join(wd, "..", "libibmocksys.so")
 	if _, err := os.Stat(shim); err != nil {
 		t.Skipf("shim not built: %v (run `make -C pkg/network/mockib`)", err)
 	}
 
 	root := t.TempDir()
-	if err := Render(Options{
+	err = Render(Options{
 		IB: config.Infiniband{
 			Enabled:   true,
 			HCAType:   "MT4129",
@@ -127,9 +117,8 @@ func TestIbvDevinfo_List_Integration(t *testing.T) {
 		GPUCount: 2,
 		NodeName: "test-node",
 		Output:   root,
-	}); err != nil {
-		t.Fatalf("Render: %v", err)
-	}
+	})
+	require.NoError(t, err, "Render")
 
 	cmd := exec.Command(ibv, "-l")
 	cmd.Env = append(os.Environ(),
@@ -138,13 +127,9 @@ func TestIbvDevinfo_List_Integration(t *testing.T) {
 		"MOCK_IB_ROOT="+root,
 	)
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("ibv_devinfo -l failed: %v\noutput:\n%s", err, out)
-	}
+	require.NoError(t, err, "ibv_devinfo -l failed\noutput:\n%s", out)
 	got := string(out)
 	for _, want := range []string{"mlx5_0", "mlx5_1"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("ibv_devinfo -l missing %q\nfull output:\n%s", want, got)
-		}
+		require.Contains(t, got, want, "ibv_devinfo -l missing %q\nfull output:\n%s", want, got)
 	}
 }

--- a/pkg/network/mockib/render/ping_integration_test.go
+++ b/pkg/network/mockib/render/ping_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/config"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIbping_Loopback_Integration(t *testing.T) {
@@ -37,9 +38,7 @@ func TestIbping_Loopback_Integration(t *testing.T) {
 	}
 
 	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
+	require.NoError(t, err, "getwd")
 	mockibDir := filepath.Join(wd, "..")
 	shimSys := filepath.Join(mockibDir, "libibmocksys.so")
 	shimUmad := filepath.Join(mockibDir, "libibmockumad.so")
@@ -49,21 +48,19 @@ func TestIbping_Loopback_Integration(t *testing.T) {
 		}
 	}
 
-	if out, err := exec.Command("make", "-C", mockibDir).CombinedOutput(); err != nil {
-		t.Fatalf("make shims: %v\n%s", err, out)
-	}
+	out, err := exec.Command("make", "-C", mockibDir).CombinedOutput()
+	require.NoError(t, err, "make shims\n%s", out)
 
 	repoRoot := filepath.Join(wd, "..", "..", "..", "..")
 	daemonBin := filepath.Join(t.TempDir(), "mock-ib")
 	build := exec.Command("go", "build", "-mod=vendor", "-o", daemonBin, "./cmd/mock-ib")
 	build.Dir = repoRoot
-	if out, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("build mock-ib: %v\n%s", err, out)
-	}
+	buildOut, err := build.CombinedOutput()
+	require.NoError(t, err, "build mock-ib\n%s", buildOut)
 
 	root := t.TempDir()
 	nodeName := "host1"
-	if err := Render(Options{
+	err = Render(Options{
 		IB: config.Infiniband{
 			Enabled:   true,
 			HCAType:   "MT4129",
@@ -73,24 +70,17 @@ func TestIbping_Loopback_Integration(t *testing.T) {
 		GPUCount: 2,
 		NodeName: nodeName,
 		Output:   root,
-	}); err != nil {
-		t.Fatalf("Render: %v", err)
-	}
+	})
+	require.NoError(t, err, "Render")
 
 	lidPath := filepath.Join(root, "sys/class/infiniband/mlx5_0/ports/1/lid")
 	guidPath := filepath.Join(root, "sys/class/infiniband/mlx5_0/ports/1/port_guid")
 	lidBytes, err := os.ReadFile(lidPath)
-	if err != nil {
-		t.Fatalf("read lid: %v", err)
-	}
+	require.NoError(t, err, "read lid")
 	lid := strings.TrimSpace(string(lidBytes))
-	if lid == "" {
-		t.Fatal("empty lid")
-	}
+	require.NotEqual(t, "", lid, "empty lid")
 	guidBytes, err := os.ReadFile(guidPath)
-	if err != nil {
-		t.Fatalf("read port_guid: %v", err)
-	}
+	require.NoError(t, err, "read port_guid")
 	guidHex := "0x" + strings.NewReplacer(":", "").Replace(strings.TrimSpace(string(guidBytes)))
 
 	runDir := t.TempDir()
@@ -101,9 +91,8 @@ func TestIbping_Loopback_Integration(t *testing.T) {
 	daemon := exec.CommandContext(ctx, daemonBin, "-socket", socketPath, "-ib-root", root)
 	daemon.Stdout = os.Stderr
 	daemon.Stderr = os.Stderr
-	if err := daemon.Start(); err != nil {
-		t.Fatalf("start mock-ib: %v", err)
-	}
+	err = daemon.Start()
+	require.NoError(t, err, "start mock-ib")
 	t.Cleanup(func() {
 		cancel()
 		_ = daemon.Wait()
@@ -130,24 +119,17 @@ func TestIbping_Loopback_Integration(t *testing.T) {
 			"can't resolve destination port",
 		}
 		for _, p := range failPatterns {
-			if strings.Contains(got, p) {
-				t.Fatalf("ibping %v output contains %q\nerr=%v\noutput:\n%s", args, p, err, got)
-			}
+			require.NotContains(t, got, p, "ibping %v output contains %q\nerr=%v\noutput:\n%s", args, p, err, got)
 		}
 
-		if err != nil {
-			t.Fatalf("ibping %v failed: %v\noutput:\n%s", args, err, got)
-		}
-		if strings.Contains(got, ", 0 received") || strings.Contains(got, "100% packet loss") {
-			t.Fatalf("ibping %v reported no replies\noutput:\n%s", args, got)
-		}
-		if !strings.Contains(got, "packets transmitted") {
-			t.Fatalf("ibping %v missing statistics\noutput:\n%s", args, got)
-		}
-		if !regexp.MustCompile(`[0-9]+ packets transmitted, [1-9][0-9]* received`).MatchString(got) &&
-			!strings.Contains(got, "0% packet loss") {
-			t.Fatalf("ibping %v did not report successful replies\noutput:\n%s", args, got)
-		}
+		require.NoError(t, err, "ibping %v failed\noutput:\n%s", args, got)
+		require.NotContains(t, got, ", 0 received", "ibping %v reported no replies\noutput:\n%s", args, got)
+		require.NotContains(t, got, "100% packet loss", "ibping %v reported no replies\noutput:\n%s", args, got)
+		require.Contains(t, got, "packets transmitted", "ibping %v missing statistics\noutput:\n%s", args, got)
+		require.True(t,
+			regexp.MustCompile(`[0-9]+ packets transmitted, [1-9][0-9]* received`).MatchString(got) ||
+				strings.Contains(got, "0% packet loss"),
+			"ibping %v did not report successful replies\noutput:\n%s", args, got)
 	}
 
 	runIbping("-c", "1", lid)
@@ -163,5 +145,5 @@ func waitForUnixSocket(t *testing.T, path string) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("unix socket %s not ready", path)
+	require.Failf(t, "unix socket not ready", "unix socket %s not ready", path)
 }

--- a/pkg/network/mockib/render/render_test.go
+++ b/pkg/network/mockib/render/render_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/config"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRender_Disabled(t *testing.T) {
@@ -33,13 +34,10 @@ func TestRender_Disabled(t *testing.T) {
 		LinkLayer:        "InfiniBand",
 		NodeDescTemplate: "{node_name} mlx5_{idx}",
 	}
-	if err := Render(Options{IB: ib, Output: dir, GPUCount: 8, NodeName: "host1"}); err != nil {
-		t.Fatalf("Render: %v", err)
-	}
+	err := Render(Options{IB: ib, Output: dir, GPUCount: 8, NodeName: "host1"})
+	require.NoError(t, err, "Render")
 	entries, _ := os.ReadDir(dir)
-	if len(entries) != 0 {
-		t.Fatalf("expected no output when disabled, got %d entries", len(entries))
-	}
+	require.Len(t, entries, 0, "expected no output when disabled")
 }
 
 func TestRender_DefaultsAndCount(t *testing.T) {
@@ -50,28 +48,20 @@ func TestRender_DefaultsAndCount(t *testing.T) {
 		NodeName: "host1",
 		Output:   dir,
 	})
-	if err != nil {
-		t.Fatalf("Render: %v", err)
-	}
+	require.NoError(t, err, "Render")
 	for i := 0; i < 4; i++ {
 		caDir := filepath.Join(dir, "sys/class/infiniband", "mlx5_"+strconv.Itoa(i))
-		if _, err := os.Stat(caDir); err != nil {
-			t.Errorf("missing CA dir mlx5_%d: %v", i, err)
-		}
+		_, err := os.Stat(caDir)
+		require.NoError(t, err, "missing CA dir mlx5_%d", i)
 	}
-	if _, err := os.Stat(filepath.Join(dir, "sys/class/infiniband", "mlx5_4")); !os.IsNotExist(err) {
-		t.Errorf("unexpected mlx5_4 (gpu_count=4 hcas_per_gpu=1): %v", err)
-	}
+	_, err = os.Stat(filepath.Join(dir, "sys/class/infiniband", "mlx5_4"))
+	require.True(t, os.IsNotExist(err), "unexpected mlx5_4 (gpu_count=4 hcas_per_gpu=1): %v", err)
 
 	mustRead := func(rel, want string) {
 		t.Helper()
 		got, err := os.ReadFile(filepath.Join(dir, rel))
-		if err != nil {
-			t.Fatalf("read %s: %v", rel, err)
-		}
-		if strings.TrimSpace(string(got)) != strings.TrimSpace(want) {
-			t.Errorf("%s: got %q want %q", rel, string(got), want)
-		}
+		require.NoError(t, err, "read %s", rel)
+		require.Equal(t, strings.TrimSpace(want), strings.TrimSpace(string(got)), "%s", rel)
 	}
 
 	mustRead("sys/class/infiniband/mlx5_0/hca_type", "MT4129")
@@ -87,25 +77,19 @@ func TestRender_DefaultsAndCount(t *testing.T) {
 
 	modaliasPath := filepath.Join(dir, "sys/class/infiniband/mlx5_0/device/modalias")
 	modalias, err := os.ReadFile(modaliasPath)
-	if err != nil {
-		t.Fatalf("read modalias: %v", err)
-	}
+	require.NoError(t, err, "read modalias")
 	// Must be in the exact kernel modalias grammar so libibverbs' fnmatch
 	// against provider match tables (e.g. mlx5's "pci:v000015B3d*sv*sd*bc*sc*i*")
 	// can claim the device. See render.go for the rationale.
 	const wantModalias = "pci:v000015B3d00001017sv000015B3sd00000008bc02sc00i00\n"
-	if string(modalias) != wantModalias {
-		t.Fatalf("modalias = %q, want %q", modalias, wantModalias)
-	}
+	require.Equal(t, wantModalias, string(modalias), "modalias")
 
 	// `gid_attrs` must be a directory in real Linux sysfs; libibverbs and
 	// iblinkinfo opendir() it. A regular file would yield ENOTDIR.
 	gidAttrs := filepath.Join(dir, "sys/class/infiniband/mlx5_0/ports/1/gid_attrs")
-	if st, err := os.Stat(gidAttrs); err != nil {
-		t.Errorf("missing gid_attrs: %v", err)
-	} else if !st.IsDir() {
-		t.Errorf("gid_attrs must be a directory, got mode %v", st.Mode())
-	}
+	st, err := os.Stat(gidAttrs)
+	require.NoError(t, err, "missing gid_attrs")
+	require.True(t, st.IsDir(), "gid_attrs must be a directory, got mode %v", st.Mode())
 
 	// port_guid is exposed by real mlx5 ports and must follow node_guid's
 	// formatting. The lower 32 bits pack the node id (bits 9..31) and HCA
@@ -125,14 +109,11 @@ func TestRender_HCAsPerGPU(t *testing.T) {
 		GPUCount: 4,
 		Output:   dir,
 	})
-	if err != nil {
-		t.Fatalf("Render: %v", err)
-	}
+	require.NoError(t, err, "Render")
 	for i := 0; i < 8; i++ {
 		caDir := filepath.Join(dir, "sys/class/infiniband", "mlx5_"+strconv.Itoa(i))
-		if _, err := os.Stat(caDir); err != nil {
-			t.Errorf("missing CA dir mlx5_%d: %v", i, err)
-		}
+		_, err := os.Stat(caDir)
+		require.NoError(t, err, "missing CA dir mlx5_%d", i)
 	}
 }
 
@@ -143,18 +124,14 @@ func TestRender_HCACountOverride(t *testing.T) {
 		GPUCount: 16, // ignored
 		Output:   dir,
 	})
-	if err != nil {
-		t.Fatalf("Render: %v", err)
-	}
+	require.NoError(t, err, "Render")
 	for i := 0; i < 2; i++ {
 		caDir := filepath.Join(dir, "sys/class/infiniband", "mlx5_"+strconv.Itoa(i))
-		if _, err := os.Stat(caDir); err != nil {
-			t.Errorf("missing CA dir mlx5_%d: %v", i, err)
-		}
+		_, err := os.Stat(caDir)
+		require.NoError(t, err, "missing CA dir mlx5_%d", i)
 	}
-	if _, err := os.Stat(filepath.Join(dir, "sys/class/infiniband", "mlx5_2")); !os.IsNotExist(err) {
-		t.Errorf("override should cap count: mlx5_2 exists: %v", err)
-	}
+	_, err = os.Stat(filepath.Join(dir, "sys/class/infiniband", "mlx5_2"))
+	require.True(t, os.IsNotExist(err), "override should cap count: mlx5_2 exists: %v", err)
 }
 
 func TestRender_RateMapping(t *testing.T) {
@@ -169,9 +146,8 @@ func TestRender_RateMapping(t *testing.T) {
 		{50, "50 Gb/sec (4X)"},
 	}
 	for _, tc := range cases {
-		if got := formatRate(tc.in); got != tc.want {
-			t.Errorf("formatRate(%d): got %q want %q", tc.in, got, tc.want)
-		}
+		got := formatRate(tc.in)
+		require.Equal(t, tc.want, got, "formatRate(%d)", tc.in)
 	}
 }
 
@@ -182,14 +158,10 @@ func TestRender_GUIDPrefixNormalization(t *testing.T) {
 		GPUCount: 1,
 		Output:   dir,
 	})
-	if err != nil {
-		t.Fatalf("Render: %v", err)
-	}
+	require.NoError(t, err, "Render")
 	got, _ := os.ReadFile(filepath.Join(dir, "sys/class/infiniband/mlx5_0/node_guid"))
 	want := "aabb:cc00:0000:0000\n"
-	if string(got) != want {
-		t.Errorf("node_guid: got %q want %q", string(got), want)
-	}
+	require.Equal(t, want, string(got), "node_guid")
 }
 
 func TestRender_NodeUniqueGUIDsAcrossNodes(t *testing.T) {
@@ -199,29 +171,21 @@ func TestRender_NodeUniqueGUIDsAcrossNodes(t *testing.T) {
 	opts := func(node, out string) Options {
 		return Options{IB: ib, GPUCount: 2, NodeName: node, Output: out}
 	}
-	if err := Render(opts("worker-a", dirA)); err != nil {
-		t.Fatal(err)
-	}
-	if err := Render(opts("worker-b", dirB)); err != nil {
-		t.Fatal(err)
-	}
+	err := Render(opts("worker-a", dirA))
+	require.NoError(t, err)
+	err = Render(opts("worker-b", dirB))
+	require.NoError(t, err)
 	readGUID := func(root, ca string) string {
 		b, err := os.ReadFile(filepath.Join(root, "sys/class/infiniband", ca, "node_guid"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		return strings.TrimSpace(string(b))
 	}
 	gA := readGUID(dirA, "mlx5_0")
 	gB := readGUID(dirB, "mlx5_0")
-	if gA == gB {
-		t.Fatalf("node_guid collision for same hca idx: %q", gA)
-	}
+	require.NotEqual(t, gB, gA, "node_guid collision for same hca idx")
 	lidA, _ := os.ReadFile(filepath.Join(dirA, "sys/class/infiniband/mlx5_0/ports/1/lid"))
 	lidB, _ := os.ReadFile(filepath.Join(dirB, "sys/class/infiniband/mlx5_0/ports/1/lid"))
-	if strings.TrimSpace(string(lidA)) == strings.TrimSpace(string(lidB)) {
-		t.Fatalf("lid collision: %q", lidA)
-	}
+	require.NotEqual(t, strings.TrimSpace(string(lidB)), strings.TrimSpace(string(lidA)), "lid collision")
 }
 
 func TestRender_NodePortGUIDsAvoidKnownHashLowBitCollision(t *testing.T) {
@@ -231,18 +195,14 @@ func TestRender_NodePortGUIDsAvoidKnownHashLowBitCollision(t *testing.T) {
 	dirA := t.TempDir()
 	dirB := t.TempDir()
 	ib := config.Infiniband{Enabled: true, HCACountOverride: 2}
-	if err := Render(Options{IB: ib, NodeName: "38", Output: dirA}); err != nil {
-		t.Fatal(err)
-	}
-	if err := Render(Options{IB: ib, NodeName: "worker-44", Output: dirB}); err != nil {
-		t.Fatal(err)
-	}
+	err := Render(Options{IB: ib, NodeName: "38", Output: dirA})
+	require.NoError(t, err)
+	err = Render(Options{IB: ib, NodeName: "worker-44", Output: dirB})
+	require.NoError(t, err)
 	read := func(root, rel string) string {
 		t.Helper()
 		b, err := os.ReadFile(filepath.Join(root, rel))
-		if err != nil {
-			t.Fatalf("read %s: %v", rel, err)
-		}
+		require.NoError(t, err, "read %s", rel)
 		return strings.TrimSpace(string(b))
 	}
 	for _, rel := range []string{
@@ -250,9 +210,8 @@ func TestRender_NodePortGUIDsAvoidKnownHashLowBitCollision(t *testing.T) {
 		"sys/class/infiniband/mlx5_0/ports/1/port_guid",
 		"sys/class/infiniband/mlx5_0/ports/1/lid",
 	} {
-		if a, b := read(dirA, rel), read(dirB, rel); a == b {
-			t.Fatalf("%s collision for known node-name pair: %q", rel, a)
-		}
+		a, b := read(dirA, rel), read(dirB, rel)
+		require.NotEqual(t, b, a, "%s collision for known node-name pair", rel)
 	}
 }
 
@@ -263,18 +222,15 @@ func TestRender_NodePortGUIDsNoOverlap(t *testing.T) {
 	// putting the index in bits 1..4 keeps every node/port GUID distinct.
 	dir := t.TempDir()
 	const hcas = 20
-	if err := Render(Options{
+	err := Render(Options{
 		IB:       config.Infiniband{Enabled: true, HCACountOverride: hcas},
 		NodeName: "worker-a",
 		Output:   dir,
-	}); err != nil {
-		t.Fatalf("Render: %v", err)
-	}
+	})
+	require.NoError(t, err, "Render")
 	read := func(rel string) string {
 		b, err := os.ReadFile(filepath.Join(dir, rel))
-		if err != nil {
-			t.Fatalf("read %s: %v", rel, err)
-		}
+		require.NoError(t, err, "read %s", rel)
 		return strings.TrimSpace(string(b))
 	}
 	seen := map[string]string{}
@@ -285,9 +241,8 @@ func TestRender_NodePortGUIDsNoOverlap(t *testing.T) {
 			{filepath.Join("sys/class/infiniband", ca, "ports/1/port_guid"), ca + " port_guid"},
 		} {
 			v := read(kind.rel)
-			if prev, dup := seen[v]; dup {
-				t.Fatalf("GUID collision: %s and %s both == %q", prev, kind.what, v)
-			}
+			prev, dup := seen[v]
+			require.False(t, dup, "GUID collision: %s and %s both == %q", prev, kind.what, v)
 			seen[v] = kind.what
 		}
 	}
@@ -300,7 +255,5 @@ func TestRender_BadGUIDPrefix(t *testing.T) {
 		GPUCount: 1,
 		Output:   dir,
 	})
-	if err == nil {
-		t.Fatalf("expected error for bad guid_prefix, got nil")
-	}
+	require.Error(t, err, "expected error for bad guid_prefix")
 }

--- a/pkg/network/mockib/subnet/drpath_test.go
+++ b/pkg/network/mockib/subnet/drpath_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/fabric"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/protocol"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/registry"
+	"github.com/stretchr/testify/require"
 )
 
 // Captured MAD header from a real `ibping <lid>` send in
@@ -39,10 +40,8 @@ var ibpingVendorPingHdr = []byte{
 func TestIsSMPSend_RejectsVendorPing(t *testing.T) {
 	umad := make([]byte, umadMADOffset+256)
 	copy(umad[umadMADOffset:], ibpingVendorPingHdr)
-	if IsSMPSend(umad) {
-		t.Fatalf("vendor ping MAD (MgmtClass=0x%02x) must not be classified as SMP",
-			umad[umadMADOffset+1])
-	}
+	require.False(t, IsSMPSend(umad), "vendor ping MAD (MgmtClass=0x%02x) must not be classified as SMP",
+		umad[umadMADOffset+1])
 }
 
 // TestIsSMPSend_AcceptsSMI / _AcceptsSMIDirect keep the positive side of the
@@ -54,9 +53,7 @@ func TestIsSMPSend_AcceptsSMI(t *testing.T) {
 	umad[umadMADOffset+1] = ibClassSMI
 	umad[umadMADOffset+2] = 0x01
 	umad[umadMADOffset+3] = 0x01
-	if !IsSMPSend(umad) {
-		t.Fatal("SMI MAD must be classified as SMP")
-	}
+	require.True(t, IsSMPSend(umad), "SMI MAD must be classified as SMP")
 }
 
 func TestIsSMPSend_AcceptsSMIDirect(t *testing.T) {
@@ -66,9 +63,7 @@ func TestIsSMPSend_AcceptsSMIDirect(t *testing.T) {
 	umad[umadMADOffset+1] = ibClassSMIDirect
 	umad[umadMADOffset+2] = 0x01
 	umad[umadMADOffset+3] = 0x01
-	if !IsSMPSend(umad) {
-		t.Fatal("SMI-direct MAD must be classified as SMP")
-	}
+	require.True(t, IsSMPSend(umad), "SMI-direct MAD must be classified as SMP")
 }
 
 // TestIsSMPSend_RejectsSA pins the SA(0x03) case so the future habit of
@@ -79,9 +74,7 @@ func TestIsSMPSend_RejectsSA(t *testing.T) {
 	umad[umadMADOffset+1] = 0x03 // SA
 	umad[umadMADOffset+2] = 0x02
 	umad[umadMADOffset+3] = 0x01
-	if IsSMPSend(umad) {
-		t.Fatal("SA MAD must not be classified as SMP")
-	}
+	require.False(t, IsSMPSend(umad), "SA MAD must not be classified as SMP")
 }
 
 func TestResolveTarget_DROneHopPeerNotLocal(t *testing.T) {
@@ -99,15 +92,9 @@ func TestResolveTarget_DROneHopPeerNotLocal(t *testing.T) {
 	mad[ibDRPathByteOff+1] = 1
 
 	p, ok := resolveTarget(g, mad, 0xffff, "mlx5_0")
-	if !ok {
-		t.Fatal("expected peer resolve")
-	}
-	if p.PortGUID == "a088:c203:00ab:5601" {
-		t.Fatalf("DR hop 1 should target peer, got local port GUID %s", p.PortGUID)
-	}
-	if p.PortGUID != "a088:c203:00ab:2001" {
-		t.Fatalf("peer GUID: got %s", p.PortGUID)
-	}
+	require.True(t, ok, "expected peer resolve")
+	require.NotEqual(t, "a088:c203:00ab:5601", p.PortGUID, "DR hop 1 should target peer, got local port GUID %s", p.PortGUID)
+	require.Equal(t, "a088:c203:00ab:2001", p.PortGUID, "peer GUID: got %s", p.PortGUID)
 }
 
 func TestResolveTarget_TwoHopDifferentPeer(t *testing.T) {
@@ -127,14 +114,8 @@ func TestResolveTarget_TwoHopDifferentPeer(t *testing.T) {
 	mad[ibDRPathByteOff+2] = 1
 
 	p, ok := resolveTarget(g, mad, 0xffff, "mlx5_0")
-	if !ok {
-		t.Fatal("expected two-hop resolve")
-	}
-	if p.PortGUID == "a088:c203:00ab:5601" {
-		t.Fatal("two-hop must not resolve to local port")
-	}
-	if p.PodIP == "10.0.0.2" {
-		// second hop should land on the other peer pod when two remotes exist
-		t.Fatalf("expected second peer pod, got %s", p.PodIP)
-	}
+	require.True(t, ok, "expected two-hop resolve")
+	require.NotEqual(t, "a088:c203:00ab:5601", p.PortGUID, "two-hop must not resolve to local port")
+	// second hop should land on the other peer pod when two remotes exist
+	require.NotEqual(t, "10.0.0.2", p.PodIP, "expected second peer pod, got %s", p.PodIP)
 }

--- a/pkg/network/mockib/subnet/madfield_test.go
+++ b/pkg/network/mockib/subnet/madfield_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/fabric"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBitsoffs_PortInfoLid(t *testing.T) {
 	// IB spec offsets are transformed by libibmad fields.c BITSOFFS macro.
-	if got, want := Bitsoffs(128, 16), 144; got != want {
-		t.Fatalf("Bitsoffs(128,16): got %d want %d", got, want)
-	}
-	if got, want := Bitsoffs(144, 16), 128; got != want {
-		t.Fatalf("Bitsoffs(144,16): got %d want %d", got, want)
-	}
+	require.Equal(t, 144, Bitsoffs(128, 16), "Bitsoffs(128,16)")
+	require.Equal(t, 128, Bitsoffs(144, 16), "Bitsoffs(144,16)")
 }
 
 func TestSetFieldPortInfoLinkUp(t *testing.T) {
@@ -46,9 +43,7 @@ func TestSetFieldPortInfoLinkUp(t *testing.T) {
 		{280, 4, linkSpeed10G},
 	}
 	for _, c := range cases {
-		if got := GetFieldSpec(pl, c.specOff, c.len); got != c.want {
-			t.Fatalf("field spec@%d len=%d: got %#x want %#x", c.specOff, c.len, got, c.want)
-		}
+		require.Equal(t, c.want, GetFieldSpec(pl, c.specOff, c.len), "field spec@%d len=%d", c.specOff, c.len)
 	}
 }
 
@@ -57,12 +52,8 @@ func TestFillNodeInfo(t *testing.T) {
 	fillNodeInfo(mad, fabricPort(0x101), 0)
 	pl := mad[ibSMPDataOff:]
 
-	if got := GetFieldSpec(pl, 16, 8); got != nodeTypeCA {
-		t.Fatalf("node type: got %d want %d", got, nodeTypeCA)
-	}
-	if got := GetFieldSpec(pl, 288, 8); got != 1 {
-		t.Fatalf("local port: got %d want 1", got)
-	}
+	require.Equal(t, uint32(nodeTypeCA), GetFieldSpec(pl, 16, 8), "node type")
+	require.Equal(t, uint32(1), GetFieldSpec(pl, 288, 8), "local port")
 }
 
 func TestFillPortInfo(t *testing.T) {
@@ -70,15 +61,9 @@ func TestFillPortInfo(t *testing.T) {
 	fillPortInfo(mad, fabricPort(0x101), 1)
 	pl := mad[ibSMPDataOff:]
 
-	if got := GetFieldSpec(pl, 264, 4); got != portPhysStateLinkUp {
-		t.Fatalf("phys state: got %d want %d", got, portPhysStateLinkUp)
-	}
-	if got := GetFieldSpec(pl, 248, 8); got != linkWidth4X {
-		t.Fatalf("link width: got %d want %d", got, linkWidth4X)
-	}
-	if got := GetFieldSpec(pl, 128, 16); got != 0x101 {
-		t.Fatalf("lid: got %#x want 0x101", got)
-	}
+	require.Equal(t, uint32(portPhysStateLinkUp), GetFieldSpec(pl, 264, 4), "phys state")
+	require.Equal(t, uint32(linkWidth4X), GetFieldSpec(pl, 248, 8), "link width")
+	require.Equal(t, uint32(0x101), GetFieldSpec(pl, 128, 16), "lid")
 }
 
 func fabricPort(lid uint16) fabric.Port {

--- a/pkg/network/mockib/subnet/synthesize_test.go
+++ b/pkg/network/mockib/subnet/synthesize_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/fabric"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/protocol"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/registry"
+	"github.com/stretchr/testify/require"
 )
 
 // writeMADHeader writes a wire-format SMP GET header (IBA §13.4) into mad:
@@ -35,13 +36,9 @@ func TestTrySynthesize_PortInfo(t *testing.T) {
 
 	binary.BigEndian.PutUint16(send[28:30], 0x101)
 	resp, ok := TrySynthesize(send, g, "mlx5_0")
-	if !ok {
-		t.Fatal("expected synthesize")
-	}
+	require.True(t, ok, "expected synthesize")
 	rm := resp[umadMADOffset:]
-	if rm[ibMADMethodOff]&0x80 == 0 {
-		t.Fatal("response method bit not set")
-	}
+	require.NotEqual(t, byte(0), rm[ibMADMethodOff]&0x80, "response method bit not set")
 }
 
 func TestTrySynthesize_SelfResolveLID0(t *testing.T) {
@@ -57,9 +54,7 @@ func TestTrySynthesize_SelfResolveLID0(t *testing.T) {
 	send[28] = 0
 	send[29] = 0
 	_, ok := TrySynthesize(send, g, "mlx5_0")
-	if !ok {
-		t.Fatal("expected synthesize for lid 0 self resolve")
-	}
+	require.True(t, ok, "expected synthesize for lid 0 self resolve")
 }
 
 func TestTrySynthesize_PortInfoMod0PhysLinkUp(t *testing.T) {
@@ -73,16 +68,10 @@ func TestTrySynthesize_PortInfoMod0PhysLinkUp(t *testing.T) {
 	binary.BigEndian.PutUint16(send[28:30], 0xffff)
 
 	resp, ok := TrySynthesize(send, g, "mlx5_0")
-	if !ok {
-		t.Fatal("expected synthesize")
-	}
+	require.True(t, ok, "expected synthesize")
 	pl := resp[umadMADOffset+ibSMPDataOff:]
-	if got := GetFieldSpec(pl, 264, 4); got != portPhysStateLinkUp {
-		t.Fatalf("phys: got %d want %d", got, portPhysStateLinkUp)
-	}
-	if got := GetFieldSpec(pl, 128, 16); got != 0x0dc0 {
-		t.Fatalf("lid: got %#x want 0x0dc0", got)
-	}
+	require.Equal(t, uint32(portPhysStateLinkUp), GetFieldSpec(pl, 264, 4), "phys")
+	require.Equal(t, uint32(0x0dc0), GetFieldSpec(pl, 128, 16), "lid")
 }
 
 func TestTrySynthesize_ShortSendBuffer(t *testing.T) {
@@ -96,19 +85,11 @@ func TestTrySynthesize_ShortSendBuffer(t *testing.T) {
 	SetField(mad, ibDRHopCntBit, 8, 0)
 
 	resp, ok := TrySynthesize(send, g, "mlx5_0")
-	if !ok {
-		t.Fatal("expected synthesize")
-	}
-	if len(resp) < minUmadLen {
-		t.Fatalf("resp len %d want >= %d", len(resp), minUmadLen)
-	}
+	require.True(t, ok, "expected synthesize")
+	require.GreaterOrEqual(t, len(resp), minUmadLen, "resp len %d want >= %d", len(resp), minUmadLen)
 	pl := resp[umadMADOffset+ibSMPDataOff:]
-	if got := GetFieldSpec(pl, 128, 16); got != 0x0f90 {
-		t.Fatalf("lid: got %#x want 0x0f90", got)
-	}
-	if got := GetFieldSpec(pl, 264, 4); got != portPhysStateLinkUp {
-		t.Fatalf("phys: got %d want %d", got, portPhysStateLinkUp)
-	}
+	require.Equal(t, uint32(0x0f90), GetFieldSpec(pl, 128, 16), "lid")
+	require.Equal(t, uint32(portPhysStateLinkUp), GetFieldSpec(pl, 264, 4), "phys")
 }
 
 // TestFillPortInfo_WireBytes pins the on-wire byte layout of a synthesized
@@ -125,25 +106,15 @@ func TestFillPortInfo_WireBytes(t *testing.T) {
 	pl := mad[ibSMPDataOff:]
 
 	// GidPrefix (spec bit 64 -> byte 8, BE64).
-	if got := binary.BigEndian.Uint64(pl[8:16]); got != defaultGidPrefix {
-		t.Fatalf("GidPrefix @byte8: got %#016x want %#016x", got, uint64(defaultGidPrefix))
-	}
+	require.Equal(t, uint64(defaultGidPrefix), binary.BigEndian.Uint64(pl[8:16]), "GidPrefix @byte8")
 	// LID (spec bit 128 -> byte 16, BE16).
-	if got := binary.BigEndian.Uint16(pl[16:18]); got != 0x0dc0 {
-		t.Fatalf("LID @byte16: got %#04x want 0x0dc0", got)
-	}
+	require.Equal(t, uint16(0x0dc0), binary.BigEndian.Uint16(pl[16:18]), "LID @byte16")
 	// MasterSMLID (spec bit 144 -> byte 18, BE16).
-	if got := binary.BigEndian.Uint16(pl[18:20]); got != defaultSMLID {
-		t.Fatalf("SMLID @byte18: got %#04x want %#04x", got, defaultSMLID)
-	}
+	require.Equal(t, uint16(defaultSMLID), binary.BigEndian.Uint16(pl[18:20]), "SMLID @byte18")
 	// PortState occupies the low nibble of wire byte 32; PortPhysState the
 	// high nibble of wire byte 33 (libibmad PORT_INFO field defs).
-	if got := pl[32] & 0x0f; got != portStateActive {
-		t.Fatalf("PortState @byte32 low nibble: got %d want %d", got, portStateActive)
-	}
-	if got := pl[33] >> 4; got != portPhysStateLinkUp {
-		t.Fatalf("PortPhysState @byte33 high nibble: got %d want %d", got, portPhysStateLinkUp)
-	}
+	require.Equal(t, byte(portStateActive), pl[32]&0x0f, "PortState @byte32 low nibble")
+	require.Equal(t, byte(portPhysStateLinkUp), pl[33]>>4, "PortPhysState @byte33 high nibble")
 }
 
 // TestFillNodeInfo_WireBytes pins the on-wire byte layout of a synthesized
@@ -156,29 +127,17 @@ func TestFillNodeInfo_WireBytes(t *testing.T) {
 	pl := mad[ibSMPDataOff:]
 
 	// NodeType (spec bit 16 -> byte 2) and NumPorts (spec bit 24 -> byte 3).
-	if pl[2] != nodeTypeCA {
-		t.Fatalf("NodeType @byte2: got %d want %d", pl[2], nodeTypeCA)
-	}
-	if pl[3] != 1 {
-		t.Fatalf("NumPorts @byte3: got %d want 1", pl[3])
-	}
+	require.Equal(t, byte(nodeTypeCA), pl[2], "NodeType @byte2")
+	require.Equal(t, byte(1), pl[3], "NumPorts @byte3")
 	// SystemGuid @byte4 and NodeGuid @byte12 are both p.NodeGUID; PortGuid
 	// @byte20 is p.PortGUID (all 8-byte BE, written by putGUID64).
 	nodeGUID := []byte{0xa0, 0x88, 0xc2, 0x03, 0x00, 0xab, 0x00, 0x00}
 	portGUID := []byte{0xa0, 0x88, 0xc2, 0x03, 0x00, 0xab, 0x00, 0x01}
-	if string(pl[4:12]) != string(nodeGUID) {
-		t.Fatalf("SystemGuid @byte4: got %x want %x", pl[4:12], nodeGUID)
-	}
-	if string(pl[12:20]) != string(nodeGUID) {
-		t.Fatalf("NodeGuid @byte12: got %x want %x", pl[12:20], nodeGUID)
-	}
-	if string(pl[20:28]) != string(portGUID) {
-		t.Fatalf("PortGuid @byte20: got %x want %x", pl[20:28], portGUID)
-	}
+	require.Equal(t, nodeGUID, pl[4:12], "SystemGuid @byte4")
+	require.Equal(t, nodeGUID, pl[12:20], "NodeGuid @byte12")
+	require.Equal(t, portGUID, pl[20:28], "PortGuid @byte20")
 	// LocalPort (spec bit 288 -> byte 36); attrMod 0 resolves to port 1.
-	if pl[36] != 1 {
-		t.Fatalf("LocalPort @byte36: got %d want 1", pl[36])
-	}
+	require.Equal(t, byte(1), pl[36], "LocalPort @byte36")
 }
 
 func TestTrySynthesize_DROneHopNodeInfo(t *testing.T) {
@@ -198,13 +157,9 @@ func TestTrySynthesize_DROneHopNodeInfo(t *testing.T) {
 	binary.BigEndian.PutUint16(send[28:30], 0xffff)
 
 	resp, ok := TrySynthesize(send, g, "mlx5_0")
-	if !ok {
-		t.Fatal("expected synthesize for DR hop")
-	}
+	require.True(t, ok, "expected synthesize for DR hop")
 	pl := resp[umadMADOffset+ibSMPDataOff:]
 	// PortGuid @ byte 20 should be the peer port (0002).
 	want := []byte{0xa0, 0x88, 0xc2, 0x03, 0x00, 0xab, 0x00, 0x02}
-	if string(pl[20:28]) != string(want) {
-		t.Fatalf("peer port guid: got %x want %x", pl[20:28], want)
-	}
+	require.Equal(t, want, pl[20:28], "peer port guid")
 }

--- a/pkg/network/mockib/sysfs/scan_parse_test.go
+++ b/pkg/network/mockib/sysfs/scan_parse_test.go
@@ -3,7 +3,11 @@
 
 package sysfs
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestParseLID(t *testing.T) {
 	tests := []struct {
@@ -19,17 +23,10 @@ func TestParseLID(t *testing.T) {
 	for _, tc := range tests {
 		got, err := parseLID(tc.in)
 		if tc.wantErr {
-			if err == nil {
-				t.Errorf("parseLID(%q): want error", tc.in)
-			}
+			require.Error(t, err, "parseLID(%q): want error", tc.in)
 			continue
 		}
-		if err != nil {
-			t.Errorf("parseLID(%q): %v", tc.in, err)
-			continue
-		}
-		if got != tc.want {
-			t.Errorf("parseLID(%q) = 0x%04x want 0x%04x", tc.in, got, tc.want)
-		}
+		require.NoError(t, err, "parseLID(%q)", tc.in)
+		require.Equal(t, tc.want, got, "parseLID(%q)", tc.in)
 	}
 }

--- a/pkg/network/mockib/sysfs/scan_test.go
+++ b/pkg/network/mockib/sysfs/scan_test.go
@@ -8,31 +8,23 @@ import (
 
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/config"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/render"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScan_RenderedTree(t *testing.T) {
 	dir := t.TempDir()
 	ib := config.Infiniband{Enabled: true}
-	if err := render.Render(render.Options{IB: ib, GPUCount: 2, NodeName: "node-a", Output: dir}); err != nil {
-		t.Fatal(err)
-	}
+	err := render.Render(render.Options{IB: ib, GPUCount: 2, NodeName: "node-a", Output: dir})
+	require.NoError(t, err)
 	ports, err := Scan(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(ports) != 2 {
-		t.Fatalf("want 2 ports, got %d: %+v", len(ports), ports)
-	}
+	require.NoError(t, err)
+	require.Len(t, ports, 2, "want 2 ports, got %d: %+v", len(ports), ports)
 	var mlx0 bool
 	for _, p := range ports {
 		if p.CAName == "mlx5_0" {
 			mlx0 = true
-			if p.Port != 1 || p.PortGUID == "" || p.LID == 0 {
-				t.Fatalf("mlx5_0 advert: %+v", p)
-			}
+			require.False(t, p.Port != 1 || p.PortGUID == "" || p.LID == 0, "mlx5_0 advert: %+v", p)
 		}
 	}
-	if !mlx0 {
-		t.Fatalf("mlx5_0 not found in %+v", ports)
-	}
+	require.True(t, mlx0, "mlx5_0 not found in %+v", ports)
 }

--- a/pkg/system/mockpcisysfs/render/render_test.go
+++ b/pkg/system/mockpcisysfs/render/render_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
 	"github.com/NVIDIA/k8s-test-infra/pkg/system/mockpcisysfs/config"
@@ -16,13 +17,9 @@ import (
 
 func TestRender_NoTopologyNoOp(t *testing.T) {
 	dir := t.TempDir()
-	if err := Render(Options{Output: dir}); err != nil {
-		t.Fatalf("Render(no topology): %v", err)
-	}
+	require.NoError(t, Render(Options{Output: dir}), "Render(no topology)")
 	entries, _ := os.ReadDir(dir)
-	if len(entries) != 0 {
-		t.Fatalf("expected empty output for nil topology, got %d entries", len(entries))
-	}
+	require.Empty(t, entries, "expected empty output for nil topology")
 }
 
 func TestRender_RequiresOutput(t *testing.T) {
@@ -32,9 +29,7 @@ func TestRender_RequiresOutput(t *testing.T) {
 			Devices: []string{"0000:07:00.0"},
 		}},
 	}})
-	if err == nil {
-		t.Fatal("expected error with empty Output")
-	}
+	require.Error(t, err, "expected error with empty Output")
 }
 
 // TestRender_FullTree exercises the documented sysfs layout end-to-end:
@@ -58,9 +53,7 @@ func TestRender_FullTree(t *testing.T) {
 			},
 		},
 	}
-	if err := Render(Options{Topology: topo, Output: dir}); err != nil {
-		t.Fatalf("Render: %v", err)
-	}
+	require.NoError(t, Render(Options{Topology: topo, Output: dir}), "Render")
 
 	// numa_node files must contain the per-root NUMA value (and *only*
 	// that — a trailing-newline regression would silently bake "0\n0\n"
@@ -68,12 +61,8 @@ func TestRender_FullTree(t *testing.T) {
 	mustRead := func(rel, want string) {
 		t.Helper()
 		got, err := os.ReadFile(filepath.Join(dir, rel))
-		if err != nil {
-			t.Fatalf("read %s: %v", rel, err)
-		}
-		if string(got) != want {
-			t.Errorf("%s: got %q want %q", rel, string(got), want)
-		}
+		require.NoError(t, err, "read %s", rel)
+		require.Equal(t, want, string(got), "%s", rel)
 	}
 	mustRead("sys/devices/pci0000:00/0000:07:00.0/numa_node", "0\n")
 	mustRead("sys/devices/pci0000:00/0000:0f:00.0/numa_node", "0\n")
@@ -86,12 +75,8 @@ func TestRender_FullTree(t *testing.T) {
 	mustLink := func(rel, wantTarget string) {
 		t.Helper()
 		target, err := os.Readlink(filepath.Join(dir, rel))
-		if err != nil {
-			t.Fatalf("readlink %s: %v", rel, err)
-		}
-		if target != wantTarget {
-			t.Errorf("%s: target=%q want %q", rel, target, wantTarget)
-		}
+		require.NoError(t, err, "readlink %s", rel)
+		require.Equal(t, wantTarget, target, "%s", rel)
 	}
 	mustLink("sys/bus/pci/devices/0000:07:00.0", "../../../devices/pci0000:00/0000:07:00.0")
 	mustLink("sys/bus/pci/devices/0000:0f:00.0", "../../../devices/pci0000:00/0000:0f:00.0")
@@ -101,12 +86,9 @@ func TestRender_FullTree(t *testing.T) {
 	// library actually performs) must land on the real numa_node file.
 	resolved, err := filepath.EvalSymlinks(
 		filepath.Join(dir, "sys/bus/pci/devices/0000:07:00.0"))
-	if err != nil {
-		t.Fatalf("EvalSymlinks: %v", err)
-	}
-	if !strings.HasSuffix(resolved, "sys/devices/pci0000:00/0000:07:00.0") {
-		t.Errorf("resolved=%q does not land under expected root complex", resolved)
-	}
+	require.NoError(t, err, "EvalSymlinks")
+	require.True(t, strings.HasSuffix(resolved, "sys/devices/pci0000:00/0000:07:00.0"),
+		"resolved=%q does not land under expected root complex", resolved)
 }
 
 func TestRender_IdempotentRerender(t *testing.T) {
@@ -118,9 +100,7 @@ func TestRender_IdempotentRerender(t *testing.T) {
 		}},
 	}
 	// First pass.
-	if err := Render(Options{Topology: topoA, Output: dir}); err != nil {
-		t.Fatalf("Render pass 1: %v", err)
-	}
+	require.NoError(t, Render(Options{Topology: topoA, Output: dir}), "Render pass 1")
 
 	// Second pass with a *different* root complex for the same BDF.
 	// Re-render must point the symlink at the new root and overwrite
@@ -131,24 +111,15 @@ func TestRender_IdempotentRerender(t *testing.T) {
 			Devices: []string{"0000:07:00.0"},
 		}},
 	}
-	if err := Render(Options{Topology: topoB, Output: dir}); err != nil {
-		t.Fatalf("Render pass 2: %v", err)
-	}
+	require.NoError(t, Render(Options{Topology: topoB, Output: dir}), "Render pass 2")
 
 	target, err := os.Readlink(filepath.Join(dir, "sys/bus/pci/devices/0000:07:00.0"))
-	if err != nil {
-		t.Fatalf("readlink: %v", err)
-	}
-	if target != "../../../devices/pci0000:c0/0000:07:00.0" {
-		t.Errorf("symlink target stale across rerender: got %q", target)
-	}
+	require.NoError(t, err, "readlink")
+	require.Equal(t, "../../../devices/pci0000:c0/0000:07:00.0", target,
+		"symlink target stale across rerender")
 	got, err := os.ReadFile(filepath.Join(dir, "sys/devices/pci0000:c0/0000:07:00.0/numa_node"))
-	if err != nil {
-		t.Fatalf("read numa_node: %v", err)
-	}
-	if string(got) != "3\n" {
-		t.Errorf("numa_node not updated: got %q", string(got))
-	}
+	require.NoError(t, err, "read numa_node")
+	require.Equal(t, "3\n", string(got), "numa_node not updated")
 }
 
 func TestRender_NormalizesUppercaseBDF(t *testing.T) {
@@ -159,22 +130,19 @@ func TestRender_NormalizesUppercaseBDF(t *testing.T) {
 			Devices: []string{"0000:BD:00.0"}, // uppercase BDF
 		}},
 	}
-	if err := Render(Options{Topology: topo, Output: dir}); err != nil {
-		t.Fatalf("Render: %v", err)
-	}
+	require.NoError(t, Render(Options{Topology: topo, Output: dir}), "Render")
 	// Real sysfs is lowercase. Render must lowercase before writing so
 	// downstream tools (lspci, libpciaccess) that string-compare BDFs
 	// see what they expect.
-	if _, err := os.Stat(filepath.Join(dir, "sys/bus/pci/devices/0000:bd:00.0")); err != nil {
-		t.Errorf("expected lowercase symlink, missing: %v", err)
-	}
+	_, err := os.Stat(filepath.Join(dir, "sys/bus/pci/devices/0000:bd:00.0"))
+	require.NoError(t, err, "expected lowercase symlink")
 }
 
 // --- Config / Validate tests --------------------------------------------------
 
 func TestValidate_AcceptsCanonicalProfile(t *testing.T) {
 	var p config.Profile
-	if err := yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 devices:
   - index: 0
     pci:
@@ -189,12 +157,8 @@ pcie_topology:
       devices:
         - "0000:07:00.0"
         - "0000:0F:00.0"
-`), &p); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if err := p.Validate(); err != nil {
-		t.Errorf("Validate: %v", err)
-	}
+`), &p), "unmarshal")
+	require.NoError(t, p.Validate(), "Validate")
 }
 
 func TestValidate_RejectsLegacy8DigitBDF(t *testing.T) {
@@ -209,22 +173,18 @@ func TestValidate_RejectsLegacy8DigitBDF(t *testing.T) {
 			Devices: []string{"00000000:07:00.0"},
 		}}},
 	}
-	if err := p.Validate(); err == nil {
-		t.Fatal("expected error for 8-digit BDF, got nil")
-	}
+	require.Error(t, p.Validate(), "expected error for 8-digit BDF")
 }
 
 func TestValidate_RejectsMalformedRoot(t *testing.T) {
 	p := config.Profile{
 		Devices: []config.Device{{Index: 0, PCI: config.PCI{BusID: "0000:07:00.0"}}},
 		PCIeTopology: &config.PCIeTopology{RootComplexes: []config.RootComplex{{
-			ID: "0000:00", // missing "pci" prefix
+			ID:      "0000:00", // missing "pci" prefix
 			Devices: []string{"0000:07:00.0"},
 		}}},
 	}
-	if err := p.Validate(); err == nil {
-		t.Fatal("expected error for malformed root id, got nil")
-	}
+	require.Error(t, p.Validate(), "expected error for malformed root id")
 }
 
 func TestValidate_RejectsDuplicateRoot(t *testing.T) {
@@ -235,9 +195,7 @@ func TestValidate_RejectsDuplicateRoot(t *testing.T) {
 			{ID: "pci0000:00", NUMANode: 1, Devices: []string{}},
 		}},
 	}
-	if err := p.Validate(); err == nil {
-		t.Fatal("expected error for duplicate root complex, got nil")
-	}
+	require.Error(t, p.Validate(), "expected error for duplicate root complex")
 }
 
 func TestValidate_RejectsDuplicateBDF(t *testing.T) {
@@ -251,9 +209,7 @@ func TestValidate_RejectsDuplicateBDF(t *testing.T) {
 			{ID: "pci0000:80", NUMANode: 1, Devices: []string{"0000:07:00.0"}},
 		}},
 	}
-	if err := p.Validate(); err == nil {
-		t.Fatal("expected error for duplicate BDF, got nil")
-	}
+	require.Error(t, p.Validate(), "expected error for duplicate BDF")
 }
 
 func TestValidate_RejectsUnknownBDF(t *testing.T) {
@@ -267,9 +223,7 @@ func TestValidate_RejectsUnknownBDF(t *testing.T) {
 			Devices: []string{"0000:99:00.0"},
 		}}},
 	}
-	if err := p.Validate(); err == nil {
-		t.Fatal("expected error for unknown BDF, got nil")
-	}
+	require.Error(t, p.Validate(), "expected error for unknown BDF")
 }
 
 func TestEffectiveTopology_DefaultFlatRoot(t *testing.T) {
@@ -280,18 +234,11 @@ func TestEffectiveTopology_DefaultFlatRoot(t *testing.T) {
 		{Index: 1, PCI: config.PCI{BusID: "0000:0F:00.0"}},
 	}}
 	topo := p.EffectiveTopology()
-	if topo == nil || len(topo.RootComplexes) != 1 {
-		t.Fatalf("expected single default root, got %+v", topo)
-	}
-	if topo.RootComplexes[0].ID != "pci0000:00" {
-		t.Errorf("default root id = %q want pci0000:00", topo.RootComplexes[0].ID)
-	}
-	if topo.RootComplexes[0].NUMANode != 0 {
-		t.Errorf("default numa_node = %d want 0", topo.RootComplexes[0].NUMANode)
-	}
-	if len(topo.RootComplexes[0].Devices) != 2 {
-		t.Errorf("default root should contain all devices, got %v", topo.RootComplexes[0].Devices)
-	}
+	require.NotNil(t, topo, "expected non-nil default topology")
+	require.Len(t, topo.RootComplexes, 1, "expected single default root")
+	require.Equal(t, "pci0000:00", topo.RootComplexes[0].ID, "default root id")
+	require.Equal(t, 0, topo.RootComplexes[0].NUMANode, "default numa_node")
+	require.Len(t, topo.RootComplexes[0].Devices, 2, "default root should contain all devices")
 }
 
 func TestEffectiveTopology_PrefersExplicit(t *testing.T) {
@@ -303,7 +250,5 @@ func TestEffectiveTopology_PrefersExplicit(t *testing.T) {
 		}}},
 	}
 	topo := p.EffectiveTopology()
-	if topo.RootComplexes[0].ID != "pci0000:80" {
-		t.Errorf("explicit topology lost: %+v", topo)
-	}
+	require.Equal(t, "pci0000:80", topo.RootComplexes[0].ID, "explicit topology lost")
 }

--- a/vendor/github.com/pmezard/go-difflib/LICENSE
+++ b/vendor/github.com/pmezard/go-difflib/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2013, Patrick Mezard
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+    The names of its contributors may not be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pmezard/go-difflib/difflib/difflib.go
+++ b/vendor/github.com/pmezard/go-difflib/difflib/difflib.go
@@ -1,0 +1,772 @@
+// Package difflib is a partial port of Python difflib module.
+//
+// It provides tools to compare sequences of strings and generate textual diffs.
+//
+// The following class and functions have been ported:
+//
+// - SequenceMatcher
+//
+// - unified_diff
+//
+// - context_diff
+//
+// Getting unified diffs was the main goal of the port. Keep in mind this code
+// is mostly suitable to output text differences in a human friendly way, there
+// are no guarantees generated diffs are consumable by patch(1).
+package difflib
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func calculateRatio(matches, length int) float64 {
+	if length > 0 {
+		return 2.0 * float64(matches) / float64(length)
+	}
+	return 1.0
+}
+
+type Match struct {
+	A    int
+	B    int
+	Size int
+}
+
+type OpCode struct {
+	Tag byte
+	I1  int
+	I2  int
+	J1  int
+	J2  int
+}
+
+// SequenceMatcher compares sequence of strings. The basic
+// algorithm predates, and is a little fancier than, an algorithm
+// published in the late 1980's by Ratcliff and Obershelp under the
+// hyperbolic name "gestalt pattern matching".  The basic idea is to find
+// the longest contiguous matching subsequence that contains no "junk"
+// elements (R-O doesn't address junk).  The same idea is then applied
+// recursively to the pieces of the sequences to the left and to the right
+// of the matching subsequence.  This does not yield minimal edit
+// sequences, but does tend to yield matches that "look right" to people.
+//
+// SequenceMatcher tries to compute a "human-friendly diff" between two
+// sequences.  Unlike e.g. UNIX(tm) diff, the fundamental notion is the
+// longest *contiguous* & junk-free matching subsequence.  That's what
+// catches peoples' eyes.  The Windows(tm) windiff has another interesting
+// notion, pairing up elements that appear uniquely in each sequence.
+// That, and the method here, appear to yield more intuitive difference
+// reports than does diff.  This method appears to be the least vulnerable
+// to synching up on blocks of "junk lines", though (like blank lines in
+// ordinary text files, or maybe "<P>" lines in HTML files).  That may be
+// because this is the only method of the 3 that has a *concept* of
+// "junk" <wink>.
+//
+// Timing:  Basic R-O is cubic time worst case and quadratic time expected
+// case.  SequenceMatcher is quadratic time for the worst case and has
+// expected-case behavior dependent in a complicated way on how many
+// elements the sequences have in common; best case time is linear.
+type SequenceMatcher struct {
+	a              []string
+	b              []string
+	b2j            map[string][]int
+	IsJunk         func(string) bool
+	autoJunk       bool
+	bJunk          map[string]struct{}
+	matchingBlocks []Match
+	fullBCount     map[string]int
+	bPopular       map[string]struct{}
+	opCodes        []OpCode
+}
+
+func NewMatcher(a, b []string) *SequenceMatcher {
+	m := SequenceMatcher{autoJunk: true}
+	m.SetSeqs(a, b)
+	return &m
+}
+
+func NewMatcherWithJunk(a, b []string, autoJunk bool,
+	isJunk func(string) bool) *SequenceMatcher {
+
+	m := SequenceMatcher{IsJunk: isJunk, autoJunk: autoJunk}
+	m.SetSeqs(a, b)
+	return &m
+}
+
+// Set two sequences to be compared.
+func (m *SequenceMatcher) SetSeqs(a, b []string) {
+	m.SetSeq1(a)
+	m.SetSeq2(b)
+}
+
+// Set the first sequence to be compared. The second sequence to be compared is
+// not changed.
+//
+// SequenceMatcher computes and caches detailed information about the second
+// sequence, so if you want to compare one sequence S against many sequences,
+// use .SetSeq2(s) once and call .SetSeq1(x) repeatedly for each of the other
+// sequences.
+//
+// See also SetSeqs() and SetSeq2().
+func (m *SequenceMatcher) SetSeq1(a []string) {
+	if &a == &m.a {
+		return
+	}
+	m.a = a
+	m.matchingBlocks = nil
+	m.opCodes = nil
+}
+
+// Set the second sequence to be compared. The first sequence to be compared is
+// not changed.
+func (m *SequenceMatcher) SetSeq2(b []string) {
+	if &b == &m.b {
+		return
+	}
+	m.b = b
+	m.matchingBlocks = nil
+	m.opCodes = nil
+	m.fullBCount = nil
+	m.chainB()
+}
+
+func (m *SequenceMatcher) chainB() {
+	// Populate line -> index mapping
+	b2j := map[string][]int{}
+	for i, s := range m.b {
+		indices := b2j[s]
+		indices = append(indices, i)
+		b2j[s] = indices
+	}
+
+	// Purge junk elements
+	m.bJunk = map[string]struct{}{}
+	if m.IsJunk != nil {
+		junk := m.bJunk
+		for s, _ := range b2j {
+			if m.IsJunk(s) {
+				junk[s] = struct{}{}
+			}
+		}
+		for s, _ := range junk {
+			delete(b2j, s)
+		}
+	}
+
+	// Purge remaining popular elements
+	popular := map[string]struct{}{}
+	n := len(m.b)
+	if m.autoJunk && n >= 200 {
+		ntest := n/100 + 1
+		for s, indices := range b2j {
+			if len(indices) > ntest {
+				popular[s] = struct{}{}
+			}
+		}
+		for s, _ := range popular {
+			delete(b2j, s)
+		}
+	}
+	m.bPopular = popular
+	m.b2j = b2j
+}
+
+func (m *SequenceMatcher) isBJunk(s string) bool {
+	_, ok := m.bJunk[s]
+	return ok
+}
+
+// Find longest matching block in a[alo:ahi] and b[blo:bhi].
+//
+// If IsJunk is not defined:
+//
+// Return (i,j,k) such that a[i:i+k] is equal to b[j:j+k], where
+//     alo <= i <= i+k <= ahi
+//     blo <= j <= j+k <= bhi
+// and for all (i',j',k') meeting those conditions,
+//     k >= k'
+//     i <= i'
+//     and if i == i', j <= j'
+//
+// In other words, of all maximal matching blocks, return one that
+// starts earliest in a, and of all those maximal matching blocks that
+// start earliest in a, return the one that starts earliest in b.
+//
+// If IsJunk is defined, first the longest matching block is
+// determined as above, but with the additional restriction that no
+// junk element appears in the block.  Then that block is extended as
+// far as possible by matching (only) junk elements on both sides.  So
+// the resulting block never matches on junk except as identical junk
+// happens to be adjacent to an "interesting" match.
+//
+// If no blocks match, return (alo, blo, 0).
+func (m *SequenceMatcher) findLongestMatch(alo, ahi, blo, bhi int) Match {
+	// CAUTION:  stripping common prefix or suffix would be incorrect.
+	// E.g.,
+	//    ab
+	//    acab
+	// Longest matching block is "ab", but if common prefix is
+	// stripped, it's "a" (tied with "b").  UNIX(tm) diff does so
+	// strip, so ends up claiming that ab is changed to acab by
+	// inserting "ca" in the middle.  That's minimal but unintuitive:
+	// "it's obvious" that someone inserted "ac" at the front.
+	// Windiff ends up at the same place as diff, but by pairing up
+	// the unique 'b's and then matching the first two 'a's.
+	besti, bestj, bestsize := alo, blo, 0
+
+	// find longest junk-free match
+	// during an iteration of the loop, j2len[j] = length of longest
+	// junk-free match ending with a[i-1] and b[j]
+	j2len := map[int]int{}
+	for i := alo; i != ahi; i++ {
+		// look at all instances of a[i] in b; note that because
+		// b2j has no junk keys, the loop is skipped if a[i] is junk
+		newj2len := map[int]int{}
+		for _, j := range m.b2j[m.a[i]] {
+			// a[i] matches b[j]
+			if j < blo {
+				continue
+			}
+			if j >= bhi {
+				break
+			}
+			k := j2len[j-1] + 1
+			newj2len[j] = k
+			if k > bestsize {
+				besti, bestj, bestsize = i-k+1, j-k+1, k
+			}
+		}
+		j2len = newj2len
+	}
+
+	// Extend the best by non-junk elements on each end.  In particular,
+	// "popular" non-junk elements aren't in b2j, which greatly speeds
+	// the inner loop above, but also means "the best" match so far
+	// doesn't contain any junk *or* popular non-junk elements.
+	for besti > alo && bestj > blo && !m.isBJunk(m.b[bestj-1]) &&
+		m.a[besti-1] == m.b[bestj-1] {
+		besti, bestj, bestsize = besti-1, bestj-1, bestsize+1
+	}
+	for besti+bestsize < ahi && bestj+bestsize < bhi &&
+		!m.isBJunk(m.b[bestj+bestsize]) &&
+		m.a[besti+bestsize] == m.b[bestj+bestsize] {
+		bestsize += 1
+	}
+
+	// Now that we have a wholly interesting match (albeit possibly
+	// empty!), we may as well suck up the matching junk on each
+	// side of it too.  Can't think of a good reason not to, and it
+	// saves post-processing the (possibly considerable) expense of
+	// figuring out what to do with it.  In the case of an empty
+	// interesting match, this is clearly the right thing to do,
+	// because no other kind of match is possible in the regions.
+	for besti > alo && bestj > blo && m.isBJunk(m.b[bestj-1]) &&
+		m.a[besti-1] == m.b[bestj-1] {
+		besti, bestj, bestsize = besti-1, bestj-1, bestsize+1
+	}
+	for besti+bestsize < ahi && bestj+bestsize < bhi &&
+		m.isBJunk(m.b[bestj+bestsize]) &&
+		m.a[besti+bestsize] == m.b[bestj+bestsize] {
+		bestsize += 1
+	}
+
+	return Match{A: besti, B: bestj, Size: bestsize}
+}
+
+// Return list of triples describing matching subsequences.
+//
+// Each triple is of the form (i, j, n), and means that
+// a[i:i+n] == b[j:j+n].  The triples are monotonically increasing in
+// i and in j. It's also guaranteed that if (i, j, n) and (i', j', n') are
+// adjacent triples in the list, and the second is not the last triple in the
+// list, then i+n != i' or j+n != j'. IOW, adjacent triples never describe
+// adjacent equal blocks.
+//
+// The last triple is a dummy, (len(a), len(b), 0), and is the only
+// triple with n==0.
+func (m *SequenceMatcher) GetMatchingBlocks() []Match {
+	if m.matchingBlocks != nil {
+		return m.matchingBlocks
+	}
+
+	var matchBlocks func(alo, ahi, blo, bhi int, matched []Match) []Match
+	matchBlocks = func(alo, ahi, blo, bhi int, matched []Match) []Match {
+		match := m.findLongestMatch(alo, ahi, blo, bhi)
+		i, j, k := match.A, match.B, match.Size
+		if match.Size > 0 {
+			if alo < i && blo < j {
+				matched = matchBlocks(alo, i, blo, j, matched)
+			}
+			matched = append(matched, match)
+			if i+k < ahi && j+k < bhi {
+				matched = matchBlocks(i+k, ahi, j+k, bhi, matched)
+			}
+		}
+		return matched
+	}
+	matched := matchBlocks(0, len(m.a), 0, len(m.b), nil)
+
+	// It's possible that we have adjacent equal blocks in the
+	// matching_blocks list now.
+	nonAdjacent := []Match{}
+	i1, j1, k1 := 0, 0, 0
+	for _, b := range matched {
+		// Is this block adjacent to i1, j1, k1?
+		i2, j2, k2 := b.A, b.B, b.Size
+		if i1+k1 == i2 && j1+k1 == j2 {
+			// Yes, so collapse them -- this just increases the length of
+			// the first block by the length of the second, and the first
+			// block so lengthened remains the block to compare against.
+			k1 += k2
+		} else {
+			// Not adjacent.  Remember the first block (k1==0 means it's
+			// the dummy we started with), and make the second block the
+			// new block to compare against.
+			if k1 > 0 {
+				nonAdjacent = append(nonAdjacent, Match{i1, j1, k1})
+			}
+			i1, j1, k1 = i2, j2, k2
+		}
+	}
+	if k1 > 0 {
+		nonAdjacent = append(nonAdjacent, Match{i1, j1, k1})
+	}
+
+	nonAdjacent = append(nonAdjacent, Match{len(m.a), len(m.b), 0})
+	m.matchingBlocks = nonAdjacent
+	return m.matchingBlocks
+}
+
+// Return list of 5-tuples describing how to turn a into b.
+//
+// Each tuple is of the form (tag, i1, i2, j1, j2).  The first tuple
+// has i1 == j1 == 0, and remaining tuples have i1 == the i2 from the
+// tuple preceding it, and likewise for j1 == the previous j2.
+//
+// The tags are characters, with these meanings:
+//
+// 'r' (replace):  a[i1:i2] should be replaced by b[j1:j2]
+//
+// 'd' (delete):   a[i1:i2] should be deleted, j1==j2 in this case.
+//
+// 'i' (insert):   b[j1:j2] should be inserted at a[i1:i1], i1==i2 in this case.
+//
+// 'e' (equal):    a[i1:i2] == b[j1:j2]
+func (m *SequenceMatcher) GetOpCodes() []OpCode {
+	if m.opCodes != nil {
+		return m.opCodes
+	}
+	i, j := 0, 0
+	matching := m.GetMatchingBlocks()
+	opCodes := make([]OpCode, 0, len(matching))
+	for _, m := range matching {
+		//  invariant:  we've pumped out correct diffs to change
+		//  a[:i] into b[:j], and the next matching block is
+		//  a[ai:ai+size] == b[bj:bj+size]. So we need to pump
+		//  out a diff to change a[i:ai] into b[j:bj], pump out
+		//  the matching block, and move (i,j) beyond the match
+		ai, bj, size := m.A, m.B, m.Size
+		tag := byte(0)
+		if i < ai && j < bj {
+			tag = 'r'
+		} else if i < ai {
+			tag = 'd'
+		} else if j < bj {
+			tag = 'i'
+		}
+		if tag > 0 {
+			opCodes = append(opCodes, OpCode{tag, i, ai, j, bj})
+		}
+		i, j = ai+size, bj+size
+		// the list of matching blocks is terminated by a
+		// sentinel with size 0
+		if size > 0 {
+			opCodes = append(opCodes, OpCode{'e', ai, i, bj, j})
+		}
+	}
+	m.opCodes = opCodes
+	return m.opCodes
+}
+
+// Isolate change clusters by eliminating ranges with no changes.
+//
+// Return a generator of groups with up to n lines of context.
+// Each group is in the same format as returned by GetOpCodes().
+func (m *SequenceMatcher) GetGroupedOpCodes(n int) [][]OpCode {
+	if n < 0 {
+		n = 3
+	}
+	codes := m.GetOpCodes()
+	if len(codes) == 0 {
+		codes = []OpCode{OpCode{'e', 0, 1, 0, 1}}
+	}
+	// Fixup leading and trailing groups if they show no changes.
+	if codes[0].Tag == 'e' {
+		c := codes[0]
+		i1, i2, j1, j2 := c.I1, c.I2, c.J1, c.J2
+		codes[0] = OpCode{c.Tag, max(i1, i2-n), i2, max(j1, j2-n), j2}
+	}
+	if codes[len(codes)-1].Tag == 'e' {
+		c := codes[len(codes)-1]
+		i1, i2, j1, j2 := c.I1, c.I2, c.J1, c.J2
+		codes[len(codes)-1] = OpCode{c.Tag, i1, min(i2, i1+n), j1, min(j2, j1+n)}
+	}
+	nn := n + n
+	groups := [][]OpCode{}
+	group := []OpCode{}
+	for _, c := range codes {
+		i1, i2, j1, j2 := c.I1, c.I2, c.J1, c.J2
+		// End the current group and start a new one whenever
+		// there is a large range with no changes.
+		if c.Tag == 'e' && i2-i1 > nn {
+			group = append(group, OpCode{c.Tag, i1, min(i2, i1+n),
+				j1, min(j2, j1+n)})
+			groups = append(groups, group)
+			group = []OpCode{}
+			i1, j1 = max(i1, i2-n), max(j1, j2-n)
+		}
+		group = append(group, OpCode{c.Tag, i1, i2, j1, j2})
+	}
+	if len(group) > 0 && !(len(group) == 1 && group[0].Tag == 'e') {
+		groups = append(groups, group)
+	}
+	return groups
+}
+
+// Return a measure of the sequences' similarity (float in [0,1]).
+//
+// Where T is the total number of elements in both sequences, and
+// M is the number of matches, this is 2.0*M / T.
+// Note that this is 1 if the sequences are identical, and 0 if
+// they have nothing in common.
+//
+// .Ratio() is expensive to compute if you haven't already computed
+// .GetMatchingBlocks() or .GetOpCodes(), in which case you may
+// want to try .QuickRatio() or .RealQuickRation() first to get an
+// upper bound.
+func (m *SequenceMatcher) Ratio() float64 {
+	matches := 0
+	for _, m := range m.GetMatchingBlocks() {
+		matches += m.Size
+	}
+	return calculateRatio(matches, len(m.a)+len(m.b))
+}
+
+// Return an upper bound on ratio() relatively quickly.
+//
+// This isn't defined beyond that it is an upper bound on .Ratio(), and
+// is faster to compute.
+func (m *SequenceMatcher) QuickRatio() float64 {
+	// viewing a and b as multisets, set matches to the cardinality
+	// of their intersection; this counts the number of matches
+	// without regard to order, so is clearly an upper bound
+	if m.fullBCount == nil {
+		m.fullBCount = map[string]int{}
+		for _, s := range m.b {
+			m.fullBCount[s] = m.fullBCount[s] + 1
+		}
+	}
+
+	// avail[x] is the number of times x appears in 'b' less the
+	// number of times we've seen it in 'a' so far ... kinda
+	avail := map[string]int{}
+	matches := 0
+	for _, s := range m.a {
+		n, ok := avail[s]
+		if !ok {
+			n = m.fullBCount[s]
+		}
+		avail[s] = n - 1
+		if n > 0 {
+			matches += 1
+		}
+	}
+	return calculateRatio(matches, len(m.a)+len(m.b))
+}
+
+// Return an upper bound on ratio() very quickly.
+//
+// This isn't defined beyond that it is an upper bound on .Ratio(), and
+// is faster to compute than either .Ratio() or .QuickRatio().
+func (m *SequenceMatcher) RealQuickRatio() float64 {
+	la, lb := len(m.a), len(m.b)
+	return calculateRatio(min(la, lb), la+lb)
+}
+
+// Convert range to the "ed" format
+func formatRangeUnified(start, stop int) string {
+	// Per the diff spec at http://www.unix.org/single_unix_specification/
+	beginning := start + 1 // lines start numbering with one
+	length := stop - start
+	if length == 1 {
+		return fmt.Sprintf("%d", beginning)
+	}
+	if length == 0 {
+		beginning -= 1 // empty ranges begin at line just before the range
+	}
+	return fmt.Sprintf("%d,%d", beginning, length)
+}
+
+// Unified diff parameters
+type UnifiedDiff struct {
+	A        []string // First sequence lines
+	FromFile string   // First file name
+	FromDate string   // First file time
+	B        []string // Second sequence lines
+	ToFile   string   // Second file name
+	ToDate   string   // Second file time
+	Eol      string   // Headers end of line, defaults to LF
+	Context  int      // Number of context lines
+}
+
+// Compare two sequences of lines; generate the delta as a unified diff.
+//
+// Unified diffs are a compact way of showing line changes and a few
+// lines of context.  The number of context lines is set by 'n' which
+// defaults to three.
+//
+// By default, the diff control lines (those with ---, +++, or @@) are
+// created with a trailing newline.  This is helpful so that inputs
+// created from file.readlines() result in diffs that are suitable for
+// file.writelines() since both the inputs and outputs have trailing
+// newlines.
+//
+// For inputs that do not have trailing newlines, set the lineterm
+// argument to "" so that the output will be uniformly newline free.
+//
+// The unidiff format normally has a header for filenames and modification
+// times.  Any or all of these may be specified using strings for
+// 'fromfile', 'tofile', 'fromfiledate', and 'tofiledate'.
+// The modification times are normally expressed in the ISO 8601 format.
+func WriteUnifiedDiff(writer io.Writer, diff UnifiedDiff) error {
+	buf := bufio.NewWriter(writer)
+	defer buf.Flush()
+	wf := func(format string, args ...interface{}) error {
+		_, err := buf.WriteString(fmt.Sprintf(format, args...))
+		return err
+	}
+	ws := func(s string) error {
+		_, err := buf.WriteString(s)
+		return err
+	}
+
+	if len(diff.Eol) == 0 {
+		diff.Eol = "\n"
+	}
+
+	started := false
+	m := NewMatcher(diff.A, diff.B)
+	for _, g := range m.GetGroupedOpCodes(diff.Context) {
+		if !started {
+			started = true
+			fromDate := ""
+			if len(diff.FromDate) > 0 {
+				fromDate = "\t" + diff.FromDate
+			}
+			toDate := ""
+			if len(diff.ToDate) > 0 {
+				toDate = "\t" + diff.ToDate
+			}
+			if diff.FromFile != "" || diff.ToFile != "" {
+				err := wf("--- %s%s%s", diff.FromFile, fromDate, diff.Eol)
+				if err != nil {
+					return err
+				}
+				err = wf("+++ %s%s%s", diff.ToFile, toDate, diff.Eol)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		first, last := g[0], g[len(g)-1]
+		range1 := formatRangeUnified(first.I1, last.I2)
+		range2 := formatRangeUnified(first.J1, last.J2)
+		if err := wf("@@ -%s +%s @@%s", range1, range2, diff.Eol); err != nil {
+			return err
+		}
+		for _, c := range g {
+			i1, i2, j1, j2 := c.I1, c.I2, c.J1, c.J2
+			if c.Tag == 'e' {
+				for _, line := range diff.A[i1:i2] {
+					if err := ws(" " + line); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+			if c.Tag == 'r' || c.Tag == 'd' {
+				for _, line := range diff.A[i1:i2] {
+					if err := ws("-" + line); err != nil {
+						return err
+					}
+				}
+			}
+			if c.Tag == 'r' || c.Tag == 'i' {
+				for _, line := range diff.B[j1:j2] {
+					if err := ws("+" + line); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// Like WriteUnifiedDiff but returns the diff a string.
+func GetUnifiedDiffString(diff UnifiedDiff) (string, error) {
+	w := &bytes.Buffer{}
+	err := WriteUnifiedDiff(w, diff)
+	return string(w.Bytes()), err
+}
+
+// Convert range to the "ed" format.
+func formatRangeContext(start, stop int) string {
+	// Per the diff spec at http://www.unix.org/single_unix_specification/
+	beginning := start + 1 // lines start numbering with one
+	length := stop - start
+	if length == 0 {
+		beginning -= 1 // empty ranges begin at line just before the range
+	}
+	if length <= 1 {
+		return fmt.Sprintf("%d", beginning)
+	}
+	return fmt.Sprintf("%d,%d", beginning, beginning+length-1)
+}
+
+type ContextDiff UnifiedDiff
+
+// Compare two sequences of lines; generate the delta as a context diff.
+//
+// Context diffs are a compact way of showing line changes and a few
+// lines of context. The number of context lines is set by diff.Context
+// which defaults to three.
+//
+// By default, the diff control lines (those with *** or ---) are
+// created with a trailing newline.
+//
+// For inputs that do not have trailing newlines, set the diff.Eol
+// argument to "" so that the output will be uniformly newline free.
+//
+// The context diff format normally has a header for filenames and
+// modification times.  Any or all of these may be specified using
+// strings for diff.FromFile, diff.ToFile, diff.FromDate, diff.ToDate.
+// The modification times are normally expressed in the ISO 8601 format.
+// If not specified, the strings default to blanks.
+func WriteContextDiff(writer io.Writer, diff ContextDiff) error {
+	buf := bufio.NewWriter(writer)
+	defer buf.Flush()
+	var diffErr error
+	wf := func(format string, args ...interface{}) {
+		_, err := buf.WriteString(fmt.Sprintf(format, args...))
+		if diffErr == nil && err != nil {
+			diffErr = err
+		}
+	}
+	ws := func(s string) {
+		_, err := buf.WriteString(s)
+		if diffErr == nil && err != nil {
+			diffErr = err
+		}
+	}
+
+	if len(diff.Eol) == 0 {
+		diff.Eol = "\n"
+	}
+
+	prefix := map[byte]string{
+		'i': "+ ",
+		'd': "- ",
+		'r': "! ",
+		'e': "  ",
+	}
+
+	started := false
+	m := NewMatcher(diff.A, diff.B)
+	for _, g := range m.GetGroupedOpCodes(diff.Context) {
+		if !started {
+			started = true
+			fromDate := ""
+			if len(diff.FromDate) > 0 {
+				fromDate = "\t" + diff.FromDate
+			}
+			toDate := ""
+			if len(diff.ToDate) > 0 {
+				toDate = "\t" + diff.ToDate
+			}
+			if diff.FromFile != "" || diff.ToFile != "" {
+				wf("*** %s%s%s", diff.FromFile, fromDate, diff.Eol)
+				wf("--- %s%s%s", diff.ToFile, toDate, diff.Eol)
+			}
+		}
+
+		first, last := g[0], g[len(g)-1]
+		ws("***************" + diff.Eol)
+
+		range1 := formatRangeContext(first.I1, last.I2)
+		wf("*** %s ****%s", range1, diff.Eol)
+		for _, c := range g {
+			if c.Tag == 'r' || c.Tag == 'd' {
+				for _, cc := range g {
+					if cc.Tag == 'i' {
+						continue
+					}
+					for _, line := range diff.A[cc.I1:cc.I2] {
+						ws(prefix[cc.Tag] + line)
+					}
+				}
+				break
+			}
+		}
+
+		range2 := formatRangeContext(first.J1, last.J2)
+		wf("--- %s ----%s", range2, diff.Eol)
+		for _, c := range g {
+			if c.Tag == 'r' || c.Tag == 'i' {
+				for _, cc := range g {
+					if cc.Tag == 'd' {
+						continue
+					}
+					for _, line := range diff.B[cc.J1:cc.J2] {
+						ws(prefix[cc.Tag] + line)
+					}
+				}
+				break
+			}
+		}
+	}
+	return diffErr
+}
+
+// Like WriteContextDiff but returns the diff a string.
+func GetContextDiffString(diff ContextDiff) (string, error) {
+	w := &bytes.Buffer{}
+	err := WriteContextDiff(w, diff)
+	return string(w.Bytes()), err
+}
+
+// Split a string on "\n" while preserving them. The output can be used
+// as input for UnifiedDiff and ContextDiff structures.
+func SplitLines(s string) []string {
+	lines := strings.SplitAfter(s, "\n")
+	lines[len(lines)-1] += "\n"
+	return lines
+}

--- a/vendor/github.com/stretchr/testify/LICENSE
+++ b/vendor/github.com/stretchr/testify/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/stretchr/testify/assert/assertion_compare.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_compare.go
@@ -1,0 +1,495 @@
+package assert
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"time"
+)
+
+// Deprecated: CompareType has only ever been for internal use and has accidentally been published since v1.6.0. Do not use it.
+type CompareType = compareResult
+
+type compareResult int
+
+const (
+	compareLess compareResult = iota - 1
+	compareEqual
+	compareGreater
+)
+
+var (
+	intType   = reflect.TypeOf(int(1))
+	int8Type  = reflect.TypeOf(int8(1))
+	int16Type = reflect.TypeOf(int16(1))
+	int32Type = reflect.TypeOf(int32(1))
+	int64Type = reflect.TypeOf(int64(1))
+
+	uintType   = reflect.TypeOf(uint(1))
+	uint8Type  = reflect.TypeOf(uint8(1))
+	uint16Type = reflect.TypeOf(uint16(1))
+	uint32Type = reflect.TypeOf(uint32(1))
+	uint64Type = reflect.TypeOf(uint64(1))
+
+	uintptrType = reflect.TypeOf(uintptr(1))
+
+	float32Type = reflect.TypeOf(float32(1))
+	float64Type = reflect.TypeOf(float64(1))
+
+	stringType = reflect.TypeOf("")
+
+	timeType  = reflect.TypeOf(time.Time{})
+	bytesType = reflect.TypeOf([]byte{})
+)
+
+func compare(obj1, obj2 interface{}, kind reflect.Kind) (compareResult, bool) {
+	obj1Value := reflect.ValueOf(obj1)
+	obj2Value := reflect.ValueOf(obj2)
+
+	// throughout this switch we try and avoid calling .Convert() if possible,
+	// as this has a pretty big performance impact
+	switch kind {
+	case reflect.Int:
+		{
+			intobj1, ok := obj1.(int)
+			if !ok {
+				intobj1 = obj1Value.Convert(intType).Interface().(int)
+			}
+			intobj2, ok := obj2.(int)
+			if !ok {
+				intobj2 = obj2Value.Convert(intType).Interface().(int)
+			}
+			if intobj1 > intobj2 {
+				return compareGreater, true
+			}
+			if intobj1 == intobj2 {
+				return compareEqual, true
+			}
+			if intobj1 < intobj2 {
+				return compareLess, true
+			}
+		}
+	case reflect.Int8:
+		{
+			int8obj1, ok := obj1.(int8)
+			if !ok {
+				int8obj1 = obj1Value.Convert(int8Type).Interface().(int8)
+			}
+			int8obj2, ok := obj2.(int8)
+			if !ok {
+				int8obj2 = obj2Value.Convert(int8Type).Interface().(int8)
+			}
+			if int8obj1 > int8obj2 {
+				return compareGreater, true
+			}
+			if int8obj1 == int8obj2 {
+				return compareEqual, true
+			}
+			if int8obj1 < int8obj2 {
+				return compareLess, true
+			}
+		}
+	case reflect.Int16:
+		{
+			int16obj1, ok := obj1.(int16)
+			if !ok {
+				int16obj1 = obj1Value.Convert(int16Type).Interface().(int16)
+			}
+			int16obj2, ok := obj2.(int16)
+			if !ok {
+				int16obj2 = obj2Value.Convert(int16Type).Interface().(int16)
+			}
+			if int16obj1 > int16obj2 {
+				return compareGreater, true
+			}
+			if int16obj1 == int16obj2 {
+				return compareEqual, true
+			}
+			if int16obj1 < int16obj2 {
+				return compareLess, true
+			}
+		}
+	case reflect.Int32:
+		{
+			int32obj1, ok := obj1.(int32)
+			if !ok {
+				int32obj1 = obj1Value.Convert(int32Type).Interface().(int32)
+			}
+			int32obj2, ok := obj2.(int32)
+			if !ok {
+				int32obj2 = obj2Value.Convert(int32Type).Interface().(int32)
+			}
+			if int32obj1 > int32obj2 {
+				return compareGreater, true
+			}
+			if int32obj1 == int32obj2 {
+				return compareEqual, true
+			}
+			if int32obj1 < int32obj2 {
+				return compareLess, true
+			}
+		}
+	case reflect.Int64:
+		{
+			int64obj1, ok := obj1.(int64)
+			if !ok {
+				int64obj1 = obj1Value.Convert(int64Type).Interface().(int64)
+			}
+			int64obj2, ok := obj2.(int64)
+			if !ok {
+				int64obj2 = obj2Value.Convert(int64Type).Interface().(int64)
+			}
+			if int64obj1 > int64obj2 {
+				return compareGreater, true
+			}
+			if int64obj1 == int64obj2 {
+				return compareEqual, true
+			}
+			if int64obj1 < int64obj2 {
+				return compareLess, true
+			}
+		}
+	case reflect.Uint:
+		{
+			uintobj1, ok := obj1.(uint)
+			if !ok {
+				uintobj1 = obj1Value.Convert(uintType).Interface().(uint)
+			}
+			uintobj2, ok := obj2.(uint)
+			if !ok {
+				uintobj2 = obj2Value.Convert(uintType).Interface().(uint)
+			}
+			if uintobj1 > uintobj2 {
+				return compareGreater, true
+			}
+			if uintobj1 == uintobj2 {
+				return compareEqual, true
+			}
+			if uintobj1 < uintobj2 {
+				return compareLess, true
+			}
+		}
+	case reflect.Uint8:
+		{
+			uint8obj1, ok := obj1.(uint8)
+			if !ok {
+				uint8obj1 = obj1Value.Convert(uint8Type).Interface().(uint8)
+			}
+			uint8obj2, ok := obj2.(uint8)
+			if !ok {
+				uint8obj2 = obj2Value.Convert(uint8Type).Interface().(uint8)
+			}
+			if uint8obj1 > uint8obj2 {
+				return compareGreater, true
+			}
+			if uint8obj1 == uint8obj2 {
+				return compareEqual, true
+			}
+			if uint8obj1 < uint8obj2 {
+				return compareLess, true
+			}
+		}
+	case reflect.Uint16:
+		{
+			uint16obj1, ok := obj1.(uint16)
+			if !ok {
+				uint16obj1 = obj1Value.Convert(uint16Type).Interface().(uint16)
+			}
+			uint16obj2, ok := obj2.(uint16)
+			if !ok {
+				uint16obj2 = obj2Value.Convert(uint16Type).Interface().(uint16)
+			}
+			if uint16obj1 > uint16obj2 {
+				return compareGreater, true
+			}
+			if uint16obj1 == uint16obj2 {
+				return compareEqual, true
+			}
+			if uint16obj1 < uint16obj2 {
+				return compareLess, true
+			}
+		}
+	case reflect.Uint32:
+		{
+			uint32obj1, ok := obj1.(uint32)
+			if !ok {
+				uint32obj1 = obj1Value.Convert(uint32Type).Interface().(uint32)
+			}
+			uint32obj2, ok := obj2.(uint32)
+			if !ok {
+				uint32obj2 = obj2Value.Convert(uint32Type).Interface().(uint32)
+			}
+			if uint32obj1 > uint32obj2 {
+				return compareGreater, true
+			}
+			if uint32obj1 == uint32obj2 {
+				return compareEqual, true
+			}
+			if uint32obj1 < uint32obj2 {
+				return compareLess, true
+			}
+		}
+	case reflect.Uint64:
+		{
+			uint64obj1, ok := obj1.(uint64)
+			if !ok {
+				uint64obj1 = obj1Value.Convert(uint64Type).Interface().(uint64)
+			}
+			uint64obj2, ok := obj2.(uint64)
+			if !ok {
+				uint64obj2 = obj2Value.Convert(uint64Type).Interface().(uint64)
+			}
+			if uint64obj1 > uint64obj2 {
+				return compareGreater, true
+			}
+			if uint64obj1 == uint64obj2 {
+				return compareEqual, true
+			}
+			if uint64obj1 < uint64obj2 {
+				return compareLess, true
+			}
+		}
+	case reflect.Float32:
+		{
+			float32obj1, ok := obj1.(float32)
+			if !ok {
+				float32obj1 = obj1Value.Convert(float32Type).Interface().(float32)
+			}
+			float32obj2, ok := obj2.(float32)
+			if !ok {
+				float32obj2 = obj2Value.Convert(float32Type).Interface().(float32)
+			}
+			if float32obj1 > float32obj2 {
+				return compareGreater, true
+			}
+			if float32obj1 == float32obj2 {
+				return compareEqual, true
+			}
+			if float32obj1 < float32obj2 {
+				return compareLess, true
+			}
+		}
+	case reflect.Float64:
+		{
+			float64obj1, ok := obj1.(float64)
+			if !ok {
+				float64obj1 = obj1Value.Convert(float64Type).Interface().(float64)
+			}
+			float64obj2, ok := obj2.(float64)
+			if !ok {
+				float64obj2 = obj2Value.Convert(float64Type).Interface().(float64)
+			}
+			if float64obj1 > float64obj2 {
+				return compareGreater, true
+			}
+			if float64obj1 == float64obj2 {
+				return compareEqual, true
+			}
+			if float64obj1 < float64obj2 {
+				return compareLess, true
+			}
+		}
+	case reflect.String:
+		{
+			stringobj1, ok := obj1.(string)
+			if !ok {
+				stringobj1 = obj1Value.Convert(stringType).Interface().(string)
+			}
+			stringobj2, ok := obj2.(string)
+			if !ok {
+				stringobj2 = obj2Value.Convert(stringType).Interface().(string)
+			}
+			if stringobj1 > stringobj2 {
+				return compareGreater, true
+			}
+			if stringobj1 == stringobj2 {
+				return compareEqual, true
+			}
+			if stringobj1 < stringobj2 {
+				return compareLess, true
+			}
+		}
+	// Check for known struct types we can check for compare results.
+	case reflect.Struct:
+		{
+			// All structs enter here. We're not interested in most types.
+			if !obj1Value.CanConvert(timeType) {
+				break
+			}
+
+			// time.Time can be compared!
+			timeObj1, ok := obj1.(time.Time)
+			if !ok {
+				timeObj1 = obj1Value.Convert(timeType).Interface().(time.Time)
+			}
+
+			timeObj2, ok := obj2.(time.Time)
+			if !ok {
+				timeObj2 = obj2Value.Convert(timeType).Interface().(time.Time)
+			}
+
+			if timeObj1.Before(timeObj2) {
+				return compareLess, true
+			}
+			if timeObj1.Equal(timeObj2) {
+				return compareEqual, true
+			}
+			return compareGreater, true
+		}
+	case reflect.Slice:
+		{
+			// We only care about the []byte type.
+			if !obj1Value.CanConvert(bytesType) {
+				break
+			}
+
+			// []byte can be compared!
+			bytesObj1, ok := obj1.([]byte)
+			if !ok {
+				bytesObj1 = obj1Value.Convert(bytesType).Interface().([]byte)
+
+			}
+			bytesObj2, ok := obj2.([]byte)
+			if !ok {
+				bytesObj2 = obj2Value.Convert(bytesType).Interface().([]byte)
+			}
+
+			return compareResult(bytes.Compare(bytesObj1, bytesObj2)), true
+		}
+	case reflect.Uintptr:
+		{
+			uintptrObj1, ok := obj1.(uintptr)
+			if !ok {
+				uintptrObj1 = obj1Value.Convert(uintptrType).Interface().(uintptr)
+			}
+			uintptrObj2, ok := obj2.(uintptr)
+			if !ok {
+				uintptrObj2 = obj2Value.Convert(uintptrType).Interface().(uintptr)
+			}
+			if uintptrObj1 > uintptrObj2 {
+				return compareGreater, true
+			}
+			if uintptrObj1 == uintptrObj2 {
+				return compareEqual, true
+			}
+			if uintptrObj1 < uintptrObj2 {
+				return compareLess, true
+			}
+		}
+	}
+
+	return compareEqual, false
+}
+
+// Greater asserts that the first element is greater than the second
+//
+//	assert.Greater(t, 2, 1)
+//	assert.Greater(t, float64(2), float64(1))
+//	assert.Greater(t, "b", "a")
+func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	failMessage := fmt.Sprintf("\"%v\" is not greater than \"%v\"", e1, e2)
+	return compareTwoValues(t, e1, e2, []compareResult{compareGreater}, failMessage, msgAndArgs...)
+}
+
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
+//
+//	assert.GreaterOrEqual(t, 2, 1)
+//	assert.GreaterOrEqual(t, 2, 2)
+//	assert.GreaterOrEqual(t, "b", "a")
+//	assert.GreaterOrEqual(t, "b", "b")
+func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	failMessage := fmt.Sprintf("\"%v\" is not greater than or equal to \"%v\"", e1, e2)
+	return compareTwoValues(t, e1, e2, []compareResult{compareGreater, compareEqual}, failMessage, msgAndArgs...)
+}
+
+// Less asserts that the first element is less than the second
+//
+//	assert.Less(t, 1, 2)
+//	assert.Less(t, float64(1), float64(2))
+//	assert.Less(t, "a", "b")
+func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	failMessage := fmt.Sprintf("\"%v\" is not less than \"%v\"", e1, e2)
+	return compareTwoValues(t, e1, e2, []compareResult{compareLess}, failMessage, msgAndArgs...)
+}
+
+// LessOrEqual asserts that the first element is less than or equal to the second
+//
+//	assert.LessOrEqual(t, 1, 2)
+//	assert.LessOrEqual(t, 2, 2)
+//	assert.LessOrEqual(t, "a", "b")
+//	assert.LessOrEqual(t, "b", "b")
+func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	failMessage := fmt.Sprintf("\"%v\" is not less than or equal to \"%v\"", e1, e2)
+	return compareTwoValues(t, e1, e2, []compareResult{compareLess, compareEqual}, failMessage, msgAndArgs...)
+}
+
+// Positive asserts that the specified element is positive
+//
+//	assert.Positive(t, 1)
+//	assert.Positive(t, 1.23)
+func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	zero := reflect.Zero(reflect.TypeOf(e))
+	failMessage := fmt.Sprintf("\"%v\" is not positive", e)
+	return compareTwoValues(t, e, zero.Interface(), []compareResult{compareGreater}, failMessage, msgAndArgs...)
+}
+
+// Negative asserts that the specified element is negative
+//
+//	assert.Negative(t, -1)
+//	assert.Negative(t, -1.23)
+func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	zero := reflect.Zero(reflect.TypeOf(e))
+	failMessage := fmt.Sprintf("\"%v\" is not negative", e)
+	return compareTwoValues(t, e, zero.Interface(), []compareResult{compareLess}, failMessage, msgAndArgs...)
+}
+
+func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []compareResult, failMessage string, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	e1Kind := reflect.ValueOf(e1).Kind()
+	e2Kind := reflect.ValueOf(e2).Kind()
+	if e1Kind != e2Kind {
+		return Fail(t, "Elements should be the same type", msgAndArgs...)
+	}
+
+	compareResult, isComparable := compare(e1, e2, e1Kind)
+	if !isComparable {
+		return Fail(t, fmt.Sprintf(`Can not compare type "%T"`, e1), msgAndArgs...)
+	}
+
+	if !containsValue(allowedComparesResults, compareResult) {
+		return Fail(t, failMessage, msgAndArgs...)
+	}
+
+	return true
+}
+
+func containsValue(values []compareResult, value compareResult) bool {
+	for _, v := range values {
+		if v == value {
+			return true
+		}
+	}
+
+	return false
+}

--- a/vendor/github.com/stretchr/testify/assert/assertion_format.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_format.go
@@ -1,0 +1,866 @@
+// Code generated with github.com/stretchr/testify/_codegen; DO NOT EDIT.
+
+package assert
+
+import (
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Conditionf uses a Comparison to assert a complex condition.
+func Conditionf(t TestingT, comp Comparison, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Condition(t, comp, append([]interface{}{msg}, args...)...)
+}
+
+// Containsf asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	assert.Containsf(t, "Hello World", "World", "error message %s", "formatted")
+//	assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
+//	assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
+func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Contains(t, s, contains, append([]interface{}{msg}, args...)...)
+}
+
+// DirExistsf checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func DirExistsf(t TestingT, path string, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return DirExists(t, path, append([]interface{}{msg}, args...)...)
+}
+
+// ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// assert.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
+func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return ElementsMatch(t, listA, listB, append([]interface{}{msg}, args...)...)
+}
+
+// Emptyf asserts that the given value is "empty".
+//
+// [Zero values] are "empty".
+//
+// Arrays are "empty" if every element is the zero value of the type (stricter than "empty").
+//
+// Slices, maps and channels with zero length are "empty".
+//
+// Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
+//
+//	assert.Emptyf(t, obj, "error message %s", "formatted")
+//
+// [Zero values]: https://go.dev/ref/spec#The_zero_value
+func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Empty(t, object, append([]interface{}{msg}, args...)...)
+}
+
+// Equalf asserts that two objects are equal.
+//
+//	assert.Equalf(t, 123, 123, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Equal(t, expected, actual, append([]interface{}{msg}, args...)...)
+}
+
+// EqualErrorf asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
+func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return EqualError(t, theError, errString, append([]interface{}{msg}, args...)...)
+}
+
+// EqualExportedValuesf asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 assert.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+//	 assert.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return EqualExportedValues(t, expected, actual, append([]interface{}{msg}, args...)...)
+}
+
+// EqualValuesf asserts that two objects are equal or convertible to the larger
+// type and equal.
+//
+//	assert.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
+func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return EqualValues(t, expected, actual, append([]interface{}{msg}, args...)...)
+}
+
+// Errorf asserts that a function returned an error (i.e. not `nil`).
+//
+//	actualObj, err := SomeFunction()
+//	assert.Errorf(t, err, "error message %s", "formatted")
+func Errorf(t TestingT, err error, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Error(t, err, append([]interface{}{msg}, args...)...)
+}
+
+// ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorAs(t, err, target, append([]interface{}{msg}, args...)...)
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorContains(t, theError, contains, append([]interface{}{msg}, args...)...)
+}
+
+// ErrorIsf asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorIs(t, err, target, append([]interface{}{msg}, args...)...)
+}
+
+// Eventuallyf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Eventually(t, condition, waitFor, tick, append([]interface{}{msg}, args...)...)
+}
+
+// EventuallyWithTf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	assert.EventuallyWithTf(t, func(c *assert.CollectT, "error message %s", "formatted") {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func EventuallyWithTf(t TestingT, condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return EventuallyWithT(t, condition, waitFor, tick, append([]interface{}{msg}, args...)...)
+}
+
+// Exactlyf asserts that two objects are equal in value and type.
+//
+//	assert.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
+func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Exactly(t, expected, actual, append([]interface{}{msg}, args...)...)
+}
+
+// Failf reports a failure through
+func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Fail(t, failureMessage, append([]interface{}{msg}, args...)...)
+}
+
+// FailNowf fails test
+func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return FailNow(t, failureMessage, append([]interface{}{msg}, args...)...)
+}
+
+// Falsef asserts that the specified value is false.
+//
+//	assert.Falsef(t, myBool, "error message %s", "formatted")
+func Falsef(t TestingT, value bool, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return False(t, value, append([]interface{}{msg}, args...)...)
+}
+
+// FileExistsf checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func FileExistsf(t TestingT, path string, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return FileExists(t, path, append([]interface{}{msg}, args...)...)
+}
+
+// Greaterf asserts that the first element is greater than the second
+//
+//	assert.Greaterf(t, 2, 1, "error message %s", "formatted")
+//	assert.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
+//	assert.Greaterf(t, "b", "a", "error message %s", "formatted")
+func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Greater(t, e1, e2, append([]interface{}{msg}, args...)...)
+}
+
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
+//
+//	assert.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
+//	assert.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	assert.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
+//	assert.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
+func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return GreaterOrEqual(t, e1, e2, append([]interface{}{msg}, args...)...)
+}
+
+// HTTPBodyContainsf asserts that a specified handler returns a
+// body that contains a string.
+//
+//	assert.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPBodyContains(t, handler, method, url, values, str, append([]interface{}{msg}, args...)...)
+}
+
+// HTTPBodyNotContainsf asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	assert.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPBodyNotContains(t, handler, method, url, values, str, append([]interface{}{msg}, args...)...)
+}
+
+// HTTPErrorf asserts that a specified handler returns an error status code.
+//
+//	assert.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPError(t, handler, method, url, values, append([]interface{}{msg}, args...)...)
+}
+
+// HTTPRedirectf asserts that a specified handler returns a redirect status code.
+//
+//	assert.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPRedirect(t, handler, method, url, values, append([]interface{}{msg}, args...)...)
+}
+
+// HTTPStatusCodef asserts that a specified handler returns a specified status code.
+//
+//	assert.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPStatusCode(t, handler, method, url, values, statuscode, append([]interface{}{msg}, args...)...)
+}
+
+// HTTPSuccessf asserts that a specified handler returns a success status code.
+//
+//	assert.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPSuccess(t, handler, method, url, values, append([]interface{}{msg}, args...)...)
+}
+
+// Implementsf asserts that an object is implemented by the specified interface.
+//
+//	assert.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Implements(t, interfaceObject, object, append([]interface{}{msg}, args...)...)
+}
+
+// InDeltaf asserts that the two numerals are within delta of each other.
+//
+//	assert.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return InDelta(t, expected, actual, delta, append([]interface{}{msg}, args...)...)
+}
+
+// InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return InDeltaMapValues(t, expected, actual, delta, append([]interface{}{msg}, args...)...)
+}
+
+// InDeltaSlicef is the same as InDelta, except it compares two slices.
+func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return InDeltaSlice(t, expected, actual, delta, append([]interface{}{msg}, args...)...)
+}
+
+// InEpsilonf asserts that expected and actual have a relative error less than epsilon
+func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return InEpsilon(t, expected, actual, epsilon, append([]interface{}{msg}, args...)...)
+}
+
+// InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return InEpsilonSlice(t, expected, actual, epsilon, append([]interface{}{msg}, args...)...)
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//	assert.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
+//	assert.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	assert.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsDecreasing(t, object, append([]interface{}{msg}, args...)...)
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//	assert.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
+//	assert.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	assert.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsIncreasing(t, object, append([]interface{}{msg}, args...)...)
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//	assert.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
+//	assert.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	assert.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonDecreasing(t, object, append([]interface{}{msg}, args...)...)
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//	assert.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
+//	assert.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	assert.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonIncreasing(t, object, append([]interface{}{msg}, args...)...)
+}
+
+// IsNotTypef asserts that the specified objects are not of the same type.
+//
+//	assert.IsNotTypef(t, &NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
+func IsNotTypef(t TestingT, theType interface{}, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNotType(t, theType, object, append([]interface{}{msg}, args...)...)
+}
+
+// IsTypef asserts that the specified objects are of the same type.
+//
+//	assert.IsTypef(t, &MyStruct{}, &MyStruct{}, "error message %s", "formatted")
+func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsType(t, expectedType, object, append([]interface{}{msg}, args...)...)
+}
+
+// JSONEqf asserts that two JSON strings are equivalent.
+//
+//	assert.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return JSONEq(t, expected, actual, append([]interface{}{msg}, args...)...)
+}
+
+// Lenf asserts that the specified object has specific length.
+// Lenf also fails if the object has a type that len() not accept.
+//
+//	assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
+func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Len(t, object, length, append([]interface{}{msg}, args...)...)
+}
+
+// Lessf asserts that the first element is less than the second
+//
+//	assert.Lessf(t, 1, 2, "error message %s", "formatted")
+//	assert.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
+//	assert.Lessf(t, "a", "b", "error message %s", "formatted")
+func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Less(t, e1, e2, append([]interface{}{msg}, args...)...)
+}
+
+// LessOrEqualf asserts that the first element is less than or equal to the second
+//
+//	assert.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
+//	assert.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	assert.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
+//	assert.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
+func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return LessOrEqual(t, e1, e2, append([]interface{}{msg}, args...)...)
+}
+
+// Negativef asserts that the specified element is negative
+//
+//	assert.Negativef(t, -1, "error message %s", "formatted")
+//	assert.Negativef(t, -1.23, "error message %s", "formatted")
+func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Negative(t, e, append([]interface{}{msg}, args...)...)
+}
+
+// Neverf asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	assert.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Never(t, condition, waitFor, tick, append([]interface{}{msg}, args...)...)
+}
+
+// Nilf asserts that the specified object is nil.
+//
+//	assert.Nilf(t, err, "error message %s", "formatted")
+func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Nil(t, object, append([]interface{}{msg}, args...)...)
+}
+
+// NoDirExistsf checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NoDirExists(t, path, append([]interface{}{msg}, args...)...)
+}
+
+// NoErrorf asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if assert.NoErrorf(t, err, "error message %s", "formatted") {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
+func NoErrorf(t TestingT, err error, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NoError(t, err, append([]interface{}{msg}, args...)...)
+}
+
+// NoFileExistsf checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NoFileExists(t, path, append([]interface{}{msg}, args...)...)
+}
+
+// NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	assert.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
+//	assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
+//	assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
+func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotContains(t, s, contains, append([]interface{}{msg}, args...)...)
+}
+
+// NotElementsMatchf asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// assert.NotElementsMatchf(t, [1, 1, 2, 3], [1, 1, 2, 3], "error message %s", "formatted") -> false
+//
+// assert.NotElementsMatchf(t, [1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
+//
+// assert.NotElementsMatchf(t, [1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
+func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotElementsMatch(t, listA, listB, append([]interface{}{msg}, args...)...)
+}
+
+// NotEmptyf asserts that the specified object is NOT [Empty].
+//
+//	if assert.NotEmptyf(t, obj, "error message %s", "formatted") {
+//	  assert.Equal(t, "two", obj[1])
+//	}
+func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotEmpty(t, object, append([]interface{}{msg}, args...)...)
+}
+
+// NotEqualf asserts that the specified values are NOT equal.
+//
+//	assert.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotEqual(t, expected, actual, append([]interface{}{msg}, args...)...)
+}
+
+// NotEqualValuesf asserts that two objects are not equal even when converted to the same type
+//
+//	assert.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
+func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotEqualValues(t, expected, actual, append([]interface{}{msg}, args...)...)
+}
+
+// NotErrorAsf asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func NotErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotErrorAs(t, err, target, append([]interface{}{msg}, args...)...)
+}
+
+// NotErrorIsf asserts that none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotErrorIs(t, err, target, append([]interface{}{msg}, args...)...)
+}
+
+// NotImplementsf asserts that an object does not implement the specified interface.
+//
+//	assert.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotImplements(t, interfaceObject, object, append([]interface{}{msg}, args...)...)
+}
+
+// NotNilf asserts that the specified object is not nil.
+//
+//	assert.NotNilf(t, err, "error message %s", "formatted")
+func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotNil(t, object, append([]interface{}{msg}, args...)...)
+}
+
+// NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	assert.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
+func NotPanicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotPanics(t, f, append([]interface{}{msg}, args...)...)
+}
+
+// NotRegexpf asserts that a specified regexp does not match a string.
+//
+//	assert.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//	assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
+func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotRegexp(t, rx, str, append([]interface{}{msg}, args...)...)
+}
+
+// NotSamef asserts that two pointers do not reference the same object.
+//
+//	assert.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotSame(t, expected, actual, append([]interface{}{msg}, args...)...)
+}
+
+// NotSubsetf asserts that the list (array, slice, or map) does NOT contain all
+// elements given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	assert.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
+//	assert.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+//	assert.NotSubsetf(t, [1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	assert.NotSubsetf(t, {"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
+func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotSubset(t, list, subset, append([]interface{}{msg}, args...)...)
+}
+
+// NotZerof asserts that i is not the zero value for its type.
+func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotZero(t, i, append([]interface{}{msg}, args...)...)
+}
+
+// Panicsf asserts that the code inside the specified PanicTestFunc panics.
+//
+//	assert.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
+func Panicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Panics(t, f, append([]interface{}{msg}, args...)...)
+}
+
+// PanicsWithErrorf asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	assert.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func PanicsWithErrorf(t TestingT, errString string, f PanicTestFunc, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return PanicsWithError(t, errString, f, append([]interface{}{msg}, args...)...)
+}
+
+// PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	assert.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func PanicsWithValuef(t TestingT, expected interface{}, f PanicTestFunc, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return PanicsWithValue(t, expected, f, append([]interface{}{msg}, args...)...)
+}
+
+// Positivef asserts that the specified element is positive
+//
+//	assert.Positivef(t, 1, "error message %s", "formatted")
+//	assert.Positivef(t, 1.23, "error message %s", "formatted")
+func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Positive(t, e, append([]interface{}{msg}, args...)...)
+}
+
+// Regexpf asserts that a specified regexp matches a string.
+//
+//	assert.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//	assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
+func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Regexp(t, rx, str, append([]interface{}{msg}, args...)...)
+}
+
+// Samef asserts that two pointers reference the same object.
+//
+//	assert.Samef(t, ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func Samef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Same(t, expected, actual, append([]interface{}{msg}, args...)...)
+}
+
+// Subsetf asserts that the list (array, slice, or map) contains all elements
+// given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	assert.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
+//	assert.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+//	assert.Subsetf(t, [1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	assert.Subsetf(t, {"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
+func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Subset(t, list, subset, append([]interface{}{msg}, args...)...)
+}
+
+// Truef asserts that the specified value is true.
+//
+//	assert.Truef(t, myBool, "error message %s", "formatted")
+func Truef(t TestingT, value bool, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return True(t, value, append([]interface{}{msg}, args...)...)
+}
+
+// WithinDurationf asserts that the two times are within duration delta of each other.
+//
+//	assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return WithinDuration(t, expected, actual, delta, append([]interface{}{msg}, args...)...)
+}
+
+// WithinRangef asserts that a time is within a time range (inclusive).
+//
+//	assert.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return WithinRange(t, actual, start, end, append([]interface{}{msg}, args...)...)
+}
+
+// YAMLEqf asserts that two YAML strings are equivalent.
+func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return YAMLEq(t, expected, actual, append([]interface{}{msg}, args...)...)
+}
+
+// Zerof asserts that i is the zero value for its type.
+func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Zero(t, i, append([]interface{}{msg}, args...)...)
+}

--- a/vendor/github.com/stretchr/testify/assert/assertion_format.go.tmpl
+++ b/vendor/github.com/stretchr/testify/assert/assertion_format.go.tmpl
@@ -1,0 +1,5 @@
+{{.CommentFormat}}
+func {{.DocInfo.Name}}f(t TestingT, {{.ParamsFormat}}) bool {
+	if h, ok := t.(tHelper); ok { h.Helper() }
+	return {{.DocInfo.Name}}(t, {{.ForwardedParamsFormat}})
+}

--- a/vendor/github.com/stretchr/testify/assert/assertion_forward.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_forward.go
@@ -1,0 +1,1723 @@
+// Code generated with github.com/stretchr/testify/_codegen; DO NOT EDIT.
+
+package assert
+
+import (
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Condition uses a Comparison to assert a complex condition.
+func (a *Assertions) Condition(comp Comparison, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Condition(a.t, comp, msgAndArgs...)
+}
+
+// Conditionf uses a Comparison to assert a complex condition.
+func (a *Assertions) Conditionf(comp Comparison, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Conditionf(a.t, comp, msg, args...)
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	a.Contains("Hello World", "World")
+//	a.Contains(["Hello", "World"], "World")
+//	a.Contains({"Hello": "World"}, "Hello")
+func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Contains(a.t, s, contains, msgAndArgs...)
+}
+
+// Containsf asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	a.Containsf("Hello World", "World", "error message %s", "formatted")
+//	a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
+//	a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
+func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Containsf(a.t, s, contains, msg, args...)
+}
+
+// DirExists checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return DirExists(a.t, path, msgAndArgs...)
+}
+
+// DirExistsf checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return DirExistsf(a.t, path, msg, args...)
+}
+
+// ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// a.ElementsMatch([1, 3, 2, 3], [1, 3, 3, 2])
+func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ElementsMatch(a.t, listA, listB, msgAndArgs...)
+}
+
+// ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// a.ElementsMatchf([1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
+func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ElementsMatchf(a.t, listA, listB, msg, args...)
+}
+
+// Empty asserts that the given value is "empty".
+//
+// [Zero values] are "empty".
+//
+// Arrays are "empty" if every element is the zero value of the type (stricter than "empty").
+//
+// Slices, maps and channels with zero length are "empty".
+//
+// Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
+//
+//	a.Empty(obj)
+//
+// [Zero values]: https://go.dev/ref/spec#The_zero_value
+func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Empty(a.t, object, msgAndArgs...)
+}
+
+// Emptyf asserts that the given value is "empty".
+//
+// [Zero values] are "empty".
+//
+// Arrays are "empty" if every element is the zero value of the type (stricter than "empty").
+//
+// Slices, maps and channels with zero length are "empty".
+//
+// Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
+//
+//	a.Emptyf(obj, "error message %s", "formatted")
+//
+// [Zero values]: https://go.dev/ref/spec#The_zero_value
+func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Emptyf(a.t, object, msg, args...)
+}
+
+// Equal asserts that two objects are equal.
+//
+//	a.Equal(123, 123)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Equal(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	a.EqualError(err,  expectedErrorString)
+func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return EqualError(a.t, theError, errString, msgAndArgs...)
+}
+
+// EqualErrorf asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
+func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return EqualErrorf(a.t, theError, errString, msg, args...)
+}
+
+// EqualExportedValues asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 a.EqualExportedValues(S{1, 2}, S{1, 3}) => true
+//	 a.EqualExportedValues(S{1, 2}, S{2, 3}) => false
+func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return EqualExportedValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualExportedValuesf asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 a.EqualExportedValuesf(S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+//	 a.EqualExportedValuesf(S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return EqualExportedValuesf(a.t, expected, actual, msg, args...)
+}
+
+// EqualValues asserts that two objects are equal or convertible to the larger
+// type and equal.
+//
+//	a.EqualValues(uint32(123), int32(123))
+func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return EqualValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualValuesf asserts that two objects are equal or convertible to the larger
+// type and equal.
+//
+//	a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
+func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return EqualValuesf(a.t, expected, actual, msg, args...)
+}
+
+// Equalf asserts that two objects are equal.
+//
+//	a.Equalf(123, 123, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Equalf(a.t, expected, actual, msg, args...)
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//	actualObj, err := SomeFunction()
+//	a.Error(err)
+func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Error(a.t, err, msgAndArgs...)
+}
+
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) ErrorAs(err error, target interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorAs(a.t, err, target, msgAndArgs...)
+}
+
+// ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorAsf(a.t, err, target, msg, args...)
+}
+
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	a.ErrorContains(err,  expectedErrorSubString)
+func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorContains(a.t, theError, contains, msgAndArgs...)
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
+func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorContainsf(a.t, theError, contains, msg, args...)
+}
+
+// ErrorIs asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorIs(a.t, err, target, msgAndArgs...)
+}
+
+// ErrorIsf asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorIsf(a.t, err, target, msg, args...)
+}
+
+// Errorf asserts that a function returned an error (i.e. not `nil`).
+//
+//	actualObj, err := SomeFunction()
+//	a.Errorf(err, "error message %s", "formatted")
+func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Errorf(a.t, err, msg, args...)
+}
+
+// Eventually asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
+func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Eventually(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// EventuallyWithT asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	a.EventuallyWithT(func(c *assert.CollectT) {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func (a *Assertions) EventuallyWithT(condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return EventuallyWithT(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// EventuallyWithTf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	a.EventuallyWithTf(func(c *assert.CollectT, "error message %s", "formatted") {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func (a *Assertions) EventuallyWithTf(condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return EventuallyWithTf(a.t, condition, waitFor, tick, msg, args...)
+}
+
+// Eventuallyf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Eventuallyf(a.t, condition, waitFor, tick, msg, args...)
+}
+
+// Exactly asserts that two objects are equal in value and type.
+//
+//	a.Exactly(int32(123), int64(123))
+func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Exactly(a.t, expected, actual, msgAndArgs...)
+}
+
+// Exactlyf asserts that two objects are equal in value and type.
+//
+//	a.Exactlyf(int32(123), int64(123), "error message %s", "formatted")
+func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Exactlyf(a.t, expected, actual, msg, args...)
+}
+
+// Fail reports a failure through
+func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Fail(a.t, failureMessage, msgAndArgs...)
+}
+
+// FailNow fails test
+func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return FailNow(a.t, failureMessage, msgAndArgs...)
+}
+
+// FailNowf fails test
+func (a *Assertions) FailNowf(failureMessage string, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return FailNowf(a.t, failureMessage, msg, args...)
+}
+
+// Failf reports a failure through
+func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Failf(a.t, failureMessage, msg, args...)
+}
+
+// False asserts that the specified value is false.
+//
+//	a.False(myBool)
+func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return False(a.t, value, msgAndArgs...)
+}
+
+// Falsef asserts that the specified value is false.
+//
+//	a.Falsef(myBool, "error message %s", "formatted")
+func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Falsef(a.t, value, msg, args...)
+}
+
+// FileExists checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileExists(path string, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return FileExists(a.t, path, msgAndArgs...)
+}
+
+// FileExistsf checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return FileExistsf(a.t, path, msg, args...)
+}
+
+// Greater asserts that the first element is greater than the second
+//
+//	a.Greater(2, 1)
+//	a.Greater(float64(2), float64(1))
+//	a.Greater("b", "a")
+func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Greater(a.t, e1, e2, msgAndArgs...)
+}
+
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
+//
+//	a.GreaterOrEqual(2, 1)
+//	a.GreaterOrEqual(2, 2)
+//	a.GreaterOrEqual("b", "a")
+//	a.GreaterOrEqual("b", "b")
+func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return GreaterOrEqual(a.t, e1, e2, msgAndArgs...)
+}
+
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
+//
+//	a.GreaterOrEqualf(2, 1, "error message %s", "formatted")
+//	a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
+//	a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
+//	a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
+func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return GreaterOrEqualf(a.t, e1, e2, msg, args...)
+}
+
+// Greaterf asserts that the first element is greater than the second
+//
+//	a.Greaterf(2, 1, "error message %s", "formatted")
+//	a.Greaterf(float64(2), float64(1), "error message %s", "formatted")
+//	a.Greaterf("b", "a", "error message %s", "formatted")
+func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Greaterf(a.t, e1, e2, msg, args...)
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//	a.HTTPBodyContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPBodyContains(a.t, handler, method, url, values, str, msgAndArgs...)
+}
+
+// HTTPBodyContainsf asserts that a specified handler returns a
+// body that contains a string.
+//
+//	a.HTTPBodyContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPBodyContainsf(a.t, handler, method, url, values, str, msg, args...)
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	a.HTTPBodyNotContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPBodyNotContains(a.t, handler, method, url, values, str, msgAndArgs...)
+}
+
+// HTTPBodyNotContainsf asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	a.HTTPBodyNotContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPBodyNotContainsf(a.t, handler, method, url, values, str, msg, args...)
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//	a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPError(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPErrorf asserts that a specified handler returns an error status code.
+//
+//	a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPErrorf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//	a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPRedirect(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPRedirectf asserts that a specified handler returns a redirect status code.
+//
+//	a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPRedirectf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPStatusCode asserts that a specified handler returns a specified status code.
+//
+//	a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPStatusCode(a.t, handler, method, url, values, statuscode, msgAndArgs...)
+}
+
+// HTTPStatusCodef asserts that a specified handler returns a specified status code.
+//
+//	a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPStatusCodef(a.t, handler, method, url, values, statuscode, msg, args...)
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//	a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPSuccess(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPSuccessf asserts that a specified handler returns a success status code.
+//
+//	a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPSuccessf(a.t, handler, method, url, values, msg, args...)
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//	a.Implements((*MyInterface)(nil), new(MyObject))
+func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Implements(a.t, interfaceObject, object, msgAndArgs...)
+}
+
+// Implementsf asserts that an object is implemented by the specified interface.
+//
+//	a.Implementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Implementsf(a.t, interfaceObject, object, msg, args...)
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+//	a.InDelta(math.Pi, 22/7.0, 0.01)
+func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return InDelta(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InDeltaMapValues(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return InDeltaMapValues(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InDeltaMapValuesf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return InDeltaMapValuesf(a.t, expected, actual, delta, msg, args...)
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaSlicef is the same as InDelta, except it compares two slices.
+func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return InDeltaSlicef(a.t, expected, actual, delta, msg, args...)
+}
+
+// InDeltaf asserts that the two numerals are within delta of each other.
+//
+//	a.InDeltaf(math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return InDeltaf(a.t, expected, actual, delta, msg, args...)
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return InEpsilonSlice(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return InEpsilonSlicef(a.t, expected, actual, epsilon, msg, args...)
+}
+
+// InEpsilonf asserts that expected and actual have a relative error less than epsilon
+func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return InEpsilonf(a.t, expected, actual, epsilon, msg, args...)
+}
+
+// IsDecreasing asserts that the collection is decreasing
+//
+//	a.IsDecreasing([]int{2, 1, 0})
+//	a.IsDecreasing([]float{2, 1})
+//	a.IsDecreasing([]string{"b", "a"})
+func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//	a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
+//	a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
+//	a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsDecreasingf(a.t, object, msg, args...)
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//	a.IsIncreasing([]int{1, 2, 3})
+//	a.IsIncreasing([]float{1, 2})
+//	a.IsIncreasing([]string{"a", "b"})
+func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//	a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
+//	a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
+//	a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsIncreasingf(a.t, object, msg, args...)
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//	a.IsNonDecreasing([]int{1, 1, 2})
+//	a.IsNonDecreasing([]float{1, 2})
+//	a.IsNonDecreasing([]string{"a", "b"})
+func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//	a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
+//	a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
+//	a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonDecreasingf(a.t, object, msg, args...)
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//	a.IsNonIncreasing([]int{2, 1, 1})
+//	a.IsNonIncreasing([]float{2, 1})
+//	a.IsNonIncreasing([]string{"b", "a"})
+func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//	a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
+//	a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
+//	a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonIncreasingf(a.t, object, msg, args...)
+}
+
+// IsNotType asserts that the specified objects are not of the same type.
+//
+//	a.IsNotType(&NotMyStruct{}, &MyStruct{})
+func (a *Assertions) IsNotType(theType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNotType(a.t, theType, object, msgAndArgs...)
+}
+
+// IsNotTypef asserts that the specified objects are not of the same type.
+//
+//	a.IsNotTypef(&NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
+func (a *Assertions) IsNotTypef(theType interface{}, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNotTypef(a.t, theType, object, msg, args...)
+}
+
+// IsType asserts that the specified objects are of the same type.
+//
+//	a.IsType(&MyStruct{}, &MyStruct{})
+func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsType(a.t, expectedType, object, msgAndArgs...)
+}
+
+// IsTypef asserts that the specified objects are of the same type.
+//
+//	a.IsTypef(&MyStruct{}, &MyStruct{}, "error message %s", "formatted")
+func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsTypef(a.t, expectedType, object, msg, args...)
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//	a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return JSONEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// JSONEqf asserts that two JSON strings are equivalent.
+//
+//	a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return JSONEqf(a.t, expected, actual, msg, args...)
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//	a.Len(mySlice, 3)
+func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Len(a.t, object, length, msgAndArgs...)
+}
+
+// Lenf asserts that the specified object has specific length.
+// Lenf also fails if the object has a type that len() not accept.
+//
+//	a.Lenf(mySlice, 3, "error message %s", "formatted")
+func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Lenf(a.t, object, length, msg, args...)
+}
+
+// Less asserts that the first element is less than the second
+//
+//	a.Less(1, 2)
+//	a.Less(float64(1), float64(2))
+//	a.Less("a", "b")
+func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Less(a.t, e1, e2, msgAndArgs...)
+}
+
+// LessOrEqual asserts that the first element is less than or equal to the second
+//
+//	a.LessOrEqual(1, 2)
+//	a.LessOrEqual(2, 2)
+//	a.LessOrEqual("a", "b")
+//	a.LessOrEqual("b", "b")
+func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return LessOrEqual(a.t, e1, e2, msgAndArgs...)
+}
+
+// LessOrEqualf asserts that the first element is less than or equal to the second
+//
+//	a.LessOrEqualf(1, 2, "error message %s", "formatted")
+//	a.LessOrEqualf(2, 2, "error message %s", "formatted")
+//	a.LessOrEqualf("a", "b", "error message %s", "formatted")
+//	a.LessOrEqualf("b", "b", "error message %s", "formatted")
+func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return LessOrEqualf(a.t, e1, e2, msg, args...)
+}
+
+// Lessf asserts that the first element is less than the second
+//
+//	a.Lessf(1, 2, "error message %s", "formatted")
+//	a.Lessf(float64(1), float64(2), "error message %s", "formatted")
+//	a.Lessf("a", "b", "error message %s", "formatted")
+func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Lessf(a.t, e1, e2, msg, args...)
+}
+
+// Negative asserts that the specified element is negative
+//
+//	a.Negative(-1)
+//	a.Negative(-1.23)
+func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Negative(a.t, e, msgAndArgs...)
+}
+
+// Negativef asserts that the specified element is negative
+//
+//	a.Negativef(-1, "error message %s", "formatted")
+//	a.Negativef(-1.23, "error message %s", "formatted")
+func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Negativef(a.t, e, msg, args...)
+}
+
+// Never asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
+func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Never(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// Neverf asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Neverf(a.t, condition, waitFor, tick, msg, args...)
+}
+
+// Nil asserts that the specified object is nil.
+//
+//	a.Nil(err)
+func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Nil(a.t, object, msgAndArgs...)
+}
+
+// Nilf asserts that the specified object is nil.
+//
+//	a.Nilf(err, "error message %s", "formatted")
+func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Nilf(a.t, object, msg, args...)
+}
+
+// NoDirExists checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func (a *Assertions) NoDirExists(path string, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NoDirExists(a.t, path, msgAndArgs...)
+}
+
+// NoDirExistsf checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func (a *Assertions) NoDirExistsf(path string, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NoDirExistsf(a.t, path, msg, args...)
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if a.NoError(err) {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
+func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NoError(a.t, err, msgAndArgs...)
+}
+
+// NoErrorf asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if a.NoErrorf(err, "error message %s", "formatted") {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
+func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NoErrorf(a.t, err, msg, args...)
+}
+
+// NoFileExists checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func (a *Assertions) NoFileExists(path string, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NoFileExists(a.t, path, msgAndArgs...)
+}
+
+// NoFileExistsf checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NoFileExistsf(a.t, path, msg, args...)
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	a.NotContains("Hello World", "Earth")
+//	a.NotContains(["Hello", "World"], "Earth")
+//	a.NotContains({"Hello": "World"}, "Earth")
+func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotContains(a.t, s, contains, msgAndArgs...)
+}
+
+// NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
+//	a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
+//	a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
+func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotContainsf(a.t, s, contains, msg, args...)
+}
+
+// NotElementsMatch asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// a.NotElementsMatch([1, 1, 2, 3], [1, 1, 2, 3]) -> false
+//
+// a.NotElementsMatch([1, 1, 2, 3], [1, 2, 3]) -> true
+//
+// a.NotElementsMatch([1, 2, 3], [1, 2, 4]) -> true
+func (a *Assertions) NotElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotElementsMatch(a.t, listA, listB, msgAndArgs...)
+}
+
+// NotElementsMatchf asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// a.NotElementsMatchf([1, 1, 2, 3], [1, 1, 2, 3], "error message %s", "formatted") -> false
+//
+// a.NotElementsMatchf([1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
+//
+// a.NotElementsMatchf([1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
+func (a *Assertions) NotElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotElementsMatchf(a.t, listA, listB, msg, args...)
+}
+
+// NotEmpty asserts that the specified object is NOT [Empty].
+//
+//	if a.NotEmpty(obj) {
+//	  assert.Equal(t, "two", obj[1])
+//	}
+func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotEmpty(a.t, object, msgAndArgs...)
+}
+
+// NotEmptyf asserts that the specified object is NOT [Empty].
+//
+//	if a.NotEmptyf(obj, "error message %s", "formatted") {
+//	  assert.Equal(t, "two", obj[1])
+//	}
+func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotEmptyf(a.t, object, msg, args...)
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//	a.NotEqual(obj1, obj2)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotEqual(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotEqualValues asserts that two objects are not equal even when converted to the same type
+//
+//	a.NotEqualValues(obj1, obj2)
+func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotEqualValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotEqualValuesf asserts that two objects are not equal even when converted to the same type
+//
+//	a.NotEqualValuesf(obj1, obj2, "error message %s", "formatted")
+func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotEqualValuesf(a.t, expected, actual, msg, args...)
+}
+
+// NotEqualf asserts that the specified values are NOT equal.
+//
+//	a.NotEqualf(obj1, obj2, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotEqualf(a.t, expected, actual, msg, args...)
+}
+
+// NotErrorAs asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func (a *Assertions) NotErrorAs(err error, target interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotErrorAs(a.t, err, target, msgAndArgs...)
+}
+
+// NotErrorAsf asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func (a *Assertions) NotErrorAsf(err error, target interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotErrorAsf(a.t, err, target, msg, args...)
+}
+
+// NotErrorIs asserts that none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotErrorIs(a.t, err, target, msgAndArgs...)
+}
+
+// NotErrorIsf asserts that none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotErrorIsf(a.t, err, target, msg, args...)
+}
+
+// NotImplements asserts that an object does not implement the specified interface.
+//
+//	a.NotImplements((*MyInterface)(nil), new(MyObject))
+func (a *Assertions) NotImplements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotImplements(a.t, interfaceObject, object, msgAndArgs...)
+}
+
+// NotImplementsf asserts that an object does not implement the specified interface.
+//
+//	a.NotImplementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func (a *Assertions) NotImplementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotImplementsf(a.t, interfaceObject, object, msg, args...)
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//	a.NotNil(err)
+func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotNil(a.t, object, msgAndArgs...)
+}
+
+// NotNilf asserts that the specified object is not nil.
+//
+//	a.NotNilf(err, "error message %s", "formatted")
+func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotNilf(a.t, object, msg, args...)
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	a.NotPanics(func(){ RemainCalm() })
+func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotPanics(a.t, f, msgAndArgs...)
+}
+
+// NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
+func (a *Assertions) NotPanicsf(f PanicTestFunc, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotPanicsf(a.t, f, msg, args...)
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
+//	a.NotRegexp("^start", "it's not starting")
+func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotRegexp(a.t, rx, str, msgAndArgs...)
+}
+
+// NotRegexpf asserts that a specified regexp does not match a string.
+//
+//	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted")
+func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotRegexpf(a.t, rx, str, msg, args...)
+}
+
+// NotSame asserts that two pointers do not reference the same object.
+//
+//	a.NotSame(ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotSame(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotSamef asserts that two pointers do not reference the same object.
+//
+//	a.NotSamef(ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotSamef(a.t, expected, actual, msg, args...)
+}
+
+// NotSubset asserts that the list (array, slice, or map) does NOT contain all
+// elements given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	a.NotSubset([1, 3, 4], [1, 2])
+//	a.NotSubset({"x": 1, "y": 2}, {"z": 3})
+//	a.NotSubset([1, 3, 4], {1: "one", 2: "two"})
+//	a.NotSubset({"x": 1, "y": 2}, ["z"])
+func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotSubset(a.t, list, subset, msgAndArgs...)
+}
+
+// NotSubsetf asserts that the list (array, slice, or map) does NOT contain all
+// elements given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	a.NotSubsetf([1, 3, 4], [1, 2], "error message %s", "formatted")
+//	a.NotSubsetf({"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+//	a.NotSubsetf([1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	a.NotSubsetf({"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
+func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotSubsetf(a.t, list, subset, msg, args...)
+}
+
+// NotZero asserts that i is not the zero value for its type.
+func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotZero(a.t, i, msgAndArgs...)
+}
+
+// NotZerof asserts that i is not the zero value for its type.
+func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotZerof(a.t, i, msg, args...)
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//	a.Panics(func(){ GoCrazy() })
+func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Panics(a.t, f, msgAndArgs...)
+}
+
+// PanicsWithError asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	a.PanicsWithError("crazy error", func(){ GoCrazy() })
+func (a *Assertions) PanicsWithError(errString string, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return PanicsWithError(a.t, errString, f, msgAndArgs...)
+}
+
+// PanicsWithErrorf asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	a.PanicsWithErrorf("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) PanicsWithErrorf(errString string, f PanicTestFunc, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return PanicsWithErrorf(a.t, errString, f, msg, args...)
+}
+
+// PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	a.PanicsWithValue("crazy error", func(){ GoCrazy() })
+func (a *Assertions) PanicsWithValue(expected interface{}, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return PanicsWithValue(a.t, expected, f, msgAndArgs...)
+}
+
+// PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) PanicsWithValuef(expected interface{}, f PanicTestFunc, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return PanicsWithValuef(a.t, expected, f, msg, args...)
+}
+
+// Panicsf asserts that the code inside the specified PanicTestFunc panics.
+//
+//	a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) Panicsf(f PanicTestFunc, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Panicsf(a.t, f, msg, args...)
+}
+
+// Positive asserts that the specified element is positive
+//
+//	a.Positive(1)
+//	a.Positive(1.23)
+func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Positive(a.t, e, msgAndArgs...)
+}
+
+// Positivef asserts that the specified element is positive
+//
+//	a.Positivef(1, "error message %s", "formatted")
+//	a.Positivef(1.23, "error message %s", "formatted")
+func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Positivef(a.t, e, msg, args...)
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//	a.Regexp(regexp.MustCompile("start"), "it's starting")
+//	a.Regexp("start...$", "it's not starting")
+func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Regexp(a.t, rx, str, msgAndArgs...)
+}
+
+// Regexpf asserts that a specified regexp matches a string.
+//
+//	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted")
+func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Regexpf(a.t, rx, str, msg, args...)
+}
+
+// Same asserts that two pointers reference the same object.
+//
+//	a.Same(ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Same(a.t, expected, actual, msgAndArgs...)
+}
+
+// Samef asserts that two pointers reference the same object.
+//
+//	a.Samef(ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Samef(a.t, expected, actual, msg, args...)
+}
+
+// Subset asserts that the list (array, slice, or map) contains all elements
+// given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	a.Subset([1, 2, 3], [1, 2])
+//	a.Subset({"x": 1, "y": 2}, {"x": 1})
+//	a.Subset([1, 2, 3], {1: "one", 2: "two"})
+//	a.Subset({"x": 1, "y": 2}, ["x"])
+func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Subset(a.t, list, subset, msgAndArgs...)
+}
+
+// Subsetf asserts that the list (array, slice, or map) contains all elements
+// given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	a.Subsetf([1, 2, 3], [1, 2], "error message %s", "formatted")
+//	a.Subsetf({"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+//	a.Subsetf([1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	a.Subsetf({"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
+func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Subsetf(a.t, list, subset, msg, args...)
+}
+
+// True asserts that the specified value is true.
+//
+//	a.True(myBool)
+func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return True(a.t, value, msgAndArgs...)
+}
+
+// Truef asserts that the specified value is true.
+//
+//	a.Truef(myBool, "error message %s", "formatted")
+func (a *Assertions) Truef(value bool, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Truef(a.t, value, msg, args...)
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//	a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
+func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// WithinDurationf asserts that the two times are within duration delta of each other.
+//
+//	a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return WithinDurationf(a.t, expected, actual, delta, msg, args...)
+}
+
+// WithinRange asserts that a time is within a time range (inclusive).
+//
+//	a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return WithinRange(a.t, actual, start, end, msgAndArgs...)
+}
+
+// WithinRangef asserts that a time is within a time range (inclusive).
+//
+//	a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return WithinRangef(a.t, actual, start, end, msg, args...)
+}
+
+// YAMLEq asserts that two YAML strings are equivalent.
+func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return YAMLEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// YAMLEqf asserts that two YAML strings are equivalent.
+func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return YAMLEqf(a.t, expected, actual, msg, args...)
+}
+
+// Zero asserts that i is the zero value for its type.
+func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Zero(a.t, i, msgAndArgs...)
+}
+
+// Zerof asserts that i is the zero value for its type.
+func (a *Assertions) Zerof(i interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Zerof(a.t, i, msg, args...)
+}

--- a/vendor/github.com/stretchr/testify/assert/assertion_forward.go.tmpl
+++ b/vendor/github.com/stretchr/testify/assert/assertion_forward.go.tmpl
@@ -1,0 +1,5 @@
+{{.CommentWithoutT "a"}}
+func (a *Assertions) {{.DocInfo.Name}}({{.Params}}) bool {
+	if h, ok := a.t.(tHelper); ok { h.Helper() }
+	return {{.DocInfo.Name}}(a.t, {{.ForwardedParams}})
+}

--- a/vendor/github.com/stretchr/testify/assert/assertion_order.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_order.go
@@ -1,0 +1,81 @@
+package assert
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// isOrdered checks that collection contains orderable elements.
+func isOrdered(t TestingT, object interface{}, allowedComparesResults []compareResult, failMessage string, msgAndArgs ...interface{}) bool {
+	objKind := reflect.TypeOf(object).Kind()
+	if objKind != reflect.Slice && objKind != reflect.Array {
+		return false
+	}
+
+	objValue := reflect.ValueOf(object)
+	objLen := objValue.Len()
+
+	if objLen <= 1 {
+		return true
+	}
+
+	value := objValue.Index(0)
+	valueInterface := value.Interface()
+	firstValueKind := value.Kind()
+
+	for i := 1; i < objLen; i++ {
+		prevValue := value
+		prevValueInterface := valueInterface
+
+		value = objValue.Index(i)
+		valueInterface = value.Interface()
+
+		compareResult, isComparable := compare(prevValueInterface, valueInterface, firstValueKind)
+
+		if !isComparable {
+			return Fail(t, fmt.Sprintf(`Can not compare type "%T" and "%T"`, value, prevValue), msgAndArgs...)
+		}
+
+		if !containsValue(allowedComparesResults, compareResult) {
+			return Fail(t, fmt.Sprintf(failMessage, prevValue, value), msgAndArgs...)
+		}
+	}
+
+	return true
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//	assert.IsIncreasing(t, []int{1, 2, 3})
+//	assert.IsIncreasing(t, []float{1, 2})
+//	assert.IsIncreasing(t, []string{"a", "b"})
+func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	return isOrdered(t, object, []compareResult{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs...)
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//	assert.IsNonIncreasing(t, []int{2, 1, 1})
+//	assert.IsNonIncreasing(t, []float{2, 1})
+//	assert.IsNonIncreasing(t, []string{"b", "a"})
+func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	return isOrdered(t, object, []compareResult{compareEqual, compareGreater}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs...)
+}
+
+// IsDecreasing asserts that the collection is decreasing
+//
+//	assert.IsDecreasing(t, []int{2, 1, 0})
+//	assert.IsDecreasing(t, []float{2, 1})
+//	assert.IsDecreasing(t, []string{"b", "a"})
+func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	return isOrdered(t, object, []compareResult{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs...)
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//	assert.IsNonDecreasing(t, []int{1, 1, 2})
+//	assert.IsNonDecreasing(t, []float{1, 2})
+//	assert.IsNonDecreasing(t, []string{"a", "b"})
+func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	return isOrdered(t, object, []compareResult{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs...)
+}

--- a/vendor/github.com/stretchr/testify/assert/assertions.go
+++ b/vendor/github.com/stretchr/testify/assert/assertions.go
@@ -1,0 +1,2295 @@
+package assert
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"reflect"
+	"regexp"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/pmezard/go-difflib/difflib"
+
+	// Wrapper around gopkg.in/yaml.v3
+	"github.com/stretchr/testify/assert/yaml"
+)
+
+//go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=assert -template=assertion_format.go.tmpl"
+
+// TestingT is an interface wrapper around *testing.T
+type TestingT interface {
+	Errorf(format string, args ...interface{})
+}
+
+// ComparisonAssertionFunc is a common function prototype when comparing two values.  Can be useful
+// for table driven tests.
+type ComparisonAssertionFunc func(TestingT, interface{}, interface{}, ...interface{}) bool
+
+// ValueAssertionFunc is a common function prototype when validating a single value.  Can be useful
+// for table driven tests.
+type ValueAssertionFunc func(TestingT, interface{}, ...interface{}) bool
+
+// BoolAssertionFunc is a common function prototype when validating a bool value.  Can be useful
+// for table driven tests.
+type BoolAssertionFunc func(TestingT, bool, ...interface{}) bool
+
+// ErrorAssertionFunc is a common function prototype when validating an error value.  Can be useful
+// for table driven tests.
+type ErrorAssertionFunc func(TestingT, error, ...interface{}) bool
+
+// PanicAssertionFunc is a common function prototype when validating a panic value.  Can be useful
+// for table driven tests.
+type PanicAssertionFunc = func(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool
+
+// Comparison is a custom function that returns true on success and false on failure
+type Comparison func() (success bool)
+
+/*
+	Helper functions
+*/
+
+// ObjectsAreEqual determines if two objects are considered equal.
+//
+// This function does no assertion of any kind.
+func ObjectsAreEqual(expected, actual interface{}) bool {
+	if expected == nil || actual == nil {
+		return expected == actual
+	}
+
+	exp, ok := expected.([]byte)
+	if !ok {
+		return reflect.DeepEqual(expected, actual)
+	}
+
+	act, ok := actual.([]byte)
+	if !ok {
+		return false
+	}
+	if exp == nil || act == nil {
+		return exp == nil && act == nil
+	}
+	return bytes.Equal(exp, act)
+}
+
+// copyExportedFields iterates downward through nested data structures and creates a copy
+// that only contains the exported struct fields.
+func copyExportedFields(expected interface{}) interface{} {
+	if isNil(expected) {
+		return expected
+	}
+
+	expectedType := reflect.TypeOf(expected)
+	expectedKind := expectedType.Kind()
+	expectedValue := reflect.ValueOf(expected)
+
+	switch expectedKind {
+	case reflect.Struct:
+		result := reflect.New(expectedType).Elem()
+		for i := 0; i < expectedType.NumField(); i++ {
+			field := expectedType.Field(i)
+			isExported := field.IsExported()
+			if isExported {
+				fieldValue := expectedValue.Field(i)
+				if isNil(fieldValue) || isNil(fieldValue.Interface()) {
+					continue
+				}
+				newValue := copyExportedFields(fieldValue.Interface())
+				result.Field(i).Set(reflect.ValueOf(newValue))
+			}
+		}
+		return result.Interface()
+
+	case reflect.Ptr:
+		result := reflect.New(expectedType.Elem())
+		unexportedRemoved := copyExportedFields(expectedValue.Elem().Interface())
+		result.Elem().Set(reflect.ValueOf(unexportedRemoved))
+		return result.Interface()
+
+	case reflect.Array, reflect.Slice:
+		var result reflect.Value
+		if expectedKind == reflect.Array {
+			result = reflect.New(reflect.ArrayOf(expectedValue.Len(), expectedType.Elem())).Elem()
+		} else {
+			result = reflect.MakeSlice(expectedType, expectedValue.Len(), expectedValue.Len())
+		}
+		for i := 0; i < expectedValue.Len(); i++ {
+			index := expectedValue.Index(i)
+			if isNil(index) {
+				continue
+			}
+			unexportedRemoved := copyExportedFields(index.Interface())
+			result.Index(i).Set(reflect.ValueOf(unexportedRemoved))
+		}
+		return result.Interface()
+
+	case reflect.Map:
+		result := reflect.MakeMap(expectedType)
+		for _, k := range expectedValue.MapKeys() {
+			index := expectedValue.MapIndex(k)
+			unexportedRemoved := copyExportedFields(index.Interface())
+			result.SetMapIndex(k, reflect.ValueOf(unexportedRemoved))
+		}
+		return result.Interface()
+
+	default:
+		return expected
+	}
+}
+
+// ObjectsExportedFieldsAreEqual determines if the exported (public) fields of two objects are
+// considered equal. This comparison of only exported fields is applied recursively to nested data
+// structures.
+//
+// This function does no assertion of any kind.
+//
+// Deprecated: Use [EqualExportedValues] instead.
+func ObjectsExportedFieldsAreEqual(expected, actual interface{}) bool {
+	expectedCleaned := copyExportedFields(expected)
+	actualCleaned := copyExportedFields(actual)
+	return ObjectsAreEqualValues(expectedCleaned, actualCleaned)
+}
+
+// ObjectsAreEqualValues gets whether two objects are equal, or if their
+// values are equal.
+func ObjectsAreEqualValues(expected, actual interface{}) bool {
+	if ObjectsAreEqual(expected, actual) {
+		return true
+	}
+
+	expectedValue := reflect.ValueOf(expected)
+	actualValue := reflect.ValueOf(actual)
+	if !expectedValue.IsValid() || !actualValue.IsValid() {
+		return false
+	}
+
+	expectedType := expectedValue.Type()
+	actualType := actualValue.Type()
+	if !expectedType.ConvertibleTo(actualType) {
+		return false
+	}
+
+	if !isNumericType(expectedType) || !isNumericType(actualType) {
+		// Attempt comparison after type conversion
+		return reflect.DeepEqual(
+			expectedValue.Convert(actualType).Interface(), actual,
+		)
+	}
+
+	// If BOTH values are numeric, there are chances of false positives due
+	// to overflow or underflow. So, we need to make sure to always convert
+	// the smaller type to a larger type before comparing.
+	if expectedType.Size() >= actualType.Size() {
+		return actualValue.Convert(expectedType).Interface() == expected
+	}
+
+	return expectedValue.Convert(actualType).Interface() == actual
+}
+
+// isNumericType returns true if the type is one of:
+// int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64,
+// float32, float64, complex64, complex128
+func isNumericType(t reflect.Type) bool {
+	return t.Kind() >= reflect.Int && t.Kind() <= reflect.Complex128
+}
+
+/* CallerInfo is necessary because the assert functions use the testing object
+internally, causing it to print the file:line of the assert method, rather than where
+the problem actually occurred in calling code.*/
+
+// CallerInfo returns an array of strings containing the file and line number
+// of each stack frame leading from the current test to the assert call that
+// failed.
+func CallerInfo() []string {
+	var pc uintptr
+	var file string
+	var line int
+	var name string
+
+	const stackFrameBufferSize = 10
+	pcs := make([]uintptr, stackFrameBufferSize)
+
+	callers := []string{}
+	offset := 1
+
+	for {
+		n := runtime.Callers(offset, pcs)
+
+		if n == 0 {
+			break
+		}
+
+		frames := runtime.CallersFrames(pcs[:n])
+
+		for {
+			frame, more := frames.Next()
+			pc = frame.PC
+			file = frame.File
+			line = frame.Line
+
+			// This is a huge edge case, but it will panic if this is the case, see #180
+			if file == "<autogenerated>" {
+				break
+			}
+
+			f := runtime.FuncForPC(pc)
+			if f == nil {
+				break
+			}
+			name = f.Name()
+
+			// testing.tRunner is the standard library function that calls
+			// tests. Subtests are called directly by tRunner, without going through
+			// the Test/Benchmark/Example function that contains the t.Run calls, so
+			// with subtests we should break when we hit tRunner, without adding it
+			// to the list of callers.
+			if name == "testing.tRunner" {
+				break
+			}
+
+			parts := strings.Split(file, "/")
+			if len(parts) > 1 {
+				filename := parts[len(parts)-1]
+				dir := parts[len(parts)-2]
+				if (dir != "assert" && dir != "mock" && dir != "require") || filename == "mock_test.go" {
+					callers = append(callers, fmt.Sprintf("%s:%d", file, line))
+				}
+			}
+
+			// Drop the package
+			dotPos := strings.LastIndexByte(name, '.')
+			name = name[dotPos+1:]
+			if isTest(name, "Test") ||
+				isTest(name, "Benchmark") ||
+				isTest(name, "Example") {
+				break
+			}
+
+			if !more {
+				break
+			}
+		}
+
+		// Next batch
+		offset += cap(pcs)
+	}
+
+	return callers
+}
+
+// Stolen from the `go test` tool.
+// isTest tells whether name looks like a test (or benchmark, according to prefix).
+// It is a Test (say) if there is a character after Test that is not a lower-case letter.
+// We don't want TesticularCancer.
+func isTest(name, prefix string) bool {
+	if !strings.HasPrefix(name, prefix) {
+		return false
+	}
+	if len(name) == len(prefix) { // "Test" is ok
+		return true
+	}
+	r, _ := utf8.DecodeRuneInString(name[len(prefix):])
+	return !unicode.IsLower(r)
+}
+
+func messageFromMsgAndArgs(msgAndArgs ...interface{}) string {
+	if len(msgAndArgs) == 0 || msgAndArgs == nil {
+		return ""
+	}
+	if len(msgAndArgs) == 1 {
+		msg := msgAndArgs[0]
+		if msgAsStr, ok := msg.(string); ok {
+			return msgAsStr
+		}
+		return fmt.Sprintf("%+v", msg)
+	}
+	if len(msgAndArgs) > 1 {
+		return fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...)
+	}
+	return ""
+}
+
+// Aligns the provided message so that all lines after the first line start at the same location as the first line.
+// Assumes that the first line starts at the correct location (after carriage return, tab, label, spacer and tab).
+// The longestLabelLen parameter specifies the length of the longest label in the output (required because this is the
+// basis on which the alignment occurs).
+func indentMessageLines(message string, longestLabelLen int) string {
+	outBuf := new(bytes.Buffer)
+
+	for i, scanner := 0, bufio.NewScanner(strings.NewReader(message)); scanner.Scan(); i++ {
+		// no need to align first line because it starts at the correct location (after the label)
+		if i != 0 {
+			// append alignLen+1 spaces to align with "{{longestLabel}}:" before adding tab
+			outBuf.WriteString("\n\t" + strings.Repeat(" ", longestLabelLen+1) + "\t")
+		}
+		outBuf.WriteString(scanner.Text())
+	}
+
+	return outBuf.String()
+}
+
+type failNower interface {
+	FailNow()
+}
+
+// FailNow fails test
+func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	Fail(t, failureMessage, msgAndArgs...)
+
+	// We cannot extend TestingT with FailNow() and
+	// maintain backwards compatibility, so we fallback
+	// to panicking when FailNow is not available in
+	// TestingT.
+	// See issue #263
+
+	if t, ok := t.(failNower); ok {
+		t.FailNow()
+	} else {
+		panic("test failed and t is missing `FailNow()`")
+	}
+	return false
+}
+
+// Fail reports a failure through
+func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	content := []labeledContent{
+		{"Error Trace", strings.Join(CallerInfo(), "\n\t\t\t")},
+		{"Error", failureMessage},
+	}
+
+	// Add test name if the Go version supports it
+	if n, ok := t.(interface {
+		Name() string
+	}); ok {
+		content = append(content, labeledContent{"Test", n.Name()})
+	}
+
+	message := messageFromMsgAndArgs(msgAndArgs...)
+	if len(message) > 0 {
+		content = append(content, labeledContent{"Messages", message})
+	}
+
+	t.Errorf("\n%s", ""+labeledOutput(content...))
+
+	return false
+}
+
+type labeledContent struct {
+	label   string
+	content string
+}
+
+// labeledOutput returns a string consisting of the provided labeledContent. Each labeled output is appended in the following manner:
+//
+//	\t{{label}}:{{align_spaces}}\t{{content}}\n
+//
+// The initial carriage return is required to undo/erase any padding added by testing.T.Errorf. The "\t{{label}}:" is for the label.
+// If a label is shorter than the longest label provided, padding spaces are added to make all the labels match in length. Once this
+// alignment is achieved, "\t{{content}}\n" is added for the output.
+//
+// If the content of the labeledOutput contains line breaks, the subsequent lines are aligned so that they start at the same location as the first line.
+func labeledOutput(content ...labeledContent) string {
+	longestLabel := 0
+	for _, v := range content {
+		if len(v.label) > longestLabel {
+			longestLabel = len(v.label)
+		}
+	}
+	var output string
+	for _, v := range content {
+		output += "\t" + v.label + ":" + strings.Repeat(" ", longestLabel-len(v.label)) + "\t" + indentMessageLines(v.content, longestLabel) + "\n"
+	}
+	return output
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//	assert.Implements(t, (*MyInterface)(nil), new(MyObject))
+func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	interfaceType := reflect.TypeOf(interfaceObject).Elem()
+
+	if object == nil {
+		return Fail(t, fmt.Sprintf("Cannot check if nil implements %v", interfaceType), msgAndArgs...)
+	}
+	if !reflect.TypeOf(object).Implements(interfaceType) {
+		return Fail(t, fmt.Sprintf("%T must implement %v", object, interfaceType), msgAndArgs...)
+	}
+
+	return true
+}
+
+// NotImplements asserts that an object does not implement the specified interface.
+//
+//	assert.NotImplements(t, (*MyInterface)(nil), new(MyObject))
+func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	interfaceType := reflect.TypeOf(interfaceObject).Elem()
+
+	if object == nil {
+		return Fail(t, fmt.Sprintf("Cannot check if nil does not implement %v", interfaceType), msgAndArgs...)
+	}
+	if reflect.TypeOf(object).Implements(interfaceType) {
+		return Fail(t, fmt.Sprintf("%T implements %v", object, interfaceType), msgAndArgs...)
+	}
+
+	return true
+}
+
+func isType(expectedType, object interface{}) bool {
+	return ObjectsAreEqual(reflect.TypeOf(object), reflect.TypeOf(expectedType))
+}
+
+// IsType asserts that the specified objects are of the same type.
+//
+//	assert.IsType(t, &MyStruct{}, &MyStruct{})
+func IsType(t TestingT, expectedType, object interface{}, msgAndArgs ...interface{}) bool {
+	if isType(expectedType, object) {
+		return true
+	}
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Fail(t, fmt.Sprintf("Object expected to be of type %T, but was %T", expectedType, object), msgAndArgs...)
+}
+
+// IsNotType asserts that the specified objects are not of the same type.
+//
+//	assert.IsNotType(t, &NotMyStruct{}, &MyStruct{})
+func IsNotType(t TestingT, theType, object interface{}, msgAndArgs ...interface{}) bool {
+	if !isType(theType, object) {
+		return true
+	}
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Fail(t, fmt.Sprintf("Object type expected to be different than %T", theType), msgAndArgs...)
+}
+
+// Equal asserts that two objects are equal.
+//
+//	assert.Equal(t, 123, 123)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if err := validateEqualArgs(expected, actual); err != nil {
+		return Fail(t, fmt.Sprintf("Invalid operation: %#v == %#v (%s)",
+			expected, actual, err), msgAndArgs...)
+	}
+
+	if !ObjectsAreEqual(expected, actual) {
+		diff := diff(expected, actual)
+		expected, actual = formatUnequalValues(expected, actual)
+		return Fail(t, fmt.Sprintf("Not equal: \n"+
+			"expected: %s\n"+
+			"actual  : %s%s", expected, actual, diff), msgAndArgs...)
+	}
+
+	return true
+}
+
+// validateEqualArgs checks whether provided arguments can be safely used in the
+// Equal/NotEqual functions.
+func validateEqualArgs(expected, actual interface{}) error {
+	if expected == nil && actual == nil {
+		return nil
+	}
+
+	if isFunction(expected) || isFunction(actual) {
+		return errors.New("cannot take func type as argument")
+	}
+	return nil
+}
+
+// Same asserts that two pointers reference the same object.
+//
+//	assert.Same(t, ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func Same(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	same, ok := samePointers(expected, actual)
+	if !ok {
+		return Fail(t, "Both arguments must be pointers", msgAndArgs...)
+	}
+
+	if !same {
+		// both are pointers but not the same type & pointing to the same address
+		return Fail(t, fmt.Sprintf("Not same: \n"+
+			"expected: %p %#[1]v\n"+
+			"actual  : %p %#[2]v",
+			expected, actual), msgAndArgs...)
+	}
+
+	return true
+}
+
+// NotSame asserts that two pointers do not reference the same object.
+//
+//	assert.NotSame(t, ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func NotSame(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	same, ok := samePointers(expected, actual)
+	if !ok {
+		// fails when the arguments are not pointers
+		return !(Fail(t, "Both arguments must be pointers", msgAndArgs...))
+	}
+
+	if same {
+		return Fail(t, fmt.Sprintf(
+			"Expected and actual point to the same object: %p %#[1]v",
+			expected), msgAndArgs...)
+	}
+	return true
+}
+
+// samePointers checks if two generic interface objects are pointers of the same
+// type pointing to the same object. It returns two values: same indicating if
+// they are the same type and point to the same object, and ok indicating that
+// both inputs are pointers.
+func samePointers(first, second interface{}) (same bool, ok bool) {
+	firstPtr, secondPtr := reflect.ValueOf(first), reflect.ValueOf(second)
+	if firstPtr.Kind() != reflect.Ptr || secondPtr.Kind() != reflect.Ptr {
+		return false, false // not both are pointers
+	}
+
+	firstType, secondType := reflect.TypeOf(first), reflect.TypeOf(second)
+	if firstType != secondType {
+		return false, true // both are pointers, but of different types
+	}
+
+	// compare pointer addresses
+	return first == second, true
+}
+
+// formatUnequalValues takes two values of arbitrary types and returns string
+// representations appropriate to be presented to the user.
+//
+// If the values are not of like type, the returned strings will be prefixed
+// with the type name, and the value will be enclosed in parentheses similar
+// to a type conversion in the Go grammar.
+func formatUnequalValues(expected, actual interface{}) (e string, a string) {
+	if reflect.TypeOf(expected) != reflect.TypeOf(actual) {
+		return fmt.Sprintf("%T(%s)", expected, truncatingFormat(expected)),
+			fmt.Sprintf("%T(%s)", actual, truncatingFormat(actual))
+	}
+	switch expected.(type) {
+	case time.Duration:
+		return fmt.Sprintf("%v", expected), fmt.Sprintf("%v", actual)
+	}
+	return truncatingFormat(expected), truncatingFormat(actual)
+}
+
+// truncatingFormat formats the data and truncates it if it's too long.
+//
+// This helps keep formatted error messages lines from exceeding the
+// bufio.MaxScanTokenSize max line length that the go testing framework imposes.
+func truncatingFormat(data interface{}) string {
+	value := fmt.Sprintf("%#v", data)
+	max := bufio.MaxScanTokenSize - 100 // Give us some space the type info too if needed.
+	if len(value) > max {
+		value = value[0:max] + "<... truncated>"
+	}
+	return value
+}
+
+// EqualValues asserts that two objects are equal or convertible to the larger
+// type and equal.
+//
+//	assert.EqualValues(t, uint32(123), int32(123))
+func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if !ObjectsAreEqualValues(expected, actual) {
+		diff := diff(expected, actual)
+		expected, actual = formatUnequalValues(expected, actual)
+		return Fail(t, fmt.Sprintf("Not equal: \n"+
+			"expected: %s\n"+
+			"actual  : %s%s", expected, actual, diff), msgAndArgs...)
+	}
+
+	return true
+}
+
+// EqualExportedValues asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 assert.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
+//	 assert.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
+func EqualExportedValues(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	aType := reflect.TypeOf(expected)
+	bType := reflect.TypeOf(actual)
+
+	if aType != bType {
+		return Fail(t, fmt.Sprintf("Types expected to match exactly\n\t%v != %v", aType, bType), msgAndArgs...)
+	}
+
+	expected = copyExportedFields(expected)
+	actual = copyExportedFields(actual)
+
+	if !ObjectsAreEqualValues(expected, actual) {
+		diff := diff(expected, actual)
+		expected, actual = formatUnequalValues(expected, actual)
+		return Fail(t, fmt.Sprintf("Not equal (comparing only exported fields): \n"+
+			"expected: %s\n"+
+			"actual  : %s%s", expected, actual, diff), msgAndArgs...)
+	}
+
+	return true
+}
+
+// Exactly asserts that two objects are equal in value and type.
+//
+//	assert.Exactly(t, int32(123), int64(123))
+func Exactly(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	aType := reflect.TypeOf(expected)
+	bType := reflect.TypeOf(actual)
+
+	if aType != bType {
+		return Fail(t, fmt.Sprintf("Types expected to match exactly\n\t%v != %v", aType, bType), msgAndArgs...)
+	}
+
+	return Equal(t, expected, actual, msgAndArgs...)
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//	assert.NotNil(t, err)
+func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	if !isNil(object) {
+		return true
+	}
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Fail(t, "Expected value not to be nil.", msgAndArgs...)
+}
+
+// isNil checks if a specified object is nil or not, without Failing.
+func isNil(object interface{}) bool {
+	if object == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(object)
+	switch value.Kind() {
+	case
+		reflect.Chan, reflect.Func,
+		reflect.Interface, reflect.Map,
+		reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+
+		return value.IsNil()
+	}
+
+	return false
+}
+
+// Nil asserts that the specified object is nil.
+//
+//	assert.Nil(t, err)
+func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	if isNil(object) {
+		return true
+	}
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Fail(t, fmt.Sprintf("Expected nil, but got: %#v", object), msgAndArgs...)
+}
+
+// isEmpty gets whether the specified object is considered empty or not.
+func isEmpty(object interface{}) bool {
+	// get nil case out of the way
+	if object == nil {
+		return true
+	}
+
+	return isEmptyValue(reflect.ValueOf(object))
+}
+
+// isEmptyValue gets whether the specified reflect.Value is considered empty or not.
+func isEmptyValue(objValue reflect.Value) bool {
+	if objValue.IsZero() {
+		return true
+	}
+	// Special cases of non-zero values that we consider empty
+	switch objValue.Kind() {
+	// collection types are empty when they have no element
+	// Note: array types are empty when they match their zero-initialized state.
+	case reflect.Chan, reflect.Map, reflect.Slice:
+		return objValue.Len() == 0
+	// non-nil pointers are empty if the value they point to is empty
+	case reflect.Ptr:
+		return isEmptyValue(objValue.Elem())
+	}
+	return false
+}
+
+// Empty asserts that the given value is "empty".
+//
+// [Zero values] are "empty".
+//
+// Arrays are "empty" if every element is the zero value of the type (stricter than "empty").
+//
+// Slices, maps and channels with zero length are "empty".
+//
+// Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
+//
+//	assert.Empty(t, obj)
+//
+// [Zero values]: https://go.dev/ref/spec#The_zero_value
+func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	pass := isEmpty(object)
+	if !pass {
+		if h, ok := t.(tHelper); ok {
+			h.Helper()
+		}
+		Fail(t, fmt.Sprintf("Should be empty, but was %v", object), msgAndArgs...)
+	}
+
+	return pass
+}
+
+// NotEmpty asserts that the specified object is NOT [Empty].
+//
+//	if assert.NotEmpty(t, obj) {
+//	  assert.Equal(t, "two", obj[1])
+//	}
+func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	pass := !isEmpty(object)
+	if !pass {
+		if h, ok := t.(tHelper); ok {
+			h.Helper()
+		}
+		Fail(t, fmt.Sprintf("Should NOT be empty, but was %v", object), msgAndArgs...)
+	}
+
+	return pass
+}
+
+// getLen tries to get the length of an object.
+// It returns (0, false) if impossible.
+func getLen(x interface{}) (length int, ok bool) {
+	v := reflect.ValueOf(x)
+	defer func() {
+		ok = recover() == nil
+	}()
+	return v.Len(), true
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//	assert.Len(t, mySlice, 3)
+func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	l, ok := getLen(object)
+	if !ok {
+		return Fail(t, fmt.Sprintf("\"%v\" could not be applied builtin len()", object), msgAndArgs...)
+	}
+
+	if l != length {
+		return Fail(t, fmt.Sprintf("\"%v\" should have %d item(s), but has %d", object, length, l), msgAndArgs...)
+	}
+	return true
+}
+
+// True asserts that the specified value is true.
+//
+//	assert.True(t, myBool)
+func True(t TestingT, value bool, msgAndArgs ...interface{}) bool {
+	if !value {
+		if h, ok := t.(tHelper); ok {
+			h.Helper()
+		}
+		return Fail(t, "Should be true", msgAndArgs...)
+	}
+
+	return true
+}
+
+// False asserts that the specified value is false.
+//
+//	assert.False(t, myBool)
+func False(t TestingT, value bool, msgAndArgs ...interface{}) bool {
+	if value {
+		if h, ok := t.(tHelper); ok {
+			h.Helper()
+		}
+		return Fail(t, "Should be false", msgAndArgs...)
+	}
+
+	return true
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//	assert.NotEqual(t, obj1, obj2)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func NotEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if err := validateEqualArgs(expected, actual); err != nil {
+		return Fail(t, fmt.Sprintf("Invalid operation: %#v != %#v (%s)",
+			expected, actual, err), msgAndArgs...)
+	}
+
+	if ObjectsAreEqual(expected, actual) {
+		return Fail(t, fmt.Sprintf("Should not be: %#v\n", actual), msgAndArgs...)
+	}
+
+	return true
+}
+
+// NotEqualValues asserts that two objects are not equal even when converted to the same type
+//
+//	assert.NotEqualValues(t, obj1, obj2)
+func NotEqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if ObjectsAreEqualValues(expected, actual) {
+		return Fail(t, fmt.Sprintf("Should not be: %#v\n", actual), msgAndArgs...)
+	}
+
+	return true
+}
+
+// containsElement try loop over the list check if the list includes the element.
+// return (false, false) if impossible.
+// return (true, false) if element was not found.
+// return (true, true) if element was found.
+func containsElement(list interface{}, element interface{}) (ok, found bool) {
+	listValue := reflect.ValueOf(list)
+	listType := reflect.TypeOf(list)
+	if listType == nil {
+		return false, false
+	}
+	listKind := listType.Kind()
+	defer func() {
+		if e := recover(); e != nil {
+			ok = false
+			found = false
+		}
+	}()
+
+	if listKind == reflect.String {
+		elementValue := reflect.ValueOf(element)
+		return true, strings.Contains(listValue.String(), elementValue.String())
+	}
+
+	if listKind == reflect.Map {
+		mapKeys := listValue.MapKeys()
+		for i := 0; i < len(mapKeys); i++ {
+			if ObjectsAreEqual(mapKeys[i].Interface(), element) {
+				return true, true
+			}
+		}
+		return true, false
+	}
+
+	for i := 0; i < listValue.Len(); i++ {
+		if ObjectsAreEqual(listValue.Index(i).Interface(), element) {
+			return true, true
+		}
+	}
+	return true, false
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	assert.Contains(t, "Hello World", "World")
+//	assert.Contains(t, ["Hello", "World"], "World")
+//	assert.Contains(t, {"Hello": "World"}, "Hello")
+func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	ok, found := containsElement(s, contains)
+	if !ok {
+		return Fail(t, fmt.Sprintf("%#v could not be applied builtin len()", s), msgAndArgs...)
+	}
+	if !found {
+		return Fail(t, fmt.Sprintf("%#v does not contain %#v", s, contains), msgAndArgs...)
+	}
+
+	return true
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	assert.NotContains(t, "Hello World", "Earth")
+//	assert.NotContains(t, ["Hello", "World"], "Earth")
+//	assert.NotContains(t, {"Hello": "World"}, "Earth")
+func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	ok, found := containsElement(s, contains)
+	if !ok {
+		return Fail(t, fmt.Sprintf("%#v could not be applied builtin len()", s), msgAndArgs...)
+	}
+	if found {
+		return Fail(t, fmt.Sprintf("%#v should not contain %#v", s, contains), msgAndArgs...)
+	}
+
+	return true
+}
+
+// Subset asserts that the list (array, slice, or map) contains all elements
+// given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	assert.Subset(t, [1, 2, 3], [1, 2])
+//	assert.Subset(t, {"x": 1, "y": 2}, {"x": 1})
+//	assert.Subset(t, [1, 2, 3], {1: "one", 2: "two"})
+//	assert.Subset(t, {"x": 1, "y": 2}, ["x"])
+func Subset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) (ok bool) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if subset == nil {
+		return true // we consider nil to be equal to the nil set
+	}
+
+	listKind := reflect.TypeOf(list).Kind()
+	if listKind != reflect.Array && listKind != reflect.Slice && listKind != reflect.Map {
+		return Fail(t, fmt.Sprintf("%q has an unsupported type %s", list, listKind), msgAndArgs...)
+	}
+
+	subsetKind := reflect.TypeOf(subset).Kind()
+	if subsetKind != reflect.Array && subsetKind != reflect.Slice && subsetKind != reflect.Map {
+		return Fail(t, fmt.Sprintf("%q has an unsupported type %s", subset, subsetKind), msgAndArgs...)
+	}
+
+	if subsetKind == reflect.Map && listKind == reflect.Map {
+		subsetMap := reflect.ValueOf(subset)
+		actualMap := reflect.ValueOf(list)
+
+		for _, k := range subsetMap.MapKeys() {
+			ev := subsetMap.MapIndex(k)
+			av := actualMap.MapIndex(k)
+
+			if !av.IsValid() {
+				return Fail(t, fmt.Sprintf("%#v does not contain %#v", list, subset), msgAndArgs...)
+			}
+			if !ObjectsAreEqual(ev.Interface(), av.Interface()) {
+				return Fail(t, fmt.Sprintf("%#v does not contain %#v", list, subset), msgAndArgs...)
+			}
+		}
+
+		return true
+	}
+
+	subsetList := reflect.ValueOf(subset)
+	if subsetKind == reflect.Map {
+		keys := make([]interface{}, subsetList.Len())
+		for idx, key := range subsetList.MapKeys() {
+			keys[idx] = key.Interface()
+		}
+		subsetList = reflect.ValueOf(keys)
+	}
+	for i := 0; i < subsetList.Len(); i++ {
+		element := subsetList.Index(i).Interface()
+		ok, found := containsElement(list, element)
+		if !ok {
+			return Fail(t, fmt.Sprintf("%#v could not be applied builtin len()", list), msgAndArgs...)
+		}
+		if !found {
+			return Fail(t, fmt.Sprintf("%#v does not contain %#v", list, element), msgAndArgs...)
+		}
+	}
+
+	return true
+}
+
+// NotSubset asserts that the list (array, slice, or map) does NOT contain all
+// elements given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	assert.NotSubset(t, [1, 3, 4], [1, 2])
+//	assert.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
+//	assert.NotSubset(t, [1, 3, 4], {1: "one", 2: "two"})
+//	assert.NotSubset(t, {"x": 1, "y": 2}, ["z"])
+func NotSubset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) (ok bool) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if subset == nil {
+		return Fail(t, "nil is the empty set which is a subset of every set", msgAndArgs...)
+	}
+
+	listKind := reflect.TypeOf(list).Kind()
+	if listKind != reflect.Array && listKind != reflect.Slice && listKind != reflect.Map {
+		return Fail(t, fmt.Sprintf("%q has an unsupported type %s", list, listKind), msgAndArgs...)
+	}
+
+	subsetKind := reflect.TypeOf(subset).Kind()
+	if subsetKind != reflect.Array && subsetKind != reflect.Slice && subsetKind != reflect.Map {
+		return Fail(t, fmt.Sprintf("%q has an unsupported type %s", subset, subsetKind), msgAndArgs...)
+	}
+
+	if subsetKind == reflect.Map && listKind == reflect.Map {
+		subsetMap := reflect.ValueOf(subset)
+		actualMap := reflect.ValueOf(list)
+
+		for _, k := range subsetMap.MapKeys() {
+			ev := subsetMap.MapIndex(k)
+			av := actualMap.MapIndex(k)
+
+			if !av.IsValid() {
+				return true
+			}
+			if !ObjectsAreEqual(ev.Interface(), av.Interface()) {
+				return true
+			}
+		}
+
+		return Fail(t, fmt.Sprintf("%q is a subset of %q", subset, list), msgAndArgs...)
+	}
+
+	subsetList := reflect.ValueOf(subset)
+	if subsetKind == reflect.Map {
+		keys := make([]interface{}, subsetList.Len())
+		for idx, key := range subsetList.MapKeys() {
+			keys[idx] = key.Interface()
+		}
+		subsetList = reflect.ValueOf(keys)
+	}
+	for i := 0; i < subsetList.Len(); i++ {
+		element := subsetList.Index(i).Interface()
+		ok, found := containsElement(list, element)
+		if !ok {
+			return Fail(t, fmt.Sprintf("%q could not be applied builtin len()", list), msgAndArgs...)
+		}
+		if !found {
+			return true
+		}
+	}
+
+	return Fail(t, fmt.Sprintf("%q is a subset of %q", subset, list), msgAndArgs...)
+}
+
+// ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// assert.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
+func ElementsMatch(t TestingT, listA, listB interface{}, msgAndArgs ...interface{}) (ok bool) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if isEmpty(listA) && isEmpty(listB) {
+		return true
+	}
+
+	if !isList(t, listA, msgAndArgs...) || !isList(t, listB, msgAndArgs...) {
+		return false
+	}
+
+	extraA, extraB := diffLists(listA, listB)
+
+	if len(extraA) == 0 && len(extraB) == 0 {
+		return true
+	}
+
+	return Fail(t, formatListDiff(listA, listB, extraA, extraB), msgAndArgs...)
+}
+
+// isList checks that the provided value is array or slice.
+func isList(t TestingT, list interface{}, msgAndArgs ...interface{}) (ok bool) {
+	kind := reflect.TypeOf(list).Kind()
+	if kind != reflect.Array && kind != reflect.Slice {
+		return Fail(t, fmt.Sprintf("%q has an unsupported type %s, expecting array or slice", list, kind),
+			msgAndArgs...)
+	}
+	return true
+}
+
+// diffLists diffs two arrays/slices and returns slices of elements that are only in A and only in B.
+// If some element is present multiple times, each instance is counted separately (e.g. if something is 2x in A and
+// 5x in B, it will be 0x in extraA and 3x in extraB). The order of items in both lists is ignored.
+func diffLists(listA, listB interface{}) (extraA, extraB []interface{}) {
+	aValue := reflect.ValueOf(listA)
+	bValue := reflect.ValueOf(listB)
+
+	aLen := aValue.Len()
+	bLen := bValue.Len()
+
+	// Mark indexes in bValue that we already used
+	visited := make([]bool, bLen)
+	for i := 0; i < aLen; i++ {
+		element := aValue.Index(i).Interface()
+		found := false
+		for j := 0; j < bLen; j++ {
+			if visited[j] {
+				continue
+			}
+			if ObjectsAreEqual(bValue.Index(j).Interface(), element) {
+				visited[j] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			extraA = append(extraA, element)
+		}
+	}
+
+	for j := 0; j < bLen; j++ {
+		if visited[j] {
+			continue
+		}
+		extraB = append(extraB, bValue.Index(j).Interface())
+	}
+
+	return
+}
+
+func formatListDiff(listA, listB interface{}, extraA, extraB []interface{}) string {
+	var msg bytes.Buffer
+
+	msg.WriteString("elements differ")
+	if len(extraA) > 0 {
+		msg.WriteString("\n\nextra elements in list A:\n")
+		msg.WriteString(spewConfig.Sdump(extraA))
+	}
+	if len(extraB) > 0 {
+		msg.WriteString("\n\nextra elements in list B:\n")
+		msg.WriteString(spewConfig.Sdump(extraB))
+	}
+	msg.WriteString("\n\nlistA:\n")
+	msg.WriteString(spewConfig.Sdump(listA))
+	msg.WriteString("\n\nlistB:\n")
+	msg.WriteString(spewConfig.Sdump(listB))
+
+	return msg.String()
+}
+
+// NotElementsMatch asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// assert.NotElementsMatch(t, [1, 1, 2, 3], [1, 1, 2, 3]) -> false
+//
+// assert.NotElementsMatch(t, [1, 1, 2, 3], [1, 2, 3]) -> true
+//
+// assert.NotElementsMatch(t, [1, 2, 3], [1, 2, 4]) -> true
+func NotElementsMatch(t TestingT, listA, listB interface{}, msgAndArgs ...interface{}) (ok bool) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if isEmpty(listA) && isEmpty(listB) {
+		return Fail(t, "listA and listB contain the same elements", msgAndArgs)
+	}
+
+	if !isList(t, listA, msgAndArgs...) {
+		return Fail(t, "listA is not a list type", msgAndArgs...)
+	}
+	if !isList(t, listB, msgAndArgs...) {
+		return Fail(t, "listB is not a list type", msgAndArgs...)
+	}
+
+	extraA, extraB := diffLists(listA, listB)
+	if len(extraA) == 0 && len(extraB) == 0 {
+		return Fail(t, "listA and listB contain the same elements", msgAndArgs)
+	}
+
+	return true
+}
+
+// Condition uses a Comparison to assert a complex condition.
+func Condition(t TestingT, comp Comparison, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	result := comp()
+	if !result {
+		Fail(t, "Condition failed!", msgAndArgs...)
+	}
+	return result
+}
+
+// PanicTestFunc defines a func that should be passed to the assert.Panics and assert.NotPanics
+// methods, and represents a simple func that takes no arguments, and returns nothing.
+type PanicTestFunc func()
+
+// didPanic returns true if the function passed to it panics. Otherwise, it returns false.
+func didPanic(f PanicTestFunc) (didPanic bool, message interface{}, stack string) {
+	didPanic = true
+
+	defer func() {
+		message = recover()
+		if didPanic {
+			stack = string(debug.Stack())
+		}
+	}()
+
+	// call the target function
+	f()
+	didPanic = false
+
+	return
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//	assert.Panics(t, func(){ GoCrazy() })
+func Panics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if funcDidPanic, panicValue, _ := didPanic(f); !funcDidPanic {
+		return Fail(t, fmt.Sprintf("func %#v should panic\n\tPanic value:\t%#v", f, panicValue), msgAndArgs...)
+	}
+
+	return true
+}
+
+// PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	assert.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
+func PanicsWithValue(t TestingT, expected interface{}, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	funcDidPanic, panicValue, panickedStack := didPanic(f)
+	if !funcDidPanic {
+		return Fail(t, fmt.Sprintf("func %#v should panic\n\tPanic value:\t%#v", f, panicValue), msgAndArgs...)
+	}
+	if panicValue != expected {
+		return Fail(t, fmt.Sprintf("func %#v should panic with value:\t%#v\n\tPanic value:\t%#v\n\tPanic stack:\t%s", f, expected, panicValue, panickedStack), msgAndArgs...)
+	}
+
+	return true
+}
+
+// PanicsWithError asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	assert.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
+func PanicsWithError(t TestingT, errString string, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	funcDidPanic, panicValue, panickedStack := didPanic(f)
+	if !funcDidPanic {
+		return Fail(t, fmt.Sprintf("func %#v should panic\n\tPanic value:\t%#v", f, panicValue), msgAndArgs...)
+	}
+	panicErr, ok := panicValue.(error)
+	if !ok || panicErr.Error() != errString {
+		return Fail(t, fmt.Sprintf("func %#v should panic with error message:\t%#v\n\tPanic value:\t%#v\n\tPanic stack:\t%s", f, errString, panicValue, panickedStack), msgAndArgs...)
+	}
+
+	return true
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	assert.NotPanics(t, func(){ RemainCalm() })
+func NotPanics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if funcDidPanic, panicValue, panickedStack := didPanic(f); funcDidPanic {
+		return Fail(t, fmt.Sprintf("func %#v should not panic\n\tPanic value:\t%v\n\tPanic stack:\t%s", f, panicValue, panickedStack), msgAndArgs...)
+	}
+
+	return true
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//	assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
+func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	dt := expected.Sub(actual)
+	if dt < -delta || dt > delta {
+		return Fail(t, fmt.Sprintf("Max difference between %v and %v allowed is %v, but difference was %v", expected, actual, delta, dt), msgAndArgs...)
+	}
+
+	return true
+}
+
+// WithinRange asserts that a time is within a time range (inclusive).
+//
+//	assert.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+func WithinRange(t TestingT, actual, start, end time.Time, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if end.Before(start) {
+		return Fail(t, "Start should be before end", msgAndArgs...)
+	}
+
+	if actual.Before(start) {
+		return Fail(t, fmt.Sprintf("Time %v expected to be in time range %v to %v, but is before the range", actual, start, end), msgAndArgs...)
+	} else if actual.After(end) {
+		return Fail(t, fmt.Sprintf("Time %v expected to be in time range %v to %v, but is after the range", actual, start, end), msgAndArgs...)
+	}
+
+	return true
+}
+
+func toFloat(x interface{}) (float64, bool) {
+	var xf float64
+	xok := true
+
+	switch xn := x.(type) {
+	case uint:
+		xf = float64(xn)
+	case uint8:
+		xf = float64(xn)
+	case uint16:
+		xf = float64(xn)
+	case uint32:
+		xf = float64(xn)
+	case uint64:
+		xf = float64(xn)
+	case int:
+		xf = float64(xn)
+	case int8:
+		xf = float64(xn)
+	case int16:
+		xf = float64(xn)
+	case int32:
+		xf = float64(xn)
+	case int64:
+		xf = float64(xn)
+	case float32:
+		xf = float64(xn)
+	case float64:
+		xf = xn
+	case time.Duration:
+		xf = float64(xn)
+	default:
+		xok = false
+	}
+
+	return xf, xok
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+//	assert.InDelta(t, math.Pi, 22/7.0, 0.01)
+func InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	af, aok := toFloat(expected)
+	bf, bok := toFloat(actual)
+
+	if !aok || !bok {
+		return Fail(t, "Parameters must be numerical", msgAndArgs...)
+	}
+
+	if math.IsNaN(af) && math.IsNaN(bf) {
+		return true
+	}
+
+	if math.IsNaN(af) {
+		return Fail(t, "Expected must not be NaN", msgAndArgs...)
+	}
+
+	if math.IsNaN(bf) {
+		return Fail(t, fmt.Sprintf("Expected %v with delta %v, but was NaN", expected, delta), msgAndArgs...)
+	}
+
+	dt := af - bf
+	if dt < -delta || dt > delta {
+		return Fail(t, fmt.Sprintf("Max difference between %v and %v allowed is %v, but difference was %v", expected, actual, delta, dt), msgAndArgs...)
+	}
+
+	return true
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func InDeltaSlice(t TestingT, expected, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if expected == nil || actual == nil ||
+		reflect.TypeOf(actual).Kind() != reflect.Slice ||
+		reflect.TypeOf(expected).Kind() != reflect.Slice {
+		return Fail(t, "Parameters must be slice", msgAndArgs...)
+	}
+
+	actualSlice := reflect.ValueOf(actual)
+	expectedSlice := reflect.ValueOf(expected)
+
+	for i := 0; i < actualSlice.Len(); i++ {
+		result := InDelta(t, actualSlice.Index(i).Interface(), expectedSlice.Index(i).Interface(), delta, msgAndArgs...)
+		if !result {
+			return result
+		}
+	}
+
+	return true
+}
+
+// InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InDeltaMapValues(t TestingT, expected, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if expected == nil || actual == nil ||
+		reflect.TypeOf(actual).Kind() != reflect.Map ||
+		reflect.TypeOf(expected).Kind() != reflect.Map {
+		return Fail(t, "Arguments must be maps", msgAndArgs...)
+	}
+
+	expectedMap := reflect.ValueOf(expected)
+	actualMap := reflect.ValueOf(actual)
+
+	if expectedMap.Len() != actualMap.Len() {
+		return Fail(t, "Arguments must have the same number of keys", msgAndArgs...)
+	}
+
+	for _, k := range expectedMap.MapKeys() {
+		ev := expectedMap.MapIndex(k)
+		av := actualMap.MapIndex(k)
+
+		if !ev.IsValid() {
+			return Fail(t, fmt.Sprintf("missing key %q in expected map", k), msgAndArgs...)
+		}
+
+		if !av.IsValid() {
+			return Fail(t, fmt.Sprintf("missing key %q in actual map", k), msgAndArgs...)
+		}
+
+		if !InDelta(
+			t,
+			ev.Interface(),
+			av.Interface(),
+			delta,
+			msgAndArgs...,
+		) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func calcRelativeError(expected, actual interface{}) (float64, error) {
+	af, aok := toFloat(expected)
+	bf, bok := toFloat(actual)
+	if !aok || !bok {
+		return 0, fmt.Errorf("Parameters must be numerical")
+	}
+	if math.IsNaN(af) && math.IsNaN(bf) {
+		return 0, nil
+	}
+	if math.IsNaN(af) {
+		return 0, errors.New("expected value must not be NaN")
+	}
+	if af == 0 {
+		return 0, fmt.Errorf("expected value must have a value other than zero to calculate the relative error")
+	}
+	if math.IsNaN(bf) {
+		return 0, errors.New("actual value must not be NaN")
+	}
+
+	return math.Abs(af-bf) / math.Abs(af), nil
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+func InEpsilon(t TestingT, expected, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if math.IsNaN(epsilon) {
+		return Fail(t, "epsilon must not be NaN", msgAndArgs...)
+	}
+	actualEpsilon, err := calcRelativeError(expected, actual)
+	if err != nil {
+		return Fail(t, err.Error(), msgAndArgs...)
+	}
+	if math.IsNaN(actualEpsilon) {
+		return Fail(t, "relative error is NaN", msgAndArgs...)
+	}
+	if actualEpsilon > epsilon {
+		return Fail(t, fmt.Sprintf("Relative error is too high: %#v (expected)\n"+
+			"        < %#v (actual)", epsilon, actualEpsilon), msgAndArgs...)
+	}
+
+	return true
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if expected == nil || actual == nil {
+		return Fail(t, "Parameters must be slice", msgAndArgs...)
+	}
+
+	expectedSlice := reflect.ValueOf(expected)
+	actualSlice := reflect.ValueOf(actual)
+
+	if expectedSlice.Type().Kind() != reflect.Slice {
+		return Fail(t, "Expected value must be slice", msgAndArgs...)
+	}
+
+	expectedLen := expectedSlice.Len()
+	if !IsType(t, expected, actual) || !Len(t, actual, expectedLen) {
+		return false
+	}
+
+	for i := 0; i < expectedLen; i++ {
+		if !InEpsilon(t, expectedSlice.Index(i).Interface(), actualSlice.Index(i).Interface(), epsilon, "at index %d", i) {
+			return false
+		}
+	}
+
+	return true
+}
+
+/*
+	Errors
+*/
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if assert.NoError(t, err) {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
+func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
+	if err != nil {
+		if h, ok := t.(tHelper); ok {
+			h.Helper()
+		}
+		return Fail(t, fmt.Sprintf("Received unexpected error:\n%+v", err), msgAndArgs...)
+	}
+
+	return true
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//	actualObj, err := SomeFunction()
+//	assert.Error(t, err)
+func Error(t TestingT, err error, msgAndArgs ...interface{}) bool {
+	if err == nil {
+		if h, ok := t.(tHelper); ok {
+			h.Helper()
+		}
+		return Fail(t, "An error is expected but got nil.", msgAndArgs...)
+	}
+
+	return true
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	assert.EqualError(t, err,  expectedErrorString)
+func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if !Error(t, theError, msgAndArgs...) {
+		return false
+	}
+	expected := errString
+	actual := theError.Error()
+	// don't need to use deep equals here, we know they are both strings
+	if expected != actual {
+		return Fail(t, fmt.Sprintf("Error message not equal:\n"+
+			"expected: %q\n"+
+			"actual  : %q", expected, actual), msgAndArgs...)
+	}
+	return true
+}
+
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	assert.ErrorContains(t, err,  expectedErrorSubString)
+func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if !Error(t, theError, msgAndArgs...) {
+		return false
+	}
+
+	actual := theError.Error()
+	if !strings.Contains(actual, contains) {
+		return Fail(t, fmt.Sprintf("Error %#v does not contain %#v", actual, contains), msgAndArgs...)
+	}
+
+	return true
+}
+
+// matchRegexp return true if a specified regexp matches a string.
+func matchRegexp(rx interface{}, str interface{}) bool {
+	var r *regexp.Regexp
+	if rr, ok := rx.(*regexp.Regexp); ok {
+		r = rr
+	} else {
+		r = regexp.MustCompile(fmt.Sprint(rx))
+	}
+
+	switch v := str.(type) {
+	case []byte:
+		return r.Match(v)
+	case string:
+		return r.MatchString(v)
+	default:
+		return r.MatchString(fmt.Sprint(v))
+	}
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//	assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
+//	assert.Regexp(t, "start...$", "it's not starting")
+func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	match := matchRegexp(rx, str)
+
+	if !match {
+		Fail(t, fmt.Sprintf("Expect \"%v\" to match \"%v\"", str, rx), msgAndArgs...)
+	}
+
+	return match
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//	assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+//	assert.NotRegexp(t, "^start", "it's not starting")
+func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	match := matchRegexp(rx, str)
+
+	if match {
+		Fail(t, fmt.Sprintf("Expect \"%v\" to NOT match \"%v\"", str, rx), msgAndArgs...)
+	}
+
+	return !match
+}
+
+// Zero asserts that i is the zero value for its type.
+func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if i != nil && !reflect.DeepEqual(i, reflect.Zero(reflect.TypeOf(i)).Interface()) {
+		return Fail(t, fmt.Sprintf("Should be zero, but was %v", i), msgAndArgs...)
+	}
+	return true
+}
+
+// NotZero asserts that i is not the zero value for its type.
+func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if i == nil || reflect.DeepEqual(i, reflect.Zero(reflect.TypeOf(i)).Interface()) {
+		return Fail(t, fmt.Sprintf("Should not be zero, but was %v", i), msgAndArgs...)
+	}
+	return true
+}
+
+// FileExists checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func FileExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Fail(t, fmt.Sprintf("unable to find file %q", path), msgAndArgs...)
+		}
+		return Fail(t, fmt.Sprintf("error when running os.Lstat(%q): %s", path, err), msgAndArgs...)
+	}
+	if info.IsDir() {
+		return Fail(t, fmt.Sprintf("%q is a directory", path), msgAndArgs...)
+	}
+	return true
+}
+
+// NoFileExists checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func NoFileExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return true
+	}
+	if info.IsDir() {
+		return true
+	}
+	return Fail(t, fmt.Sprintf("file %q exists", path), msgAndArgs...)
+}
+
+// DirExists checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func DirExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Fail(t, fmt.Sprintf("unable to find file %q", path), msgAndArgs...)
+		}
+		return Fail(t, fmt.Sprintf("error when running os.Lstat(%q): %s", path, err), msgAndArgs...)
+	}
+	if !info.IsDir() {
+		return Fail(t, fmt.Sprintf("%q is a file", path), msgAndArgs...)
+	}
+	return true
+}
+
+// NoDirExists checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true
+		}
+		return true
+	}
+	if !info.IsDir() {
+		return true
+	}
+	return Fail(t, fmt.Sprintf("directory %q exists", path), msgAndArgs...)
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//	assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	var expectedJSONAsInterface, actualJSONAsInterface interface{}
+
+	if err := json.Unmarshal([]byte(expected), &expectedJSONAsInterface); err != nil {
+		return Fail(t, fmt.Sprintf("Expected value ('%s') is not valid json.\nJSON parsing error: '%s'", expected, err.Error()), msgAndArgs...)
+	}
+
+	// Shortcut if same bytes
+	if actual == expected {
+		return true
+	}
+
+	if err := json.Unmarshal([]byte(actual), &actualJSONAsInterface); err != nil {
+		return Fail(t, fmt.Sprintf("Input ('%s') needs to be valid json.\nJSON parsing error: '%s'", actual, err.Error()), msgAndArgs...)
+	}
+
+	return Equal(t, expectedJSONAsInterface, actualJSONAsInterface, msgAndArgs...)
+}
+
+// YAMLEq asserts that two YAML strings are equivalent.
+func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	var expectedYAMLAsInterface, actualYAMLAsInterface interface{}
+
+	if err := yaml.Unmarshal([]byte(expected), &expectedYAMLAsInterface); err != nil {
+		return Fail(t, fmt.Sprintf("Expected value ('%s') is not valid yaml.\nYAML parsing error: '%s'", expected, err.Error()), msgAndArgs...)
+	}
+
+	// Shortcut if same bytes
+	if actual == expected {
+		return true
+	}
+
+	if err := yaml.Unmarshal([]byte(actual), &actualYAMLAsInterface); err != nil {
+		return Fail(t, fmt.Sprintf("Input ('%s') needs to be valid yaml.\nYAML error: '%s'", actual, err.Error()), msgAndArgs...)
+	}
+
+	return Equal(t, expectedYAMLAsInterface, actualYAMLAsInterface, msgAndArgs...)
+}
+
+func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
+	t := reflect.TypeOf(v)
+	k := t.Kind()
+
+	if k == reflect.Ptr {
+		t = t.Elem()
+		k = t.Kind()
+	}
+	return t, k
+}
+
+// diff returns a diff of both values as long as both are of the same type and
+// are a struct, map, slice, array or string. Otherwise it returns an empty string.
+func diff(expected interface{}, actual interface{}) string {
+	if expected == nil || actual == nil {
+		return ""
+	}
+
+	et, ek := typeAndKind(expected)
+	at, _ := typeAndKind(actual)
+
+	if et != at {
+		return ""
+	}
+
+	if ek != reflect.Struct && ek != reflect.Map && ek != reflect.Slice && ek != reflect.Array && ek != reflect.String {
+		return ""
+	}
+
+	var e, a string
+
+	switch et {
+	case reflect.TypeOf(""):
+		e = reflect.ValueOf(expected).String()
+		a = reflect.ValueOf(actual).String()
+	case reflect.TypeOf(time.Time{}):
+		e = spewConfigStringerEnabled.Sdump(expected)
+		a = spewConfigStringerEnabled.Sdump(actual)
+	default:
+		e = spewConfig.Sdump(expected)
+		a = spewConfig.Sdump(actual)
+	}
+
+	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(e),
+		B:        difflib.SplitLines(a),
+		FromFile: "Expected",
+		FromDate: "",
+		ToFile:   "Actual",
+		ToDate:   "",
+		Context:  1,
+	})
+
+	return "\n\nDiff:\n" + diff
+}
+
+func isFunction(arg interface{}) bool {
+	if arg == nil {
+		return false
+	}
+	return reflect.TypeOf(arg).Kind() == reflect.Func
+}
+
+var spewConfig = spew.ConfigState{
+	Indent:                  " ",
+	DisablePointerAddresses: true,
+	DisableCapacities:       true,
+	SortKeys:                true,
+	DisableMethods:          true,
+	MaxDepth:                10,
+}
+
+var spewConfigStringerEnabled = spew.ConfigState{
+	Indent:                  " ",
+	DisablePointerAddresses: true,
+	DisableCapacities:       true,
+	SortKeys:                true,
+	MaxDepth:                10,
+}
+
+type tHelper = interface {
+	Helper()
+}
+
+// Eventually asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	assert.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
+func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	ch := make(chan bool, 1)
+	checkCond := func() { ch <- condition() }
+
+	timer := time.NewTimer(waitFor)
+	defer timer.Stop()
+
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+
+	var tickC <-chan time.Time
+
+	// Check the condition once first on the initial call.
+	go checkCond()
+
+	for {
+		select {
+		case <-timer.C:
+			return Fail(t, "Condition never satisfied", msgAndArgs...)
+		case <-tickC:
+			tickC = nil
+			go checkCond()
+		case v := <-ch:
+			if v {
+				return true
+			}
+			tickC = ticker.C
+		}
+	}
+}
+
+// CollectT implements the TestingT interface and collects all errors.
+type CollectT struct {
+	// A slice of errors. Non-nil slice denotes a failure.
+	// If it's non-nil but len(c.errors) == 0, this is also a failure
+	// obtained by direct c.FailNow() call.
+	errors []error
+}
+
+// Helper is like [testing.T.Helper] but does nothing.
+func (CollectT) Helper() {}
+
+// Errorf collects the error.
+func (c *CollectT) Errorf(format string, args ...interface{}) {
+	c.errors = append(c.errors, fmt.Errorf(format, args...))
+}
+
+// FailNow stops execution by calling runtime.Goexit.
+func (c *CollectT) FailNow() {
+	c.fail()
+	runtime.Goexit()
+}
+
+// Deprecated: That was a method for internal usage that should not have been published. Now just panics.
+func (*CollectT) Reset() {
+	panic("Reset() is deprecated")
+}
+
+// Deprecated: That was a method for internal usage that should not have been published. Now just panics.
+func (*CollectT) Copy(TestingT) {
+	panic("Copy() is deprecated")
+}
+
+func (c *CollectT) fail() {
+	if !c.failed() {
+		c.errors = []error{} // Make it non-nil to mark a failure.
+	}
+}
+
+func (c *CollectT) failed() bool {
+	return c.errors != nil
+}
+
+// EventuallyWithT asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func EventuallyWithT(t TestingT, condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	var lastFinishedTickErrs []error
+	ch := make(chan *CollectT, 1)
+
+	checkCond := func() {
+		collect := new(CollectT)
+		defer func() {
+			ch <- collect
+		}()
+		condition(collect)
+	}
+
+	timer := time.NewTimer(waitFor)
+	defer timer.Stop()
+
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+
+	var tickC <-chan time.Time
+
+	// Check the condition once first on the initial call.
+	go checkCond()
+
+	for {
+		select {
+		case <-timer.C:
+			for _, err := range lastFinishedTickErrs {
+				t.Errorf("%v", err)
+			}
+			return Fail(t, "Condition never satisfied", msgAndArgs...)
+		case <-tickC:
+			tickC = nil
+			go checkCond()
+		case collect := <-ch:
+			if !collect.failed() {
+				return true
+			}
+			// Keep the errors from the last ended condition, so that they can be copied to t if timeout is reached.
+			lastFinishedTickErrs = collect.errors
+			tickC = ticker.C
+		}
+	}
+}
+
+// Never asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	assert.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
+func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	ch := make(chan bool, 1)
+	checkCond := func() { ch <- condition() }
+
+	timer := time.NewTimer(waitFor)
+	defer timer.Stop()
+
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+
+	var tickC <-chan time.Time
+
+	// Check the condition once first on the initial call.
+	go checkCond()
+
+	for {
+		select {
+		case <-timer.C:
+			return true
+		case <-tickC:
+			tickC = nil
+			go checkCond()
+		case v := <-ch:
+			if v {
+				return Fail(t, "Condition satisfied", msgAndArgs...)
+			}
+			tickC = ticker.C
+		}
+	}
+}
+
+// ErrorIs asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func ErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if errors.Is(err, target) {
+		return true
+	}
+
+	var expectedText string
+	if target != nil {
+		expectedText = target.Error()
+		if err == nil {
+			return Fail(t, fmt.Sprintf("Expected error with %q in chain but got nil.", expectedText), msgAndArgs...)
+		}
+	}
+
+	chain := buildErrorChainString(err, false)
+
+	return Fail(t, fmt.Sprintf("Target error should be in err chain:\n"+
+		"expected: %q\n"+
+		"in chain: %s", expectedText, chain,
+	), msgAndArgs...)
+}
+
+// NotErrorIs asserts that none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func NotErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if !errors.Is(err, target) {
+		return true
+	}
+
+	var expectedText string
+	if target != nil {
+		expectedText = target.Error()
+	}
+
+	chain := buildErrorChainString(err, false)
+
+	return Fail(t, fmt.Sprintf("Target error should not be in err chain:\n"+
+		"found: %q\n"+
+		"in chain: %s", expectedText, chain,
+	), msgAndArgs...)
+}
+
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if errors.As(err, target) {
+		return true
+	}
+
+	expectedType := reflect.TypeOf(target).Elem().String()
+	if err == nil {
+		return Fail(t, fmt.Sprintf("An error is expected but got nil.\n"+
+			"expected: %s", expectedType), msgAndArgs...)
+	}
+
+	chain := buildErrorChainString(err, true)
+
+	return Fail(t, fmt.Sprintf("Should be in error chain:\n"+
+		"expected: %s\n"+
+		"in chain: %s", expectedType, chain,
+	), msgAndArgs...)
+}
+
+// NotErrorAs asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func NotErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if !errors.As(err, target) {
+		return true
+	}
+
+	chain := buildErrorChainString(err, true)
+
+	return Fail(t, fmt.Sprintf("Target error should not be in err chain:\n"+
+		"found: %s\n"+
+		"in chain: %s", reflect.TypeOf(target).Elem().String(), chain,
+	), msgAndArgs...)
+}
+
+func unwrapAll(err error) (errs []error) {
+	errs = append(errs, err)
+	switch x := err.(type) {
+	case interface{ Unwrap() error }:
+		err = x.Unwrap()
+		if err == nil {
+			return
+		}
+		errs = append(errs, unwrapAll(err)...)
+	case interface{ Unwrap() []error }:
+		for _, err := range x.Unwrap() {
+			errs = append(errs, unwrapAll(err)...)
+		}
+	}
+	return
+}
+
+func buildErrorChainString(err error, withType bool) string {
+	if err == nil {
+		return ""
+	}
+
+	var chain string
+	errs := unwrapAll(err)
+	for i := range errs {
+		if i != 0 {
+			chain += "\n\t"
+		}
+		chain += fmt.Sprintf("%q", errs[i].Error())
+		if withType {
+			chain += fmt.Sprintf(" (%T)", errs[i])
+		}
+	}
+	return chain
+}

--- a/vendor/github.com/stretchr/testify/assert/doc.go
+++ b/vendor/github.com/stretchr/testify/assert/doc.go
@@ -1,0 +1,50 @@
+// Package assert provides a set of comprehensive testing tools for use with the normal Go testing system.
+//
+// # Note
+//
+// All functions in this package return a bool value indicating whether the assertion has passed.
+//
+// # Example Usage
+//
+// The following is a complete example using assert in a standard test function:
+//
+//	import (
+//	  "testing"
+//	  "github.com/stretchr/testify/assert"
+//	)
+//
+//	func TestSomething(t *testing.T) {
+//
+//	  var a string = "Hello"
+//	  var b string = "Hello"
+//
+//	  assert.Equal(t, a, b, "The two words should be the same.")
+//
+//	}
+//
+// if you assert many times, use the format below:
+//
+//	import (
+//	  "testing"
+//	  "github.com/stretchr/testify/assert"
+//	)
+//
+//	func TestSomething(t *testing.T) {
+//	  assert := assert.New(t)
+//
+//	  var a string = "Hello"
+//	  var b string = "Hello"
+//
+//	  assert.Equal(a, b, "The two words should be the same.")
+//	}
+//
+// # Assertions
+//
+// Assertions allow you to easily write test code, and are global funcs in the `assert` package.
+// All assertion functions take, as the first argument, the `*testing.T` object provided by the
+// testing framework. This allows the assertion funcs to write the failings and other details to
+// the correct place.
+//
+// Every assertion function also takes an optional string message as the final argument,
+// allowing custom error messages to be appended to the message the assertion method outputs.
+package assert

--- a/vendor/github.com/stretchr/testify/assert/errors.go
+++ b/vendor/github.com/stretchr/testify/assert/errors.go
@@ -1,0 +1,10 @@
+package assert
+
+import (
+	"errors"
+)
+
+// AnError is an error instance useful for testing.  If the code does not care
+// about error specifics, and only needs to return the error for example, this
+// error should be used to make the test code more readable.
+var AnError = errors.New("assert.AnError general error for testing")

--- a/vendor/github.com/stretchr/testify/assert/forward_assertions.go
+++ b/vendor/github.com/stretchr/testify/assert/forward_assertions.go
@@ -1,0 +1,16 @@
+package assert
+
+// Assertions provides assertion methods around the
+// TestingT interface.
+type Assertions struct {
+	t TestingT
+}
+
+// New makes a new Assertions object for the specified TestingT.
+func New(t TestingT) *Assertions {
+	return &Assertions{
+		t: t,
+	}
+}
+
+//go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=assert -template=assertion_forward.go.tmpl -include-format-funcs"

--- a/vendor/github.com/stretchr/testify/assert/http_assertions.go
+++ b/vendor/github.com/stretchr/testify/assert/http_assertions.go
@@ -1,0 +1,165 @@
+package assert
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+)
+
+// httpCode is a helper that returns HTTP code of the response. It returns -1 and
+// an error if building a new request fails.
+func httpCode(handler http.HandlerFunc, method, url string, values url.Values) (int, error) {
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest(method, url, http.NoBody)
+	if err != nil {
+		return -1, err
+	}
+	req.URL.RawQuery = values.Encode()
+	handler(w, req)
+	return w.Code, nil
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//	assert.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPSuccess(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	code, err := httpCode(handler, method, url, values)
+	if err != nil {
+		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err), msgAndArgs...)
+	}
+
+	isSuccessCode := code >= http.StatusOK && code <= http.StatusPartialContent
+	if !isSuccessCode {
+		Fail(t, fmt.Sprintf("Expected HTTP success status code for %q but received %d", url+"?"+values.Encode(), code), msgAndArgs...)
+	}
+
+	return isSuccessCode
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//	assert.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPRedirect(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	code, err := httpCode(handler, method, url, values)
+	if err != nil {
+		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err), msgAndArgs...)
+	}
+
+	isRedirectCode := code >= http.StatusMultipleChoices && code <= http.StatusTemporaryRedirect
+	if !isRedirectCode {
+		Fail(t, fmt.Sprintf("Expected HTTP redirect status code for %q but received %d", url+"?"+values.Encode(), code), msgAndArgs...)
+	}
+
+	return isRedirectCode
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//	assert.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPError(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	code, err := httpCode(handler, method, url, values)
+	if err != nil {
+		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err), msgAndArgs...)
+	}
+
+	isErrorCode := code >= http.StatusBadRequest
+	if !isErrorCode {
+		Fail(t, fmt.Sprintf("Expected HTTP error status code for %q but received %d", url+"?"+values.Encode(), code), msgAndArgs...)
+	}
+
+	return isErrorCode
+}
+
+// HTTPStatusCode asserts that a specified handler returns a specified status code.
+//
+//	assert.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	code, err := httpCode(handler, method, url, values)
+	if err != nil {
+		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err), msgAndArgs...)
+	}
+
+	successful := code == statuscode
+	if !successful {
+		Fail(t, fmt.Sprintf("Expected HTTP status code %d for %q but received %d", statuscode, url+"?"+values.Encode(), code), msgAndArgs...)
+	}
+
+	return successful
+}
+
+// HTTPBody is a helper that returns HTTP body of the response. It returns
+// empty string if building a new request fails.
+func HTTPBody(handler http.HandlerFunc, method, url string, values url.Values) string {
+	w := httptest.NewRecorder()
+	if len(values) > 0 {
+		url += "?" + values.Encode()
+	}
+	req, err := http.NewRequest(method, url, http.NoBody)
+	if err != nil {
+		return ""
+	}
+	handler(w, req)
+	return w.Body.String()
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//	assert.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	body := HTTPBody(handler, method, url, values)
+
+	contains := strings.Contains(body, fmt.Sprint(str))
+	if !contains {
+		Fail(t, fmt.Sprintf("Expected response body for %q to contain %q but found %q", url+"?"+values.Encode(), str, body), msgAndArgs...)
+	}
+
+	return contains
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	assert.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	body := HTTPBody(handler, method, url, values)
+
+	contains := strings.Contains(body, fmt.Sprint(str))
+	if contains {
+		Fail(t, fmt.Sprintf("Expected response body for %q to NOT contain %q but found %q", url+"?"+values.Encode(), str, body), msgAndArgs...)
+	}
+
+	return !contains
+}

--- a/vendor/github.com/stretchr/testify/assert/yaml/yaml_custom.go
+++ b/vendor/github.com/stretchr/testify/assert/yaml/yaml_custom.go
@@ -1,0 +1,24 @@
+//go:build testify_yaml_custom && !testify_yaml_fail && !testify_yaml_default
+
+// Package yaml is an implementation of YAML functions that calls a pluggable implementation.
+//
+// This implementation is selected with the testify_yaml_custom build tag.
+//
+//	go test -tags testify_yaml_custom
+//
+// This implementation can be used at build time to replace the default implementation
+// to avoid linking with [gopkg.in/yaml.v3].
+//
+// In your test package:
+//
+//		import assertYaml "github.com/stretchr/testify/assert/yaml"
+//
+//		func init() {
+//			assertYaml.Unmarshal = func (in []byte, out interface{}) error {
+//				// ...
+//	     			return nil
+//			}
+//		}
+package yaml
+
+var Unmarshal func(in []byte, out interface{}) error

--- a/vendor/github.com/stretchr/testify/assert/yaml/yaml_default.go
+++ b/vendor/github.com/stretchr/testify/assert/yaml/yaml_default.go
@@ -1,0 +1,36 @@
+//go:build !testify_yaml_fail && !testify_yaml_custom
+
+// Package yaml is just an indirection to handle YAML deserialization.
+//
+// This package is just an indirection that allows the builder to override the
+// indirection with an alternative implementation of this package that uses
+// another implementation of YAML deserialization. This allows to not either not
+// use YAML deserialization at all, or to use another implementation than
+// [gopkg.in/yaml.v3] (for example for license compatibility reasons, see [PR #1120]).
+//
+// Alternative implementations are selected using build tags:
+//
+//   - testify_yaml_fail: [Unmarshal] always fails with an error
+//   - testify_yaml_custom: [Unmarshal] is a variable. Caller must initialize it
+//     before calling any of [github.com/stretchr/testify/assert.YAMLEq] or
+//     [github.com/stretchr/testify/assert.YAMLEqf].
+//
+// Usage:
+//
+//	go test -tags testify_yaml_fail
+//
+// You can check with "go list" which implementation is linked:
+//
+//	go list -f '{{.Imports}}' github.com/stretchr/testify/assert/yaml
+//	go list -tags testify_yaml_fail -f '{{.Imports}}' github.com/stretchr/testify/assert/yaml
+//	go list -tags testify_yaml_custom -f '{{.Imports}}' github.com/stretchr/testify/assert/yaml
+//
+// [PR #1120]: https://github.com/stretchr/testify/pull/1120
+package yaml
+
+import goyaml "gopkg.in/yaml.v3"
+
+// Unmarshal is just a wrapper of [gopkg.in/yaml.v3.Unmarshal].
+func Unmarshal(in []byte, out interface{}) error {
+	return goyaml.Unmarshal(in, out)
+}

--- a/vendor/github.com/stretchr/testify/assert/yaml/yaml_fail.go
+++ b/vendor/github.com/stretchr/testify/assert/yaml/yaml_fail.go
@@ -1,0 +1,17 @@
+//go:build testify_yaml_fail && !testify_yaml_custom && !testify_yaml_default
+
+// Package yaml is an implementation of YAML functions that always fail.
+//
+// This implementation can be used at build time to replace the default implementation
+// to avoid linking with [gopkg.in/yaml.v3]:
+//
+//	go test -tags testify_yaml_fail
+package yaml
+
+import "errors"
+
+var errNotImplemented = errors.New("YAML functions are not available (see https://pkg.go.dev/github.com/stretchr/testify/assert/yaml)")
+
+func Unmarshal([]byte, interface{}) error {
+	return errNotImplemented
+}

--- a/vendor/github.com/stretchr/testify/require/doc.go
+++ b/vendor/github.com/stretchr/testify/require/doc.go
@@ -1,0 +1,31 @@
+// Package require implements the same assertions as the `assert` package but
+// stops test execution when a test fails.
+//
+// # Example Usage
+//
+// The following is a complete example using require in a standard test function:
+//
+//	import (
+//	  "testing"
+//	  "github.com/stretchr/testify/require"
+//	)
+//
+//	func TestSomething(t *testing.T) {
+//
+//	  var a string = "Hello"
+//	  var b string = "Hello"
+//
+//	  require.Equal(t, a, b, "The two words should be the same.")
+//
+//	}
+//
+// # Assertions
+//
+// The `require` package have same global functions as in the `assert` package,
+// but instead of returning a boolean result they call `t.FailNow()`.
+// A consequence of this is that it must be called from the goroutine running
+// the test function, not from other goroutines created during the test.
+//
+// Every assertion function also takes an optional string message as the final argument,
+// allowing custom error messages to be appended to the message the assertion method outputs.
+package require

--- a/vendor/github.com/stretchr/testify/require/forward_requirements.go
+++ b/vendor/github.com/stretchr/testify/require/forward_requirements.go
@@ -1,0 +1,16 @@
+package require
+
+// Assertions provides assertion methods around the
+// TestingT interface.
+type Assertions struct {
+	t TestingT
+}
+
+// New makes a new Assertions object for the specified TestingT.
+func New(t TestingT) *Assertions {
+	return &Assertions{
+		t: t,
+	}
+}
+
+//go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=require -template=require_forward.go.tmpl -include-format-funcs"

--- a/vendor/github.com/stretchr/testify/require/require.go
+++ b/vendor/github.com/stretchr/testify/require/require.go
@@ -1,0 +1,2180 @@
+// Code generated with github.com/stretchr/testify/_codegen; DO NOT EDIT.
+
+package require
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Condition uses a Comparison to assert a complex condition.
+func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Condition(t, comp, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Conditionf uses a Comparison to assert a complex condition.
+func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Conditionf(t, comp, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	require.Contains(t, "Hello World", "World")
+//	require.Contains(t, ["Hello", "World"], "World")
+//	require.Contains(t, {"Hello": "World"}, "Hello")
+func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Contains(t, s, contains, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Containsf asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	require.Containsf(t, "Hello World", "World", "error message %s", "formatted")
+//	require.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
+//	require.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
+func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Containsf(t, s, contains, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// DirExists checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.DirExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// DirExistsf checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.DirExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// require.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
+func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ElementsMatch(t, listA, listB, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// require.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
+func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ElementsMatchf(t, listA, listB, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Empty asserts that the given value is "empty".
+//
+// [Zero values] are "empty".
+//
+// Arrays are "empty" if every element is the zero value of the type (stricter than "empty").
+//
+// Slices, maps and channels with zero length are "empty".
+//
+// Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
+//
+//	require.Empty(t, obj)
+//
+// [Zero values]: https://go.dev/ref/spec#The_zero_value
+func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Empty(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Emptyf asserts that the given value is "empty".
+//
+// [Zero values] are "empty".
+//
+// Arrays are "empty" if every element is the zero value of the type (stricter than "empty").
+//
+// Slices, maps and channels with zero length are "empty".
+//
+// Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
+//
+//	require.Emptyf(t, obj, "error message %s", "formatted")
+//
+// [Zero values]: https://go.dev/ref/spec#The_zero_value
+func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Emptyf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Equal asserts that two objects are equal.
+//
+//	require.Equal(t, 123, 123)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Equal(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	require.EqualError(t, err,  expectedErrorString)
+func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualError(t, theError, errString, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualErrorf asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	require.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
+func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualErrorf(t, theError, errString, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualExportedValues asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 require.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
+//	 require.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
+func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualExportedValues(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualExportedValuesf asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 require.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+//	 require.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualExportedValuesf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualValues asserts that two objects are equal or convertible to the larger
+// type and equal.
+//
+//	require.EqualValues(t, uint32(123), int32(123))
+func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualValues(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualValuesf asserts that two objects are equal or convertible to the larger
+// type and equal.
+//
+//	require.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
+func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualValuesf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Equalf asserts that two objects are equal.
+//
+//	require.Equalf(t, 123, 123, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Equalf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//	actualObj, err := SomeFunction()
+//	require.Error(t, err)
+func Error(t TestingT, err error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Error(t, err, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorAs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorAsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	require.ErrorContains(t, err,  expectedErrorSubString)
+func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorContains(t, theError, contains, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	require.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorContainsf(t, theError, contains, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorIs asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorIs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorIsf asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorIsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Errorf asserts that a function returned an error (i.e. not `nil`).
+//
+//	actualObj, err := SomeFunction()
+//	require.Errorf(t, err, "error message %s", "formatted")
+func Errorf(t TestingT, err error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Errorf(t, err, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Eventually asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	require.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
+func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Eventually(t, condition, waitFor, tick, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EventuallyWithT asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	require.EventuallyWithT(t, func(c *require.CollectT) {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		require.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EventuallyWithT(t, condition, waitFor, tick, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EventuallyWithTf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	require.EventuallyWithTf(t, func(c *require.CollectT, "error message %s", "formatted") {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		require.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EventuallyWithTf(t, condition, waitFor, tick, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Eventuallyf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	require.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Eventuallyf(t, condition, waitFor, tick, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Exactly asserts that two objects are equal in value and type.
+//
+//	require.Exactly(t, int32(123), int64(123))
+func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Exactly(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Exactlyf asserts that two objects are equal in value and type.
+//
+//	require.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
+func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Exactlyf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Fail reports a failure through
+func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Fail(t, failureMessage, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FailNow fails test
+func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FailNow(t, failureMessage, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FailNowf fails test
+func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FailNowf(t, failureMessage, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Failf reports a failure through
+func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Failf(t, failureMessage, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// False asserts that the specified value is false.
+//
+//	require.False(t, myBool)
+func False(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.False(t, value, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Falsef asserts that the specified value is false.
+//
+//	require.Falsef(t, myBool, "error message %s", "formatted")
+func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Falsef(t, value, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FileExists checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FileExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FileExistsf checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FileExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Greater asserts that the first element is greater than the second
+//
+//	require.Greater(t, 2, 1)
+//	require.Greater(t, float64(2), float64(1))
+//	require.Greater(t, "b", "a")
+func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Greater(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
+//
+//	require.GreaterOrEqual(t, 2, 1)
+//	require.GreaterOrEqual(t, 2, 2)
+//	require.GreaterOrEqual(t, "b", "a")
+//	require.GreaterOrEqual(t, "b", "b")
+func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.GreaterOrEqual(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
+//
+//	require.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
+func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.GreaterOrEqualf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Greaterf asserts that the first element is greater than the second
+//
+//	require.Greaterf(t, 2, 1, "error message %s", "formatted")
+//	require.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
+//	require.Greaterf(t, "b", "a", "error message %s", "formatted")
+func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Greaterf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//	require.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyContains(t, handler, method, url, values, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyContainsf asserts that a specified handler returns a
+// body that contains a string.
+//
+//	require.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyContainsf(t, handler, method, url, values, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	require.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyNotContains(t, handler, method, url, values, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyNotContainsf asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	require.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyNotContainsf(t, handler, method, url, values, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//	require.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPError(t, handler, method, url, values, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPErrorf asserts that a specified handler returns an error status code.
+//
+//	require.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPErrorf(t, handler, method, url, values, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//	require.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPRedirect(t, handler, method, url, values, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPRedirectf asserts that a specified handler returns a redirect status code.
+//
+//	require.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPRedirectf(t, handler, method, url, values, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPStatusCode asserts that a specified handler returns a specified status code.
+//
+//	require.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPStatusCode(t, handler, method, url, values, statuscode, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPStatusCodef asserts that a specified handler returns a specified status code.
+//
+//	require.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPStatusCodef(t, handler, method, url, values, statuscode, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//	require.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPSuccess(t, handler, method, url, values, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPSuccessf asserts that a specified handler returns a success status code.
+//
+//	require.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPSuccessf(t, handler, method, url, values, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//	require.Implements(t, (*MyInterface)(nil), new(MyObject))
+func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Implements(t, interfaceObject, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Implementsf asserts that an object is implemented by the specified interface.
+//
+//	require.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Implementsf(t, interfaceObject, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+//	require.InDelta(t, math.Pi, 22/7.0, 0.01)
+func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InDeltaMapValues(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaMapValues(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaMapValuesf(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaSlice(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaSlicef is the same as InDelta, except it compares two slices.
+func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaSlicef(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaf asserts that the two numerals are within delta of each other.
+//
+//	require.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaf(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilonSlice(t, expected, actual, epsilon, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilonSlicef(t, expected, actual, epsilon, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilonf asserts that expected and actual have a relative error less than epsilon
+func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilonf(t, expected, actual, epsilon, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsDecreasing asserts that the collection is decreasing
+//
+//	require.IsDecreasing(t, []int{2, 1, 0})
+//	require.IsDecreasing(t, []float{2, 1})
+//	require.IsDecreasing(t, []string{"b", "a"})
+func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsDecreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//	require.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
+//	require.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	require.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsDecreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//	require.IsIncreasing(t, []int{1, 2, 3})
+//	require.IsIncreasing(t, []float{1, 2})
+//	require.IsIncreasing(t, []string{"a", "b"})
+func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsIncreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//	require.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
+//	require.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	require.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsIncreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//	require.IsNonDecreasing(t, []int{1, 1, 2})
+//	require.IsNonDecreasing(t, []float{1, 2})
+//	require.IsNonDecreasing(t, []string{"a", "b"})
+func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonDecreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//	require.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
+//	require.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	require.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonDecreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//	require.IsNonIncreasing(t, []int{2, 1, 1})
+//	require.IsNonIncreasing(t, []float{2, 1})
+//	require.IsNonIncreasing(t, []string{"b", "a"})
+func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonIncreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//	require.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
+//	require.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	require.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonIncreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNotType asserts that the specified objects are not of the same type.
+//
+//	require.IsNotType(t, &NotMyStruct{}, &MyStruct{})
+func IsNotType(t TestingT, theType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNotType(t, theType, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNotTypef asserts that the specified objects are not of the same type.
+//
+//	require.IsNotTypef(t, &NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
+func IsNotTypef(t TestingT, theType interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNotTypef(t, theType, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsType asserts that the specified objects are of the same type.
+//
+//	require.IsType(t, &MyStruct{}, &MyStruct{})
+func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsType(t, expectedType, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsTypef asserts that the specified objects are of the same type.
+//
+//	require.IsTypef(t, &MyStruct{}, &MyStruct{}, "error message %s", "formatted")
+func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsTypef(t, expectedType, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//	require.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.JSONEq(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// JSONEqf asserts that two JSON strings are equivalent.
+//
+//	require.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.JSONEqf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//	require.Len(t, mySlice, 3)
+func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Len(t, object, length, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Lenf asserts that the specified object has specific length.
+// Lenf also fails if the object has a type that len() not accept.
+//
+//	require.Lenf(t, mySlice, 3, "error message %s", "formatted")
+func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Lenf(t, object, length, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Less asserts that the first element is less than the second
+//
+//	require.Less(t, 1, 2)
+//	require.Less(t, float64(1), float64(2))
+//	require.Less(t, "a", "b")
+func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Less(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// LessOrEqual asserts that the first element is less than or equal to the second
+//
+//	require.LessOrEqual(t, 1, 2)
+//	require.LessOrEqual(t, 2, 2)
+//	require.LessOrEqual(t, "a", "b")
+//	require.LessOrEqual(t, "b", "b")
+func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.LessOrEqual(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// LessOrEqualf asserts that the first element is less than or equal to the second
+//
+//	require.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
+//	require.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	require.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
+//	require.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
+func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.LessOrEqualf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Lessf asserts that the first element is less than the second
+//
+//	require.Lessf(t, 1, 2, "error message %s", "formatted")
+//	require.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
+//	require.Lessf(t, "a", "b", "error message %s", "formatted")
+func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Lessf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Negative asserts that the specified element is negative
+//
+//	require.Negative(t, -1)
+//	require.Negative(t, -1.23)
+func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Negative(t, e, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Negativef asserts that the specified element is negative
+//
+//	require.Negativef(t, -1, "error message %s", "formatted")
+//	require.Negativef(t, -1.23, "error message %s", "formatted")
+func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Negativef(t, e, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Never asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	require.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
+func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Never(t, condition, waitFor, tick, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Neverf asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	require.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Neverf(t, condition, waitFor, tick, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Nil asserts that the specified object is nil.
+//
+//	require.Nil(t, err)
+func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Nil(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Nilf asserts that the specified object is nil.
+//
+//	require.Nilf(t, err, "error message %s", "formatted")
+func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Nilf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoDirExists checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoDirExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoDirExistsf checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoDirExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if require.NoError(t, err) {
+//		   require.Equal(t, expectedObj, actualObj)
+//	  }
+func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoError(t, err, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoErrorf asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if require.NoErrorf(t, err, "error message %s", "formatted") {
+//		   require.Equal(t, expectedObj, actualObj)
+//	  }
+func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoErrorf(t, err, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoFileExists checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func NoFileExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoFileExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoFileExistsf checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoFileExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	require.NotContains(t, "Hello World", "Earth")
+//	require.NotContains(t, ["Hello", "World"], "Earth")
+//	require.NotContains(t, {"Hello": "World"}, "Earth")
+func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotContains(t, s, contains, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	require.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
+//	require.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
+//	require.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
+func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotContainsf(t, s, contains, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotElementsMatch asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// require.NotElementsMatch(t, [1, 1, 2, 3], [1, 1, 2, 3]) -> false
+//
+// require.NotElementsMatch(t, [1, 1, 2, 3], [1, 2, 3]) -> true
+//
+// require.NotElementsMatch(t, [1, 2, 3], [1, 2, 4]) -> true
+func NotElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotElementsMatch(t, listA, listB, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotElementsMatchf asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// require.NotElementsMatchf(t, [1, 1, 2, 3], [1, 1, 2, 3], "error message %s", "formatted") -> false
+//
+// require.NotElementsMatchf(t, [1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
+//
+// require.NotElementsMatchf(t, [1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
+func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotElementsMatchf(t, listA, listB, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEmpty asserts that the specified object is NOT [Empty].
+//
+//	if require.NotEmpty(t, obj) {
+//	  require.Equal(t, "two", obj[1])
+//	}
+func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEmpty(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEmptyf asserts that the specified object is NOT [Empty].
+//
+//	if require.NotEmptyf(t, obj, "error message %s", "formatted") {
+//	  require.Equal(t, "two", obj[1])
+//	}
+func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEmptyf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//	require.NotEqual(t, obj1, obj2)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqual(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqualValues asserts that two objects are not equal even when converted to the same type
+//
+//	require.NotEqualValues(t, obj1, obj2)
+func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqualValues(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqualValuesf asserts that two objects are not equal even when converted to the same type
+//
+//	require.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
+func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqualValuesf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqualf asserts that the specified values are NOT equal.
+//
+//	require.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqualf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorAs asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func NotErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorAs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorAsf asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func NotErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorAsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorIs asserts that none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorIs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorIsf asserts that none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorIsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotImplements asserts that an object does not implement the specified interface.
+//
+//	require.NotImplements(t, (*MyInterface)(nil), new(MyObject))
+func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotImplements(t, interfaceObject, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotImplementsf asserts that an object does not implement the specified interface.
+//
+//	require.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotImplementsf(t, interfaceObject, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//	require.NotNil(t, err)
+func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotNil(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotNilf asserts that the specified object is not nil.
+//
+//	require.NotNilf(t, err, "error message %s", "formatted")
+func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotNilf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	require.NotPanics(t, func(){ RemainCalm() })
+func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotPanics(t, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	require.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
+func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotPanicsf(t, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//	require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+//	require.NotRegexp(t, "^start", "it's not starting")
+func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotRegexp(t, rx, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotRegexpf asserts that a specified regexp does not match a string.
+//
+//	require.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//	require.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
+func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotRegexpf(t, rx, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSame asserts that two pointers do not reference the same object.
+//
+//	require.NotSame(t, ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSame(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSamef asserts that two pointers do not reference the same object.
+//
+//	require.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSamef(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSubset asserts that the list (array, slice, or map) does NOT contain all
+// elements given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	require.NotSubset(t, [1, 3, 4], [1, 2])
+//	require.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
+//	require.NotSubset(t, [1, 3, 4], {1: "one", 2: "two"})
+//	require.NotSubset(t, {"x": 1, "y": 2}, ["z"])
+func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSubset(t, list, subset, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSubsetf asserts that the list (array, slice, or map) does NOT contain all
+// elements given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	require.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
+//	require.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+//	require.NotSubsetf(t, [1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	require.NotSubsetf(t, {"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
+func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSubsetf(t, list, subset, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotZero asserts that i is not the zero value for its type.
+func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotZero(t, i, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotZerof asserts that i is not the zero value for its type.
+func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotZerof(t, i, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//	require.Panics(t, func(){ GoCrazy() })
+func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Panics(t, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithError asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	require.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
+func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithError(t, errString, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithErrorf asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	require.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithErrorf(t, errString, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	require.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
+func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithValue(t, expected, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	require.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithValuef(t, expected, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Panicsf asserts that the code inside the specified PanicTestFunc panics.
+//
+//	require.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
+func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Panicsf(t, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Positive asserts that the specified element is positive
+//
+//	require.Positive(t, 1)
+//	require.Positive(t, 1.23)
+func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Positive(t, e, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Positivef asserts that the specified element is positive
+//
+//	require.Positivef(t, 1, "error message %s", "formatted")
+//	require.Positivef(t, 1.23, "error message %s", "formatted")
+func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Positivef(t, e, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//	require.Regexp(t, regexp.MustCompile("start"), "it's starting")
+//	require.Regexp(t, "start...$", "it's not starting")
+func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Regexp(t, rx, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Regexpf asserts that a specified regexp matches a string.
+//
+//	require.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//	require.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
+func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Regexpf(t, rx, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Same asserts that two pointers reference the same object.
+//
+//	require.Same(t, ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Same(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Samef asserts that two pointers reference the same object.
+//
+//	require.Samef(t, ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func Samef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Samef(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Subset asserts that the list (array, slice, or map) contains all elements
+// given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	require.Subset(t, [1, 2, 3], [1, 2])
+//	require.Subset(t, {"x": 1, "y": 2}, {"x": 1})
+//	require.Subset(t, [1, 2, 3], {1: "one", 2: "two"})
+//	require.Subset(t, {"x": 1, "y": 2}, ["x"])
+func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Subset(t, list, subset, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Subsetf asserts that the list (array, slice, or map) contains all elements
+// given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	require.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
+//	require.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+//	require.Subsetf(t, [1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	require.Subsetf(t, {"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
+func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Subsetf(t, list, subset, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// True asserts that the specified value is true.
+//
+//	require.True(t, myBool)
+func True(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.True(t, value, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Truef asserts that the specified value is true.
+//
+//	require.Truef(t, myBool, "error message %s", "formatted")
+func Truef(t TestingT, value bool, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Truef(t, value, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//	require.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
+func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinDurationf asserts that the two times are within duration delta of each other.
+//
+//	require.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinDurationf(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinRange asserts that a time is within a time range (inclusive).
+//
+//	require.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinRange(t, actual, start, end, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinRangef asserts that a time is within a time range (inclusive).
+//
+//	require.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinRangef(t, actual, start, end, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// YAMLEq asserts that two YAML strings are equivalent.
+func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.YAMLEq(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// YAMLEqf asserts that two YAML strings are equivalent.
+func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.YAMLEqf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Zero asserts that i is the zero value for its type.
+func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Zero(t, i, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Zerof asserts that i is the zero value for its type.
+func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Zerof(t, i, msg, args...) {
+		return
+	}
+	t.FailNow()
+}

--- a/vendor/github.com/stretchr/testify/require/require.go.tmpl
+++ b/vendor/github.com/stretchr/testify/require/require.go.tmpl
@@ -1,0 +1,6 @@
+{{ replace .Comment "assert." "require."}}
+func {{.DocInfo.Name}}(t TestingT, {{.Params}}) {
+	if h, ok := t.(tHelper); ok { h.Helper() }
+	if assert.{{.DocInfo.Name}}(t, {{.ForwardedParams}}) { return }
+	t.FailNow()
+}

--- a/vendor/github.com/stretchr/testify/require/require_forward.go
+++ b/vendor/github.com/stretchr/testify/require/require_forward.go
@@ -1,0 +1,1724 @@
+// Code generated with github.com/stretchr/testify/_codegen; DO NOT EDIT.
+
+package require
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Condition uses a Comparison to assert a complex condition.
+func (a *Assertions) Condition(comp assert.Comparison, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Condition(a.t, comp, msgAndArgs...)
+}
+
+// Conditionf uses a Comparison to assert a complex condition.
+func (a *Assertions) Conditionf(comp assert.Comparison, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Conditionf(a.t, comp, msg, args...)
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	a.Contains("Hello World", "World")
+//	a.Contains(["Hello", "World"], "World")
+//	a.Contains({"Hello": "World"}, "Hello")
+func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Contains(a.t, s, contains, msgAndArgs...)
+}
+
+// Containsf asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	a.Containsf("Hello World", "World", "error message %s", "formatted")
+//	a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
+//	a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
+func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Containsf(a.t, s, contains, msg, args...)
+}
+
+// DirExists checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	DirExists(a.t, path, msgAndArgs...)
+}
+
+// DirExistsf checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	DirExistsf(a.t, path, msg, args...)
+}
+
+// ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// a.ElementsMatch([1, 3, 2, 3], [1, 3, 3, 2])
+func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ElementsMatch(a.t, listA, listB, msgAndArgs...)
+}
+
+// ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// a.ElementsMatchf([1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
+func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ElementsMatchf(a.t, listA, listB, msg, args...)
+}
+
+// Empty asserts that the given value is "empty".
+//
+// [Zero values] are "empty".
+//
+// Arrays are "empty" if every element is the zero value of the type (stricter than "empty").
+//
+// Slices, maps and channels with zero length are "empty".
+//
+// Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
+//
+//	a.Empty(obj)
+//
+// [Zero values]: https://go.dev/ref/spec#The_zero_value
+func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Empty(a.t, object, msgAndArgs...)
+}
+
+// Emptyf asserts that the given value is "empty".
+//
+// [Zero values] are "empty".
+//
+// Arrays are "empty" if every element is the zero value of the type (stricter than "empty").
+//
+// Slices, maps and channels with zero length are "empty".
+//
+// Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
+//
+//	a.Emptyf(obj, "error message %s", "formatted")
+//
+// [Zero values]: https://go.dev/ref/spec#The_zero_value
+func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Emptyf(a.t, object, msg, args...)
+}
+
+// Equal asserts that two objects are equal.
+//
+//	a.Equal(123, 123)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Equal(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	a.EqualError(err,  expectedErrorString)
+func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualError(a.t, theError, errString, msgAndArgs...)
+}
+
+// EqualErrorf asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
+func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualErrorf(a.t, theError, errString, msg, args...)
+}
+
+// EqualExportedValues asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 a.EqualExportedValues(S{1, 2}, S{1, 3}) => true
+//	 a.EqualExportedValues(S{1, 2}, S{2, 3}) => false
+func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualExportedValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualExportedValuesf asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 a.EqualExportedValuesf(S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+//	 a.EqualExportedValuesf(S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualExportedValuesf(a.t, expected, actual, msg, args...)
+}
+
+// EqualValues asserts that two objects are equal or convertible to the larger
+// type and equal.
+//
+//	a.EqualValues(uint32(123), int32(123))
+func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualValuesf asserts that two objects are equal or convertible to the larger
+// type and equal.
+//
+//	a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
+func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualValuesf(a.t, expected, actual, msg, args...)
+}
+
+// Equalf asserts that two objects are equal.
+//
+//	a.Equalf(123, 123, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Equalf(a.t, expected, actual, msg, args...)
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//	actualObj, err := SomeFunction()
+//	a.Error(err)
+func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Error(a.t, err, msgAndArgs...)
+}
+
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) ErrorAs(err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorAs(a.t, err, target, msgAndArgs...)
+}
+
+// ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorAsf(a.t, err, target, msg, args...)
+}
+
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	a.ErrorContains(err,  expectedErrorSubString)
+func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorContains(a.t, theError, contains, msgAndArgs...)
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
+func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorContainsf(a.t, theError, contains, msg, args...)
+}
+
+// ErrorIs asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorIs(a.t, err, target, msgAndArgs...)
+}
+
+// ErrorIsf asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorIsf(a.t, err, target, msg, args...)
+}
+
+// Errorf asserts that a function returned an error (i.e. not `nil`).
+//
+//	actualObj, err := SomeFunction()
+//	a.Errorf(err, "error message %s", "formatted")
+func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Errorf(a.t, err, msg, args...)
+}
+
+// Eventually asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
+func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Eventually(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// EventuallyWithT asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	a.EventuallyWithT(func(c *assert.CollectT) {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func (a *Assertions) EventuallyWithT(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EventuallyWithT(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// EventuallyWithTf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	a.EventuallyWithTf(func(c *assert.CollectT, "error message %s", "formatted") {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func (a *Assertions) EventuallyWithTf(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EventuallyWithTf(a.t, condition, waitFor, tick, msg, args...)
+}
+
+// Eventuallyf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Eventuallyf(a.t, condition, waitFor, tick, msg, args...)
+}
+
+// Exactly asserts that two objects are equal in value and type.
+//
+//	a.Exactly(int32(123), int64(123))
+func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Exactly(a.t, expected, actual, msgAndArgs...)
+}
+
+// Exactlyf asserts that two objects are equal in value and type.
+//
+//	a.Exactlyf(int32(123), int64(123), "error message %s", "formatted")
+func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Exactlyf(a.t, expected, actual, msg, args...)
+}
+
+// Fail reports a failure through
+func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Fail(a.t, failureMessage, msgAndArgs...)
+}
+
+// FailNow fails test
+func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FailNow(a.t, failureMessage, msgAndArgs...)
+}
+
+// FailNowf fails test
+func (a *Assertions) FailNowf(failureMessage string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FailNowf(a.t, failureMessage, msg, args...)
+}
+
+// Failf reports a failure through
+func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Failf(a.t, failureMessage, msg, args...)
+}
+
+// False asserts that the specified value is false.
+//
+//	a.False(myBool)
+func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	False(a.t, value, msgAndArgs...)
+}
+
+// Falsef asserts that the specified value is false.
+//
+//	a.Falsef(myBool, "error message %s", "formatted")
+func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Falsef(a.t, value, msg, args...)
+}
+
+// FileExists checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FileExists(a.t, path, msgAndArgs...)
+}
+
+// FileExistsf checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FileExistsf(a.t, path, msg, args...)
+}
+
+// Greater asserts that the first element is greater than the second
+//
+//	a.Greater(2, 1)
+//	a.Greater(float64(2), float64(1))
+//	a.Greater("b", "a")
+func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Greater(a.t, e1, e2, msgAndArgs...)
+}
+
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
+//
+//	a.GreaterOrEqual(2, 1)
+//	a.GreaterOrEqual(2, 2)
+//	a.GreaterOrEqual("b", "a")
+//	a.GreaterOrEqual("b", "b")
+func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	GreaterOrEqual(a.t, e1, e2, msgAndArgs...)
+}
+
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
+//
+//	a.GreaterOrEqualf(2, 1, "error message %s", "formatted")
+//	a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
+//	a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
+//	a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
+func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	GreaterOrEqualf(a.t, e1, e2, msg, args...)
+}
+
+// Greaterf asserts that the first element is greater than the second
+//
+//	a.Greaterf(2, 1, "error message %s", "formatted")
+//	a.Greaterf(float64(2), float64(1), "error message %s", "formatted")
+//	a.Greaterf("b", "a", "error message %s", "formatted")
+func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Greaterf(a.t, e1, e2, msg, args...)
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//	a.HTTPBodyContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyContains(a.t, handler, method, url, values, str, msgAndArgs...)
+}
+
+// HTTPBodyContainsf asserts that a specified handler returns a
+// body that contains a string.
+//
+//	a.HTTPBodyContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyContainsf(a.t, handler, method, url, values, str, msg, args...)
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	a.HTTPBodyNotContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyNotContains(a.t, handler, method, url, values, str, msgAndArgs...)
+}
+
+// HTTPBodyNotContainsf asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	a.HTTPBodyNotContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyNotContainsf(a.t, handler, method, url, values, str, msg, args...)
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//	a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPError(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPErrorf asserts that a specified handler returns an error status code.
+//
+//	a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPErrorf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//	a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPRedirect(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPRedirectf asserts that a specified handler returns a redirect status code.
+//
+//	a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPRedirectf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPStatusCode asserts that a specified handler returns a specified status code.
+//
+//	a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPStatusCode(a.t, handler, method, url, values, statuscode, msgAndArgs...)
+}
+
+// HTTPStatusCodef asserts that a specified handler returns a specified status code.
+//
+//	a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPStatusCodef(a.t, handler, method, url, values, statuscode, msg, args...)
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//	a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPSuccess(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPSuccessf asserts that a specified handler returns a success status code.
+//
+//	a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPSuccessf(a.t, handler, method, url, values, msg, args...)
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//	a.Implements((*MyInterface)(nil), new(MyObject))
+func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Implements(a.t, interfaceObject, object, msgAndArgs...)
+}
+
+// Implementsf asserts that an object is implemented by the specified interface.
+//
+//	a.Implementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Implementsf(a.t, interfaceObject, object, msg, args...)
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+//	a.InDelta(math.Pi, 22/7.0, 0.01)
+func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDelta(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InDeltaMapValues(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaMapValues(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InDeltaMapValuesf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaMapValuesf(a.t, expected, actual, delta, msg, args...)
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaSlicef is the same as InDelta, except it compares two slices.
+func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaSlicef(a.t, expected, actual, delta, msg, args...)
+}
+
+// InDeltaf asserts that the two numerals are within delta of each other.
+//
+//	a.InDeltaf(math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaf(a.t, expected, actual, delta, msg, args...)
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilonSlice(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilonSlicef(a.t, expected, actual, epsilon, msg, args...)
+}
+
+// InEpsilonf asserts that expected and actual have a relative error less than epsilon
+func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilonf(a.t, expected, actual, epsilon, msg, args...)
+}
+
+// IsDecreasing asserts that the collection is decreasing
+//
+//	a.IsDecreasing([]int{2, 1, 0})
+//	a.IsDecreasing([]float{2, 1})
+//	a.IsDecreasing([]string{"b", "a"})
+func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//	a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
+//	a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
+//	a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsDecreasingf(a.t, object, msg, args...)
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//	a.IsIncreasing([]int{1, 2, 3})
+//	a.IsIncreasing([]float{1, 2})
+//	a.IsIncreasing([]string{"a", "b"})
+func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//	a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
+//	a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
+//	a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsIncreasingf(a.t, object, msg, args...)
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//	a.IsNonDecreasing([]int{1, 1, 2})
+//	a.IsNonDecreasing([]float{1, 2})
+//	a.IsNonDecreasing([]string{"a", "b"})
+func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//	a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
+//	a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
+//	a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonDecreasingf(a.t, object, msg, args...)
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//	a.IsNonIncreasing([]int{2, 1, 1})
+//	a.IsNonIncreasing([]float{2, 1})
+//	a.IsNonIncreasing([]string{"b", "a"})
+func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//	a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
+//	a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
+//	a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonIncreasingf(a.t, object, msg, args...)
+}
+
+// IsNotType asserts that the specified objects are not of the same type.
+//
+//	a.IsNotType(&NotMyStruct{}, &MyStruct{})
+func (a *Assertions) IsNotType(theType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNotType(a.t, theType, object, msgAndArgs...)
+}
+
+// IsNotTypef asserts that the specified objects are not of the same type.
+//
+//	a.IsNotTypef(&NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
+func (a *Assertions) IsNotTypef(theType interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNotTypef(a.t, theType, object, msg, args...)
+}
+
+// IsType asserts that the specified objects are of the same type.
+//
+//	a.IsType(&MyStruct{}, &MyStruct{})
+func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsType(a.t, expectedType, object, msgAndArgs...)
+}
+
+// IsTypef asserts that the specified objects are of the same type.
+//
+//	a.IsTypef(&MyStruct{}, &MyStruct{}, "error message %s", "formatted")
+func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsTypef(a.t, expectedType, object, msg, args...)
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//	a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	JSONEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// JSONEqf asserts that two JSON strings are equivalent.
+//
+//	a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	JSONEqf(a.t, expected, actual, msg, args...)
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//	a.Len(mySlice, 3)
+func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Len(a.t, object, length, msgAndArgs...)
+}
+
+// Lenf asserts that the specified object has specific length.
+// Lenf also fails if the object has a type that len() not accept.
+//
+//	a.Lenf(mySlice, 3, "error message %s", "formatted")
+func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Lenf(a.t, object, length, msg, args...)
+}
+
+// Less asserts that the first element is less than the second
+//
+//	a.Less(1, 2)
+//	a.Less(float64(1), float64(2))
+//	a.Less("a", "b")
+func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Less(a.t, e1, e2, msgAndArgs...)
+}
+
+// LessOrEqual asserts that the first element is less than or equal to the second
+//
+//	a.LessOrEqual(1, 2)
+//	a.LessOrEqual(2, 2)
+//	a.LessOrEqual("a", "b")
+//	a.LessOrEqual("b", "b")
+func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	LessOrEqual(a.t, e1, e2, msgAndArgs...)
+}
+
+// LessOrEqualf asserts that the first element is less than or equal to the second
+//
+//	a.LessOrEqualf(1, 2, "error message %s", "formatted")
+//	a.LessOrEqualf(2, 2, "error message %s", "formatted")
+//	a.LessOrEqualf("a", "b", "error message %s", "formatted")
+//	a.LessOrEqualf("b", "b", "error message %s", "formatted")
+func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	LessOrEqualf(a.t, e1, e2, msg, args...)
+}
+
+// Lessf asserts that the first element is less than the second
+//
+//	a.Lessf(1, 2, "error message %s", "formatted")
+//	a.Lessf(float64(1), float64(2), "error message %s", "formatted")
+//	a.Lessf("a", "b", "error message %s", "formatted")
+func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Lessf(a.t, e1, e2, msg, args...)
+}
+
+// Negative asserts that the specified element is negative
+//
+//	a.Negative(-1)
+//	a.Negative(-1.23)
+func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Negative(a.t, e, msgAndArgs...)
+}
+
+// Negativef asserts that the specified element is negative
+//
+//	a.Negativef(-1, "error message %s", "formatted")
+//	a.Negativef(-1.23, "error message %s", "formatted")
+func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Negativef(a.t, e, msg, args...)
+}
+
+// Never asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
+func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Never(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// Neverf asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Neverf(a.t, condition, waitFor, tick, msg, args...)
+}
+
+// Nil asserts that the specified object is nil.
+//
+//	a.Nil(err)
+func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Nil(a.t, object, msgAndArgs...)
+}
+
+// Nilf asserts that the specified object is nil.
+//
+//	a.Nilf(err, "error message %s", "formatted")
+func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Nilf(a.t, object, msg, args...)
+}
+
+// NoDirExists checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func (a *Assertions) NoDirExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoDirExists(a.t, path, msgAndArgs...)
+}
+
+// NoDirExistsf checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func (a *Assertions) NoDirExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoDirExistsf(a.t, path, msg, args...)
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if a.NoError(err) {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
+func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoError(a.t, err, msgAndArgs...)
+}
+
+// NoErrorf asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if a.NoErrorf(err, "error message %s", "formatted") {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
+func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoErrorf(a.t, err, msg, args...)
+}
+
+// NoFileExists checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func (a *Assertions) NoFileExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoFileExists(a.t, path, msgAndArgs...)
+}
+
+// NoFileExistsf checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoFileExistsf(a.t, path, msg, args...)
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	a.NotContains("Hello World", "Earth")
+//	a.NotContains(["Hello", "World"], "Earth")
+//	a.NotContains({"Hello": "World"}, "Earth")
+func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotContains(a.t, s, contains, msgAndArgs...)
+}
+
+// NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
+//	a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
+//	a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
+func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotContainsf(a.t, s, contains, msg, args...)
+}
+
+// NotElementsMatch asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// a.NotElementsMatch([1, 1, 2, 3], [1, 1, 2, 3]) -> false
+//
+// a.NotElementsMatch([1, 1, 2, 3], [1, 2, 3]) -> true
+//
+// a.NotElementsMatch([1, 2, 3], [1, 2, 4]) -> true
+func (a *Assertions) NotElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotElementsMatch(a.t, listA, listB, msgAndArgs...)
+}
+
+// NotElementsMatchf asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// a.NotElementsMatchf([1, 1, 2, 3], [1, 1, 2, 3], "error message %s", "formatted") -> false
+//
+// a.NotElementsMatchf([1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
+//
+// a.NotElementsMatchf([1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
+func (a *Assertions) NotElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotElementsMatchf(a.t, listA, listB, msg, args...)
+}
+
+// NotEmpty asserts that the specified object is NOT [Empty].
+//
+//	if a.NotEmpty(obj) {
+//	  assert.Equal(t, "two", obj[1])
+//	}
+func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEmpty(a.t, object, msgAndArgs...)
+}
+
+// NotEmptyf asserts that the specified object is NOT [Empty].
+//
+//	if a.NotEmptyf(obj, "error message %s", "formatted") {
+//	  assert.Equal(t, "two", obj[1])
+//	}
+func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEmptyf(a.t, object, msg, args...)
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//	a.NotEqual(obj1, obj2)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqual(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotEqualValues asserts that two objects are not equal even when converted to the same type
+//
+//	a.NotEqualValues(obj1, obj2)
+func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqualValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotEqualValuesf asserts that two objects are not equal even when converted to the same type
+//
+//	a.NotEqualValuesf(obj1, obj2, "error message %s", "formatted")
+func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqualValuesf(a.t, expected, actual, msg, args...)
+}
+
+// NotEqualf asserts that the specified values are NOT equal.
+//
+//	a.NotEqualf(obj1, obj2, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqualf(a.t, expected, actual, msg, args...)
+}
+
+// NotErrorAs asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func (a *Assertions) NotErrorAs(err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorAs(a.t, err, target, msgAndArgs...)
+}
+
+// NotErrorAsf asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func (a *Assertions) NotErrorAsf(err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorAsf(a.t, err, target, msg, args...)
+}
+
+// NotErrorIs asserts that none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorIs(a.t, err, target, msgAndArgs...)
+}
+
+// NotErrorIsf asserts that none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorIsf(a.t, err, target, msg, args...)
+}
+
+// NotImplements asserts that an object does not implement the specified interface.
+//
+//	a.NotImplements((*MyInterface)(nil), new(MyObject))
+func (a *Assertions) NotImplements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotImplements(a.t, interfaceObject, object, msgAndArgs...)
+}
+
+// NotImplementsf asserts that an object does not implement the specified interface.
+//
+//	a.NotImplementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func (a *Assertions) NotImplementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotImplementsf(a.t, interfaceObject, object, msg, args...)
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//	a.NotNil(err)
+func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotNil(a.t, object, msgAndArgs...)
+}
+
+// NotNilf asserts that the specified object is not nil.
+//
+//	a.NotNilf(err, "error message %s", "formatted")
+func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotNilf(a.t, object, msg, args...)
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	a.NotPanics(func(){ RemainCalm() })
+func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotPanics(a.t, f, msgAndArgs...)
+}
+
+// NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
+func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotPanicsf(a.t, f, msg, args...)
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
+//	a.NotRegexp("^start", "it's not starting")
+func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotRegexp(a.t, rx, str, msgAndArgs...)
+}
+
+// NotRegexpf asserts that a specified regexp does not match a string.
+//
+//	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted")
+func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotRegexpf(a.t, rx, str, msg, args...)
+}
+
+// NotSame asserts that two pointers do not reference the same object.
+//
+//	a.NotSame(ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSame(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotSamef asserts that two pointers do not reference the same object.
+//
+//	a.NotSamef(ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSamef(a.t, expected, actual, msg, args...)
+}
+
+// NotSubset asserts that the list (array, slice, or map) does NOT contain all
+// elements given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	a.NotSubset([1, 3, 4], [1, 2])
+//	a.NotSubset({"x": 1, "y": 2}, {"z": 3})
+//	a.NotSubset([1, 3, 4], {1: "one", 2: "two"})
+//	a.NotSubset({"x": 1, "y": 2}, ["z"])
+func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSubset(a.t, list, subset, msgAndArgs...)
+}
+
+// NotSubsetf asserts that the list (array, slice, or map) does NOT contain all
+// elements given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	a.NotSubsetf([1, 3, 4], [1, 2], "error message %s", "formatted")
+//	a.NotSubsetf({"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+//	a.NotSubsetf([1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	a.NotSubsetf({"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
+func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSubsetf(a.t, list, subset, msg, args...)
+}
+
+// NotZero asserts that i is not the zero value for its type.
+func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotZero(a.t, i, msgAndArgs...)
+}
+
+// NotZerof asserts that i is not the zero value for its type.
+func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotZerof(a.t, i, msg, args...)
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//	a.Panics(func(){ GoCrazy() })
+func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Panics(a.t, f, msgAndArgs...)
+}
+
+// PanicsWithError asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	a.PanicsWithError("crazy error", func(){ GoCrazy() })
+func (a *Assertions) PanicsWithError(errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithError(a.t, errString, f, msgAndArgs...)
+}
+
+// PanicsWithErrorf asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	a.PanicsWithErrorf("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) PanicsWithErrorf(errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithErrorf(a.t, errString, f, msg, args...)
+}
+
+// PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	a.PanicsWithValue("crazy error", func(){ GoCrazy() })
+func (a *Assertions) PanicsWithValue(expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithValue(a.t, expected, f, msgAndArgs...)
+}
+
+// PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) PanicsWithValuef(expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithValuef(a.t, expected, f, msg, args...)
+}
+
+// Panicsf asserts that the code inside the specified PanicTestFunc panics.
+//
+//	a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Panicsf(a.t, f, msg, args...)
+}
+
+// Positive asserts that the specified element is positive
+//
+//	a.Positive(1)
+//	a.Positive(1.23)
+func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Positive(a.t, e, msgAndArgs...)
+}
+
+// Positivef asserts that the specified element is positive
+//
+//	a.Positivef(1, "error message %s", "formatted")
+//	a.Positivef(1.23, "error message %s", "formatted")
+func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Positivef(a.t, e, msg, args...)
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//	a.Regexp(regexp.MustCompile("start"), "it's starting")
+//	a.Regexp("start...$", "it's not starting")
+func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Regexp(a.t, rx, str, msgAndArgs...)
+}
+
+// Regexpf asserts that a specified regexp matches a string.
+//
+//	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted")
+func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Regexpf(a.t, rx, str, msg, args...)
+}
+
+// Same asserts that two pointers reference the same object.
+//
+//	a.Same(ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Same(a.t, expected, actual, msgAndArgs...)
+}
+
+// Samef asserts that two pointers reference the same object.
+//
+//	a.Samef(ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Samef(a.t, expected, actual, msg, args...)
+}
+
+// Subset asserts that the list (array, slice, or map) contains all elements
+// given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	a.Subset([1, 2, 3], [1, 2])
+//	a.Subset({"x": 1, "y": 2}, {"x": 1})
+//	a.Subset([1, 2, 3], {1: "one", 2: "two"})
+//	a.Subset({"x": 1, "y": 2}, ["x"])
+func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Subset(a.t, list, subset, msgAndArgs...)
+}
+
+// Subsetf asserts that the list (array, slice, or map) contains all elements
+// given in the subset (array, slice, or map).
+// Map elements are key-value pairs unless compared with an array or slice where
+// only the map key is evaluated.
+//
+//	a.Subsetf([1, 2, 3], [1, 2], "error message %s", "formatted")
+//	a.Subsetf({"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+//	a.Subsetf([1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	a.Subsetf({"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
+func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Subsetf(a.t, list, subset, msg, args...)
+}
+
+// True asserts that the specified value is true.
+//
+//	a.True(myBool)
+func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	True(a.t, value, msgAndArgs...)
+}
+
+// Truef asserts that the specified value is true.
+//
+//	a.Truef(myBool, "error message %s", "formatted")
+func (a *Assertions) Truef(value bool, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Truef(a.t, value, msg, args...)
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//	a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
+func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// WithinDurationf asserts that the two times are within duration delta of each other.
+//
+//	a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinDurationf(a.t, expected, actual, delta, msg, args...)
+}
+
+// WithinRange asserts that a time is within a time range (inclusive).
+//
+//	a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinRange(a.t, actual, start, end, msgAndArgs...)
+}
+
+// WithinRangef asserts that a time is within a time range (inclusive).
+//
+//	a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinRangef(a.t, actual, start, end, msg, args...)
+}
+
+// YAMLEq asserts that two YAML strings are equivalent.
+func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	YAMLEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// YAMLEqf asserts that two YAML strings are equivalent.
+func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	YAMLEqf(a.t, expected, actual, msg, args...)
+}
+
+// Zero asserts that i is the zero value for its type.
+func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Zero(a.t, i, msgAndArgs...)
+}
+
+// Zerof asserts that i is the zero value for its type.
+func (a *Assertions) Zerof(i interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Zerof(a.t, i, msg, args...)
+}

--- a/vendor/github.com/stretchr/testify/require/require_forward.go.tmpl
+++ b/vendor/github.com/stretchr/testify/require/require_forward.go.tmpl
@@ -1,0 +1,5 @@
+{{.CommentWithoutT "a"}}
+func (a *Assertions) {{.DocInfo.Name}}({{.Params}}) {
+	if h, ok := a.t.(tHelper); ok { h.Helper() }
+	{{.DocInfo.Name}}(a.t, {{.ForwardedParams}})
+}

--- a/vendor/github.com/stretchr/testify/require/requirements.go
+++ b/vendor/github.com/stretchr/testify/require/requirements.go
@@ -1,0 +1,29 @@
+package require
+
+// TestingT is an interface wrapper around *testing.T
+type TestingT interface {
+	Errorf(format string, args ...interface{})
+	FailNow()
+}
+
+type tHelper = interface {
+	Helper()
+}
+
+// ComparisonAssertionFunc is a common function prototype when comparing two values.  Can be useful
+// for table driven tests.
+type ComparisonAssertionFunc func(TestingT, interface{}, interface{}, ...interface{})
+
+// ValueAssertionFunc is a common function prototype when validating a single value.  Can be useful
+// for table driven tests.
+type ValueAssertionFunc func(TestingT, interface{}, ...interface{})
+
+// BoolAssertionFunc is a common function prototype when validating a bool value.  Can be useful
+// for table driven tests.
+type BoolAssertionFunc func(TestingT, bool, ...interface{})
+
+// ErrorAssertionFunc is a common function prototype when validating an error value.  Can be useful
+// for table driven tests.
+type ErrorAssertionFunc func(TestingT, error, ...interface{})
+
+//go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=require -template=require.go.tmpl -include-format-funcs"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -111,6 +111,14 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
+# github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
+## explicit
+github.com/pmezard/go-difflib/difflib
+# github.com/stretchr/testify v1.11.1
+## explicit; go 1.17
+github.com/stretchr/testify/assert
+github.com/stretchr/testify/assert/yaml
+github.com/stretchr/testify/require
 # github.com/x448/float16 v0.8.4
 ## explicit; go 1.11
 github.com/x448/float16


### PR DESCRIPTION
## Summary
- Standardize the entire Go test suite on `github.com/stretchr/testify/require` so all tests share a single, fail-fast assertion paradigm (previously hand-rolled `if got != want { t.Errorf(...) }` checks).
- Add `github.com/stretchr/testify v1.11.1` as a direct dependency (vendored).
- Convert **49 test files** (~900+ assertions) across `cmd/`, `pkg/gpu/`, `pkg/network/mockib/`, `pkg/imexcoord/`, and `pkg/system/`.

## Conversion conventions
- `if err != nil {...}` → `require.NoError`; `if err == nil {...}` → `require.Error`
- `if got != want {...}` → `require.Equal(t, want, got, …)` (expected-first)
- bool / nil / length / substring checks → `require.True`/`False`/`Nil`/`NotNil`/`Len`/`Contains`
- terminal poll-loop timeouts → `require.Fail`/`require.Failf`
- `require.*` only (fail-fast) — no `assert.*`
- No production code changes; test logic, table cases, subtests, and case-identifying messages preserved.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all packages pass)
- [x] `gofmt -l` clean across all test files
- [x] No remaining `t.Errorf`/`t.Fatal`/`t.Fatalf` assertions