### PR TITLE
fix(ci): retry helm push on ghcr tag-consistency flake

### DIFF
--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -48,12 +48,26 @@ jobs:
       - name: Package chart
         run: helm package ${{ env.CHART_DIR }}/${{ env.CHART_NAME }} --destination .cr-release-packages
 
+      # ghcr intermittently 404s the tag operation right after a fresh
+      # manifest upload ("failed to perform Tag ...: not found"), leaving an
+      # untagged package version behind; a short retry finds the
+      # already-uploaded manifest and tags it.
       - name: Push chart to OCI registry
         id: push
         run: |
           set -o pipefail
-          helm push .cr-release-packages/${{ env.CHART_NAME }}-${{ steps.chart.outputs.version }}.tgz \
-            oci://ghcr.io/nvidia/k8s-test-infra/chart 2>&1 | tee push.log
+          for attempt in 1 2 3; do
+            if helm push .cr-release-packages/${{ env.CHART_NAME }}-${{ steps.chart.outputs.version }}.tgz \
+              oci://ghcr.io/nvidia/k8s-test-infra/chart 2>&1 | tee push.log; then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "helm push failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+            echo "helm push attempt ${attempt} failed; retrying in 10s" >&2
+            sleep 10
+          done
           digest=$(awk '/^Digest:/ {print $2}' push.log)
           if [ -z "${digest}" ]; then
             echo "could not extract chart digest from helm push output" >&2


### PR DESCRIPTION
## Problem
On freshly-built chart versions, helm push to oci://ghcr.io/nvidia/k8s-test-infra/chart intermittently fails with: failed to perform "Tag" on destination: sha256:...: not found. The manifest upload succeeds (an untagged package version appears on ghcr) but the immediate tag operation 404s — read-after-write lag on the registry. Hit on run 27402415484 publishing chart 0.2.0 (succeeded on manual rerun); matching untagged orphans exist from 2026-05-07/08/25.

## Approach
Wrap helm push in a 3-attempt loop with a 10s pause. A retry finds the already-uploaded manifest and only needs the tag write — the same thing the manual rerun did. The set -o pipefail / tee push.log / digest extraction from #388 is preserved and still gates signing.

Not included: deleting the existing orphaned untagged package versions. They are cosmetic; if wanted, a one-time cleanup via the packages API is safer done by hand than automated (the chart signature artifacts live in the same package as sha256-* tagged versions).

## Testing
actionlint clean. Exercised on the next chart-version bump; behavior identical to today's flow when the first push succeeds.