### PR TITLE
fix(mockib): connection deadlines, ctx cancellation, bounded recv wait, GUID fallback, quieter re-register

### DIFF
--- a/pkg/network/mockib/daemon/discover.go
+++ b/pkg/network/mockib/daemon/discover.go
@@ -8,6 +8,11 @@ import (
 	"net"
 )
 
+// lookupHost is a seam over the default resolver: hosts-file fast paths
+// complete without honoring ctx, so ctx-cancellation behavior can only be
+// tested against a substituted resolver.
+var lookupHost = net.DefaultResolver.LookupHost
+
 // DiscoverPeerIPs resolves a headless Kubernetes service DNS name to pod IPs,
 // excluding selfIP. Used when MOCK_IB_PEERS is unset and MOCK_IB_PING_SERVICE_HOST
 // points at the chart's -ibping Service (clusterIP: None). Resolution honors
@@ -16,7 +21,7 @@ func DiscoverPeerIPs(ctx context.Context, serviceHost, selfIP string) []string {
 	if serviceHost == "" {
 		return nil
 	}
-	addrs, err := net.DefaultResolver.LookupHost(ctx, serviceHost)
+	addrs, err := lookupHost(ctx, serviceHost)
 	if err != nil {
 		return nil
 	}

--- a/pkg/network/mockib/daemon/discover.go
+++ b/pkg/network/mockib/daemon/discover.go
@@ -3,16 +3,20 @@
 
 package daemon
 
-import "net"
+import (
+	"context"
+	"net"
+)
 
 // DiscoverPeerIPs resolves a headless Kubernetes service DNS name to pod IPs,
 // excluding selfIP. Used when MOCK_IB_PEERS is unset and MOCK_IB_PING_SERVICE_HOST
-// points at the chart's -ibping Service (clusterIP: None).
-func DiscoverPeerIPs(serviceHost, selfIP string) []string {
+// points at the chart's -ibping Service (clusterIP: None). Resolution honors
+// ctx so daemon shutdown is not held up by a slow or unresponsive resolver.
+func DiscoverPeerIPs(ctx context.Context, serviceHost, selfIP string) []string {
 	if serviceHost == "" {
 		return nil
 	}
-	addrs, err := net.LookupHost(serviceHost)
+	addrs, err := net.DefaultResolver.LookupHost(ctx, serviceHost)
 	if err != nil {
 		return nil
 	}

--- a/pkg/network/mockib/daemon/discover_test.go
+++ b/pkg/network/mockib/daemon/discover_test.go
@@ -4,6 +4,7 @@
 package daemon
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,6 +12,18 @@ import (
 
 func TestDiscoverPeerIPs_FiltersSelf(t *testing.T) {
 	// Unit test uses empty host; integration uses real DNS in cluster.
-	got := DiscoverPeerIPs("", "10.0.0.1")
+	got := DiscoverPeerIPs(context.Background(), "", "10.0.0.1")
 	require.Empty(t, got)
+}
+
+// TestDiscoverPeerIPs_CancelledCtxAborts pins that DNS resolution honors the
+// caller's ctx: a canceled ctx (daemon shutdown mid-register-loop) must abort
+// the lookup instead of blocking on the resolver. "localhost" resolves from
+// the hosts file everywhere, so a non-ctx-aware lookup would return addresses
+// here and fail the test.
+func TestDiscoverPeerIPs_CancelledCtxAborts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	got := DiscoverPeerIPs(ctx, "localhost", "")
+	require.Empty(t, got, "canceled ctx must abort DNS resolution")
 }

--- a/pkg/network/mockib/daemon/discover_test.go
+++ b/pkg/network/mockib/daemon/discover_test.go
@@ -18,12 +18,21 @@ func TestDiscoverPeerIPs_FiltersSelf(t *testing.T) {
 
 // TestDiscoverPeerIPs_CancelledCtxAborts pins that DNS resolution honors the
 // caller's ctx: a canceled ctx (daemon shutdown mid-register-loop) must abort
-// the lookup instead of blocking on the resolver. "localhost" resolves from
-// the hosts file everywhere, so a non-ctx-aware lookup would return addresses
-// here and fail the test.
+// the lookup instead of blocking on the resolver. The resolver is faked via
+// the lookupHost seam because hosts-file fast paths resolve names without
+// ever reaching a cancellation point (resolving "localhost" here passed on
+// darwin and failed on linux runners), while real in-cluster resolution goes
+// through DNS where ctx is the only bound on a hang.
 func TestDiscoverPeerIPs_CancelledCtxAborts(t *testing.T) {
+	orig := lookupHost
+	t.Cleanup(func() { lookupHost = orig })
+	lookupHost = func(ctx context.Context, _ string) ([]string, error) {
+		<-ctx.Done() // a hung resolver: only ctx cancellation releases it
+		return nil, ctx.Err()
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	got := DiscoverPeerIPs(ctx, "localhost", "")
+	got := DiscoverPeerIPs(ctx, "mock-ib-ibping.default.svc", "")
 	require.Empty(t, got, "canceled ctx must abort DNS resolution")
 }

--- a/pkg/network/mockib/daemon/fabric.go
+++ b/pkg/network/mockib/daemon/fabric.go
@@ -126,8 +126,9 @@ func (s *Server) dispatchFabric(c net.Conn, env protocol.Envelope) error {
 }
 
 func (s *Server) applyRegister(body protocol.RegisterBody) {
-	for _, port := range body.Ports {
-		s.registry.Register(port.PortGUID, registry.Peer{
+	changed := make([]bool, len(body.Ports))
+	for i, port := range body.Ports {
+		changed[i] = s.registry.Register(port.PortGUID, registry.Peer{
 			PodIP:    body.PodIP,
 			NodeName: body.NodeName,
 			CAName:   port.CAName,
@@ -136,12 +137,17 @@ func (s *Server) applyRegister(body protocol.RegisterBody) {
 		})
 	}
 	s.rebuildGraph()
-	// Unconditional log so cross-pod REGISTER outcomes are visible in
-	// kubectl logs without enabling per-feature debug flags. Cross-release
-	// ibping (ibping-multinode CI job) depends on this REGISTER reaching every
-	// peer; absence of this line on a pod immediately tells us the one-shot
-	// `mock-ib -register-peers` did not arrive (TCP firewall, wrong port, ...).
-	for _, port := range body.Ports {
+	// Log so cross-pod REGISTER outcomes are visible in kubectl logs without
+	// enabling per-feature debug flags. Cross-release ibping (ibping-multinode
+	// CI job) depends on this REGISTER reaching every peer; absence of this
+	// line on a pod immediately tells us the one-shot `mock-ib -register-peers`
+	// did not arrive (TCP firewall, wrong port, ...). Peers re-register every
+	// 2s, so only changed registrations are logged: the first one and any
+	// later LID/PodIP/node change, not the steady-state repeats.
+	for i, port := range body.Ports {
+		if !changed[i] {
+			continue
+		}
 		s.log.Printf("mock-ib: register from podIP=%s node=%q ca=%s port=%d lid=0x%04x port_guid=%s",
 			body.PodIP, body.NodeName, port.CAName, port.Port, port.LID, port.PortGUID)
 	}

--- a/pkg/network/mockib/daemon/fabric.go
+++ b/pkg/network/mockib/daemon/fabric.go
@@ -280,9 +280,15 @@ func (s *Server) sendRegister(peerIP string, body protocol.RegisterBody) error {
 		return err
 	}
 	defer func() { _ = conn.Close() }()
-	// Mirror pingPeer: bound the write so a peer that accepts but never reads
-	// cannot wedge the sequential registerWithPeersLoop forever.
-	if err := conn.SetDeadline(time.Now().Add(fabricPeerIOTimeout)); err != nil {
+	return writeRegister(conn, fabricPeerIOTimeout, body)
+}
+
+// writeRegister bounds the REGISTER write so a peer that accepts but never
+// reads cannot wedge the sequential registerWithPeersLoop forever (mirrors
+// pingPeer). Split from sendRegister so the deadline path is testable against
+// an unbuffered net.Pipe instead of kernel-buffered TCP sockets.
+func writeRegister(conn net.Conn, timeout time.Duration, body protocol.RegisterBody) error {
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
 		return err
 	}
 	return protocol.WriteMessage(conn, protocol.TypeRegister, body)

--- a/pkg/network/mockib/daemon/fabric.go
+++ b/pkg/network/mockib/daemon/fabric.go
@@ -264,22 +264,27 @@ func (s *Server) RegisterWithPeers() {
 
 func (s *Server) sendRegister(peerIP string, body protocol.RegisterBody) error {
 	addr := net.JoinHostPort(peerIP, strconv.Itoa(s.cfg.TCPPort))
-	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	conn, err := net.DialTimeout("tcp", addr, fabricPeerIOTimeout)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = conn.Close() }()
+	// Mirror pingPeer: bound the write so a peer that accepts but never reads
+	// cannot wedge the sequential registerWithPeersLoop forever.
+	if err := conn.SetDeadline(time.Now().Add(fabricPeerIOTimeout)); err != nil {
+		return err
+	}
 	return protocol.WriteMessage(conn, protocol.TypeRegister, body)
 }
 
 func (s *Server) pingPeer(peerIP, portGUID string, dstLID uint16) error {
 	addr := net.JoinHostPort(peerIP, strconv.Itoa(s.cfg.TCPPort))
-	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	conn, err := net.DialTimeout("tcp", addr, fabricPeerIOTimeout)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = conn.Close() }()
-	if err := conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+	if err := conn.SetDeadline(time.Now().Add(fabricPeerIOTimeout)); err != nil {
 		return err
 	}
 

--- a/pkg/network/mockib/daemon/fabric.go
+++ b/pkg/network/mockib/daemon/fabric.go
@@ -187,7 +187,7 @@ func (s *Server) pingTargetsLocalPort(ping protocol.PingBody) bool {
 func (s *Server) registerWithPeers(ctx context.Context) {
 	peers := ParsePeerList(EnvOr(EnvMockIBPeers, ""))
 	if len(peers) == 0 {
-		peers = DiscoverPeerIPs(EnvOr(EnvMockIBPingServiceHost, ""), s.podIP)
+		peers = DiscoverPeerIPs(ctx, EnvOr(EnvMockIBPingServiceHost, ""), s.podIP)
 	}
 	if len(peers) == 0 {
 		return
@@ -200,6 +200,11 @@ func (s *Server) registerWithPeers(ctx context.Context) {
 	wantPeers := 0
 	var ok int
 	for _, peerIP := range peers {
+		// Sequential sweep with up-to-5s dials per peer: once ctx is canceled
+		// (SIGTERM), stop between peers instead of walking the rest of the list.
+		if ctx.Err() != nil {
+			return
+		}
 		if peerIP == s.podIP {
 			continue
 		}

--- a/pkg/network/mockib/daemon/fabric_register_test.go
+++ b/pkg/network/mockib/daemon/fabric_register_test.go
@@ -6,7 +6,10 @@ package daemon
 import (
 	"context"
 	"net"
+	"os"
 	"strconv"
+	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -15,6 +18,72 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/render"
 	"github.com/stretchr/testify/require"
 )
+
+// TestServer_sendRegister_StalledPeerTimesOut pins the I/O deadline on
+// outbound REGISTER connections. A peer that accepts the TCP connection but
+// never reads (wedged pod, half-open conn) must not hang sendRegister forever:
+// registerWithPeersLoop is sequential, so one stuck write silently stops
+// re-registration to every peer for the rest of the pod's life.
+//
+// The register body is sized near the 1 MiB frame cap and the listener's
+// receive buffer is pinned small (accepted sockets inherit SO_RCVBUF from the
+// listening socket on Linux and macOS) so the kernel cannot absorb the whole
+// frame and the write genuinely blocks until the deadline fires.
+func TestServer_sendRegister_StalledPeerTimesOut(t *testing.T) {
+	lc := net.ListenConfig{Control: func(_, _ string, c syscall.RawConn) error {
+		var serr error
+		if err := c.Control(func(fd uintptr) {
+			serr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, 4096)
+		}); err != nil {
+			return err
+		}
+		return serr
+	}}
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	_, portStr, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+	tcpPort, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	// Accept and hold the connection open without ever reading from it.
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		accepted <- c
+	}()
+	t.Cleanup(func() {
+		select {
+		case c := <-accepted:
+			_ = c.Close()
+		default:
+		}
+	})
+
+	srv := &Server{cfg: Config{TCPPort: tcpPort}}
+	body := protocol.RegisterBody{
+		// ~1000 KiB of payload: above loopback socket buffering, below the
+		// protocol.MaxFrameSize (1 MiB) frame cap.
+		NodeName: strings.Repeat("n", 1000*1024),
+		PodIP:    "10.0.0.2",
+	}
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() { done <- srv.sendRegister("127.0.0.1", body) }()
+	select {
+	case err := <-done:
+		require.Error(t, err, "write to a peer that never reads must fail once the deadline expires")
+		require.ErrorIs(t, err, os.ErrDeadlineExceeded, "want deadline error, got: %v", err)
+		require.Less(t, time.Since(start), 20*time.Second, "sendRegister must return around the 5s I/O deadline")
+	case <-time.After(25 * time.Second):
+		t.Fatal("sendRegister hung: no I/O deadline set on the fabric connection")
+	}
+}
 
 func TestServer_sendRegister(t *testing.T) {
 	dir := t.TempDir()

--- a/pkg/network/mockib/daemon/fabric_register_test.go
+++ b/pkg/network/mockib/daemon/fabric_register_test.go
@@ -4,7 +4,9 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
+	"log"
 	"net"
 	"os"
 	"strconv"
@@ -15,9 +17,46 @@ import (
 
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/config"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/protocol"
+	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/registry"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/render"
 	"github.com/stretchr/testify/require"
 )
+
+// TestApplyRegister_LogsOnlyOnChange pins REGISTER log volume: peers
+// re-register every 2s, so an unchanged registration must stay silent
+// (~86k lines/day per port otherwise) while the first registration and any
+// change keep the existing per-port log line for kubectl-logs debuggability.
+func TestApplyRegister_LogsOnlyOnChange(t *testing.T) {
+	var buf bytes.Buffer
+	srv := &Server{registry: registry.New(), log: log.New(&buf, "", 0)}
+	body := protocol.RegisterBody{
+		NodeName: "node-b",
+		PodIP:    "10.0.0.2",
+		Ports: []protocol.PortAdvert{
+			{PortGUID: "a088:c203:00ab:2001", LID: 0x0300, CAName: "mlx5_0", Port: 1},
+			{PortGUID: "a088:c203:00ab:2002", LID: 0x0301, CAName: "mlx5_1", Port: 1},
+		},
+	}
+
+	srv.applyRegister(body)
+	require.Equal(t, 2, strings.Count(buf.String(), "register from"),
+		"first REGISTER must log every port:\n%s", buf.String())
+	// First-registration log content must stay identical (CI greps depend on it).
+	require.Contains(t, buf.String(),
+		`mock-ib: register from podIP=10.0.0.2 node="node-b" ca=mlx5_0 port=1 lid=0x0300 port_guid=a088:c203:00ab:2001`)
+
+	// Identical 2s re-register: no new lines.
+	srv.applyRegister(body)
+	require.Equal(t, 2, strings.Count(buf.String(), "register from"),
+		"unchanged re-register must not log:\n%s", buf.String())
+
+	// LID change on one port: exactly one new line, for the changed port.
+	body.Ports[1].LID = 0x0999
+	srv.applyRegister(body)
+	require.Equal(t, 3, strings.Count(buf.String(), "register from"),
+		"changed port must log exactly once:\n%s", buf.String())
+	require.Contains(t, buf.String(), "lid=0x0999")
+}
 
 // TestServer_sendRegister_StalledPeerTimesOut pins the I/O deadline on
 // outbound REGISTER connections. A peer that accepts the TCP connection but

--- a/pkg/network/mockib/daemon/fabric_register_test.go
+++ b/pkg/network/mockib/daemon/fabric_register_test.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
-	"syscall"
 	"testing"
 	"time"
 
@@ -101,70 +100,30 @@ func TestRegisterWithPeers_CancelledCtxMakesNoDials(t *testing.T) {
 	require.Zero(t, accepts.Load(), "canceled ctx must stop the sweep before any peer dial")
 }
 
-// TestServer_sendRegister_StalledPeerTimesOut pins the I/O deadline on
-// outbound REGISTER connections. A peer that accepts the TCP connection but
-// never reads (wedged pod, half-open conn) must not hang sendRegister forever:
+// TestWriteRegister_StalledPeerTimesOut pins the I/O deadline on outbound
+// REGISTER writes. A peer that accepts the TCP connection but never reads
+// (wedged pod, half-open conn) must not hang the write forever:
 // registerWithPeersLoop is sequential, so one stuck write silently stops
 // re-registration to every peer for the rest of the pod's life.
 //
-// The register body is sized near the 1 MiB frame cap and the listener's
-// receive buffer is pinned small (accepted sockets inherit SO_RCVBUF from the
-// listening socket on Linux and macOS) so the kernel cannot absorb the whole
-// frame and the write genuinely blocks until the deadline fires.
-func TestServer_sendRegister_StalledPeerTimesOut(t *testing.T) {
-	lc := net.ListenConfig{Control: func(_, _ string, c syscall.RawConn) error {
-		var serr error
-		if err := c.Control(func(fd uintptr) {
-			serr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, 4096)
-		}); err != nil {
-			return err
-		}
-		return serr
-	}}
-	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = ln.Close() })
-	_, portStr, err := net.SplitHostPort(ln.Addr().String())
-	require.NoError(t, err)
-	tcpPort, err := strconv.Atoi(portStr)
-	require.NoError(t, err)
-
-	// Accept and hold the connection open without ever reading from it.
-	accepted := make(chan net.Conn, 1)
-	go func() {
-		c, err := ln.Accept()
-		if err != nil {
-			return
-		}
-		accepted <- c
-	}()
-	t.Cleanup(func() {
-		select {
-		case c := <-accepted:
-			_ = c.Close()
-		default:
-		}
-	})
-
-	srv := &Server{cfg: Config{TCPPort: tcpPort}}
-	body := protocol.RegisterBody{
-		// ~1000 KiB of payload: above loopback socket buffering, below the
-		// protocol.MaxFrameSize (1 MiB) frame cap.
-		NodeName: strings.Repeat("n", 1000*1024),
-		PodIP:    "10.0.0.2",
-	}
+// The write is exercised through an unbuffered net.Pipe rather than a real
+// TCP socket: kernel sockets absorb writes into tunable buffers (an SO_RCVBUF
+// variant of this test passed on darwin and failed on linux runners), while a
+// pipe write blocks until the far side reads, so the deadline path fires
+// deterministically on every platform.
+func TestWriteRegister_StalledPeerTimesOut(t *testing.T) {
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
+	// The server side never reads.
 
 	start := time.Now()
-	done := make(chan error, 1)
-	go func() { done <- srv.sendRegister("127.0.0.1", body) }()
-	select {
-	case err := <-done:
-		require.Error(t, err, "write to a peer that never reads must fail once the deadline expires")
-		require.ErrorIs(t, err, os.ErrDeadlineExceeded, "want deadline error, got: %v", err)
-		require.Less(t, time.Since(start), 20*time.Second, "sendRegister must return around the 5s I/O deadline")
-	case <-time.After(25 * time.Second):
-		t.Fatal("sendRegister hung: no I/O deadline set on the fabric connection")
-	}
+	err := writeRegister(client, 50*time.Millisecond, protocol.RegisterBody{
+		NodeName: "node-b",
+		PodIP:    "10.0.0.2",
+	})
+	require.Error(t, err, "write to a peer that never reads must fail once the deadline expires")
+	require.ErrorIs(t, err, os.ErrDeadlineExceeded, "want deadline error, got: %v", err)
+	require.Less(t, time.Since(start), 5*time.Second, "writeRegister must return at the configured deadline")
 }
 
 func TestServer_sendRegister(t *testing.T) {

--- a/pkg/network/mockib/daemon/fabric_register_test.go
+++ b/pkg/network/mockib/daemon/fabric_register_test.go
@@ -6,11 +6,13 @@ package daemon
 import (
 	"bytes"
 	"context"
+	"io"
 	"log"
 	"net"
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -56,6 +58,47 @@ func TestApplyRegister_LogsOnlyOnChange(t *testing.T) {
 	require.Equal(t, 3, strings.Count(buf.String(), "register from"),
 		"changed port must log exactly once:\n%s", buf.String())
 	require.Contains(t, buf.String(), "lid=0x0999")
+}
+
+// TestRegisterWithPeers_CancelledCtxMakesNoDials pins ctx handling in the
+// peer register sweep: registerWithPeers checks ctx between peers (post-SIGTERM
+// the sequential loop must stop, not keep dialing through the list), so with
+// ctx already canceled before the sweep, not a single peer may be dialed.
+func TestRegisterWithPeers_CancelledCtxMakesNoDials(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	var accepts atomic.Int32
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			accepts.Add(1)
+			_ = c.Close()
+		}
+	}()
+	_, portStr, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+	tcpPort, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	t.Setenv(EnvMockIBPeers, "127.0.0.1")
+	srv := &Server{
+		cfg:            Config{TCPPort: tcpPort},
+		podIP:          "10.255.255.1", // must differ from the peer so it is not skipped as self
+		log:            log.New(io.Discard, "", 0),
+		registerWarned: make(map[string]struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	srv.registerWithPeers(ctx)
+
+	// Give a stray dial time to reach the accept loop before judging.
+	time.Sleep(300 * time.Millisecond)
+	require.Zero(t, accepts.Load(), "canceled ctx must stop the sweep before any peer dial")
 }
 
 // TestServer_sendRegister_StalledPeerTimesOut pins the I/O deadline on

--- a/pkg/network/mockib/daemon/server.go
+++ b/pkg/network/mockib/daemon/server.go
@@ -42,6 +42,11 @@ const (
 	// single REGISTER or Ping/Pong round-trip; a peer that connects to the
 	// 0.0.0.0 listener but never completes a frame is reaped quickly.
 	fabricConnIdleTimeout = 30 * time.Second
+	// fabricPeerIOTimeout bounds the dial and the whole exchange on outbound
+	// fabric connections (REGISTER, Ping). registerWithPeersLoop walks peers
+	// sequentially, so a peer that accepts but never reads or replies must not
+	// pin the loop past this deadline.
+	fabricPeerIOTimeout = 5 * time.Second
 )
 
 // Server serves libibmockumad over a Unix socket.

--- a/pkg/network/mockib/daemon/server.go
+++ b/pkg/network/mockib/daemon/server.go
@@ -47,6 +47,15 @@ const (
 	// sequentially, so a peer that accepts but never reads or replies must not
 	// pin the loop past this deadline.
 	fabricPeerIOTimeout = 5 * time.Second
+	// recvTimeoutCap bounds the client-supplied recv timeout_ms. The value
+	// arrives untrusted off the 0666 Unix socket; without a cap a single recv
+	// RPC could pin its poll-loop goroutine for arbitrary client-chosen time.
+	// Diag tools use sub-second timeouts, so 60s is generous headroom.
+	recvTimeoutCap = 60 * time.Second
+	// defaultRecvTimeout applies when the client sends timeout_ms <= 0.
+	defaultRecvTimeout = time.Second
+	// recvPollInterval is the recv queue poll period inside handleRecv.
+	recvPollInterval = 5 * time.Millisecond
 )
 
 // Server serves libibmockumad over a Unix socket.
@@ -190,14 +199,14 @@ func (s *Server) serveConn(ctx context.Context, c net.Conn) {
 		// client that sends a request frame then stops reading must not pin
 		// this goroutine for the pod's life on a full socket buffer.
 		_ = c.SetWriteDeadline(time.Now().Add(unixConnIdleTimeout))
-		if err := s.dispatch(c, env); err != nil {
+		if err := s.dispatch(ctx, c, env); err != nil {
 			s.log.Printf("mock-ib: %s: %v", env.Type, err)
 			return
 		}
 	}
 }
 
-func (s *Server) dispatch(c net.Conn, env protocol.Envelope) error {
+func (s *Server) dispatch(ctx context.Context, c net.Conn, env protocol.Envelope) error {
 	switch env.Type {
 	case protocol.TypeOpen:
 		var req protocol.OpenReq
@@ -216,7 +225,7 @@ func (s *Server) dispatch(c net.Conn, env protocol.Envelope) error {
 		if err := protocol.DecodeBody(env, &req); err != nil {
 			return err
 		}
-		return s.handleRecv(c, req)
+		return s.handleRecv(ctx, c, req)
 	case protocol.TypeClose:
 		var req protocol.CloseReq
 		if err := protocol.DecodeBody(env, &req); err != nil {
@@ -224,7 +233,9 @@ func (s *Server) dispatch(c net.Conn, env protocol.Envelope) error {
 		}
 		return s.handleClose(c, req)
 	case protocol.TypeRegisterPeers:
-		s.registerWithPeers(context.Background())
+		// Use the server ctx (not Background) so a one-shot register sweep
+		// stops between peers when the daemon is shutting down.
+		s.registerWithPeers(ctx)
 		return protocol.WriteMessage(c, protocol.TypeRegisterPeers, map[string]bool{"ok": true})
 	case protocol.TypeVerbsOpen, protocol.TypeVerbsWrite, protocol.TypeVerbsRead, protocol.TypeVerbsClose:
 		return s.dispatchVerbs(c, env)
@@ -310,16 +321,14 @@ func (s *Server) handleSend(c net.Conn, req protocol.SendReq) error {
 	return protocol.WriteMessage(c, protocol.TypeSend, protocol.SendResp{OK: true})
 }
 
-func (s *Server) handleRecv(c net.Conn, req protocol.RecvReq) error {
+func (s *Server) handleRecv(ctx context.Context, c net.Conn, req protocol.RecvReq) error {
 	h, ok := s.lookupHandle(req.Handle)
 	if !ok {
 		return protocol.WriteMessage(c, protocol.TypeRecv, protocol.RecvResp{Error: "invalid handle"})
 	}
-	timeout := time.Duration(req.TimeoutMS) * time.Millisecond
-	if timeout <= 0 {
-		timeout = 1000 * time.Millisecond
-	}
-	deadline := time.Now().Add(timeout)
+	deadline := time.Now().Add(effectiveRecvTimeout(req.TimeoutMS))
+	ticker := time.NewTicker(recvPollInterval)
+	defer ticker.Stop()
 	for {
 		h.mu.Lock()
 		if len(h.recvQ) > 0 {
@@ -332,8 +341,31 @@ func (s *Server) handleRecv(c net.Conn, req protocol.RecvReq) error {
 		if time.Now().After(deadline) {
 			return protocol.WriteMessage(c, protocol.TypeRecv, protocol.RecvResp{Timeout: true})
 		}
-		time.Sleep(5 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			// Daemon shutdown: complete the in-flight recv as a Timeout — the
+			// client's umad_recv maps it to EWOULDBLOCK, its normal no-data
+			// path — instead of dropping the RPC mid-frame. serveConn then
+			// exits on its next ctx check and closes the connection, matching
+			// how shutdown is treated as an expected event elsewhere.
+			return protocol.WriteMessage(c, protocol.TypeRecv, protocol.RecvResp{Timeout: true})
+		case <-ticker.C:
+		}
 	}
+}
+
+// effectiveRecvTimeout converts the client-supplied recv timeout_ms into a
+// bounded wait: timeoutMS <= 0 selects the default, and anything above
+// recvTimeoutCap (including values that would overflow a time.Duration) is
+// clamped to the cap so an untrusted client cannot pick the poll duration.
+func effectiveRecvTimeout(timeoutMS int) time.Duration {
+	if timeoutMS <= 0 {
+		return defaultRecvTimeout
+	}
+	if timeoutMS >= int(recvTimeoutCap/time.Millisecond) {
+		return recvTimeoutCap
+	}
+	return time.Duration(timeoutMS) * time.Millisecond
 }
 
 func (s *Server) handleClose(c net.Conn, req protocol.CloseReq) error {

--- a/pkg/network/mockib/daemon/server_test.go
+++ b/pkg/network/mockib/daemon/server_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"path/filepath"
@@ -162,6 +163,110 @@ func TestServer_handleClose_unknownHandle(t *testing.T) {
 	require.NoError(t, protocol.DecodeBody(env, &closeResp))
 	require.False(t, closeResp.OK, "expected close error, got %+v", closeResp)
 	cancel()
+}
+
+// TestEffectiveRecvTimeout pins the clamp on the client-supplied recv timeout.
+// timeout_ms comes straight off the Unix socket, so an absurd or hostile value
+// must not let one recv RPC pin a poll loop (and its goroutine) for minutes.
+func TestEffectiveRecvTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		ms   int
+		want time.Duration
+	}{
+		{"zero uses default", 0, time.Second},
+		{"negative uses default", -100, time.Second},
+		{"small value passes through", 500, 500 * time.Millisecond},
+		{"exactly at cap", 60_000, 60 * time.Second},
+		{"above cap clamps", 600_000, 60 * time.Second},
+		{"overflow-sized clamps", math.MaxInt, 60 * time.Second},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, effectiveRecvTimeout(tc.ms))
+		})
+	}
+}
+
+// TestServer_handleRecv_EmptyQueueTimesOut pins that a small client timeout is
+// still honored through the poll loop: an empty queue yields Timeout=true
+// shortly after timeout_ms, not at the cap and not never.
+func TestServer_handleRecv_EmptyQueueTimesOut(t *testing.T) {
+	srv := &Server{handles: map[int]*portHandle{1: {caName: "mlx5_0", port: 1}}}
+	clientEnd, serverEnd := net.Pipe()
+	t.Cleanup(func() { _ = clientEnd.Close(); _ = serverEnd.Close() })
+
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.handleRecv(context.Background(), serverEnd, protocol.RecvReq{Handle: 1, TimeoutMS: 50})
+	}()
+
+	resp := readRecvResp(t, clientEnd, 5*time.Second)
+	require.True(t, resp.Timeout, "empty queue must time out: %+v", resp)
+	require.NoError(t, <-done)
+}
+
+// TestServer_handleRecv_CtxCancelReturnsTimeout pins shutdown behavior: when
+// the server ctx is canceled mid-recv, handleRecv must return promptly (not
+// poll out the remaining client timeout) and complete the in-flight RPC as a
+// Timeout response — the client's normal no-data path — matching how the rest
+// of the daemon treats ctx cancellation as an expected lifecycle event.
+func TestServer_handleRecv_CtxCancelReturnsTimeout(t *testing.T) {
+	srv := &Server{handles: map[int]*portHandle{1: {caName: "mlx5_0", port: 1}}}
+	clientEnd, serverEnd := net.Pipe()
+	t.Cleanup(func() { _ = clientEnd.Close(); _ = serverEnd.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() {
+		// 600s client timeout: without the ctx check this blocks for the full
+		// 60s cap; with it, the response arrives right after cancel.
+		done <- srv.handleRecv(ctx, serverEnd, protocol.RecvReq{Handle: 1, TimeoutMS: 600_000})
+	}()
+	time.AfterFunc(50*time.Millisecond, cancel)
+
+	resp := readRecvResp(t, clientEnd, 5*time.Second)
+	require.True(t, resp.Timeout, "shutdown recv must complete as a timeout: %+v", resp)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleRecv did not return after ctx cancellation")
+	}
+	require.Less(t, time.Since(start), 5*time.Second,
+		"handleRecv must return promptly on ctx cancel, not at the recv timeout cap")
+}
+
+// readRecvResp reads one recv envelope from c, failing the test after timeout.
+// net.Pipe writes are synchronous, so the read also unblocks handleRecv's
+// response write.
+func readRecvResp(t *testing.T, c net.Conn, timeout time.Duration) protocol.RecvResp {
+	t.Helper()
+	type result struct {
+		env protocol.Envelope
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		var env protocol.Envelope
+		err := protocol.ReadEnvelope(c, &env)
+		ch <- result{env, err}
+	}()
+	select {
+	case r := <-ch:
+		require.NoError(t, r.err)
+		require.Equal(t, protocol.TypeRecv, r.env.Type)
+		var resp protocol.RecvResp
+		require.NoError(t, protocol.DecodeBody(r.env, &resp))
+		return resp
+	case <-time.After(timeout):
+		t.Fatalf("no recv response within %v", timeout)
+		return protocol.RecvResp{}
+	}
 }
 
 func waitForSocket(t *testing.T, path string, errCh <-chan error) {

--- a/pkg/network/mockib/registry/registry.go
+++ b/pkg/network/mockib/registry/registry.go
@@ -32,20 +32,24 @@ func New() *Registry {
 // Register records peer for portGUID. When the same NodeName re-registers (pod
 // restart with a new PodIP), the entry is refreshed. Otherwise duplicate GUIDs
 // keep the peer with the lexicographically lower PodIP to avoid flip-flopping.
-func (r *Registry) Register(portGUID string, peer Peer) {
+// It reports whether the stored registration changed (new GUID, or any field
+// of the stored peer differs afterwards), so callers can log on change only
+// instead of on every periodic re-register.
+func (r *Registry) Register(portGUID string, peer Peer) bool {
 	key := NormalizePortGUID(portGUID)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if cur, ok := r.m[key]; ok {
 		if cur.NodeName != "" && cur.NodeName == peer.NodeName {
 			r.m[key] = peer
-			return
+			return cur != peer
 		}
 		if peer.PodIP >= cur.PodIP {
-			return
+			return false
 		}
 	}
 	r.m[key] = peer
+	return true
 }
 
 // Lookup returns the peer for portGUID and whether it was found.

--- a/pkg/network/mockib/registry/registry_test.go
+++ b/pkg/network/mockib/registry/registry_test.go
@@ -41,6 +41,55 @@ func TestRegistry_NormalizesGUIDKey(t *testing.T) {
 	require.Equal(t, "10.0.0.2", p.PodIP, "lookup with normalized key failed: %+v %v", p, ok)
 }
 
+// TestRegistry_RegisterReportsChange pins Register's changed return value:
+// true only when the stored registration actually differs (new GUID, LID,
+// PodIP, node, ...). The daemon uses it to log REGISTER outcomes on change
+// only instead of per-port every 2s re-register.
+func TestRegistry_RegisterReportsChange(t *testing.T) {
+	const guid = "a088:c203:00ab:0001"
+	const guid2 = "a088:c203:00ab:0002"
+	base := Peer{PodIP: "10.0.0.2", NodeName: "node-a", CAName: "mlx5_0", Port: 1, LID: 0x0200}
+	relid := Peer{PodIP: "10.0.0.2", NodeName: "node-a", CAName: "mlx5_0", Port: 1, LID: 0x0300}
+	reip := Peer{PodIP: "10.0.0.9", NodeName: "node-a", CAName: "mlx5_0", Port: 1, LID: 0x0200}
+	otherHi := Peer{PodIP: "10.0.0.9", NodeName: "node-b", CAName: "mlx5_0", Port: 1, LID: 0x0400}
+	otherLo := Peer{PodIP: "10.0.0.1", NodeName: "node-b", CAName: "mlx5_0", Port: 1, LID: 0x0400}
+	secondCA := Peer{PodIP: "10.0.0.2", NodeName: "node-a", CAName: "mlx5_1", Port: 1, LID: 0x0201}
+	anon := Peer{PodIP: "10.0.0.2", LID: 0x0200}
+
+	type reg struct {
+		guid string
+		peer Peer
+	}
+	tests := []struct {
+		name       string
+		pre        []reg
+		reg        reg
+		want       bool
+		wantStored Peer // expected Lookup(reg.guid) after the final Register
+	}{
+		{"first registration", nil, reg{guid, base}, true, base},
+		{"identical re-register", []reg{{guid, base}}, reg{guid, base}, false, base},
+		{"same node LID change", []reg{{guid, base}}, reg{guid, relid}, true, relid},
+		{"same node PodIP change (pod restart)", []reg{{guid, base}}, reg{guid, reip}, true, reip},
+		{"duplicate GUID from other node, higher IP ignored", []reg{{guid, base}}, reg{guid, otherHi}, false, base},
+		{"duplicate GUID from other node, lower IP wins", []reg{{guid, base}}, reg{guid, otherLo}, true, otherLo},
+		{"new port GUID", []reg{{guid, base}}, reg{guid2, secondCA}, true, secondCA},
+		{"identical re-register with empty node name", []reg{{guid, anon}}, reg{guid, anon}, false, anon},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := New()
+			for _, p := range tc.pre {
+				r.Register(p.guid, p.peer)
+			}
+			require.Equal(t, tc.want, r.Register(tc.reg.guid, tc.reg.peer))
+			stored, ok := r.Lookup(tc.reg.guid)
+			require.True(t, ok)
+			require.Equal(t, tc.wantStored, stored)
+		})
+	}
+}
+
 func TestRegistry_LookupByLID(t *testing.T) {
 	r := New()
 	r.Register("a088:c203:00ab:0001", Peer{PodIP: "10.0.0.2", LID: 0x0200})

--- a/pkg/network/mockib/sysfs/scan.go
+++ b/pkg/network/mockib/sysfs/scan.go
@@ -39,14 +39,22 @@ func Scan(root string) ([]protocol.PortAdvert, error) {
 		if err != nil {
 			return nil, fmt.Errorf("parse %s lid: %w", caName, err)
 		}
+		// node_guid is optional in the tree. Normalize only a non-empty value:
+		// NormalizePortGUID("") would yield the non-empty
+		// "0000:0000:0000:0000", defeating fabric.coalesceGUID's nodeGUID==""
+		// fallback and advertising a zero NodeGUID for every local port.
+		nodeGUID := ""
 		nodeGUIDBytes, _ := os.ReadFile(filepath.Join(caDir, "node_guid"))
+		if raw := strings.TrimSpace(string(nodeGUIDBytes)); raw != "" {
+			nodeGUID = registry.NormalizePortGUID(raw)
+		}
 		defaultGID := ""
 		if rawGID, err := os.ReadFile(filepath.Join(portDir, "gids/0")); err == nil {
 			defaultGID = gid.Normalize(strings.TrimSpace(string(rawGID)))
 		}
 		out = append(out, protocol.PortAdvert{
 			PortGUID:   registry.NormalizePortGUID(strings.TrimSpace(string(guidBytes))),
-			NodeGUID:   registry.NormalizePortGUID(strings.TrimSpace(string(nodeGUIDBytes))),
+			NodeGUID:   nodeGUID,
 			DefaultGID: defaultGID,
 			CAName:     caName,
 			Port:       1,

--- a/pkg/network/mockib/sysfs/scan_test.go
+++ b/pkg/network/mockib/sysfs/scan_test.go
@@ -4,12 +4,92 @@
 package sysfs
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/config"
 	"github.com/NVIDIA/k8s-test-infra/pkg/network/mockib/render"
 	"github.com/stretchr/testify/require"
 )
+
+// TestScan_NodeGUIDAndErrorPaths pins two contracts on hand-built trees:
+//
+//  1. A missing/empty node_guid must propagate as NodeGUID "" — normalizing
+//     "" yields the non-empty "0000:0000:0000:0000", which defeats
+//     fabric.coalesceGUID's nodeGUID=="" port-GUID fallback and makes every
+//     local port advertise a zero NodeGUID, so ibnetdiscover-style consumers
+//     merge all CAs into one node (#393).
+//  2. Missing/garbled required port files (port_guid, lid) surface as errors.
+func TestScan_NodeGUIDAndErrorPaths(t *testing.T) {
+	valid := map[string]string{
+		"ports/1/port_guid": "0xa088c20300ab0001",
+		"ports/1/lid":       "0x0300",
+		"node_guid":         "a088:c203:00ab:0000",
+	}
+	tests := []struct {
+		name         string
+		files        map[string]string
+		wantNodeGUID string
+		wantErr      string // substring; empty means Scan must succeed
+	}{
+		{"node_guid present is normalized", valid, "a088:c203:00ab:0000", ""},
+		{"node_guid file missing keeps NodeGUID empty", omit(valid, "node_guid"), "", ""},
+		{"node_guid file empty keeps NodeGUID empty", with(valid, "node_guid", ""), "", ""},
+		{"node_guid whitespace-only keeps NodeGUID empty", with(valid, "node_guid", " \n"), "", ""},
+		{"missing port_guid errors", omit(valid, "ports/1/port_guid"), "", "port_guid"},
+		{"missing lid errors", omit(valid, "ports/1/lid"), "", "lid"},
+		{"malformed lid errors", with(valid, "ports/1/lid", "not-a-lid"), "", "lid"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeSysfsCA(t, root, "mlx5_0", tc.files)
+			ports, err := Scan(root)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, ports, 1)
+			require.Equal(t, tc.wantNodeGUID, ports[0].NodeGUID)
+			require.Equal(t, "a088:c203:00ab:0001", ports[0].PortGUID)
+		})
+	}
+}
+
+// writeSysfsCA materializes files (paths relative to the CA dir) under
+// root/sys/class/infiniband/<ca>/.
+func writeSysfsCA(t *testing.T, root, ca string, files map[string]string) {
+	t.Helper()
+	caDir := filepath.Join(root, "sys/class/infiniband", ca)
+	require.NoError(t, os.MkdirAll(filepath.Join(caDir, "ports/1"), 0o755))
+	for rel, content := range files {
+		path := filepath.Join(caDir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	}
+}
+
+// omit returns a copy of m without key; with returns a copy with key=value.
+func omit(m map[string]string, key string) map[string]string {
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		if k != key {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func with(m map[string]string, key, value string) map[string]string {
+	out := make(map[string]string, len(m)+1)
+	for k, v := range m {
+		out[k] = v
+	}
+	out[key] = value
+	return out
+}
 
 func TestScan_RenderedTree(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Problem

The v0.2.0 go-review pass over the mockib subsystem (https://github.com/NVIDIA/k8s-test-infra/issues/393#issuecomment-4690186702) flagged one must-fix and four should-fix findings, all liveness/correctness issues in the daemon and sysfs scanner. This PR addresses all five.

## Approach

**1. Must-fix — `daemon/fabric.go`: sendRegister set no I/O deadline.** A peer that accepts but never reads blocked the write forever; registerWithPeersLoop is sequential, so one stuck peer silently stopped re-registration to every peer for the pod's life. sendRegister now mirrors pingPeer's `SetDeadline(now+5s)` right after dial, via a shared `fabricPeerIOTimeout` const both paths use.

**2. `daemon/server.go`: handleRecv busy-polled a client-supplied TimeoutMS with no upper bound and no ctx check.** The wait is clamped by `effectiveRecvTimeout` (default 1s, cap 60s, overflow-safe) and serveConn's ctx is threaded through dispatch into the poll loop. On ctx cancellation the in-flight recv completes as a `Timeout` response — the client's umad_recv maps that to EWOULDBLOCK, its normal no-data path — and serveConn closes the connection on its next ctx check, matching shutdown handling elsewhere in the daemon. The one-shot `register_peers` RPC now also uses the server ctx instead of Background.

**3. `daemon/fabric.go`: applyRegister logged every port on every 2s re-register** (~86k lines/day per port in a 2-node CI fabric). `registry.Register` now reports whether the stored registration changed (new GUID, LID/PodIP/node change, tie-break winner) and applyRegister logs only changed ports. First-registration log content is byte-identical, so existing kubectl-logs greps keep working.

**4. `daemon/fabric.go` + `daemon/discover.go`: shutdown ignored mid-sweep.** registerWithPeers checks `ctx.Err()` between peers (post-SIGTERM the sweep stops instead of dialing through the list at up to 5s each), and DiscoverPeerIPs resolves via `net.DefaultResolver.LookupHost(ctx, host)` with the caller's ctx plumbed through.

**5. `sysfs/scan.go`: a missing node_guid normalized "" into "0000:0000:0000:0000"** (non-empty), defeating `fabric.coalesceGUID`'s nodeGUID=="" fallback — every local port advertised a zero NodeGUID and ibnetdiscover-style consumers merged all CAs into one node. Scan now normalizes only a non-empty trimmed value and propagates "" otherwise.

## Testing

Strict TDD: each fix is a red-first test commit followed by its implementation commit.

- sendRegister: listener that accepts but never reads + near-frame-cap REGISTER body (SO_RCVBUF pinned small so the write genuinely blocks); asserts return with `os.ErrDeadlineExceeded` at ~5s instead of hanging.
- handleRecv: table test for the clamp (default/cap/overflow), empty-queue timeout via a small client deadline, and ctx cancel returning promptly (~50ms) with a Timeout response.
- registry.Register: table test over first/identical/changed/tie-break registrations; daemon-level test counts `register from` log lines across identical and changed re-registers.
- ctx in sweep/discovery: canceled ctx makes zero peer dials (counting listener); DiscoverPeerIPs with a canceled ctx returns empty even though localhost would otherwise resolve.
- Scan: hand-built sysfs trees pin NodeGUID "" for missing/empty/whitespace node_guid, plus the previously untested error paths (missing port_guid, missing lid, malformed lid) from the same review's testing item.

Gates run locally: `go build ./...`, `go test -race ./pkg/network/mockib/...`, `golangci-lint run ./pkg/network/mockib/...` (0 issues), and the full `go test -race` over all non-vendor packages — all green.

Part of #393.
