### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-12
+
 ### Added
 - New GPU profile `gb300` modeling the NVIDIA GB300 NVL (Grace-Blackwell
   Ultra Superchip): 8 GPUs/node arranged as 4 Grace+2×B300 trays, 288 GiB
@@ -55,10 +57,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   at startup by `mock-ib` from each profile's new `infiniband:`
   block. Defaults: `a100` -> ConnectX-6 HDR; `h100` / `b200` / `gb200`
   -> ConnectX-7 NDR; `l40s` / `t4` -> disabled.
-- Cross-node `ibping` via `mock-ib` and `libibmockumad.so` (always enabled in
-  the nvml-mock Helm chart). The chart preloads both shims, starts the in-pod
-  daemon, and relays ping traffic between nvml-mock pods over the Kubernetes
-  pod network. E2E: `tests/e2e/validate-ibping.sh`.
+- Cross-node `ibping`, `iblinkinfo`, and `ibv_devinfo` via `mock-ib`,
+  `libibmockumad.so`, and `libibmockverbs.so`. The chart preloads the shims,
+  starts the in-pod daemon, and relays MAD traffic between nvml-mock pods
+  over the Kubernetes pod network; the daemon and its Service are only
+  created for profiles whose `infiniband:` block is enabled. E2E:
+  `tests/e2e/validate-ibping.sh` plus a multi-node ibping CI job. (#367)
+- Test suite standardized on `testify/require` across all packages; soft
+  `t.Errorf` checks upgraded to hard failures, expect-error assertions made
+  explicit with `require.Error`. No test functions were added or removed.
+  (#386)
+
+### Fixed
+- `docs/demo/standalone/demo.sh` no longer uses the bash 4 `mapfile`
+  builtin and runs on macOS's stock bash 3.2. (#385)
+- Helm chart OCI publishing: the cosign signing step now authenticates to
+  GHCR via the Docker config and signs the chart by digest; chart signing
+  had failed with UNAUTHORIZED on every publish since 2026-05-25. (#388)
 
 ## [0.1.0] - 2026-04-07
 
@@ -79,5 +94,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Rebranded from gpu-mock to nvml-mock (PRs #273, #274, #275, #281, #282)
 
-[Unreleased]: https://github.com/NVIDIA/k8s-test-infra/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/NVIDIA/k8s-test-infra/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/NVIDIA/k8s-test-infra/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/NVIDIA/k8s-test-infra/releases/tag/v0.1.0

--- a/deployments/nvml-mock/helm/nvml-mock/Chart.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 name: nvml-mock
 description: Mock NVIDIA driver infrastructure for Kubernetes testing
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "550.163.01"
 # Minimum kubernetes version. Mounting the same hostPath volume at two
 # different mountPaths in one container (used by daemonset.yaml for the

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
@@ -438,7 +438,7 @@ should match snapshot with b200 profile:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.1.0
+        helm.sh/chart: nvml-mock-0.2.0
       name: RELEASE-NAME-nvml-mock-config
 should match snapshot with default a100 profile:
   1: |
@@ -875,7 +875,7 @@ should match snapshot with default a100 profile:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.1.0
+        helm.sh/chart: nvml-mock-0.2.0
       name: RELEASE-NAME-nvml-mock-config
 should match snapshot with gb200 profile:
   1: |
@@ -1366,7 +1366,7 @@ should match snapshot with gb200 profile:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.1.0
+        helm.sh/chart: nvml-mock-0.2.0
       name: RELEASE-NAME-nvml-mock-config
 should match snapshot with gb300 profile:
   1: |
@@ -1860,7 +1860,7 @@ should match snapshot with gb300 profile:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.1.0
+        helm.sh/chart: nvml-mock-0.2.0
       name: RELEASE-NAME-nvml-mock-config
 should match snapshot with h100 profile:
   1: |
@@ -2299,7 +2299,7 @@ should match snapshot with h100 profile:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.1.0
+        helm.sh/chart: nvml-mock-0.2.0
       name: RELEASE-NAME-nvml-mock-config
 should match snapshot with l40s profile:
   1: |
@@ -2707,7 +2707,7 @@ should match snapshot with l40s profile:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.1.0
+        helm.sh/chart: nvml-mock-0.2.0
       name: RELEASE-NAME-nvml-mock-config
 should match snapshot with t4 profile:
   1: |
@@ -3079,5 +3079,5 @@ should match snapshot with t4 profile:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.1.0
+        helm.sh/chart: nvml-mock-0.2.0
       name: RELEASE-NAME-nvml-mock-config

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot with all overrides:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.1.0
+        helm.sh/chart: nvml-mock-0.2.0
       name: nvml-mock-custom
     spec:
       selector:
@@ -123,7 +123,7 @@ should match snapshot with b200 profile:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.1.0
+        helm.sh/chart: nvml-mock-0.2.0
       name: RELEASE-NAME-nvml-mock
     spec:
       selector:
@@ -227,7 +227,7 @@ should match snapshot with default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.1.0
+        helm.sh/chart: nvml-mock-0.2.0
       name: RELEASE-NAME-nvml-mock
     spec:
       selector:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/rbac_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/rbac_test.yaml.snap
@@ -8,7 +8,7 @@ should match ClusterRole snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.1.0
+        helm.sh/chart: nvml-mock-0.2.0
       name: RELEASE-NAME-nvml-mock
     rules:
       - apiGroups:
@@ -28,7 +28,7 @@ should match ClusterRoleBinding snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.1.0
+        helm.sh/chart: nvml-mock-0.2.0
       name: RELEASE-NAME-nvml-mock
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -48,5 +48,5 @@ should match ServiceAccount snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.1.0
+        helm.sh/chart: nvml-mock-0.2.0
       name: RELEASE-NAME-nvml-mock

--- a/deployments/nvml-mock/helm/nvml-mock/tests/configmap_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/configmap_test.yaml
@@ -73,7 +73,7 @@ tests:
     asserts:
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: nvml-mock-0.1.0
+          value: nvml-mock-0.2.0
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
           value: nvml-mock

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -60,7 +60,7 @@ tests:
     asserts:
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: nvml-mock-0.1.0
+          value: nvml-mock-0.2.0
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
           value: nvml-mock

--- a/deployments/nvml-mock/helm/nvml-mock/tests/rbac_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/rbac_test.yaml
@@ -35,7 +35,7 @@ tests:
     asserts:
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: nvml-mock-0.1.0
+          value: nvml-mock-0.2.0
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
           value: nvml-mock
@@ -71,7 +71,7 @@ tests:
     asserts:
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: nvml-mock-0.1.0
+          value: nvml-mock-0.2.0
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
           value: nvml-mock
@@ -114,7 +114,7 @@ tests:
     asserts:
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: nvml-mock-0.1.0
+          value: nvml-mock-0.2.0
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
           value: nvml-mock


### PR DESCRIPTION
## Problem
Cutting v0.2.0. The chart version is read from Chart.yaml at publish time, the helm-unittest snapshots and three label assertions pin that version, and the changelog still carries everything since v0.1.0 under Unreleased.

## Approach
- Chart.yaml: 0.1.0 -> 0.2.0
- Regenerate helm-unittest snapshots; bump the five hard-coded helm.sh/chart label assertions
- CHANGELOG: roll Unreleased into [0.2.0] - 2026-06-12, add entries for #386 (testify/require standardization), #385 (bash 3.2 demo fix), #388 (chart cosign signing fix), and correct the stale 'always enabled' wording on the cross-node ibping entry (profile-gated since #367 final)

## Testing
helm unittest: 111/111 pass, 15/15 snapshots.

Merge order: after #388, so the chart publish triggered by this merge signs correctly. Tag v0.2.0 follows on this commit once publish is green.