### PR TITLE
feat(mockib): mock subnet manager for sminfo and ibnetdiscover

### DIFF
--- a/.github/workflows/nvml-mock-e2e.yaml
+++ b/.github/workflows/nvml-mock-e2e.yaml
@@ -933,6 +933,26 @@ jobs:
             -o jsonpath='{.items[0].metadata.name}')
           ./tests/e2e/validate-iblinkinfo.sh "$W1" "$W2" a100 2
 
+      - name: Validate sminfo (master subnet manager)
+        run: |
+          chmod +x tests/e2e/validate-sminfo.sh
+          W1=$(kubectl get pods -l app.kubernetes.io/instance=nvml-mock-w1 \
+            -o jsonpath='{.items[0].metadata.name}')
+          W2=$(kubectl get pods -l app.kubernetes.io/instance=nvml-mock-w2 \
+            -o jsonpath='{.items[0].metadata.name}')
+          # Pass W2 as peer so the validator also asserts both pods agree on a
+          # single master SM GUID (the consistent-SM-identity property).
+          ./tests/e2e/validate-sminfo.sh "$W1" a100 2 "$W2"
+
+      - name: Validate cross-node ibnetdiscover
+        run: |
+          chmod +x tests/e2e/validate-ibnetdiscover.sh
+          W1=$(kubectl get pods -l app.kubernetes.io/instance=nvml-mock-w1 \
+            -o jsonpath='{.items[0].metadata.name}')
+          W2=$(kubectl get pods -l app.kubernetes.io/instance=nvml-mock-w2 \
+            -o jsonpath='{.items[0].metadata.name}')
+          ./tests/e2e/validate-ibnetdiscover.sh "$W1" "$W2" a100 2
+
       - name: Collect logs on failure
         if: failure()
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ pkg/network/*/libibmock*
 AGENTS.md
 docs/plans/
 docs/superpowers/
+docs/magi/
 .worktrees/

--- a/pkg/network/mockib/README.md
+++ b/pkg/network/mockib/README.md
@@ -120,6 +120,12 @@ intercepts run before sysfs path rewriting.
   the container; both are guaranteed by `render.go` + the chart image.
   Full per-device `ibv_devinfo` (without `-l`) is intentionally not
   supported — see the same section below.
+- **`sminfo`** — UMAD plus SMInfo (attr `0x0020`) synthesis. The daemon
+  reports a mock master subnet manager (`SMState=MASTER`). See
+  [sminfo and ibnetdiscover](#sminfo-and-ibnetdiscover).
+- **`ibnetdiscover`** — UMAD plus the same SMP direct-route synthesis as
+  `iblinkinfo`; lists the local CA and its cross-pod peer(s). See
+  [sminfo and ibnetdiscover](#sminfo-and-ibnetdiscover).
 
 ### Environment variables
 
@@ -266,6 +272,58 @@ supported: after `ibv_get_device_list` claims a device, libmlx5's
 from a userspace `LD_PRELOAD` shim is well beyond the scope of this
 mock; per-port state (which `ibv_devinfo` would otherwise print) is
 covered by `ibstatus`, which reads the same sysfs files.
+
+## sminfo and ibnetdiscover
+
+These two tools round out the mock with a subnet-manager identity and a
+whole-fabric view. Both ride the existing `libibmockumad` UMAD path — no
+chart, Dockerfile, or `setup.sh` changes — and are synthesized Go-side in
+`subnet/` over the same `fabric.Graph` that drives `iblinkinfo`.
+
+### sminfo (master subnet manager)
+
+`sminfo` reads its local `PORT_INFO` (`MasterSMLID = 1`) and sends a
+`SubnGet(SMInfo)` (attribute `0x0020`) to that SM LID. No rendered HCA owns
+LID 1, so the daemon answers it specially: `subnet.TrySynthesize` handles
+`SMInfo` **before** direct-route target resolution and fills the reply from
+the elected **master SM** — the lowest-`PortGUID` port in the merged
+local+peer graph (`fabric.(*Graph).MasterSM`). Every pod that has converged
+on the same fabric therefore reports one consistent SM identity, with
+`SMState = MASTER (3)`.
+
+The SMInfo payload follows libibmad `fields.c`: GUID `{0,64}` and SM_Key
+`{64,64}` as plain big-endian (`putGUID64`/`SetField64`), ActCount `{128,32}`,
+Priority `{160,4}`, and SMState `{164,4}` via the `BITSOFFS` helpers. Only
+`SubnGet` is answered; `sminfo -p/-s/-a` issue `SubnSet` to mutate SM state,
+which the mock has no persistent SM to honor and so does not synthesize.
+
+```bash
+kubectl exec "$POD" -- sminfo
+```
+
+End-to-end validation: [`tests/e2e/validate-sminfo.sh`](../../../tests/e2e/validate-sminfo.sh).
+
+### ibnetdiscover (whole-fabric scan)
+
+`ibnetdiscover` runs the same `libibnetdisc` direct-route walk as
+`iblinkinfo` over the existing NODE_INFO / NODE_DESC / PORT_INFO synthesis,
+so it needs no new SMP handling. It lists the local CA and its cross-pod
+peer(s).
+
+> **Topology limit.** The mock fabric is point-to-point with no switches:
+> each one-port CA selects a single outbound neighbor (lowest-GUID non-self
+> port; see `fabric.PeerAtOutbound`), and CAs do not forward directed-route
+> SMPs. A scan from one pod therefore reaches the local CA plus one neighbor
+> — sufficient for the two-node E2E (cross-pod visibility), but it does not
+> enumerate every port of a 3+ node fabric. True whole-fabric enumeration
+> would require modeling a synthetic switch (NodeType=2 + `SwitchInfo`),
+> which is left as a follow-up.
+
+```bash
+kubectl exec "$POD" -- ibnetdiscover
+```
+
+End-to-end validation: [`tests/e2e/validate-ibnetdiscover.sh`](../../../tests/e2e/validate-ibnetdiscover.sh).
 
 ### Build notes
 

--- a/pkg/network/mockib/daemon/server_smp_test.go
+++ b/pkg/network/mockib/daemon/server_smp_test.go
@@ -142,3 +142,63 @@ func TestServer_SMPNodeInfoThenPortInfo(t *testing.T) {
 	require.Equal(t, uint32(5), subnet.GetFieldSpec(pl, 264, 4), "PORT_INFO phys: want 5")
 	require.NotContains(t, []uint32{0, 1}, subnet.GetFieldSpec(pl, 128, 16), "PORT_INFO lid")
 }
+
+// TestServer_SMInfoMaster drives the sminfo path end to end over the Unix
+// socket: a SubnGet(SMInfo) LID-routed to the advertised SM LID (1) must return
+// a master SM (SMState=3) with a non-zero GUID, even though no rendered HCA
+// owns LID 1.
+func TestServer_SMInfoMaster(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, render.Render(render.Options{
+		IB: config.Infiniband{Enabled: true}, GPUCount: 2, NodeName: "node-a", Output: dir,
+	}))
+	safe := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+	sock := filepath.Join(os.TempDir(), "mock-ib-"+safe+".sock")
+	t.Cleanup(func() { _ = os.Remove(sock) })
+
+	srv, err := NewServer(Config{SocketPath: sock, IBRoot: dir, Fabric: true}, nil)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.ListenAndServe(ctx) }()
+	waitForSocket(t, sock, errCh)
+
+	conn, err := net.Dial("unix", sock)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	var env protocol.Envelope
+	require.NoError(t, protocol.WriteMessage(conn, protocol.TypeOpen, protocol.OpenReq{CAName: "mlx5_0", Port: 1}))
+	require.NoError(t, protocol.ReadEnvelope(conn, &env))
+	var openResp protocol.OpenResp
+	require.NoError(t, protocol.DecodeBody(env, &openResp))
+	require.NotZero(t, openResp.Handle, "open: %+v", openResp)
+
+	send := make([]byte, umadMADOffset+64)
+	mad := send[umadMADOffset:]
+	// Wire-format SMI (LID-routed) SMInfo GET, as sminfo issues it.
+	mad[0] = 0x01                                  // BaseVersion
+	mad[1] = 0x01                                  // MgmtClass = SMI (LID-routed)
+	mad[2] = 0x01                                  // ClassVersion
+	mad[3] = 0x01                                  // Method = Get
+	binary.BigEndian.PutUint16(mad[16:18], 0x0020) // SMInfo
+	binary.BigEndian.PutUint16(send[28:30], 1)     // DLID = advertised SM LID
+
+	require.NoError(t, protocol.WriteMessage(conn, protocol.TypeSend, protocol.SendReq{Handle: openResp.Handle, MAD: send}))
+	require.NoError(t, protocol.ReadEnvelope(conn, &env))
+	var sendResp protocol.SendResp
+	require.NoError(t, protocol.DecodeBody(env, &sendResp))
+	require.True(t, sendResp.OK, "send: %+v", sendResp)
+
+	require.NoError(t, protocol.WriteMessage(conn, protocol.TypeRecv, protocol.RecvReq{Handle: openResp.Handle, TimeoutMS: 500}))
+	require.NoError(t, protocol.ReadEnvelope(conn, &env))
+	var recvResp protocol.RecvResp
+	require.NoError(t, protocol.DecodeBody(env, &recvResp))
+	require.False(t, recvResp.Timeout, "recv: %+v", recvResp)
+	require.GreaterOrEqual(t, len(recvResp.MAD), umadMADOffset+64+24, "recv len %d", len(recvResp.MAD))
+
+	pl := recvResp.MAD[umadMADOffset+64:]
+	require.Equal(t, uint32(3), subnet.GetFieldSpec(pl, 164, 4), "SMState: want 3 (MASTER)")
+	require.NotEqual(t, make([]byte, 8), pl[0:8], "SM GUID must be non-zero")
+}

--- a/pkg/network/mockib/fabric/graph.go
+++ b/pkg/network/mockib/fabric/graph.go
@@ -80,6 +80,23 @@ func (g *Graph) ByLID(lid uint16) (Port, bool) {
 	return p, ok
 }
 
+// MasterSM returns the port elected as the fabric's master subnet manager: the
+// lowest-PortGUID port in the merged graph. Build already sorts ports ascending
+// by PortGUID, so this is g.ports[0]. Every pod that has converged on the same
+// local+peer set therefore elects the same master, so sminfo reports one
+// consistent SM identity across the fabric (the election only differs during the
+// pre-REGISTER convergence window). Returns false for an empty graph.
+//
+// This assumes a CA-only graph; the mock models no switches. If a synthetic
+// switch node is ever added to the graph it must be excluded here so the elected
+// SM stays an HCA port.
+func (g *Graph) MasterSM() (Port, bool) {
+	if len(g.ports) == 0 {
+		return Port{}, false
+	}
+	return g.ports[0], true
+}
+
 // ByCAName returns the local port for an HCA name (e.g. mlx5_0).
 func (g *Graph) ByCAName(caName string) (Port, bool) {
 	for _, p := range g.ports {

--- a/pkg/network/mockib/fabric/graph_test.go
+++ b/pkg/network/mockib/fabric/graph_test.go
@@ -25,3 +25,22 @@ func TestGraph_BuildAndLookup(t *testing.T) {
 	require.True(t, ok, "ByLID: %+v ok=%v", remote, ok)
 	require.Equal(t, "10.0.0.2", remote.PodIP, "ByLID: %+v ok=%v", remote, ok)
 }
+
+func TestGraph_MasterSM(t *testing.T) {
+	// Local and peer ports given out of GUID order; MasterSM must elect the
+	// lowest PortGUID across the merged graph so every pod agrees on one SM.
+	local := []protocol.PortAdvert{
+		{PortGUID: "a088:c203:00ab:0005", LID: 0x105, CAName: "mlx5_1"},
+	}
+	peers := map[string]registry.Peer{
+		"a088:c203:00ab:0002": {LID: 0x102, CAName: "mlx5_0", PodIP: "10.0.0.2"},
+		"a088:c203:00ab:0009": {LID: 0x109, CAName: "mlx5_1", PodIP: "10.0.0.3"},
+	}
+	g := Build(local, peers)
+	sm, ok := g.MasterSM()
+	require.True(t, ok, "MasterSM ok")
+	require.Equal(t, "a088:c203:00ab:0002", sm.PortGUID, "lowest PortGUID elected")
+
+	_, ok = Build(nil, nil).MasterSM()
+	require.False(t, ok, "empty graph has no master SM")
+}

--- a/pkg/network/mockib/subnet/synthesize.go
+++ b/pkg/network/mockib/subnet/synthesize.go
@@ -37,8 +37,17 @@ const (
 	ibAttrNodeDesc   = 0x0010
 	ibAttrNodeInfo   = 0x0011
 	ibAttrPortInfo   = 0x0015
+	ibAttrSMInfo     = 0x0020
 	ibClassSMI       = 0x01
 	ibClassSMIDirect = 0x81
+
+	// SMInfo (IBA Vol.1 §14.2.5.13, Table 120) values for the mock master SM.
+	// sminfo prints ActCount and Priority verbatim; the mock has no live SM, so
+	// they are deterministic constants rather than mutable state.
+	smStateMaster     = 3      // SMINFO_MASTER
+	defaultSMPriority = 15     // cosmetic
+	defaultSMKey      = 0      // unprotected subnet
+	smActCount        = 0x1000 // deterministic, non-zero
 
 	// PortInfo / NodeInfo values understood by libibmad / iblinkinfo.
 	portStateActive     = 4 // PORT_ACTIVE
@@ -77,6 +86,23 @@ func TrySynthesize(sendMad []byte, g *fabric.Graph, localCA string) ([]byte, boo
 		return nil, false
 	}
 	attrID := binary.BigEndian.Uint16(mad[ibMADAttrIDOff : ibMADAttrIDOff+2])
+
+	// SMInfo (sminfo) reports a fabric-global SM identity, not a DR-target
+	// attribute. sminfo LID-routes it to the advertised SM LID (defaultSMLID=1),
+	// which is not a real port in the graph, so resolveTarget below would reject
+	// it. Answer it here, before any target/DLID resolution, from the elected
+	// master SM (lowest-PortGUID port) so every pod reports the same identity.
+	if attrID == ibAttrSMInfo {
+		sm, smOK := g.MasterSM()
+		if !smOK {
+			return nil, false
+		}
+		out := newSMPResp(sendMad, method)
+		fillSMInfo(out[umadMADOffset:], sm)
+		smpLogf("attr=0x%04x SMInfo -> master sm guid=%s lid=0x%x state=MASTER", attrID, sm.PortGUID, sm.LID)
+		return out, true
+	}
+
 	attrMod := binary.BigEndian.Uint32(mad[20:24])
 
 	lid, ok := destLID(sendMad)
@@ -116,6 +142,46 @@ func TrySynthesize(sendMad []byte, g *fabric.Graph, localCA string) ([]byte, boo
 	default:
 		return nil, false
 	}
+}
+
+// newSMPResp clones a SEND umad into a GETRESP buffer: padded to at least a full
+// legacy umad frame (so short libibmad sends still carry the 256-byte MAD),
+// umad.status zeroed (a non-zero status makes libibmad discard the reply), and
+// the MAD method's response bit (0x80) set. It mirrors the inline response setup
+// in TrySynthesize and is used by the SMInfo branch.
+func newSMPResp(sendMad []byte, method byte) []byte {
+	out := make([]byte, len(sendMad))
+	if len(sendMad) < minUmadLen {
+		out = make([]byte, minUmadLen)
+	}
+	copy(out, sendMad)
+	if len(out) >= 8 {
+		binary.LittleEndian.PutUint32(out[4:8], 0)
+	}
+	out[umadMADOffset+ibMADMethodOff] = method | 0x80
+	return out
+}
+
+// fillSMInfo writes a master-SM SMInfo payload (AttrID 0x0020) for sm into the
+// SMP data block. Layout per IBA Vol.1 §14.2.5.13 Table 120 / libibmad fields.c:
+// GUID {0,64}, SM_Key {64,64}, ActCount {128,32}, Priority {160,4}, SMState
+// {164,4}. The two 64-bit fields are plain big-endian (putGUID64 / SetField64),
+// matching how NodeGuid/PortGuid/GidPrefix are written; the sub-32-bit fields use
+// the libibmad BITSOFFS convention via SetFieldSpec, so byte 20 of the block ends
+// up (Priority<<4)|SMState.
+func fillSMInfo(mad []byte, sm fabric.Port) {
+	if len(mad) < ibSMPDataOff+64 {
+		return
+	}
+	pl := mad[ibSMPDataOff:]
+	for i := range pl {
+		pl[i] = 0
+	}
+	putGUID64(pl, 0, sm.PortGUID)    // GUID @ bit 0
+	SetField64(pl, 64, defaultSMKey) // SM_Key @ bit 64
+	SetFieldSpec(pl, 128, 32, smActCount)
+	SetFieldSpec(pl, 160, 4, defaultSMPriority)
+	SetFieldSpec(pl, 164, 4, smStateMaster)
 }
 
 func fillNodeDesc(mad []byte, p fabric.Port) {

--- a/pkg/network/mockib/subnet/synthesize.go
+++ b/pkg/network/mockib/subnet/synthesize.go
@@ -118,17 +118,8 @@ func TrySynthesize(sendMad []byte, g *fabric.Graph, localCA string) ([]byte, boo
 	smpLogf("attr=0x%04x mod=0x%x lid=0x%x localCA=%s hopCnt=%d hops=%02x:%02x:%02x:%02x -> %s/%s lid=0x%x local=%t podIP=%s",
 		attrID, attrMod, lid, localCA, drHopCnt(mad), drPathByte(mad, 1), drPathByte(mad, 2), drPathByte(mad, 3), drPathByte(mad, 4),
 		target.CAName, target.PortGUID, target.LID, target.Local, target.PodIP)
-	out := make([]byte, len(sendMad))
-	if len(sendMad) < minUmadLen {
-		out = make([]byte, minUmadLen)
-	}
-	copy(out, sendMad)
-	if len(out) >= 8 {
-		// ib_user_mad.status (offset 4); non-zero makes libibmad mad_rpc retry/discard.
-		binary.LittleEndian.PutUint32(out[4:8], 0)
-	}
+	out := newSMPResp(sendMad, method)
 	respMAD := out[umadMADOffset:]
-	respMAD[ibMADMethodOff] = method | 0x80
 	switch attrID {
 	case ibAttrNodeDesc:
 		fillNodeDesc(respMAD, target)
@@ -147,8 +138,9 @@ func TrySynthesize(sendMad []byte, g *fabric.Graph, localCA string) ([]byte, boo
 // newSMPResp clones a SEND umad into a GETRESP buffer: padded to at least a full
 // legacy umad frame (so short libibmad sends still carry the 256-byte MAD),
 // umad.status zeroed (a non-zero status makes libibmad discard the reply), and
-// the MAD method's response bit (0x80) set. It mirrors the inline response setup
-// in TrySynthesize and is used by the SMInfo branch.
+// the MAD method's response bit (0x80) set. It is the single response-framing
+// helper for TrySynthesize, used by both the SMInfo branch and the directed-route
+// NODE_DESC/NODE_INFO/PORT_INFO path.
 func newSMPResp(sendMad []byte, method byte) []byte {
 	out := make([]byte, len(sendMad))
 	if len(sendMad) < minUmadLen {

--- a/pkg/network/mockib/subnet/synthesize_test.go
+++ b/pkg/network/mockib/subnet/synthesize_test.go
@@ -140,6 +140,70 @@ func TestFillNodeInfo_WireBytes(t *testing.T) {
 	require.Equal(t, byte(1), pl[36], "LocalPort @byte36")
 }
 
+// TestFillSMInfo_WireBytes pins the on-wire byte layout of a synthesized SMInfo
+// SMP via raw big-endian reads at the libibmad fields.c byte offsets, NOT via
+// GetFieldSpec (see TestFillPortInfo_WireBytes rationale). Byte 20 carries
+// Priority in the high nibble and SMState in the low nibble.
+func TestFillSMInfo_WireBytes(t *testing.T) {
+	mad := make([]byte, ibSMPDataOff+64)
+	fillSMInfo(mad, fabricPort(0x101))
+	pl := mad[ibSMPDataOff:]
+
+	// GUID (spec bit 0 -> byte 0, BE64, plain via putGUID64).
+	require.Equal(t, []byte{0xa0, 0x88, 0xc2, 0x03, 0x00, 0xab, 0x00, 0x01}, pl[0:8], "SM GUID @byte0")
+	// SM_Key (spec bit 64 -> byte 8, BE64).
+	require.Equal(t, uint64(defaultSMKey), binary.BigEndian.Uint64(pl[8:16]), "SM_Key @byte8")
+	// ActCount (spec bit 128 -> byte 16, BE32).
+	require.Equal(t, uint32(smActCount), binary.BigEndian.Uint32(pl[16:20]), "ActCount @byte16")
+	// Priority high nibble + SMState low nibble of byte 20.
+	require.Equal(t, byte(defaultSMPriority), pl[20]>>4, "Priority @byte20 high nibble")
+	require.Equal(t, byte(smStateMaster), pl[20]&0x0f, "SMState @byte20 low nibble")
+}
+
+func TestTrySynthesize_SMInfo(t *testing.T) {
+	// sminfo LID-routes SMInfo to the advertised SM LID (1), which is not a real
+	// port; the daemon must still answer from the elected master (lowest GUID).
+	g := fabric.Build([]protocol.PortAdvert{
+		{PortGUID: "a088:c203:00ab:0005", LID: 0x105, CAName: "mlx5_0"},
+	}, map[string]registry.Peer{
+		"a088:c203:00ab:0002": {LID: 0x102, CAName: "mlx5_0", PodIP: "10.0.0.2"},
+	})
+	send := make([]byte, umadMADOffset+64)
+	mad := send[umadMADOffset:]
+	writeMADHeader(mad, ibClassSMI, ibAttrSMInfo)
+	binary.BigEndian.PutUint16(send[28:30], defaultSMLID)
+
+	resp, ok := TrySynthesize(send, g, "mlx5_0")
+	require.True(t, ok, "expected SMInfo synthesize")
+	require.GreaterOrEqual(t, len(resp), minUmadLen, "resp padded to full umad frame")
+	rm := resp[umadMADOffset:]
+	require.NotEqual(t, byte(0), rm[ibMADMethodOff]&0x80, "response method bit not set")
+
+	pl := resp[umadMADOffset+ibSMPDataOff:]
+	// Master SM GUID = lowest PortGUID across the merged graph (peer 0002).
+	require.Equal(t, []byte{0xa0, 0x88, 0xc2, 0x03, 0x00, 0xab, 0x00, 0x02}, pl[0:8], "SM GUID = lowest PortGUID")
+	require.Equal(t, uint32(smStateMaster), GetFieldSpec(pl, 164, 4), "SMState MASTER")
+}
+
+func TestTrySynthesize_SMInfoSubnSetIgnored(t *testing.T) {
+	g := fabric.Build([]protocol.PortAdvert{
+		{PortGUID: "a088:c203:00ab:0001", LID: 0x101, CAName: "mlx5_0"},
+	}, nil)
+	send := make([]byte, umadMADOffset+64)
+	mad := send[umadMADOffset:]
+	writeMADHeader(mad, ibClassSMI, ibAttrSMInfo)
+	mad[ibMADMethodOff] = 0x02 // SubnSet (sminfo -p/-s/-a); mock has no mutable SM
+	_, ok := TrySynthesize(send, g, "mlx5_0")
+	require.False(t, ok, "SubnSet(SMInfo) must not be synthesized")
+}
+
+func TestTrySynthesize_SMInfoEmptyGraph(t *testing.T) {
+	send := make([]byte, umadMADOffset+64)
+	writeMADHeader(send[umadMADOffset:], ibClassSMI, ibAttrSMInfo)
+	_, ok := TrySynthesize(send, fabric.Build(nil, nil), "mlx5_0")
+	require.False(t, ok, "no master SM without any ports")
+}
+
 func TestTrySynthesize_DROneHopNodeInfo(t *testing.T) {
 	local := []protocol.PortAdvert{
 		{PortGUID: "a088:c203:00ab:0001", NodeGUID: "a088:c203:00ab:0000", LID: 0x101, CAName: "mlx5_0"},

--- a/tests/e2e/validate-ibnetdiscover.sh
+++ b/tests/e2e/validate-ibnetdiscover.sh
@@ -58,15 +58,22 @@ for P in "$LOCAL_POD" "$PEER_POD"; do
   fi
 done
 
-# Local pod's own port GUIDs come from the rendered mock sysfs tree. Any GUID in
+# Local pod's own GUIDs come from the rendered mock sysfs tree. Any GUID in
 # ibnetdiscover's output that is not in this set is, by construction, a peer-pod
-# port (same technique as validate-iblinkinfo.sh).
+# GUID (same technique as validate-iblinkinfo.sh). We collect port_guid AND the
+# CA-level node_guid / sys_image_guid: ibnetdiscover prints node GUIDs (caguid=)
+# in addition to port GUIDs, and the mock derives node_guid from port_guid by
+# clearing the EUI-64 U/L bit (fabric.nodeGUIDFromPortGUID), so node_guid !=
+# port_guid. Excluding only port_guid would let the local CA's own node GUID be
+# misclassified as a cross-pod peer and false-pass the assertion below.
 LOCAL_GUIDS=$(kubectl exec "$LOCAL_POD" -- sh -c '
-  for f in /var/lib/nvml-mock/ib/sys/class/infiniband/*/ports/1/port_guid; do
-    [ -r "$f" ] && cat "$f"
+  for ca in /var/lib/nvml-mock/ib/sys/class/infiniband/*; do
+    for f in "$ca/ports/1/port_guid" "$ca/node_guid" "$ca/sys_image_guid"; do
+      [ -r "$f" ] && cat "$f"
+    done
   done' 2>/dev/null | tr -d ':[:space:]' | tr 'A-F' 'a-f' | sort -u)
 if [ -z "$LOCAL_GUIDS" ]; then
-  echo "FAIL: could not enumerate local port GUIDs from sysfs on $LOCAL_POD"
+  echo "FAIL: could not enumerate local GUIDs (port/node/sys_image) from sysfs on $LOCAL_POD"
   exit 1
 fi
 

--- a/tests/e2e/validate-ibnetdiscover.sh
+++ b/tests/e2e/validate-ibnetdiscover.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Validate ibnetdiscover whole-fabric scan (requires mock-ib fabric ready + peer
+# pods). ibnetdiscover runs the same libibnetdisc directed-route walk as
+# iblinkinfo over the NODE_INFO/NODE_DESC/PORT_INFO synthesis the daemon already
+# serves.
+#
+# The mock fabric is point-to-point (no switches): each local CA picks ONE
+# outbound neighbor (lowest-GUID non-self port; see fabric.PeerAtOutbound), so a
+# scan from one pod cannot enumerate every port of a >2-node fabric. As with
+# validate-iblinkinfo.sh, the assertion is the property we actually care about:
+# ibnetdiscover's scan reaches AT LEAST ONE non-local CA (cross-pod visibility).
+#
+# Usage:
+#   validate-ibnetdiscover.sh <local-pod> <peer-pod> <profile> <expected-hcas>
+set -euo pipefail
+
+LOCAL_POD="${1:?Usage: $0 <local-pod> <peer-pod> <profile> <expected-hcas>}"
+PEER_POD="${2:?}"
+PROFILE="${3:?}"
+EXPECTED="${4:?}"
+
+case "$PROFILE" in
+  l40s|t4) EXPECTED=0 ;;
+esac
+
+MOCK_IBPING_SOCKET="${MOCK_IB_PING_SOCKET:-/run/mock-ib.sock}"
+MAX_RETRIES="${IBNETDISCOVER_E2E_RETRIES:-3}"
+RETRY_SLEEP="${IBNETDISCOVER_E2E_RETRY_SLEEP:-5}"
+
+echo "=== Validating ibnetdiscover local=$LOCAL_POD peer=$PEER_POD profile=$PROFILE ==="
+
+if [ "$EXPECTED" -eq 0 ]; then
+  echo "SKIP: IB disabled for profile $PROFILE"
+  exit 0
+fi
+
+# ibnetdiscover needs the mock-ib UMAD daemon; under MOCK_IB=sysfs (no socket)
+# there is nothing to answer the DR walk, so skip rather than hard-fail.
+if ! kubectl exec "$LOCAL_POD" -- test -S "${MOCK_IBPING_SOCKET}" 2>/dev/null; then
+  for i in $(seq 1 30); do
+    if kubectl exec "$LOCAL_POD" -- test -S "${MOCK_IBPING_SOCKET}" 2>/dev/null; then
+      break
+    fi
+    sleep 1
+  done
+fi
+if ! kubectl exec "$LOCAL_POD" -- test -S "${MOCK_IBPING_SOCKET}" 2>/dev/null; then
+  echo "SKIP: mock-ib socket ${MOCK_IBPING_SOCKET} not present on $LOCAL_POD (UMAD daemon not running)"
+  exit 0
+fi
+
+for P in "$LOCAL_POD" "$PEER_POD"; do
+  if ! kubectl logs "$P" 2>/dev/null | grep -q 'fabric ready'; then
+    echo "WARN: pod $P logs do not show 'fabric ready' yet"
+  fi
+done
+
+# Local pod's own port GUIDs come from the rendered mock sysfs tree. Any GUID in
+# ibnetdiscover's output that is not in this set is, by construction, a peer-pod
+# port (same technique as validate-iblinkinfo.sh).
+LOCAL_GUIDS=$(kubectl exec "$LOCAL_POD" -- sh -c '
+  for f in /var/lib/nvml-mock/ib/sys/class/infiniband/*/ports/1/port_guid; do
+    [ -r "$f" ] && cat "$f"
+  done' 2>/dev/null | tr -d ':[:space:]' | tr 'A-F' 'a-f' | sort -u)
+if [ -z "$LOCAL_GUIDS" ]; then
+  echo "FAIL: could not enumerate local port GUIDs from sysfs on $LOCAL_POD"
+  exit 1
+fi
+
+attempt_discover() {
+  local out found_guids cross_pod g p
+  out=$(kubectl exec "$LOCAL_POD" -- ibnetdiscover 2>&1) || true
+  echo "--- ibnetdiscover ---"
+  printf '%s\n' "$out"
+
+  for p in 'iberror:' "can't open UMAD port" 'mad_rpc' 'Resource temporarily unavailable'; do
+    if printf '%s\n' "$out" | grep -Fq "$p"; then
+      echo "ibnetdiscover output contains forbidden pattern: $p"
+      return 1
+    fi
+  done
+
+  # ibnetdiscover prints a Ca record per discovered HCA (caguid=...).
+  if ! printf '%s\n' "$out" | grep -qiE '^caguid='; then
+    echo "ibnetdiscover printed no Ca records (caguid=)"
+    return 1
+  fi
+
+  found_guids=$(printf '%s\n' "$out" \
+    | grep -oiE '0x[0-9a-f]{16}' \
+    | tr 'A-F' 'a-f' \
+    | sed 's/^0x//' \
+    | sort -u)
+  if [ -z "$found_guids" ]; then
+    echo "ibnetdiscover on $LOCAL_POD printed no port GUIDs"
+    return 1
+  fi
+
+  cross_pod=""
+  for g in $found_guids; do
+    if ! printf '%s\n' "$LOCAL_GUIDS" | grep -qx "$g"; then
+      cross_pod="$g"
+      break
+    fi
+  done
+  if [ -z "$cross_pod" ]; then
+    echo "ibnetdiscover on $LOCAL_POD found only local GUIDs ($found_guids), no cross-pod peer"
+    return 1
+  fi
+
+  echo "OK: ibnetdiscover scan from $LOCAL_POD reached cross-pod peer $cross_pod"
+  echo "    (mock fabric is point-to-point lowest-GUID, see fabric.PeerAtOutbound —"
+  echo "     cross-pod visibility is the assertion)"
+  return 0
+}
+
+for attempt in $(seq 1 "$MAX_RETRIES"); do
+  echo "--- ibnetdiscover attempt $attempt/$MAX_RETRIES ---"
+  if attempt_discover; then
+    echo "=== ibnetdiscover validation PASSED ==="
+    exit 0
+  fi
+  if [ "$attempt" -lt "$MAX_RETRIES" ]; then
+    echo "Retrying in ${RETRY_SLEEP}s..."
+    sleep "$RETRY_SLEEP"
+  fi
+done
+
+echo "FAIL: ibnetdiscover did not reach a cross-pod peer after $MAX_RETRIES attempts"
+kubectl exec "$LOCAL_POD" -- tail -40 /tmp/mock-ib.log 2>/dev/null || true
+exit 1

