### PR TITLE
fix(ci): publish image on tag pushes; add workflow_dispatch

### DIFF
--- a/.github/workflows/nvml-mock-publish.yaml
+++ b/.github/workflows/nvml-mock-publish.yaml
@@ -4,16 +4,18 @@ name: nvml-mock Publish
 
 permissions: {}
 
+# No paths filter here: GitHub applies paths filters to tag pushes too, and
+# a tag push has no changed-files diff, so a paths filter silently suppresses
+# every tag-triggered run (the v0.2.0 tag published no image until it was
+# retagged by hand). workflow_dispatch allows re-running a publish at any ref
+# without re-pushing tags.
 on:
   push:
     branches:
       - main
     tags:
       - 'v*'
-    paths:
-      - 'pkg/gpu/**'
-      - 'deployments/nvml-mock/**'
-      - '.github/workflows/nvml-mock-publish.yaml'
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -77,7 +79,7 @@ jobs:
       - name: Sign container image
         run: |
           cosign sign --yes \
-            $(echo "${{ steps.meta.outputs.tags }}" | head -1)
+            "$(echo "${{ steps.meta.outputs.tags }}" | head -1)"
         env:
           COSIGN_EXPERIMENTAL: "true"
 
@@ -94,4 +96,4 @@ jobs:
         run: |
           cosign attest --yes --predicate sbom.spdx.json \
             --type spdxjson \
-            $(echo "${{ steps.meta.outputs.tags }}" | head -1)
+            "$(echo "${{ steps.meta.outputs.tags }}" | head -1)"


### PR DESCRIPTION
## Problem
nvml-mock-publish.yaml combined on.push tags: ['v*'] with a paths: filter. GitHub applies paths filters to tag pushes too, and a tag push has no changed-files diff, so tag pushes NEVER triggered the workflow. Today's v0.2.0 tag produced zero publish runs; the 0.2.0/0.2 image tags had to be created manually with docker buildx imagetools create from the sha-0f0572c image (digest-preserving, so cosign signatures still applied).

## Approach
- Drop the paths filter instead of splitting the workflow or adding a changed-files job: the repo is public (runner minutes free), main merges are infrequent, and the filter's only benefit was skipping image rebuilds for unrelated pushes — at the cost of breaking every release. A comment in the trigger block documents why no paths filter may be re-added.
- Add workflow_dispatch so a publish can be re-run at any ref without re-pushing tags. docker/metadata-action needs no changes: semver tags activate on tag refs, latest on the default branch, sha tags always.
- Quote the two cosign target command substitutions flagged by actionlint (SC2046) so the file lints clean.

## Testing
actionlint clean. Verifiable post-merge by dispatching the workflow at the v0.2.0 ref (idempotent: re-pushes the same tags) or on the next release tag.

Companion: #390 (helm push retry).