### PR TITLE
fix(mocknvml): NOT_FOUND for unknown UUID; repair tests/mocknvml build

### DIFF
--- a/pkg/gpu/mocknvml/engine/engine.go
+++ b/pkg/gpu/mocknvml/engine/engine.go
@@ -178,8 +178,12 @@ func (e *Engine) createDefaultDevices(server *MockServer, base *dgxa100.Server) 
 			continue
 		}
 
-		// Deterministic UUID and PCI bus ID based on device index.
-		uuid := fmt.Sprintf("GPU-00000000-0000-0000-0000-%012d", i)
+		// Deterministic UUID and PCI bus ID based on device index. The first
+		// hex group spells "MOCK" (0x4d4f434b) so that no device ever carries
+		// the all-zeros nil UUID: real GPUs never report it, and NVML
+		// consumers use it as the canonical nonexistent-UUID probe, which
+		// DeviceGetHandleByUUID must answer with ERROR_NOT_FOUND.
+		uuid := fmt.Sprintf("GPU-4d4f434b-0000-0000-0000-%012d", i)
 		pciBusID := fmt.Sprintf("0000:%02X:00.0", i+1)
 
 		server.configurableDevices[i] = NewConfigurableDevice(

--- a/pkg/gpu/mocknvml/engine/engine_test.go
+++ b/pkg/gpu/mocknvml/engine/engine_test.go
@@ -16,6 +16,7 @@ package engine
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
@@ -265,13 +266,106 @@ func TestEngine_DeviceGetHandleByUUID(t *testing.T) {
 	require.Equal(t, handle, handleByUUID, "Expected same handle for same device")
 }
 
-func TestEngine_DeviceGetHandleByUUIDInvalid(t *testing.T) {
-	e := NewEngine(nil)
-	_ = e.Init()
+// TestEngine_DeviceGetHandleByUUID_UnknownUUID verifies that UUID lookup
+// misses surface as ERROR_NOT_FOUND, matching real NVML semantics: NOT_FOUND
+// signals a lookup miss (same convention as GetMigDeviceHandleByIndex), while
+// NOT_SUPPORTED would be fatal to consumers. The all-zeros nil UUID is the
+// canonical nonexistent-UUID probe (used by tests/mocknvml
+// boundary/uuid_invalid) and must never resolve to a device.
+func TestEngine_DeviceGetHandleByUUID_UnknownUUID(t *testing.T) {
+	e := NewEngine(&Config{NumDevices: 4, DriverVersion: "550.54.15"})
+	require.Equal(t, nvml.SUCCESS, e.Init(), "Init failed")
 	defer func() { _ = e.Shutdown() }()
 
-	_, ret := e.DeviceGetHandleByUUID("invalid-uuid-12345")
-	require.NotEqual(t, nvml.SUCCESS, ret, "Expected error for invalid UUID")
+	// Derive a known-good UUID through the index path, independently of the
+	// UUID lookup under test.
+	handle, ret := e.DeviceGetHandleByIndex(0)
+	require.Equal(t, nvml.SUCCESS, ret, "DeviceGetHandleByIndex failed")
+	knownUUID, ret := e.LookupDevice(handle).GetUUID()
+	require.Equal(t, nvml.SUCCESS, ret, "GetUUID failed")
+
+	tests := []struct {
+		name string
+		uuid string
+		want nvml.Return
+	}{
+		{"known UUID resolves", knownUUID, nvml.SUCCESS},
+		{"nil UUID is not a device", "GPU-00000000-0000-0000-0000-000000000000", nvml.ERROR_NOT_FOUND},
+		{"well-formed unknown UUID", "GPU-ffffffff-ffff-ffff-ffff-ffffffffffff", nvml.ERROR_NOT_FOUND},
+		{"malformed UUID", "invalid-uuid-12345", nvml.ERROR_NOT_FOUND},
+		{"missing GPU- prefix", strings.TrimPrefix(knownUUID, "GPU-"), nvml.ERROR_NOT_FOUND},
+		{"empty string", "", nvml.ERROR_NOT_FOUND},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ret := e.DeviceGetHandleByUUID(tc.uuid)
+			require.Equal(t, tc.want, ret, "DeviceGetHandleByUUID(%q)", tc.uuid)
+		})
+	}
+}
+
+// TestEngine_DeviceGetHandleByUUID_ExactMatch pins the lookup's matching
+// semantics: byte-exact comparison with no case folding and no prefix
+// normalization, consistent with how YAML profiles declare UUIDs.
+func TestEngine_DeviceGetHandleByUUID_ExactMatch(t *testing.T) {
+	const configuredUUID = "GPU-AaBbCcDd-1111-2222-3333-444455556666"
+	e := NewEngine(&Config{
+		NumDevices:    1,
+		DriverVersion: "550.54.15",
+		YAMLConfig: &YAMLConfig{
+			System:  SystemConfig{NumDevices: 1, DriverVersion: "550.54.15"},
+			Devices: []DeviceOverride{{Index: 0, UUID: configuredUUID}},
+		},
+	})
+	require.Equal(t, nvml.SUCCESS, e.Init(), "Init failed")
+	defer func() { _ = e.Shutdown() }()
+
+	tests := []struct {
+		name string
+		uuid string
+		want nvml.Return
+	}{
+		{"exact case resolves", configuredUUID, nvml.SUCCESS},
+		{"lowercased variant misses", strings.ToLower(configuredUUID), nvml.ERROR_NOT_FOUND},
+		{"uppercased variant misses", strings.ToUpper(configuredUUID), nvml.ERROR_NOT_FOUND},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ret := e.DeviceGetHandleByUUID(tc.uuid)
+			require.Equal(t, tc.want, ret, "DeviceGetHandleByUUID(%q)", tc.uuid)
+		})
+	}
+}
+
+// TestEngine_DefaultDeviceUUIDs verifies the deterministic UUIDs assigned in
+// legacy env-var mode (no YAML config): GPU- prefixed, unique per index,
+// never the all-zeros nil UUID, and round-trippable through
+// DeviceGetHandleByUUID. Determinism across processes is required for shared
+// GPU scenarios, but the nil UUID must stay free so that lookups of it
+// report ERROR_NOT_FOUND.
+func TestEngine_DefaultDeviceUUIDs(t *testing.T) {
+	e := NewEngine(&Config{NumDevices: MaxDevices, DriverVersion: "550.54.15"})
+	require.Equal(t, nvml.SUCCESS, e.Init(), "Init failed")
+	defer func() { _ = e.Shutdown() }()
+
+	seen := make(map[string]int, MaxDevices)
+	for i := 0; i < MaxDevices; i++ {
+		handle, ret := e.DeviceGetHandleByIndex(i)
+		require.Equal(t, nvml.SUCCESS, ret, "DeviceGetHandleByIndex(%d) failed", i)
+		uuid, ret := e.LookupDevice(handle).GetUUID()
+		require.Equal(t, nvml.SUCCESS, ret, "GetUUID for device %d failed", i)
+
+		require.True(t, strings.HasPrefix(uuid, "GPU-"), "device %d UUID %q must carry the GPU- prefix", i, uuid)
+		require.NotEqual(t, "GPU-00000000-0000-0000-0000-000000000000", uuid, "device %d must not carry the nil UUID", i)
+		prev, dup := seen[uuid]
+		require.False(t, dup, "device %d reuses UUID %q of device %d", i, uuid, prev)
+		seen[uuid] = i
+
+		// Round-trip: the UUID a device reports must resolve back to it.
+		rtHandle, ret := e.DeviceGetHandleByUUID(uuid)
+		require.Equal(t, nvml.SUCCESS, ret, "device %d UUID %q must round-trip through DeviceGetHandleByUUID", i, uuid)
+		require.Equal(t, handle, rtHandle, "device %d round-trip returned a different handle", i)
+	}
 }
 
 func TestEngine_DeviceGetHandleByPciBusId(t *testing.T) {

--- a/tests/mocknvml/Dockerfile
+++ b/tests/mocknvml/Dockerfile
@@ -38,7 +38,7 @@ COPY tests/mocknvml/go.mod tests/mocknvml/go.sum* ./
 RUN go mod download
 
 COPY tests/mocknvml/*.go ./
-RUN CGO_ENABLED=1 go build -o mocknvml-test main.go
+RUN CGO_ENABLED=1 go build -o mocknvml-test .
 
 # Runtime stage
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Problem

Two bugs from the 2026-06-12 audit (#393):

1. **`nvmlDeviceGetHandleByUUID` returns SUCCESS for a nonexistent UUID** (#393 section A). The lookup logic itself was correct — the real bug is that legacy env-var mode (`createDefaultDevices`) assigned device 0 the UUID `GPU-00000000-0000-0000-0000-000000000000`, the all-zeros nil UUID that NVML consumers (including our own `boundary/uuid_invalid` bridge test) use as the canonical nonexistent-UUID probe. The probe therefore resolved to a real device and returned SUCCESS where real NVML reports `NVML_ERROR_NOT_FOUND`. Real GPUs never carry the nil UUID.

2. **`tests/mocknvml` harness no longer builds** (#393 section B, regression from #269). `tests/mocknvml/Dockerfile` compiled the harness with `go build -o mocknvml-test main.go` (file-list mode). #269 added `bridge_tests.go` with `runBridgeTests`, called from `main.go` — file-list mode excludes it, so the image build fails with `undefined: runBridgeTests` and `make test` has been broken since. No CI workflow runs this suite, so nothing caught it.

## Approach

- `pkg/gpu/mocknvml/engine/engine.go`: keep the default-mode UUID scheme deterministic per index (required so multiple processes sharing a device agree on its identity), but move the first hex group to `4d4f434b` ("MOCK" in ASCII hex). The nil UUID is now permanently unassigned, so looking it up reports `ERROR_NOT_FOUND` — matching the established lookup-miss convention (NOT_FOUND = miss, NOT_SUPPORTED = fatal, as with `GetMigDeviceHandleByIndex`).
- `tests/mocknvml/Dockerfile`: build the whole package (`go build -o mocknvml-test .`) instead of just `main.go`.
- TDD: tests landed first in their own commit and fail on main (`nil UUID is not a device` gets SUCCESS; `TestEngine_DefaultDeviceUUIDs` sees the nil UUID on device 0).

## Testing

- New table-driven engine tests (`engine_test.go`): unknown-UUID misses (nil UUID, well-formed unknown, malformed, missing `GPU-` prefix, empty string), byte-exact match semantics (no case folding), and default-mode UUID invariants (`GPU-` prefix, uniqueness, nil-free, `GetUUID` → `GetHandleByUUID` round-trip, same handle back).
- `go build ./...` clean; `go test -race ./pkg/gpu/mocknvml/...` green; `golangci-lint run ./pkg/gpu/mocknvml/...` 0 issues.
- Containerized suite: `make -C tests/mocknvml test` now builds and passes **25/25** (was: image build failure; with the build patched manually, 24 passed / 1 failed on `boundary/uuid_invalid`):

  ```
  PASS  boundary/uuid_invalid (correctly returned: ERROR_NOT_FOUND)
  ...
  === Bridge Tests: 25 passed, 0 failed ===
  ```

- Observation while running the suite (pre-existing, untouched here): the `errstr/*` subtests pass but log garbled detail strings (e.g. `errstr/UNINITIALIZED (}&a?...ZED)`), which looks like a C-string lifetime issue in the harness's error-string reporting — worth a follow-up under #393.

Refs #393 (sections A1 and B1)