--- a/tests/e2e/validate-ibnetdiscover.sh
+++ b/tests/e2e/validate-ibnetdiscover.sh
@@ -39,15 +39,18 @@ fi
 
 # ibnetdiscover needs the mock-ib UMAD daemon; under MOCK_IB=sysfs (no socket)
 # there is nothing to answer the DR walk, so skip rather than hard-fail.
-if ! kubectl exec "$LOCAL_POD" -- test -S "${MOCK_IBPING_SOCKET}" 2>/dev/null; then
+wait_for_socket() {
+  local pod=$1 i
   for i in $(seq 1 30); do
-    if kubectl exec "$LOCAL_POD" -- test -S "${MOCK_IBPING_SOCKET}" 2>/dev/null; then
-      break
+    if kubectl exec "$pod" -- test -S "${MOCK_IBPING_SOCKET}" 2>/dev/null; then
+      return 0
     fi
     sleep 1
   done
-fi
-if ! kubectl exec "$LOCAL_POD" -- test -S "${MOCK_IBPING_SOCKET}" 2>/dev/null; then
+  return 1
+}
+
+if ! wait_for_socket "$LOCAL_POD"; then
   echo "SKIP: mock-ib socket ${MOCK_IBPING_SOCKET} not present on $LOCAL_POD (UMAD daemon not running)"
   exit 0
 fi

