### PR TITLE
chore(release): prepare v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-12
+
+### Fixed
+- Release machinery: chart pushes to ghcr retry through the registry's tag
+  read-after-write lag (#390); image publishing now triggers on `v*` tag
+  pushes (a `paths:` filter silently suppressed every tag-triggered run)
+  and supports `workflow_dispatch` (#391).
+- Stale Go pins bumped to 1.26.4 across the build (deployment and test
+  Dockerfiles, mocknvml/mockcuda Makefiles, e2e dispatch default, helper
+  scripts), unbreaking the documented `make docker-build`; bundled
+  `kubectl` bumped v1.32.0 -> v1.36.1, cutting the image's CRITICAL/HIGH
+  CVE findings from that binary from 17 to 8. (#394)
+- mocknvml: `nvmlDeviceGetHandleByUUID` returns `NOT_FOUND` for unknown
+  UUIDs; the legacy default UUID scheme no longer assigns device 0 the
+  canonical nil UUID; the `tests/mocknvml` harness builds again (broken
+  since #269). (#395)
+- mockib hardening from review: peer-registration I/O carries deadlines
+  (one wedged peer no longer halts re-registration), `recv` waits are
+  bounded and honor daemon shutdown, peer discovery and registration
+  sweeps respect context cancellation, missing sysfs `node_guid` no
+  longer renders an all-zero NodeGUID, and steady-state re-register
+  logging only fires on change. (#396)
+
 ## [0.2.0] - 2026-06-12
 
 ### Added
@@ -41,6 +64,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parse. Defaults populated for every profile: `a100`/`b200`/`h100`/`l40s`
   -> 2 root complexes (dual-socket), `gb200` -> 4 root complexes (one per
   Grace pair), `t4` -> 1 root complex. (#263)
+- Dynamic per-query metric sampling: utilization, temperature, power, and
+  clocks vary plausibly across calls instead of returning static values.
+  (#323)
+- GPU failure injection: profiles can trip `ecc_uncorrectable`, `lost`,
+  and `fallen_off_bus` modes at runtime, including Xid 79 propagation.
+  (#328)
+- ComputeDomain / NVLink fabric simulation: `nvmlDeviceGetGpuFabricInfo`
+  (+`InfoV`) driven by a cluster-level topology ConfigMap, plus fake
+  `nvidia-imex` / `nvidia-imex-ctl` binaries coordinating peer readiness
+  through marker files on a shared volume. (#337, #342)
+- Toolkit-ready marker file for GPU Operator validator compatibility.
+  (#346)
 
 ### Changed
 - nvml-mock profile `bus_id` fields now use the canonical Linux sysfs
@@ -94,6 +129,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Rebranded from gpu-mock to nvml-mock (PRs #273, #274, #275, #281, #282)
 
-[Unreleased]: https://github.com/NVIDIA/k8s-test-infra/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/NVIDIA/k8s-test-infra/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/NVIDIA/k8s-test-infra/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/NVIDIA/k8s-test-infra/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/NVIDIA/k8s-test-infra/releases/tag/v0.1.0

--- a/deployments/nvml-mock/helm/nvml-mock/Chart.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 name: nvml-mock
 description: Mock NVIDIA driver infrastructure for Kubernetes testing
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "550.163.01"
 # Minimum kubernetes version. Mounting the same hostPath volume at two
 # different mountPaths in one container (used by daemonset.yaml for the

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
@@ -438,7 +438,7 @@ should match snapshot with b200 profile:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.2.0
+        helm.sh/chart: nvml-mock-0.2.1
       name: RELEASE-NAME-nvml-mock-config
 should match snapshot with default a100 profile:
   1: |
@@ -875,7 +875,7 @@ should match snapshot with default a100 profile:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.2.0
+        helm.sh/chart: nvml-mock-0.2.1
       name: RELEASE-NAME-nvml-mock-config
 should match snapshot with gb200 profile:
   1: |
@@ -1366,7 +1366,7 @@ should match snapshot with gb200 profile:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.2.0
+        helm.sh/chart: nvml-mock-0.2.1
       name: RELEASE-NAME-nvml-mock-config
 should match snapshot with gb300 profile:
   1: |
@@ -1860,7 +1860,7 @@ should match snapshot with gb300 profile:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.2.0
+        helm.sh/chart: nvml-mock-0.2.1
       name: RELEASE-NAME-nvml-mock-config
 should match snapshot with h100 profile:
   1: |
@@ -2299,7 +2299,7 @@ should match snapshot with h100 profile:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.2.0
+        helm.sh/chart: nvml-mock-0.2.1
       name: RELEASE-NAME-nvml-mock-config
 should match snapshot with l40s profile:
   1: |
@@ -2707,7 +2707,7 @@ should match snapshot with l40s profile:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.2.0
+        helm.sh/chart: nvml-mock-0.2.1
       name: RELEASE-NAME-nvml-mock-config
 should match snapshot with t4 profile:
   1: |
@@ -3079,5 +3079,5 @@ should match snapshot with t4 profile:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.2.0
+        helm.sh/chart: nvml-mock-0.2.1
       name: RELEASE-NAME-nvml-mock-config

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot with all overrides:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.2.0
+        helm.sh/chart: nvml-mock-0.2.1
       name: nvml-mock-custom
     spec:
       selector:
@@ -123,7 +123,7 @@ should match snapshot with b200 profile:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.2.0
+        helm.sh/chart: nvml-mock-0.2.1
       name: RELEASE-NAME-nvml-mock
     spec:
       selector:
@@ -227,7 +227,7 @@ should match snapshot with default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.2.0
+        helm.sh/chart: nvml-mock-0.2.1
       name: RELEASE-NAME-nvml-mock
     spec:
       selector:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/rbac_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/rbac_test.yaml.snap
@@ -8,7 +8,7 @@ should match ClusterRole snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.2.0
+        helm.sh/chart: nvml-mock-0.2.1
       name: RELEASE-NAME-nvml-mock
     rules:
       - apiGroups:
@@ -28,7 +28,7 @@ should match ClusterRoleBinding snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.2.0
+        helm.sh/chart: nvml-mock-0.2.1
       name: RELEASE-NAME-nvml-mock
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -48,5 +48,5 @@ should match ServiceAccount snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: nvml-mock
         app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.2.0
+        helm.sh/chart: nvml-mock-0.2.1
       name: RELEASE-NAME-nvml-mock

--- a/deployments/nvml-mock/helm/nvml-mock/tests/configmap_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/configmap_test.yaml
@@ -73,7 +73,7 @@ tests:
     asserts:
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: nvml-mock-0.2.0
+          value: nvml-mock-0.2.1
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
           value: nvml-mock

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -60,7 +60,7 @@ tests:
     asserts:
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: nvml-mock-0.2.0
+          value: nvml-mock-0.2.1
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
           value: nvml-mock

--- a/deployments/nvml-mock/helm/nvml-mock/tests/rbac_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/rbac_test.yaml
@@ -35,7 +35,7 @@ tests:
     asserts:
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: nvml-mock-0.2.0
+          value: nvml-mock-0.2.1
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
           value: nvml-mock
@@ -71,7 +71,7 @@ tests:
     asserts:
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: nvml-mock-0.2.0
+          value: nvml-mock-0.2.1
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
           value: nvml-mock
@@ -114,7 +114,7 @@ tests:
     asserts:
       - equal:
           path: metadata.labels["helm.sh/chart"]
-          value: nvml-mock-0.2.0
+          value: nvml-mock-0.2.1
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
           value: nvml-mock


### PR DESCRIPTION
## Problem
Cutting v0.2.1 (CVE refresh + post-release fixes). Chart version, snapshots, and changelog need the roll; the 0.2.0 changelog section also omitted four shipped features (audit finding, #393).

## Approach
- Chart.yaml 0.1.0-style bump: 0.2.0 -> 0.2.1; snapshots + the five version-pinned label assertions regenerated
- CHANGELOG: new [0.2.1] section covering #390, #391, #394, #395, #396; retroactive 0.2.0 entries for #323, #328, #337/#342, #346
- v0.2.0 GitHub release notes get the same retro amendments after merge (gh release edit)

## Testing
helm unittest 111/111, snapshots 15/15.

Merge LAST after #394/#395/#396; tag v0.2.1 lands on this commit.