### PR TITLE
fix(e2e): avoid SIGPIPE false-negative in IB validation scripts

### DIFF
--- a/tests/e2e/validate-iblinkinfo.sh
+++ b/tests/e2e/validate-iblinkinfo.sh
@@ -76,7 +76,7 @@ fi
 
 CROSS_POD=""
 for g in $FOUND_GUIDS; do
-  if ! printf '%s\n' "$LOCAL_GUIDS" | grep -qx "$g"; then
+  if ! grep -qx "$g" <<<"$LOCAL_GUIDS"; then
     CROSS_POD="$g"
     break
   fi

--- a/tests/e2e/validate-ibnetdiscover.sh
+++ b/tests/e2e/validate-ibnetdiscover.sh
@@ -111,7 +111,7 @@ attempt_discover() {
 
   cross_pod=""
   for g in $found_guids; do
-    if ! printf '%s\n' "$LOCAL_GUIDS" | grep -qx "$g"; then
+    if ! grep -qx "$g" <<<"$LOCAL_GUIDS"; then
       cross_pod="$g"
       break
     fi

--- a/tests/e2e/validate-ibv-devinfo.sh
+++ b/tests/e2e/validate-ibv-devinfo.sh
@@ -91,7 +91,7 @@ echo "PASS: ibv_devinfo -l listed $ACTUAL devices"
 DEVICES=$(kubectl exec "$POD" -- ibv_devices 2>&1)
 echo "--- ibv_devices ---"
 printf '%s\n' "$DEVICES"
-if ! printf '%s\n' "$DEVICES" | grep -qE '^[[:space:]]+mlx5_0[[:space:]]+[0-9a-f]{16}'; then
+if ! grep -qE '^[[:space:]]+mlx5_0[[:space:]]+[0-9a-f]{16}' <<<"$DEVICES"; then
   echo "FAIL: ibv_devices did not list mlx5_0 with a node GUID"
   exit 1
 fi
@@ -105,7 +105,7 @@ if [ "$ACTIVE_PORTS" -lt "$EXPECTED" ]; then
   echo "FAIL: ibstatus reports $ACTIVE_PORTS ACTIVE ports, expected at least $EXPECTED"
   exit 1
 fi
-if ! printf '%s\n' "$FULL" | grep -qE 'phys state:[[:space:]]+5: LinkUp'; then
+if ! grep -qE 'phys state:[[:space:]]+5: LinkUp' <<<"$FULL"; then
   echo "FAIL: ibstatus output missing 'phys state: 5: LinkUp'"
   exit 1
 fi


### PR DESCRIPTION
## Summary

The InfiniBand e2e validation scripts run under `set -euo pipefail` and check for expected output with `printf '%s\n' "$VAR" | grep -q ...`. When `grep -q` finds its match it exits `0` and closes the read end of the pipe **before** `printf` finishes writing the (multi-HCA) blob, so `printf` dies with `SIGPIPE`. Under `pipefail` the pipeline then inherits `printf`'s non-zero status, flipping `if ! pipeline` into a false-negative failure even though the expected line was present.

This is timing/buffer-dependent, so it shows up as a flaky e2e run. Observed in [run 27936780842 / e2e-device-plugin (h100)](https://github.com/NVIDIA/k8s-test-infra/actions/runs/27936780842):

```
validate-ibv-devinfo.sh: line 108: printf: write error: Broken pipe
FAIL: ibstatus output missing 'phys state: 5: LinkUp'
```

(The `LinkUp` line *was* present — `grep` matched it — the broken pipe just flipped the result.)

## Fix

Replace the `printf '%s\n' "$VAR" | grep -q ...` pattern with a here-string (`grep -q ... <<<"$VAR"`), eliminating the pipe entirely so there is nothing to break. Applied to:

- `tests/e2e/validate-ibv-devinfo.sh` — `mlx5_0` GUID check and `phys state: 5: LinkUp` check
- `tests/e2e/validate-iblinkinfo.sh` — cross-pod GUID check
- `tests/e2e/validate-ibnetdiscover.sh` — cross-pod GUID check

All three scripts are `#!/bin/bash`, so here-strings are supported.

## Test plan

Reproducer confirming the behavior (5000-line input forces the race deterministically):

```
$ bash -c 'set -euo pipefail; FULL=$(printf "phys state: 5: LinkUp\n%.0s" {1..5000})
  grep -qE "phys state:[[:space:]]+5: LinkUp" <<<"$FULL" && echo "NEW rc=0"
  set +e; printf "%s\n" "$FULL" | grep -qE "phys state:[[:space:]]+5: LinkUp"; echo "OLD rc=$?"'
NEW rc=0
OLD rc=141   # SIGPIPE -> false-negative under pipefail
```

- [x] `bash -n` passes on all three scripts
- [x] Reproducer shows old pattern fails (rc=141), new pattern succeeds (rc=0)