--- a/tests/e2e/validate-sminfo.sh
+++ b/tests/e2e/validate-sminfo.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Validate `sminfo` against the mock-ib master subnet manager.
+#
+# sminfo reads its local PortInfo (MasterSMLID=1), then issues a SubnGet(SMInfo)
+# to that SM LID. The mock-ib daemon answers from the elected master SM (lowest
+# port GUID in the fabric graph) with SMState=MASTER(3). This needs the UMAD
+# daemon (MOCK_IB=full), so it is skipped for IB-disabled profiles.
+#
+# With an optional <peer-pod>, also assert that both pods report the SAME master
+# SM GUID — the cross-fabric "consistent SM identity" property.
+#
+# Usage:
+#   validate-sminfo.sh <pod> <profile> <expected-hcas> [peer-pod]
+set -euo pipefail
+
+POD="${1:?Usage: $0 <pod> <profile> <expected-hcas> [peer-pod]}"
+PROFILE="${2:?}"
+EXPECTED="${3:?}"
+PEER_POD="${4:-}"
+
+case "$PROFILE" in
+  l40s|t4) EXPECTED=0 ;;
+esac
+
+MOCK_IBPING_SOCKET="${MOCK_IB_PING_SOCKET:-/run/mock-ib.sock}"
+MAX_RETRIES="${SMINFO_E2E_RETRIES:-3}"
+RETRY_SLEEP="${SMINFO_E2E_RETRY_SLEEP:-5}"
+
+echo "=== Validating sminfo pod=$POD profile=$PROFILE peer=${PEER_POD:-<none>} ==="
+
+if [ "$EXPECTED" -eq 0 ]; then
+  echo "SKIP: IB disabled for profile $PROFILE"
+  exit 0
+fi
+
+# sminfo needs the mock-ib UMAD daemon; under MOCK_IB=sysfs (no socket) there is
+# nothing to answer the SubnGet, so skip rather than fail.
+wait_for_socket() {
+  local pod=$1 i
+  for i in $(seq 1 30); do
+    if kubectl exec "$pod" -- test -S "${MOCK_IBPING_SOCKET}" 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+if ! wait_for_socket "$POD"; then
+  echo "SKIP: mock-ib socket ${MOCK_IBPING_SOCKET} not present on $POD (UMAD daemon not running)"
+  exit 0
+fi
+
+sminfo_fail_patterns() {
+  local out=$1 p
+  for p in \
+    'iberror:' \
+    "can't open UMAD port" \
+    'ibwarn:' \
+    'mad_rpc' \
+    'umad_get_mad' \
+    'Resource temporarily unavailable' \
+    'query failed'; do
+    if printf '%s\n' "$out" | grep -Fq "$p"; then
+      echo "FAIL: sminfo output contains forbidden pattern: $p"
+      return 1
+    fi
+  done
+  return 0
+}
+
+# A believable master SM: SMState MASTER (printed as "state 3 SMINFO_MASTER")
+# and a non-zero SM GUID.
+sminfo_success() {
+  local out=$1
+  if ! printf '%s\n' "$out" | grep -Eiq 'SMINFO_MASTER|state 3'; then
+    echo "FAIL: sminfo did not report a master SM (no SMINFO_MASTER / state 3)"
+    return 1
+  fi
+  if ! printf '%s\n' "$out" | grep -Eiq 'sm guid 0x0*[1-9a-f][0-9a-f]*'; then
+    echo "FAIL: sminfo did not report a non-zero SM GUID"
+    return 1
+  fi
+  return 0
+}
+
+sm_guid() {
+  printf '%s\n' "$1" | grep -oiE 'sm guid 0x[0-9a-f]+' | head -1 | awk '{print $NF}' | tr 'A-F' 'a-f'
+}
+
+# run_sminfo PODNAME -> echoes the validated sminfo output (or exits non-zero).
+run_sminfo() {
+  local pod=$1 attempt out
+  for attempt in $(seq 1 "$MAX_RETRIES"); do
+    echo "--- sminfo on $pod attempt $attempt/$MAX_RETRIES ---" >&2
+    out=$(kubectl exec "$pod" -- sminfo 2>&1) || true
+    printf '%s\n' "$out" >&2
+    if sminfo_fail_patterns "$out" && sminfo_success "$out"; then
+      printf '%s' "$out"
+      return 0
+    fi
+    if [ "$attempt" -lt "$MAX_RETRIES" ]; then
+      echo "Retrying in ${RETRY_SLEEP}s..." >&2
+      sleep "$RETRY_SLEEP"
+    fi
+  done
+  return 1
+}
+
+if ! OUT=$(run_sminfo "$POD"); then
+  echo "FAIL: sminfo did not report a master SM on $POD after $MAX_RETRIES attempts"
+  kubectl exec "$POD" -- tail -40 /tmp/mock-ib.log 2>/dev/null || true
+  exit 1
+fi
+GUID=$(sm_guid "$OUT")
+echo "OK: $POD reports master SM guid=$GUID state=MASTER"
+
+if [ -n "$PEER_POD" ]; then
+  if ! wait_for_socket "$PEER_POD"; then
+    echo "SKIP cross-pod check: mock-ib socket not present on peer $PEER_POD"
+    echo "=== sminfo validation PASSED ==="
+    exit 0
+  fi
+  if ! PEER_OUT=$(run_sminfo "$PEER_POD"); then
+    echo "FAIL: sminfo did not report a master SM on peer $PEER_POD"
+    kubectl exec "$PEER_POD" -- tail -40 /tmp/mock-ib.log 2>/dev/null || true
+    exit 1
+  fi
+  PEER_GUID=$(sm_guid "$PEER_OUT")
+  echo "OK: $PEER_POD reports master SM guid=$PEER_GUID state=MASTER"
+  if [ "$GUID" != "$PEER_GUID" ]; then
+    echo "FAIL: pods disagree on the master SM GUID ($POD=$GUID, $PEER_POD=$PEER_GUID)"
+    exit 1
+  fi
+  echo "OK: both pods agree on a single master SM ($GUID)"
+fi
+
+echo "=== sminfo validation PASSED ==="


### PR DESCRIPTION
## Summary

Adds a mock subnet-manager identity so `sminfo` works, and validates whole-fabric `ibnetdiscover`, rounding out the IB diagnostics mocked in #367/#368. Implements the must-have scope of #373; the UFM REST endpoint and a synthetic switch for >2-node enumeration are deferred to follow-ups.

- **`sminfo`** — synthesize the `SMInfo` SMP attribute (`0x0020`). The daemon answers with a master SM (`SMState=MASTER`) whose GUID is the lowest-`PortGUID` port in the merged local+peer `fabric.Graph` (`(*Graph).MasterSM`), so every pod converges on one consistent SM identity. SMInfo is dispatched early in `subnet.TrySynthesize`, before directed-route target resolution, because it is LID-routed to the advertised SM LID (`1`), which is not a real graph port. GUID/SM_Key are plain big-endian; ActCount/Priority/SMState use the existing libibmad BITSOFFS helpers. SubnGet only.
- **`ibnetdiscover`** — reuses the existing directed-route `NODE_INFO`/`NODE_DESC`/`PORT_INFO` synthesis (the same walk `iblinkinfo` uses); lists the local CA and its cross-pod peer(s).
- **No deployment changes** — both tools ride the existing `libibmockumad` UMAD path; `infiniband-diags` is already installed and the shim already preloaded. Pure Go-side + tests + e2e scripts.

### Known limitation
The mock fabric is point-to-point with no switches: each one-port CA selects a single outbound neighbor and CAs do not forward directed-route SMPs, so a scan from one pod reaches the local CA plus one neighbor — sufficient for the two-node e2e, but it does not enumerate every port of a 3+ node fabric. True whole-fabric enumeration would need a synthetic switch (NodeType=2 + `SwitchInfo 0x0012`), left as a follow-up. This is documented in the README.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/network/mockib/...`
- [x] `gofmt -l` clean
- [x] `golangci-lint run pkg/network/mockib/...` (0 issues)
- [x] `go test -race ./pkg/network/mockib/...`
  - `TestFillSMInfo_WireBytes` (raw byte-pinned layout), `TestTrySynthesize_SMInfo` + SubnSet/empty-graph negatives, `TestGraph_MasterSM`, `TestServer_SMInfoMaster` (socket round-trip)
- [ ] E2E (CI, multinode job): `validate-sminfo.sh` asserts `SMINFO_MASTER` + non-zero GUID and that both pods agree on a single master SM GUID; `validate-ibnetdiscover.sh` asserts ≥1 cross-pod CA. Both skip IB-disabled profiles (l40s/t4) and `MOCK_IB=sysfs`.

Refs #373