### PR TITLE
feat(nvml-mock): NCCL / nccl-tests collective-comms simulation

### DIFF
--- a/.github/workflows/nvml-mock-e2e.yaml
+++ b/.github/workflows/nvml-mock-e2e.yaml
@@ -1073,3 +1073,60 @@ jobs:
           kubectl logs -l app.kubernetes.io/instance=nvml-mock-w2 --tail=50 || true
           echo "=== events ==="
           kubectl get events --sort-by=.lastTimestamp | tail -30 || true
+
+  nccl-multinode:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
+
+      - name: Create multi-node Kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
+        with:
+          cluster_name: nccl-fleet
+          config: tests/e2e/kind-multi-node-config.yaml
+
+      - name: Build nvml-mock image
+        run: |
+          docker build -t nvml-mock:e2e -f deployments/nvml-mock/Dockerfile \
+            --build-arg GOLANG_VERSION=${{ inputs.golang_version }} .
+
+      - name: Load image into Kind
+        run: |
+          kind load docker-image nvml-mock:e2e --name nccl-fleet
+
+      # Single cluster-wide release: the DaemonSet tolerates all nodes (no
+      # nodeSelector) and the 2-pod NCCL Job spreads across hosts via its own
+      # podAntiAffinity, so a per-worker install (as in e2e-multi-node) is not
+      # needed here. a100 is IB-enabled, exercising the mock transport path.
+      # helm --wait gates on DaemonSet readiness (it does not wait for Job
+      # completion without --wait-for-jobs); the validator performs its own
+      # Job-completion wait and reads the rank-0 busbw.
+      - name: Install nvml-mock chart with NCCL test enabled (a100, IB-enabled)
+        run: |
+          helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+            --set image.repository=nvml-mock \
+            --set image.tag=e2e \
+            --set gpu.profile=a100 \
+            --set nccl.test.enabled=true \
+            --set nccl.test.worldSize=2 \
+            --wait --timeout 120s
+
+      - name: Validate 2-pod NCCL busbw
+        run: |
+          ./tests/e2e/validate-nccl.sh default nvml-mock-nccl-test
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== nccl test job ==="
+          kubectl describe job/nvml-mock-nccl-test || true
+          kubectl logs -l app.kubernetes.io/component=nccl-test --tail=100 --prefix || true
+          echo "=== rdzv service + endpoints ==="
+          kubectl get svc,endpoints -l app.kubernetes.io/component=nccl-test -o wide || true
+          echo "=== pods ==="
+          kubectl get pods -o wide || true
+          echo "=== events ==="
+          kubectl get events --sort-by=.lastTimestamp | tail -40 || true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build artifacts
 *.so
+*.so.*
 *.dll
 *.dylib
 *.out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **NCCL collective-comms simulation** (`pkg/gpu/mocknccl`): hardware-free mock
+  `libnccl.so.2` with a topology-derived linear cost model, mock CUDA event
+  timing, an MPI-free Indexed-Job rendezvous, and a `mock-coll-perf` driver. A
+  2-pod `all_reduce`-style run reports non-zero `busbw` on Kind. (#372)
+
 ## [0.2.1] - 2026-06-12
 
 ### Fixed

--- a/deployments/nvml-mock/Dockerfile
+++ b/deployments/nvml-mock/Dockerfile
@@ -19,6 +19,7 @@ COPY go.mod go.sum ./
 COPY vendor/ vendor/
 COPY pkg/gpu/mocknvml/ pkg/gpu/mocknvml/
 COPY pkg/gpu/mockcuda/ pkg/gpu/mockcuda/
+COPY pkg/gpu/mocknccl/ pkg/gpu/mocknccl/
 COPY pkg/network/mockib/ pkg/network/mockib/
 COPY pkg/system/mockpcisysfs/ pkg/system/mockpcisysfs/
 COPY pkg/imexcoord/ pkg/imexcoord/
@@ -30,6 +31,7 @@ COPY cmd/fake-fabricmanager/ cmd/fake-fabricmanager/
 COPY cmd/check-fabric/ cmd/check-fabric/
 RUN cd pkg/gpu/mocknvml && make clean && make
 RUN cd pkg/gpu/mockcuda && make clean && make
+RUN cd pkg/gpu/mocknccl && make clean && make
 RUN cd pkg/network/mockib && make clean && make
 RUN mkdir -p /out \
     && go build -mod=vendor -o /out/mock-ib ./cmd/mock-ib \
@@ -40,11 +42,24 @@ RUN mkdir -p /out \
     && go build -mod=vendor -o /out/nv-fabricmanager-ctl ./cmd/fake-fabricmanager/ctl \
     && go build -mod=vendor -o /out/check-fabric    ./cmd/check-fabric
 
+# Build the mock-coll-perf driver against the mock NCCL/CUDA libs + headers.
+RUN gcc -O2 \
+      -I pkg/gpu/mocknccl/bridge -I pkg/gpu/mockcuda/bridge \
+      -o /out/mock-coll-perf pkg/gpu/mocknccl/perf/mock-coll-perf.c \
+      -L pkg/gpu/mocknccl -lnccl -L pkg/gpu/mockcuda -lcuda \
+      -Wl,-rpath,/usr/local/lib
+
 FROM debian:bookworm-slim
 ARG KUBECTL_VERSION=v1.36.1
 ARG TARGETARCH
 COPY --from=builder /src/pkg/gpu/mocknvml/libnvidia-ml.so.* /usr/local/lib/
 COPY --from=builder /src/pkg/gpu/mockcuda/libcuda.so.* /usr/local/lib/
+COPY --from=builder /src/pkg/gpu/mocknccl/libnccl.so.* /usr/local/lib/
+# mock-coll-perf records bare libnccl.so/libcuda.so NEEDED entries (the
+# c-shared SONAME), but the .so.* globs above only copy the versioned files.
+# Recreate the bare-name symlinks so the driver's dynamic deps resolve.
+RUN ln -sf libnccl.so.2 /usr/local/lib/libnccl.so \
+    && ln -sf libcuda.so.1 /usr/local/lib/libcuda.so
 COPY --from=builder /src/pkg/network/mockib/libibmocksys.so.* /usr/local/lib/
 COPY --from=builder /src/pkg/network/mockib/libibmockumad.so.* /usr/local/lib/
 COPY --from=builder /src/pkg/network/mockib/libibmockverbs.so.* /usr/local/lib/
@@ -67,6 +82,7 @@ COPY --from=builder /out/nv-fabricmanager-ctl /usr/bin/nv-fabricmanager-ctl
 # to confirm the topology overlay assigned the expected clique to each
 # node. See NVIDIA/k8s-test-infra#304.
 COPY --from=builder /out/check-fabric    /usr/local/bin/check-fabric
+COPY --from=builder /out/mock-coll-perf /usr/local/bin/mock-coll-perf
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends curl ca-certificates gnupg2 \

--- a/deployments/nvml-mock/helm/nvml-mock/templates/nccl-test-job.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/nccl-test-job.yaml
@@ -1,0 +1,61 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.nccl.test.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "nvml-mock.fullname" . }}-nccl-test
+  labels:
+    {{- include "nvml-mock.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nccl-test
+spec:
+  completions: {{ .Values.nccl.test.worldSize }}
+  parallelism: {{ .Values.nccl.test.worldSize }}
+  completionMode: Indexed
+  backoffLimit: 4
+  template:
+    metadata:
+      labels:
+        {{- include "nvml-mock.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: nccl-test
+    spec:
+      restartPolicy: Never
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/component: nccl-test
+      containers:
+        - name: nccl-perf
+          image: {{ .Values.nccl.test.image | default (printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion)) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              export RANK="${JOB_COMPLETION_INDEX:-0}"
+              export WORLD_SIZE="{{ .Values.nccl.test.worldSize }}"
+              export MOCK_NCCL_RDZV="{{ include "nvml-mock.fullname" . }}-nccl-rdzv:{{ .Values.nccl.test.rendezvousPort }}"
+              exec /usr/local/bin/mock-coll-perf {{ .Values.nccl.test.collective }} \
+                -b {{ .Values.nccl.test.minBytes }} -e {{ .Values.nccl.test.maxBytes }} \
+                -f 2 -n {{ .Values.nccl.test.iters }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: LD_LIBRARY_PATH
+              value: /usr/local/lib
+            - name: MOCK_NCCL_CONFIG
+              value: /etc/nvml-mock/config.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nvml-mock
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "nvml-mock.fullname" . }}-config
+{{- end }}

--- a/deployments/nvml-mock/helm/nvml-mock/templates/service-nccl.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/service-nccl.yaml
@@ -1,0 +1,22 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.nccl.test.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nvml-mock.fullname" . }}-nccl-rdzv
+  labels:
+    {{- include "nvml-mock.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nccl-test
+spec:
+  clusterIP: None
+  selector:
+    {{- include "nvml-mock.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: nccl-test
+    batch.kubernetes.io/job-completion-index: "0"
+  ports:
+    - name: rdzv
+      protocol: TCP
+      port: {{ .Values.nccl.test.rendezvousPort }}
+      targetPort: {{ .Values.nccl.test.rendezvousPort }}
+{{- end }}

--- a/deployments/nvml-mock/helm/nvml-mock/tests/nccl_test_job_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/nccl_test_job_test.yaml
@@ -1,0 +1,42 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+suite: nccl test job
+templates:
+  - templates/nccl-test-job.yaml
+  - templates/service-nccl.yaml
+tests:
+  - it: renders nothing by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: renders Job and Service when enabled
+    set:
+      nccl.test.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/nccl-test-job.yaml
+      - equal:
+          path: spec.completionMode
+          value: Indexed
+        template: templates/nccl-test-job.yaml
+      - equal:
+          path: spec.parallelism
+          value: 2
+        template: templates/nccl-test-job.yaml
+      - equal:
+          path: spec.clusterIP
+          value: None
+        template: templates/service-nccl.yaml
+      - equal:
+          path: spec.selector["batch.kubernetes.io/job-completion-index"]
+          value: "0"
+        template: templates/service-nccl.yaml
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: nccl-test
+        template: templates/service-nccl.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "nccl-rdzv:29500"
+        template: templates/nccl-test-job.yaml

--- a/deployments/nvml-mock/helm/nvml-mock/values.schema.json
+++ b/deployments/nvml-mock/helm/nvml-mock/values.schema.json
@@ -194,6 +194,36 @@
           }
         }
       }
+    },
+    "nccl": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "NCCL collective-comms simulation (mock libnccl + mock-coll-perf).",
+      "properties": {
+        "test": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Optional 2-pod all_reduce_perf-style test Job. Off by default.",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "collective": {
+              "type": "string",
+              "description": "Collective operation exercised by mock-coll-perf.",
+              "enum": ["all_reduce", "all_gather", "reduce_scatter", "broadcast", "reduce"]
+            },
+            "worldSize": { "type": "integer", "minimum": 1 },
+            "minBytes": { "type": "integer", "minimum": 1 },
+            "maxBytes": { "type": "integer", "minimum": 1 },
+            "iters": { "type": "integer", "minimum": 1 },
+            "rendezvousPort": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            "image": { "type": "string" }
+          }
+        }
+      }
     }
   }
 }

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -164,3 +164,17 @@ integrations:
     # Labels applied to per-profile ConfigMaps for discovery
     profileLabels:
       run.ai/gpu-profile: "true"
+
+# NCCL collective-comms simulation (mock libnccl + mock-coll-perf).
+nccl:
+  # Optional 2-pod all_reduce_perf-style test Job. Off by default; the E2E
+  # harness and `helm install --set nccl.test.enabled=true` turn it on.
+  test:
+    enabled: false
+    collective: all_reduce   # all_reduce|all_gather|reduce_scatter|broadcast|reduce
+    worldSize: 2
+    minBytes: 1024
+    maxBytes: 67108864
+    iters: 20
+    rendezvousPort: 29500
+    image: ""   # defaults to the chart's nvml-mock image when empty

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ full walkthrough.
 | [Architecture](architecture.md) | System design and component overview |
 | [Configuration Reference](configuration.md) | Complete YAML configuration guide |
 | [CUDA Mock](cuda-mock.md) | Mock CUDA driver library details |
+| [NCCL Mock](../pkg/gpu/mocknccl/README.md) | Hardware-free NCCL collective-comms simulation |
 | [Development Guide](development.md) | Contributing and extending the project |
 | [Examples](examples.md) | Common usage patterns and scenarios |
 | [Troubleshooting](troubleshooting.md) | Common issues and solutions |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -370,6 +370,59 @@ a smaller scale (15 functions vs 400).
 
 See [CUDA Mock](cuda-mock.md) for full details.
 
+## Mock NCCL Architecture
+
+The NCCL mock reuses the same engine/bridge split to simulate GPU
+collective communication with no GPUs and no NVLink/InfiniBand hardware.
+
+- **Bridge (`libnccl.so.2`).** A cgo `c-shared` library exporting the
+  common NCCL C ABI (comm lifecycle, queries, grouping, and the
+  `AllReduce` / `AllGather` / `ReduceScatter` / `Broadcast` / `Reduce`
+  collectives). Each collective resolves its communicator and delegates to
+  the engine; no buffers are read or written.
+- **Engine (Go).** Owns a linear cost model
+  (`time = latency + msgBytes / algbw`, with `algbw = EffectiveBusBW /
+  busbwFactor`), the resolved communicator, and an MPI-free rendezvous.
+  Bandwidths derive from the mock-nvml profile's `nvlink:` (intra-node) and
+  `infiniband:` (inter-node) blocks, with `nccl:` YAML keys and
+  `MOCK_NCCL_*` env vars as overrides.
+- **Timing coupling with mockcuda.** The engine performs no measurement —
+  it sleeps the host for the modeled duration (capped by
+  `MOCK_NCCL_MAX_SLEEP_MS`). Consumers bracket the collective with
+  `cudaEventRecord` / `cudaEventElapsedTime`, which mockcuda implements as
+  host monotonic timestamps, so the reported `busbw` is derived from real
+  wall-clock — exactly as nccl-tests does on hardware.
+
+### Two-pod rendezvous data flow
+
+The Helm chart's opt-in NCCL test runs `mock-coll-perf` as an `Indexed`
+Job, one pod per rank, fronted by a headless Service:
+
+```
+            ┌─────────────────────────── headless Service ──────────────────────────┐
+            │  <release>-nccl-rdzv:29500  (selector pins job-completion-index="0")   │
+            └──────────────▲─────────────────────────────────────────────────────────┘
+                           │ resolves to rank 0
+   rank 0 pod              │                         rank 1 pod
+   RANK=JOB_COMPLETION_INDEX=0                       RANK=JOB_COMPLETION_INDEX=1
+   WORLD_SIZE=2, POD_IP=…                            WORLD_SIZE=2, POD_IP=…
+   ncclCommInitRank ──► binds :29500, serves ◄────── ncclCommInitRank dials rdzv
+        │                roster (peers, inter-node)        │
+        ▼                                                  ▼
+   collective loop (cudaEvent-timed)               collective loop
+        │
+        ▼  rank 0 prints "# Avg bus bandwidth : N"  ──► validate-nccl.sh asserts N > 0
+```
+
+Each pod derives `RANK` from `JOB_COMPLETION_INDEX`, takes `WORLD_SIZE`
+from the chart value, and `POD_IP` from the downward API. Rank 0 binds the
+rendezvous port and serves the roster; other ranks dial the headless
+Service. More than one distinct pod IP in the roster selects the
+inter-node (InfiniBand) bandwidth.
+
+See [`pkg/gpu/mocknccl/README.md`](../pkg/gpu/mocknccl/README.md) for the
+cost-model details, configuration reference, and ABI surface.
+
 ## Extending the Library
 
 See [Development Guide](development.md) for:

--- a/docs/cuda-mock.md
+++ b/docs/cuda-mock.md
@@ -4,8 +4,10 @@ The mock CUDA library provides a minimal implementation of CUDA Driver and Runti
 APIs for container validation workloads. It is built alongside the mock NVML library
 and deployed via the same DaemonSet.
 
-**Status:** Early stage -- 15 functions implemented. Sufficient for basic validation
-workloads (e.g., `cuda-sample:vectoradd`) but not for complex CUDA applications.
+**Status:** Early stage -- 26 functions implemented. Sufficient for basic validation
+workloads (e.g., `cuda-sample:vectoradd`) and for host-timed mock collective
+benchmarks (see [Mock NCCL](../pkg/gpu/mocknccl/README.md)), but not for complex
+CUDA applications.
 
 ## Implemented Functions
 
@@ -13,8 +15,10 @@ workloads (e.g., `cuda-sample:vectoradd`) but not for complex CUDA applications.
 |-------------------|----------------------------------------------------------------------------|--------------------------------------------------------|
 | Initialization    | `cuInit`, `cudaDriverGetVersion`, `cudaRuntimeGetVersion`                  | Returns configured driver/runtime versions             |
 | Device Management | `cudaGetDeviceCount`, `cudaSetDevice`, `cudaGetDevice`, `cudaDeviceReset`  | Tracks active device index                             |
-| Memory            | `cudaMalloc`, `cudaFree`, `cudaMemcpy`                                     | Real host allocation via malloc; device copies are no-ops |
+| Memory            | `cudaMalloc`, `cudaFree`, `cudaMemcpy`, `cudaMemset`                       | Real host allocation via malloc; device copies are no-ops |
 | Execution         | `cudaLaunchKernel`, `cudaDeviceSynchronize`                                | No-ops (no actual computation)                         |
+| Streams           | `cudaStreamCreate`, `cudaStreamCreateWithFlags`, `cudaStreamSynchronize`, `cudaStreamDestroy` | Opaque handles; synchronize is a no-op    |
+| Events            | `cudaEventCreate`, `cudaEventCreateWithFlags`, `cudaEventRecord`, `cudaEventSynchronize`, `cudaEventDestroy`, `cudaEventElapsedTime` | Host wall-clock timing -- `cudaEventElapsedTime` returns real elapsed ms between recorded events |
 | Error Handling    | `cudaGetErrorString`, `cudaGetLastError`, `cudaPeekAtLastError`            | Thread-local error tracking                            |
 
 ## How It Works
@@ -39,7 +43,7 @@ compatibility workaround -- applications that link against `libcudart.so` (such 
 ```
 ┌──────────────────────────────────┐
 │   CGo Bridge (bridge/cuda.go)    │
-│   15 C function exports          │
+│   26 C function exports          │
 │   C <-> Go type conversion       │
 └──────────────┬───────────────────┘
                │
@@ -60,7 +64,9 @@ manages state (active device index, allocated memory pointers, error codes).
 
 - **No actual computation** -- kernel launches are no-ops.
 - **No multi-GPU** -- device selection is tracked but has no effect.
-- **No streams/events** -- async operations are not implemented.
+- **Streams/events are timing-only** -- stream/event handles and `cudaEventElapsedTime`
+  provide host wall-clock timing (used by the mock NCCL driver), but there is no real
+  asynchronous execution; stream synchronize is a no-op.
 - **Memory copies** -- only host-to-host actually copies data; other directions are no-ops.
 - **No CUDA context management** -- `cuCtxCreate`, `cuCtxDestroy`, etc. are not implemented.
 
@@ -75,8 +81,10 @@ make
 
 | File                                    | Description                                |
 |-----------------------------------------|--------------------------------------------|
-| `pkg/gpu/mockcuda/bridge/cuda.go`       | CGo bridge -- 15 exported C functions      |
+| `pkg/gpu/mockcuda/bridge/cuda.go`       | CGo bridge -- 26 exported C functions      |
 | `pkg/gpu/mockcuda/bridge/cuda_types.h`  | C type definitions                         |
+| `pkg/gpu/mockcuda/bridge/cuda_runtime.h`| Public runtime header (consumed by the mock NCCL driver) |
 | `pkg/gpu/mockcuda/engine/cuda.go`       | Go engine -- device and memory management  |
+| `pkg/gpu/mockcuda/engine/timing.go`     | Go engine -- stream/event host wall-clock timing |
 | `pkg/gpu/mockcuda/engine/types.go`      | Error codes and type definitions           |
 | `pkg/gpu/mockcuda/Makefile`             | Build configuration                        |

--- a/pkg/gpu/mockcuda/bridge/cuda.go
+++ b/pkg/gpu/mockcuda/bridge/cuda.go
@@ -195,3 +195,125 @@ func cudaRuntimeGetVersion(runtimeVersion *C.int) C.cudaError_t {
 	*runtimeVersion = C.int(ver)
 	return C.cudaSuccess
 }
+
+// =============================================================================
+// Streams
+// =============================================================================
+
+//export cudaStreamCreate
+func cudaStreamCreate(pStream *C.cudaStream_t) C.cudaError_t {
+	if pStream == nil {
+		return C.cudaErrorInvalidValue
+	}
+	// Back the opaque handle with real C memory holding the engine id, so the
+	// pointer is valid and go vet clean (mirrors cudaMalloc's rationale).
+	h := C.malloc(C.size_t(8))
+	if h == nil {
+		return C.cudaErrorMemoryAllocation
+	}
+	*(*uint64)(h) = uint64(engine.GetEngine().StreamCreate())
+	*pStream = C.cudaStream_t(h)
+	return C.cudaSuccess
+}
+
+//export cudaStreamCreateWithFlags
+func cudaStreamCreateWithFlags(pStream *C.cudaStream_t, flags C.uint) C.cudaError_t {
+	return cudaStreamCreate(pStream)
+}
+
+//export cudaStreamSynchronize
+func cudaStreamSynchronize(stream C.cudaStream_t) C.cudaError_t {
+	if stream == nil { // stream 0 (default) is always valid
+		return C.cudaSuccess
+	}
+	id := *(*uint64)(unsafe.Pointer(stream))
+	return toCudaError(engine.GetEngine().StreamSynchronize(id))
+}
+
+//export cudaStreamDestroy
+func cudaStreamDestroy(stream C.cudaStream_t) C.cudaError_t {
+	if stream == nil {
+		return C.cudaSuccess
+	}
+	id := *(*uint64)(unsafe.Pointer(stream))
+	rc := toCudaError(engine.GetEngine().StreamDestroy(id))
+	C.free(unsafe.Pointer(stream))
+	return rc
+}
+
+// =============================================================================
+// Events
+// =============================================================================
+
+//export cudaEventCreate
+func cudaEventCreate(pEvent *C.cudaEvent_t) C.cudaError_t {
+	if pEvent == nil {
+		return C.cudaErrorInvalidValue
+	}
+	// Back the opaque handle with real C memory holding the engine id, so the
+	// pointer is valid and go vet clean (mirrors cudaMalloc's rationale).
+	h := C.malloc(C.size_t(8))
+	if h == nil {
+		return C.cudaErrorMemoryAllocation
+	}
+	*(*uint64)(h) = uint64(engine.GetEngine().EventCreate())
+	*pEvent = C.cudaEvent_t(h)
+	return C.cudaSuccess
+}
+
+//export cudaEventCreateWithFlags
+func cudaEventCreateWithFlags(pEvent *C.cudaEvent_t, flags C.uint) C.cudaError_t {
+	return cudaEventCreate(pEvent)
+}
+
+//export cudaEventRecord
+func cudaEventRecord(event C.cudaEvent_t, stream C.cudaStream_t) C.cudaError_t {
+	if event == nil {
+		return C.cudaErrorInvalidValue
+	}
+	id := *(*uint64)(unsafe.Pointer(event))
+	return toCudaError(engine.GetEngine().EventRecord(id))
+}
+
+//export cudaEventSynchronize
+func cudaEventSynchronize(event C.cudaEvent_t) C.cudaError_t {
+	if event == nil {
+		return C.cudaErrorInvalidValue
+	}
+	id := *(*uint64)(unsafe.Pointer(event))
+	return toCudaError(engine.GetEngine().EventSynchronize(id))
+}
+
+//export cudaEventDestroy
+func cudaEventDestroy(event C.cudaEvent_t) C.cudaError_t {
+	if event == nil {
+		return C.cudaErrorInvalidValue
+	}
+	id := *(*uint64)(unsafe.Pointer(event))
+	rc := toCudaError(engine.GetEngine().EventDestroy(id))
+	C.free(unsafe.Pointer(event))
+	return rc
+}
+
+//export cudaEventElapsedTime
+func cudaEventElapsedTime(ms *C.float, start C.cudaEvent_t, stop C.cudaEvent_t) C.cudaError_t {
+	if ms == nil || start == nil || stop == nil {
+		return C.cudaErrorInvalidValue
+	}
+	sid := *(*uint64)(unsafe.Pointer(start))
+	eid := *(*uint64)(unsafe.Pointer(stop))
+	v, err := engine.GetEngine().EventElapsedTime(sid, eid)
+	if err != engine.CudaSuccess {
+		return toCudaError(err)
+	}
+	*ms = C.float(v)
+	return C.cudaSuccess
+}
+
+//export cudaMemset
+func cudaMemset(devPtr unsafe.Pointer, value C.int, count C.size_t) C.cudaError_t {
+	if devPtr != nil && count > 0 {
+		C.memset(devPtr, value, count)
+	}
+	return C.cudaSuccess
+}

--- a/pkg/gpu/mockcuda/bridge/cuda_runtime.h
+++ b/pkg/gpu/mockcuda/bridge/cuda_runtime.h
@@ -1,0 +1,34 @@
+/*
+ * cuda_runtime.h - public CUDA Runtime API surface for the mock libcuda.
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Aggregates the mock CUDA types plus the runtime function prototypes the
+ * mock-coll-perf driver uses. The implementations are exported from
+ * pkg/gpu/mockcuda/bridge (libcuda.so).
+ */
+#ifndef MOCK_CUDA_RUNTIME_H
+#define MOCK_CUDA_RUNTIME_H
+
+#include <stddef.h>
+#include "cuda_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern cudaError_t cudaSetDevice(int device);
+extern cudaError_t cudaMalloc(void **devPtr, size_t size);
+extern cudaError_t cudaFree(void *devPtr);
+extern cudaError_t cudaStreamCreate(cudaStream_t *pStream);
+extern cudaError_t cudaStreamDestroy(cudaStream_t stream);
+extern cudaError_t cudaEventCreate(cudaEvent_t *event);
+extern cudaError_t cudaEventDestroy(cudaEvent_t event);
+extern cudaError_t cudaEventRecord(cudaEvent_t event, cudaStream_t stream);
+extern cudaError_t cudaEventSynchronize(cudaEvent_t event);
+extern cudaError_t cudaEventElapsedTime(float *ms, cudaEvent_t start, cudaEvent_t stop);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* MOCK_CUDA_RUNTIME_H */

--- a/pkg/gpu/mockcuda/bridge/cuda_types.h
+++ b/pkg/gpu/mockcuda/bridge/cuda_types.h
@@ -60,6 +60,11 @@ typedef struct {
  */
 typedef struct CUstream_st* cudaStream_t;
 
+/*
+ * cudaEvent_t - opaque event handle
+ */
+typedef struct CUevent_st* cudaEvent_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/pkg/gpu/mockcuda/engine/cuda.go
+++ b/pkg/gpu/mockcuda/engine/cuda.go
@@ -43,6 +43,7 @@ type Engine struct {
 	currentDevice int
 	allocations   map[uintptr]AllocationInfo
 	nextAllocID   uintptr
+	timing        *timing // stream/event state
 }
 
 var (
@@ -92,6 +93,7 @@ func NewEngine() *Engine {
 		driverVersion: driverVersion,
 		allocations:   make(map[uintptr]AllocationInfo),
 		nextAllocID:   0x1000, // Start at a non-zero fake address
+		timing:        newTiming(),
 	}
 }
 
@@ -229,4 +231,9 @@ func (e *Engine) GetAllocation(ptr uintptr) (AllocationInfo, bool) {
 	defer e.mu.Unlock()
 	info, ok := e.allocations[ptr]
 	return info, ok
+}
+
+// timingState returns the stream/event state.
+func (e *Engine) timingState() *timing {
+	return e.timing
 }

--- a/pkg/gpu/mockcuda/engine/timing.go
+++ b/pkg/gpu/mockcuda/engine/timing.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"sync"
+	"time"
+)
+
+// timing holds stream/event state. Streams are opaque tokens; events capture a
+// host monotonic timestamp on Record so ElapsedTime returns real wall-clock.
+type timing struct {
+	mu      sync.Mutex
+	nextID  uint64
+	streams map[uint64]struct{}
+	events  map[uint64]*eventState
+}
+
+type eventState struct {
+	recorded bool
+	at       time.Time
+}
+
+func newTiming() *timing {
+	return &timing{nextID: 1, streams: make(map[uint64]struct{}), events: make(map[uint64]*eventState)}
+}
+
+// StreamCreate returns a new opaque stream id (>0).
+func (e *Engine) StreamCreate() uint64 {
+	t := e.timingState()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	id := t.nextID
+	t.nextID++
+	t.streams[id] = struct{}{}
+	return id
+}
+
+// StreamSynchronize is a no-op for a known stream.
+func (e *Engine) StreamSynchronize(id uint64) CudaError {
+	t := e.timingState()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, ok := t.streams[id]; !ok {
+		return CudaErrorInvalidValue
+	}
+	return CudaSuccess
+}
+
+// StreamDestroy removes a known stream.
+func (e *Engine) StreamDestroy(id uint64) CudaError {
+	t := e.timingState()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, ok := t.streams[id]; !ok {
+		return CudaErrorInvalidValue
+	}
+	delete(t.streams, id)
+	return CudaSuccess
+}
+
+// EventCreate returns a new opaque event id (>0).
+func (e *Engine) EventCreate() uint64 {
+	t := e.timingState()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	id := t.nextID
+	t.nextID++
+	t.events[id] = &eventState{}
+	return id
+}
+
+// EventRecord stamps the event with the current host time.
+func (e *Engine) EventRecord(id uint64) CudaError {
+	t := e.timingState()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	ev, ok := t.events[id]
+	if !ok {
+		return CudaErrorInvalidValue
+	}
+	ev.recorded = true
+	ev.at = time.Now()
+	return CudaSuccess
+}
+
+// EventSynchronize is a no-op for a known event.
+func (e *Engine) EventSynchronize(id uint64) CudaError {
+	t := e.timingState()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, ok := t.events[id]; !ok {
+		return CudaErrorInvalidValue
+	}
+	return CudaSuccess
+}
+
+// EventDestroy removes a known event.
+func (e *Engine) EventDestroy(id uint64) CudaError {
+	t := e.timingState()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, ok := t.events[id]; !ok {
+		return CudaErrorInvalidValue
+	}
+	delete(t.events, id)
+	return CudaSuccess
+}
+
+// EventElapsedTime returns stop-start in milliseconds. Both events must have
+// been recorded.
+func (e *Engine) EventElapsedTime(start, stop uint64) (float64, CudaError) {
+	t := e.timingState()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	a, okA := t.events[start]
+	b, okB := t.events[stop]
+	if !okA || !okB {
+		return 0, CudaErrorInvalidValue
+	}
+	if !a.recorded || !b.recorded {
+		return 0, CudaErrorNotReady
+	}
+	return float64(b.at.Sub(a.at)) / float64(time.Millisecond), CudaSuccess
+}

--- a/pkg/gpu/mockcuda/engine/timing_test.go
+++ b/pkg/gpu/mockcuda/engine/timing_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventElapsedMeasuresWallClock(t *testing.T) {
+	e := NewEngine()
+	start := e.EventCreate()
+	require.Equal(t, CudaSuccess, e.EventRecord(start))
+	time.Sleep(5 * time.Millisecond)
+	stop := e.EventCreate()
+	require.Equal(t, CudaSuccess, e.EventRecord(stop))
+	ms, err := e.EventElapsedTime(start, stop)
+	require.Equal(t, CudaSuccess, err)
+	require.GreaterOrEqual(t, ms, 4.0)
+	require.LessOrEqual(t, ms, 50.0)
+}
+
+func TestEventElapsedUnrecorded(t *testing.T) {
+	e := NewEngine()
+	a := e.EventCreate()
+	b := e.EventCreate()
+	_, err := e.EventElapsedTime(a, b)
+	require.Equal(t, CudaErrorNotReady, err)
+}
+
+func TestStreamLifecycle(t *testing.T) {
+	e := NewEngine()
+	s := e.StreamCreate()
+	require.Equal(t, CudaSuccess, e.StreamSynchronize(s))
+	require.Equal(t, CudaSuccess, e.StreamDestroy(s))
+	require.Equal(t, CudaErrorInvalidValue, e.StreamSynchronize(s))
+}
+
+func TestTimingConcurrentCreate(t *testing.T) {
+	e := NewEngine()
+	const goroutines = 8
+	const perG = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perG; j++ {
+				_ = e.StreamCreate()
+				_ = e.EventCreate()
+			}
+		}()
+	}
+	wg.Wait()
+	// All ids unique & monotonic counter advanced by exactly goroutines*perG*2.
+	tm := e.timingState()
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	require.Len(t, tm.streams, goroutines*perG)
+	require.Len(t, tm.events, goroutines*perG)
+}

--- a/pkg/gpu/mocknccl/Makefile
+++ b/pkg/gpu/mocknccl/Makefile
@@ -1,0 +1,30 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LIB_VERSION ?= 2.23.4
+LIB_NAME    := libnccl.so
+LIB_SONAME  := $(LIB_NAME).2
+LIB_REALNAME := $(LIB_NAME).$(LIB_VERSION)
+
+.PHONY: all clean
+all: $(LIB_NAME)
+
+$(LIB_NAME): $(LIB_REALNAME)
+	ln -sf $(LIB_REALNAME) $(LIB_SONAME)
+	ln -sf $(LIB_SONAME) $(LIB_NAME)
+
+$(LIB_REALNAME):
+	go build -buildmode=c-shared -o $(LIB_REALNAME) ./bridge
+
+clean:
+	rm -f $(LIB_NAME)*

--- a/pkg/gpu/mocknccl/README.md
+++ b/pkg/gpu/mocknccl/README.md
@@ -1,0 +1,316 @@
+# mocknccl
+
+Hardware-free NCCL collective-communications simulation for Kubernetes
+testing. Ships a mock `libnccl.so.2` so unmodified NCCL consumers
+(`all_reduce_perf`, the bundled `mock-coll-perf`, anything that links
+`libnccl`) run on Kind / CI with **no GPUs and no NVLink/InfiniBand
+hardware**, and still report a plausible, non-zero `busbw`.
+
+This package is the NCCL counterpart of [`pkg/gpu/mocknvml`](../mocknvml/)
+and [`pkg/gpu/mockcuda`](../mockcuda/): mocknvml fakes `libnvidia-ml.so`,
+mockcuda fakes `libcuda.so`, and mocknccl fakes `libnccl.so.2`. Together
+they let a GPU collective benchmark execute end-to-end without a real
+device.
+
+**Acceptance goal:** a 2-pod `all_reduce`-style run on Kind completes the
+MPI-free rendezvous and the rank-0 pod prints a positive
+`# Avg bus bandwidth` line.
+
+## Components
+
+```
+pkg/gpu/mocknccl/
+├── bridge/                 # libnccl.so.2 — cgo c-shared NCCL ABI exports
+│   ├── nccl.go             #   comm lifecycle + collectives -> engine
+│   ├── helpers.go          #   main(), elementSize, maxSleep, errStr
+│   ├── nccl_types.h        #   minimal NCCL ABI types (result/datatype/redop)
+│   └── nccl.h              #   public prototypes for driver consumers
+├── engine/                 # pure-Go cost model + comm state + rendezvous
+│   ├── types.go            #   Collective enum + BusBWFactor
+│   ├── model.go            #   linear cost model (EffectiveBusBW, OpTime)
+│   ├── config.go           #   profile YAML + MOCK_NCCL_* env resolution
+│   ├── comm.go             #   RunCollective (model -> capped host sleep)
+│   └── rendezvous.go       #   MPI-free TCP barrier (rank 0 serves)
+├── perf/
+│   └── mock-coll-perf.c    #   nccl-tests-style driver (links mock nccl+cuda)
+└── Makefile                #   builds libnccl.so.2
+```
+
+The design is the same engine/bridge split used across the repo:
+
+1. **Bridge (`libnccl.so.2`).** A cgo `c-shared` library that exports the
+   common NCCL C ABI. Each collective looks up its communicator and
+   delegates to the engine; comm handles are backed by real C memory
+   (keyed by pointer) so consumers can hold an opaque `ncclComm_t`.
+
+2. **Engine (Go).** Owns the cost model, the resolved communicator
+   (rank / world size / intra- vs inter-node scope), and the MPI-free
+   rendezvous. It performs no data movement — it computes a *modeled*
+   duration and sleeps the host for that long (subject to a cap).
+
+3. **Timing borrows mockcuda CUDA events.** mocknccl does **not** measure
+   time itself. The driver brackets its collective loop with
+   `cudaEventRecord` / `cudaEventElapsedTime`, which
+   [`pkg/gpu/mockcuda`](../mockcuda/engine/timing.go) implements as host
+   monotonic timestamps. So the *reported* time is the real wall-clock of
+   the engine's host sleep, and `busbw` is derived from that — exactly how
+   nccl-tests derives it on real hardware.
+
+## Cost model
+
+The engine models one collective call with a single linear term:
+
+```
+time = latency + msgBytes / algbw
+algbw = EffectiveBusBW / busbwFactor
+```
+
+where:
+
+- `EffectiveBusBW` is the topology bandwidth after an efficiency factor:
+  `EffectiveBusBW = (interNode ? InterBytesPerSec : IntraBytesPerSec) * efficiency`.
+  Intra-node uses the aggregate NVLink bandwidth per GPU; inter-node uses
+  the InfiniBand-derived bandwidth. Scope (intra vs inter) is decided by
+  the rendezvous: more than one distinct pod IP ⇒ inter-node.
+- `busbwFactor` is the nccl-tests bus-bandwidth factor for the collective
+  (table below).
+
+A consumer that times the call and computes
+`busbw = (msgBytes / time) * busbwFactor` recovers `EffectiveBusBW` for
+large messages and is latency-bound for small ones — matching real
+nccl-tests reporting. When the factor is `0` (single rank), `msgBytes <= 0`,
+or the effective bandwidth is `0`, only `latency` applies.
+
+### Bus-bandwidth factor
+
+From `engine/types.go` (`BusBWFactor(op, n)`), for `n` ranks:
+
+| Collective | Factor | Notes |
+|------------|--------|-------|
+| `AllReduce` | `2*(n-1)/n` | moves the buffer twice (reduce-scatter + all-gather) |
+| `AllGather` | `(n-1)/n` | |
+| `ReduceScatter` | `(n-1)/n` | |
+| `Broadcast` | `1` | full buffer once |
+| `Reduce` | `1` | full buffer once |
+| any, `n <= 1` | `0` | no inter-rank traffic (single-rank ⇒ `busbw = 0`) |
+
+The `mock-coll-perf` driver reimplements the identical factor in C, so the
+busbw it prints is consistent with the engine's modeled time.
+
+## Configuration
+
+Configuration is resolved in three layers, each overriding the previous:
+
+1. **Built-in defaults** (a bare run still produces non-zero busbw).
+2. **Profile YAML** at `MOCK_NCCL_CONFIG` — the `nvlink:` / `infiniband:`
+   blocks derive the bandwidths, and an optional `nccl:` block tunes the
+   model directly.
+3. **`MOCK_NCCL_*` environment variables** — final override.
+
+### Defaults
+
+| Parameter | Default | Source |
+|-----------|---------|--------|
+| Latency | `6.0` µs | `DefaultLatencyUS` |
+| Efficiency | `0.90` | `DefaultEfficiency` |
+| Reported version | `22304` (NCCL 2.23.4) | `DefaultVersion` |
+| Intra-node BW (fallback) | `450 GB/s` (`450e9` B/s, ≈18×25 GB/s NVLink) | `fallbackIntraBytesPerSec` |
+| Inter-node BW (fallback) | `50 GB/s` (`400e9/8` B/s, one 400 Gbps NDR HCA) | `fallbackInterBytesPerSec` |
+
+### Profile YAML — `nccl:` block
+
+These keys are read from the profile referenced by `MOCK_NCCL_CONFIG`
+(the same mock-nvml profile that drives the rest of the chart):
+
+| Key | Type | Effect |
+|-----|------|--------|
+| `nccl.enabled` | bool | Mock NCCL enabled flag (default `true`). |
+| `nccl.version` | int | Version returned by `ncclGetVersion` (e.g. `22304`). |
+| `nccl.latency_us` | float | Per-collective latency term, microseconds. |
+| `nccl.efficiency` | float | Bandwidth efficiency multiplier (0–1). |
+| `nccl.intra_node_bandwidth_gbps` | float | Intra-node BW in **Gbit/s** (divided by 8 → bytes/s). Overrides the NVLink-derived value. |
+| `nccl.inter_node_bandwidth_gbps` | float | Inter-node BW in **Gbit/s** (divided by 8 → bytes/s). Overrides the IB-derived value. |
+
+### Profile-derived bandwidths (`nvlink:` / `infiniband:`)
+
+When `nccl.intra_node_bandwidth_gbps` / `nccl.inter_node_bandwidth_gbps`
+are not set, the model derives bandwidths from the same profile blocks the
+NVML and IB mocks already use:
+
+- **Intra-node (NVLink):**
+  `intraBytesPerSec = nvlink.links_per_gpu * nvlink.bandwidth_per_link_gbps * 1e9`.
+  Note `bandwidth_per_link_gbps` here is treated as **GB/s (bytes)** by
+  convention, so there is no `/8`.
+- **Inter-node (InfiniBand):**
+  `interBytesPerSec = infiniband.rate_gbps * 1e9 / 8 * hca`, where `hca`
+  is `infiniband.hca_count` if positive, else `infiniband.hcas_per_gpu`,
+  else `1`. `rate_gbps` is Gbit/s, hence the `/8`.
+
+### `MOCK_NCCL_*` environment variables
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `MOCK_NCCL_CONFIG` | (unset) | Path to the profile YAML. Empty ⇒ defaults only. |
+| `MOCK_NCCL_VERSION` | `22304` | Override the reported NCCL version (int > 0). |
+| `MOCK_NCCL_LATENCY_US` | `6.0` | Override latency term, microseconds (≥ 0). |
+| `MOCK_NCCL_EFFICIENCY` | `0.90` | Override efficiency multiplier (> 0). |
+| `MOCK_NCCL_INTRA_GBPS` | (profile) | Intra-node BW in **Gbit/s** (`/8` → bytes/s). |
+| `MOCK_NCCL_INTER_GBPS` | (profile) | Inter-node BW in **Gbit/s** (`/8` → bytes/s). |
+| `MOCK_NCCL_MAX_SLEEP_MS` | `50` | Cap on the per-collective host sleep (ms). `0` or negative disables the cap (sleep the full modeled time). |
+| `MOCK_NCCL_RDZV` | (unset) | Rendezvous address `host:port` for multi-rank `ncclCommInitRank`. |
+
+The communicator also reads the standard launch variables:
+
+| Variable | Meaning |
+|----------|---------|
+| `RANK` | This process's rank (used by the driver and as a `POD_IP` fallback). |
+| `WORLD_SIZE` | Total rank count (read by the driver). |
+| `POD_IP` | This rank's address for inter-node detection; falls back to `rank-<RANK>` when unset. |
+
+## NCCL ABI surface
+
+The mock `libnccl.so.2` exports the common NCCL collective surface
+(`bridge/nccl.go`):
+
+| Category | Functions |
+|----------|-----------|
+| Version / error | `ncclGetVersion`, `ncclGetUniqueId`, `ncclGetErrorString`, `ncclGetLastError` |
+| Comm lifecycle | `ncclCommInitRank`, `ncclCommInitAll`, `ncclCommDestroy`, `ncclCommAbort` |
+| Comm queries | `ncclCommCount`, `ncclCommUserRank`, `ncclCommCuDevice` |
+| Grouping | `ncclGroupStart`, `ncclGroupEnd` (no-ops) |
+| Collectives | `ncclAllReduce`, `ncclAllGather`, `ncclReduceScatter`, `ncclBroadcast`, `ncclBcast`, `ncclReduce` |
+
+`ncclGetUniqueId` returns a zeroed id (the rendezvous is env/TCP-driven, not
+id-driven). `ncclGetLastError` always reports success. Collectives compute
+`msgBytes = count * elementSize(datatype)` and model the call; no buffers
+are read or written.
+
+## Running it
+
+### 1. Two-pod test Job via the Helm chart
+
+The nvml-mock chart ships an opt-in Indexed Job that runs `mock-coll-perf`
+across `worldSize` pods, plus a headless Service used as the rendezvous
+endpoint:
+
+```bash
+helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+  --set gpu.profile=a100 \
+  --set nccl.test.enabled=true \
+  --set nccl.test.worldSize=2
+```
+
+`nccl.test.*` values (`deployments/nvml-mock/helm/nvml-mock/values.yaml`):
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `nccl.test.enabled` | `false` | Render the test Job + rendezvous Service. |
+| `nccl.test.collective` | `all_reduce` | One of `all_reduce`, `all_gather`, `reduce_scatter`, `broadcast`, `reduce`. |
+| `nccl.test.worldSize` | `2` | Job completions/parallelism (= rank count). |
+| `nccl.test.minBytes` | `1024` | Driver `-b`. |
+| `nccl.test.maxBytes` | `67108864` | Driver `-e`. |
+| `nccl.test.iters` | `20` | Driver `-n`. |
+| `nccl.test.rendezvousPort` | `29500` | Headless Service / `MOCK_NCCL_RDZV` port. |
+| `nccl.test.image` | `""` | Defaults to the chart's nvml-mock image. |
+
+The Job runs in `Indexed` completion mode, so each pod derives its rank
+from `JOB_COMPLETION_INDEX` (→ `RANK`), `WORLD_SIZE` from the chart value,
+and `POD_IP` from the downward API. It points `MOCK_NCCL_RDZV` at the
+`<release>-nccl-rdzv:29500` headless Service (whose selector pins
+`job-completion-index: "0"`, so it always resolves to rank 0) and mounts
+the profile ConfigMap at `MOCK_NCCL_CONFIG=/etc/nvml-mock/config.yaml`.
+Rank 0 serves the rendezvous; the others dial it; once all `WORLD_SIZE`
+ranks register, every rank gets the roster and the collective loop runs.
+
+### 2. The `mock-coll-perf` driver
+
+```
+mock-coll-perf [all_reduce|all_gather|reduce_scatter|broadcast|reduce] \
+               -b <minBytes> -e <maxBytes> -f <factor> -n <iters>
+```
+
+Defaults: op `all_reduce`, `-b 1024`, `-e 67108864`, `-f 2`, `-n 20`.
+`factor` is clamped to `>= 2` so the size loop always advances. `RANK` and
+`WORLD_SIZE` come from the environment; for `WORLD_SIZE > 1` the comm
+rendezvous runs inside `ncclCommInitRank` via `MOCK_NCCL_RDZV`.
+
+Sample rank-0 output:
+
+```
+# nReps 20  nRanks 2  nccl 22304  op all_reduce
+#     size(B)       count     type    redop time(us) busbw(GB/s)
+        1024         256    float      sum      6.5      0.08
+        2048         512    float      sum      6.6      0.15
+...
+    67108864    16777216    float      sum   1398.2     48.00
+# Avg bus bandwidth : 21.7943
+```
+
+Only rank 0 prints the table and the final `# Avg bus bandwidth` line; the
+E2E validator asserts that average is positive.
+
+### 3. Single-process tools
+
+Tools that build their communicators with `ncclCommInitAll` (e.g. stock
+nccl-tests `all_reduce_perf -g N`) work inside a single pod with no
+rendezvous: `ncclCommInitAll` creates `N` intra-node comms directly.
+
+## Build
+
+```bash
+make -C pkg/gpu/mocknccl
+# -> libnccl.so.2.23.4, with libnccl.so.2 and libnccl.so symlinks
+#    (go build -buildmode=c-shared ./bridge)
+```
+
+ABI smoke test (loads the built `libnccl.so.2` and exercises a
+version + `CommInitAll`/`AllReduce`/`CommDestroy` round trip):
+
+```bash
+go test -tags=integration ./tests/mocknccl/...
+# or: make -C tests/mocknccl   (builds the lib first, then runs the test)
+```
+
+## End-to-end test
+
+The E2E coverage is a **shell validator plus a CI job**, not a Go ginkgo
+harness:
+
+- [`tests/e2e/validate-nccl.sh`](../../../tests/e2e/validate-nccl.sh) waits
+  for the Indexed Job to reach `complete`, finds the rank-0 pod by its
+  `batch.kubernetes.io/job-completion-index=0` +
+  `app.kubernetes.io/component=nccl-test` labels, reads its log, and fails
+  unless the `# Avg bus bandwidth` value is positive.
+- The `nccl-multinode` job in
+  [`.github/workflows/nvml-mock-e2e.yaml`](../../../.github/workflows/nvml-mock-e2e.yaml)
+  builds the image, creates a multi-node Kind cluster, installs the chart
+  with `nccl.test.enabled=true nccl.test.worldSize=2` on an IB-enabled
+  `a100` profile, and runs the validator. The 2-pod Job spreads across
+  hosts via `podAntiAffinity`.
+
+## Limitations
+
+- **No real data movement or numerical correctness.** Collectives do not
+  read or write the send/recv buffers; only the message size feeds the cost
+  model. The result is a timing/bandwidth simulation, not a computation.
+- **Common collective surface only.** `AllReduce`, `AllGather`,
+  `ReduceScatter`, `Broadcast`/`Bcast`, and `Reduce` are modeled. There is
+  no `AllToAll` and no point-to-point `ncclSend`/`ncclRecv`.
+- **Sleep cap.** `MOCK_NCCL_MAX_SLEEP_MS` (default `50` ms) caps the host
+  sleep per collective, so the *reported* time equals the *modeled* time
+  only while the modeled time stays under the cap. For large messages whose
+  modeled time exceeds the cap, the reported (and therefore measured)
+  busbw is bounded by the cap rather than the modeled bandwidth — absolute
+  busbw is representative, not a real-hardware measurement. Set the cap to
+  `0` to sleep the full modeled time.
+
+## See also
+
+- [`pkg/gpu/mockcuda`](../mockcuda/) — mock `libcuda.so`; supplies the CUDA
+  event timing this package depends on.
+- [`pkg/gpu/mocknvml`](../mocknvml/) — mock `libnvidia-ml.so` and the GPU
+  profiles whose `nvlink:` / `infiniband:` blocks feed the cost model.
+- [Architecture Guide](../../../docs/architecture.md#mock-nccl-architecture)
+  — where mocknccl fits in the overall mock stack.
+- [Helm chart README](../../../deployments/nvml-mock/helm/nvml-mock/README.md)
+  — install instructions and the `nccl.test.*` reference.

--- a/pkg/gpu/mocknccl/bridge/helpers.go
+++ b/pkg/gpu/mocknccl/bridge/helpers.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main builds the mock libnccl.so.2 via buildmode=c-shared.
+package main
+
+/*
+#include <stdlib.h>
+#include <string.h>
+#include "nccl_types.h"
+*/
+import "C"
+import (
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+func main() {}
+
+// elementSize maps an ncclDataType_t to its byte width.
+func elementSize(dt C.ncclDataType_t) int64 {
+	switch dt {
+	case C.ncclInt8, C.ncclUint8:
+		return 1
+	case C.ncclFloat16, C.ncclBfloat16:
+		return 2
+	case C.ncclInt32, C.ncclUint32, C.ncclFloat32:
+		return 4
+	case C.ncclInt64, C.ncclUint64, C.ncclFloat64:
+		return 8
+	default:
+		return 4
+	}
+}
+
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+func maxSleep() time.Duration {
+	return time.Duration(envInt("MOCK_NCCL_MAX_SLEEP_MS", 50)) * time.Millisecond
+}
+
+// errStr returns a cached C string for an ncclResult_t (callers must not free).
+var (
+	errMu    sync.Mutex
+	errCache = map[C.ncclResult_t]*C.char{}
+)
+
+func errStr(r C.ncclResult_t) *C.char {
+	errMu.Lock()
+	defer errMu.Unlock()
+	if s, ok := errCache[r]; ok {
+		return s
+	}
+	msg := "unknown result"
+	switch r {
+	case C.ncclSuccess:
+		msg = "no error"
+	case C.ncclInvalidArgument:
+		msg = "invalid argument"
+	case C.ncclSystemError:
+		msg = "unhandled system error"
+	case C.ncclInternalError:
+		msg = "internal error"
+	}
+	cs := C.CString(msg)
+	errCache[r] = cs
+	return cs
+}

--- a/pkg/gpu/mocknccl/bridge/nccl.go
+++ b/pkg/gpu/mocknccl/bridge/nccl.go
@@ -1,0 +1,260 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+/*
+#include <stdlib.h>
+#include <string.h>
+#include "nccl_types.h"
+*/
+import "C"
+import (
+	"context"
+	"os"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknccl/engine"
+)
+
+// commRegistry maps C ncclComm_t handles (real C pointers) to engine comms.
+var (
+	commMu  sync.Mutex
+	comms   = map[uintptr]*engine.Comm{}
+	cfgOnce sync.Once
+	cfg     engine.Config
+)
+
+func loadCfg() engine.Config {
+	cfgOnce.Do(func() {
+		cfg = engine.LoadConfig(os.Getenv("MOCK_NCCL_CONFIG"))
+	})
+	return cfg
+}
+
+//export ncclGetVersion
+func ncclGetVersion(version *C.int) C.ncclResult_t {
+	if version == nil {
+		return C.ncclInvalidArgument
+	}
+	*version = C.int(loadCfg().Version)
+	return C.ncclSuccess
+}
+
+//export ncclGetUniqueId
+func ncclGetUniqueId(out *C.ncclUniqueId) C.ncclResult_t {
+	if out == nil {
+		return C.ncclInvalidArgument
+	}
+	// The id is opaque in our MPI-free flow (rank/world come from env); zero it.
+	C.memset(unsafe.Pointer(out), 0, C.size_t(C.NCCL_UNIQUE_ID_BYTES))
+	return C.ncclSuccess
+}
+
+//export ncclGetErrorString
+func ncclGetErrorString(result C.ncclResult_t) *C.char {
+	return errStr(result)
+}
+
+// ncclGetLastError intentionally ignores comm and always reports success
+// (mock simplification, consistent with the mockcuda bridge).
+//
+//export ncclGetLastError
+func ncclGetLastError(comm C.ncclComm_t) *C.char {
+	return errStr(C.ncclSuccess)
+}
+
+// ncclCommInitRank forms the comm. Rank/world come from the args (the driver
+// reads RANK/WORLD_SIZE); the rendezvous barrier confirms cross-pod liveness
+// and selects intra/inter-node scope.
+//
+//export ncclCommInitRank
+func ncclCommInitRank(comm *C.ncclComm_t, nranks C.int, commId C.ncclUniqueId, rank C.int) C.ncclResult_t {
+	if comm == nil {
+		return C.ncclInvalidArgument
+	}
+	c, rc := buildComm(int(rank), int(nranks))
+	if rc != C.ncclSuccess {
+		return rc
+	}
+	h := registerComm(c)
+	if h == nil {
+		return C.ncclSystemError
+	}
+	*comm = C.ncclComm_t(h)
+	return C.ncclSuccess
+}
+
+// ncclCommInitAll forms nGpus single-process comms (no rendezvous).
+//
+//export ncclCommInitAll
+func ncclCommInitAll(comms_ *C.ncclComm_t, ndev C.int, devlist *C.int) C.ncclResult_t {
+	if comms_ == nil || ndev <= 0 {
+		return C.ncclInvalidArgument
+	}
+	conf := loadCfg()
+	out := unsafe.Slice(comms_, int(ndev))
+	for i := 0; i < int(ndev); i++ {
+		c := &engine.Comm{Rank: i, WorldSize: int(ndev), InterNode: false,
+			Model: conf.Model(), MaxSleep: maxSleep()}
+		h := registerComm(c)
+		if h == nil {
+			return C.ncclSystemError
+		}
+		out[i] = C.ncclComm_t(h)
+	}
+	return C.ncclSuccess
+}
+
+//export ncclCommDestroy
+func ncclCommDestroy(comm C.ncclComm_t) C.ncclResult_t {
+	key := uintptr(unsafe.Pointer(comm))
+	commMu.Lock()
+	_, ok := comms[key]
+	delete(comms, key)
+	commMu.Unlock()
+	if ok {
+		C.free(unsafe.Pointer(comm))
+	}
+	return C.ncclSuccess
+}
+
+//export ncclCommAbort
+func ncclCommAbort(comm C.ncclComm_t) C.ncclResult_t {
+	return ncclCommDestroy(comm)
+}
+
+//export ncclCommCount
+func ncclCommCount(comm C.ncclComm_t, count *C.int) C.ncclResult_t {
+	c := lookupComm(comm)
+	if c == nil || count == nil {
+		return C.ncclInvalidArgument
+	}
+	*count = C.int(c.WorldSize)
+	return C.ncclSuccess
+}
+
+//export ncclCommUserRank
+func ncclCommUserRank(comm C.ncclComm_t, rank *C.int) C.ncclResult_t {
+	c := lookupComm(comm)
+	if c == nil || rank == nil {
+		return C.ncclInvalidArgument
+	}
+	*rank = C.int(c.Rank)
+	return C.ncclSuccess
+}
+
+//export ncclCommCuDevice
+func ncclCommCuDevice(comm C.ncclComm_t, device *C.int) C.ncclResult_t {
+	c := lookupComm(comm)
+	if c == nil || device == nil {
+		return C.ncclInvalidArgument
+	}
+	*device = C.int(c.Rank)
+	return C.ncclSuccess
+}
+
+//export ncclGroupStart
+func ncclGroupStart() C.ncclResult_t { return C.ncclSuccess }
+
+//export ncclGroupEnd
+func ncclGroupEnd() C.ncclResult_t { return C.ncclSuccess }
+
+// --- collectives: all delegate to runColl with the right element count ---
+
+//export ncclAllReduce
+func ncclAllReduce(sendbuff, recvbuff unsafe.Pointer, count C.size_t, datatype C.ncclDataType_t, op C.ncclRedOp_t, comm C.ncclComm_t, stream C.cudaStream_t) C.ncclResult_t {
+	return runColl(engine.AllReduce, comm, int64(count), datatype)
+}
+
+//export ncclAllGather
+func ncclAllGather(sendbuff, recvbuff unsafe.Pointer, sendcount C.size_t, datatype C.ncclDataType_t, comm C.ncclComm_t, stream C.cudaStream_t) C.ncclResult_t {
+	return runColl(engine.AllGather, comm, int64(sendcount), datatype)
+}
+
+//export ncclReduceScatter
+func ncclReduceScatter(sendbuff, recvbuff unsafe.Pointer, recvcount C.size_t, datatype C.ncclDataType_t, op C.ncclRedOp_t, comm C.ncclComm_t, stream C.cudaStream_t) C.ncclResult_t {
+	return runColl(engine.ReduceScatter, comm, int64(recvcount), datatype)
+}
+
+//export ncclBroadcast
+func ncclBroadcast(sendbuff, recvbuff unsafe.Pointer, count C.size_t, datatype C.ncclDataType_t, root C.int, comm C.ncclComm_t, stream C.cudaStream_t) C.ncclResult_t {
+	return runColl(engine.Broadcast, comm, int64(count), datatype)
+}
+
+//export ncclBcast
+func ncclBcast(buff unsafe.Pointer, count C.size_t, datatype C.ncclDataType_t, root C.int, comm C.ncclComm_t, stream C.cudaStream_t) C.ncclResult_t {
+	return runColl(engine.Broadcast, comm, int64(count), datatype)
+}
+
+//export ncclReduce
+func ncclReduce(sendbuff, recvbuff unsafe.Pointer, count C.size_t, datatype C.ncclDataType_t, op C.ncclRedOp_t, root C.int, comm C.ncclComm_t, stream C.cudaStream_t) C.ncclResult_t {
+	return runColl(engine.Reduce, comm, int64(count), datatype)
+}
+
+// --- internal helpers ---
+
+func runColl(op engine.Collective, comm C.ncclComm_t, count int64, dt C.ncclDataType_t) C.ncclResult_t {
+	c := lookupComm(comm)
+	if c == nil {
+		return C.ncclInvalidArgument
+	}
+	c.RunCollective(op, count*elementSize(dt))
+	return C.ncclSuccess
+}
+
+func buildComm(rank, nranks int) (*engine.Comm, C.ncclResult_t) {
+	conf := loadCfg()
+	interNode := false
+	if nranks > 1 {
+		rdzv := os.Getenv("MOCK_NCCL_RDZV")
+		self := os.Getenv("POD_IP")
+		if self == "" {
+			self = "rank-" + os.Getenv("RANK")
+		}
+		if rdzv != "" {
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+			res, err := engine.Rendezvous(ctx, rank, nranks, rdzv, self)
+			if err != nil {
+				return nil, C.ncclSystemError
+			}
+			interNode = res.InterNode
+		} else {
+			interNode = true // multi-rank without local rendezvous => assume cross-node
+		}
+	}
+	return &engine.Comm{Rank: rank, WorldSize: nranks, InterNode: interNode,
+		Model: conf.Model(), MaxSleep: maxSleep()}, C.ncclSuccess
+}
+
+// registerComm backs the opaque handle with real C memory (vet-clean, mirrors
+// cudaMalloc) keyed by the real pointer's uintptr; freed in ncclCommDestroy.
+func registerComm(c *engine.Comm) unsafe.Pointer {
+	h := C.malloc(C.size_t(1))
+	if h == nil {
+		return nil
+	}
+	commMu.Lock()
+	defer commMu.Unlock()
+	comms[uintptr(h)] = c
+	return h
+}
+
+func lookupComm(comm C.ncclComm_t) *engine.Comm {
+	commMu.Lock()
+	defer commMu.Unlock()
+	return comms[uintptr(unsafe.Pointer(comm))]
+}

--- a/pkg/gpu/mocknccl/bridge/nccl.h
+++ b/pkg/gpu/mocknccl/bridge/nccl.h
@@ -1,0 +1,39 @@
+/*
+ * nccl.h - public NCCL API surface for the mock libnccl.
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Aggregates the mock NCCL types plus the collective/comm prototypes the
+ * mock-coll-perf driver uses. Implementations are exported from
+ * pkg/gpu/mocknccl/bridge (libnccl.so.2).
+ */
+#ifndef MOCK_NCCL_H
+#define MOCK_NCCL_H
+
+#include <stddef.h>
+#include "nccl_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern ncclResult_t ncclGetVersion(int *version);
+extern ncclResult_t ncclGetUniqueId(ncclUniqueId *uniqueId);
+extern const char  *ncclGetErrorString(ncclResult_t result);
+extern ncclResult_t ncclCommInitRank(ncclComm_t *comm, int nranks, ncclUniqueId commId, int rank);
+extern ncclResult_t ncclCommInitAll(ncclComm_t *comm, int ndev, const int *devlist);
+extern ncclResult_t ncclCommDestroy(ncclComm_t comm);
+extern ncclResult_t ncclCommCount(ncclComm_t comm, int *count);
+extern ncclResult_t ncclCommUserRank(ncclComm_t comm, int *rank);
+extern ncclResult_t ncclGroupStart(void);
+extern ncclResult_t ncclGroupEnd(void);
+extern ncclResult_t ncclAllReduce(const void *sendbuff, void *recvbuff, size_t count, ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream);
+extern ncclResult_t ncclAllGather(const void *sendbuff, void *recvbuff, size_t sendcount, ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream);
+extern ncclResult_t ncclReduceScatter(const void *sendbuff, void *recvbuff, size_t recvcount, ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream);
+extern ncclResult_t ncclBroadcast(const void *sendbuff, void *recvbuff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm, cudaStream_t stream);
+extern ncclResult_t ncclReduce(const void *sendbuff, void *recvbuff, size_t count, ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* MOCK_NCCL_H */

--- a/pkg/gpu/mocknccl/bridge/nccl_types.h
+++ b/pkg/gpu/mocknccl/bridge/nccl_types.h
@@ -1,0 +1,53 @@
+/* pkg/gpu/mocknccl/bridge/nccl_types.h
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Minimal NCCL ABI types for the mock libnccl.so.2 — matches the public
+ * nccl.h layout for the common collective surface.
+ */
+#ifndef MOCK_NCCL_TYPES_H
+#define MOCK_NCCL_TYPES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define NCCL_UNIQUE_ID_BYTES 128
+typedef struct { char internal[NCCL_UNIQUE_ID_BYTES]; } ncclUniqueId;
+
+typedef enum {
+    ncclSuccess                 = 0,
+    ncclUnhandledCudaError      = 1,
+    ncclSystemError             = 2,
+    ncclInternalError           = 3,
+    ncclInvalidArgument         = 4,
+    ncclInvalidUsage            = 5,
+    ncclRemoteError             = 6,
+    ncclInProgress              = 7,
+    ncclNumResults              = 8
+} ncclResult_t;
+
+typedef struct ncclComm* ncclComm_t;
+
+typedef enum {
+    ncclInt8 = 0, ncclChar = 0, ncclUint8 = 1,
+    ncclInt32 = 2, ncclInt = 2, ncclUint32 = 3,
+    ncclInt64 = 4, ncclUint64 = 5,
+    ncclFloat16 = 6, ncclHalf = 6,
+    ncclFloat32 = 7, ncclFloat = 7,
+    ncclFloat64 = 8, ncclDouble = 8,
+    ncclBfloat16 = 9,
+    ncclNumTypes = 10
+} ncclDataType_t;
+
+typedef enum {
+    ncclSum = 0, ncclProd = 1, ncclMax = 2, ncclMin = 3, ncclAvg = 4,
+    ncclNumOps = 5
+} ncclRedOp_t;
+
+typedef struct CUstream_st* cudaStream_t;
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* MOCK_NCCL_TYPES_H */

--- a/pkg/gpu/mocknccl/engine/comm.go
+++ b/pkg/gpu/mocknccl/engine/comm.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import "time"
+
+// Comm is a resolved communicator: membership + cost model + sleep cap.
+type Comm struct {
+	Rank      int
+	WorldSize int
+	InterNode bool
+	Model     Model
+	MaxSleep  time.Duration
+}
+
+// RunCollective models one collective call: it computes the modeled duration,
+// sleeps for min(modeled, MaxSleep) on the host, and returns the MODELED
+// duration (callers time it via CUDA events, which capture the real sleep; the
+// returned value is for engine-side assertions/debug). Reported time is the
+// measured sleep, accurate while modeled <= cap. A MaxSleep <= 0 disables the
+// cap, so the host sleeps for the full modeled duration with no upper bound.
+func (c *Comm) RunCollective(op Collective, msgBytes int64) time.Duration {
+	modeled := c.Model.OpTime(op, msgBytes, c.WorldSize, c.InterNode)
+	sleep := modeled
+	if c.MaxSleep > 0 && sleep > c.MaxSleep {
+		sleep = c.MaxSleep
+	}
+	if sleep > 0 {
+		time.Sleep(sleep)
+	}
+	return modeled
+}

--- a/pkg/gpu/mocknccl/engine/comm_test.go
+++ b/pkg/gpu/mocknccl/engine/comm_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommRunCollectiveSleepsAndReportsTime(t *testing.T) {
+	comm := &Comm{
+		Rank:      0,
+		WorldSize: 2,
+		InterNode: true,
+		Model:     Model{LatencyUS: 0, Efficiency: 1, InterBytesPerSec: 1e9}, // 1 GB/s
+		MaxSleep:  10 * time.Millisecond,
+	}
+	// 1 MB at 1 GB/s, factor(AllReduce,2)=1 => ~1ms modeled, under the cap.
+	d := comm.RunCollective(AllReduce, 1<<20)
+	require.GreaterOrEqual(t, d, 900*time.Microsecond)
+	require.LessOrEqual(t, d, 5*time.Millisecond)
+}
+
+func TestCommRunCollectiveRespectsCap(t *testing.T) {
+	comm := &Comm{
+		Rank: 0, WorldSize: 2, InterNode: true,
+		Model:    Model{LatencyUS: 0, Efficiency: 1, InterBytesPerSec: 1e9},
+		MaxSleep: 2 * time.Millisecond,
+	}
+	start := time.Now()
+	_ = comm.RunCollective(AllReduce, 1<<30) // huge => modeled >> cap
+	elapsed := time.Since(start)
+	// Huge message => sleep = min(modeled, MaxSleep) = MaxSleep, and
+	// time.Sleep guarantees at least that duration (non-flaky lower bound).
+	require.GreaterOrEqual(t, elapsed, comm.MaxSleep)
+	require.LessOrEqual(t, elapsed, 50*time.Millisecond)
+}

--- a/pkg/gpu/mocknccl/engine/config.go
+++ b/pkg/gpu/mocknccl/engine/config.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"os"
+	"strconv"
+
+	"sigs.k8s.io/yaml"
+)
+
+// Defaults for the cost model when the profile/env do not specify them.
+const (
+	DefaultLatencyUS  = 6.0
+	DefaultEfficiency = 0.90
+	DefaultVersion    = 22304 // NCCL 2.23.4
+	// Fallback bandwidths (bytes/sec) when neither profile nor env provide
+	// derivable values, so a bare run still reports non-zero busbw.
+	fallbackInterBytesPerSec = 400e9 / 8 // 400 Gbps single NDR HCA
+	fallbackIntraBytesPerSec = 450e9     // 18 * 25 GB/s
+)
+
+// Config is the resolved mock NCCL configuration.
+type Config struct {
+	Enabled          bool
+	Version          int
+	latencyUS        float64
+	efficiency       float64
+	intraBytesPerSec float64
+	interBytesPerSec float64
+}
+
+// profileYAML is the minimal slice of the mock-nvml profile this package reads.
+type profileYAML struct {
+	NVLink *struct {
+		LinksPerGPU          int `json:"links_per_gpu"`
+		BandwidthPerLinkGBPS int `json:"bandwidth_per_link_gbps"`
+	} `json:"nvlink"`
+	Infiniband *struct {
+		Enabled  bool `json:"enabled"`
+		RateGbps int  `json:"rate_gbps"`
+		HCACount int  `json:"hca_count"`
+		HCAsPer  int  `json:"hcas_per_gpu"`
+	} `json:"infiniband"`
+	NCCL *struct {
+		Enabled    *bool   `json:"enabled"`
+		Version    int     `json:"version"`
+		LatencyUS  float64 `json:"latency_us"`
+		Efficiency float64 `json:"efficiency"`
+		IntraGbps  float64 `json:"intra_node_bandwidth_gbps"`
+		InterGbps  float64 `json:"inter_node_bandwidth_gbps"`
+	} `json:"nccl"`
+}
+
+// LoadConfig reads the profile YAML at path (empty => skip), then derives the
+// cost-model bandwidths from the nvlink/infiniband blocks, applies any nccl
+// block, and finally lets MOCK_NCCL_* env vars override. Missing inputs fall
+// back to NDR/NVLink defaults so a bare run still produces non-zero busbw.
+func LoadConfig(path string) Config {
+	cfg := Config{
+		Enabled:          true,
+		Version:          DefaultVersion,
+		latencyUS:        DefaultLatencyUS,
+		efficiency:       DefaultEfficiency,
+		intraBytesPerSec: fallbackIntraBytesPerSec,
+		interBytesPerSec: fallbackInterBytesPerSec,
+	}
+
+	var p profileYAML
+	if path != "" {
+		if b, err := os.ReadFile(path); err == nil {
+			_ = yaml.Unmarshal(b, &p)
+		}
+	}
+
+	if p.NVLink != nil && p.NVLink.LinksPerGPU > 0 && p.NVLink.BandwidthPerLinkGBPS > 0 {
+		// NVLink bandwidth_per_link_gbps is conventionally GB/s (bytes), so no /8.
+		cfg.intraBytesPerSec = float64(p.NVLink.LinksPerGPU) * float64(p.NVLink.BandwidthPerLinkGBPS) * 1e9
+	}
+	if p.Infiniband != nil && p.Infiniband.RateGbps > 0 {
+		hca := p.Infiniband.HCACount
+		if hca <= 0 {
+			hca = p.Infiniband.HCAsPer
+		}
+		if hca <= 0 {
+			hca = 1
+		}
+		// IB rate_gbps is Gbit/s, so /8 converts to bytes/sec.
+		cfg.interBytesPerSec = float64(p.Infiniband.RateGbps) * 1e9 / 8 * float64(hca)
+	}
+	if p.NCCL != nil {
+		if p.NCCL.Enabled != nil {
+			cfg.Enabled = *p.NCCL.Enabled
+		}
+		if p.NCCL.Version > 0 {
+			cfg.Version = p.NCCL.Version
+		}
+		if p.NCCL.LatencyUS > 0 {
+			cfg.latencyUS = p.NCCL.LatencyUS
+		}
+		if p.NCCL.Efficiency > 0 {
+			cfg.efficiency = p.NCCL.Efficiency
+		}
+		if p.NCCL.IntraGbps > 0 {
+			// nccl.intra_node_bandwidth_gbps is Gbit/s, so /8 converts to bytes/sec.
+			cfg.intraBytesPerSec = p.NCCL.IntraGbps * 1e9 / 8
+		}
+		if p.NCCL.InterGbps > 0 {
+			// nccl.inter_node_bandwidth_gbps is Gbit/s, so /8 converts to bytes/sec.
+			cfg.interBytesPerSec = p.NCCL.InterGbps * 1e9 / 8
+		}
+	}
+
+	applyEnvOverrides(&cfg)
+	return cfg
+}
+
+func applyEnvOverrides(cfg *Config) {
+	if v := os.Getenv("MOCK_NCCL_VERSION"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Version = n
+		}
+	}
+	if v := os.Getenv("MOCK_NCCL_LATENCY_US"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f >= 0 {
+			cfg.latencyUS = f
+		}
+	}
+	if v := os.Getenv("MOCK_NCCL_EFFICIENCY"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+			cfg.efficiency = f
+		}
+	}
+	// MOCK_NCCL_*_GBPS mirror the nccl block semantics: Gbit/s, so /8 -> bytes/sec.
+	if v := os.Getenv("MOCK_NCCL_INTRA_GBPS"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+			cfg.intraBytesPerSec = f * 1e9 / 8
+		}
+	}
+	if v := os.Getenv("MOCK_NCCL_INTER_GBPS"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+			cfg.interBytesPerSec = f * 1e9 / 8
+		}
+	}
+}
+
+// Model projects the resolved config into a cost Model.
+func (c Config) Model() Model {
+	return Model{
+		LatencyUS:        c.latencyUS,
+		Efficiency:       c.efficiency,
+		IntraBytesPerSec: c.intraBytesPerSec,
+		InterBytesPerSec: c.interBytesPerSec,
+	}
+}

--- a/pkg/gpu/mocknccl/engine/config_test.go
+++ b/pkg/gpu/mocknccl/engine/config_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeProfile(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "profile.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	return path
+}
+
+func TestLoadConfigDerivesBandwidth(t *testing.T) {
+	path := writeProfile(t, `
+nvlink:
+  links_per_gpu: 18
+  bandwidth_per_link_gbps: 25
+infiniband:
+  rate_gbps: 400
+  hca_count: 4
+nccl:
+  enabled: true
+  latency_us: 6
+  efficiency: 0.9
+`)
+
+	m := LoadConfig(path).Model()
+	require.Equal(t, 200e9, m.InterBytesPerSec)
+	require.Equal(t, 450e9, m.IntraBytesPerSec)
+	require.Equal(t, 6.0, m.LatencyUS)
+	require.Equal(t, 0.9, m.Efficiency)
+}
+
+func TestEnvOverridesWin(t *testing.T) {
+	t.Setenv("MOCK_NCCL_INTER_GBPS", "800")
+	t.Setenv("MOCK_NCCL_LATENCY_US", "3")
+
+	path := writeProfile(t, `
+infiniband:
+  rate_gbps: 400
+  hca_count: 1
+nccl:
+  enabled: true
+`)
+
+	m := LoadConfig(path).Model()
+	require.Equal(t, 800e9/8, m.InterBytesPerSec)
+	require.Equal(t, 3.0, m.LatencyUS)
+}
+
+func TestDefaultsWhenAbsent(t *testing.T) {
+	cfg := LoadConfig("")
+	m := cfg.Model()
+	require.Equal(t, DefaultEfficiency, m.Efficiency)
+	require.Equal(t, DefaultLatencyUS, m.LatencyUS)
+	require.Equal(t, DefaultVersion, cfg.Version)
+}
+
+func TestNCCLBlockOverridesDerivedBandwidth(t *testing.T) {
+	path := writeProfile(t, `
+nvlink:
+  links_per_gpu: 18
+  bandwidth_per_link_gbps: 25
+infiniband:
+  rate_gbps: 400
+  hca_count: 4
+nccl:
+  enabled: true
+  intra_node_bandwidth_gbps: 800
+  inter_node_bandwidth_gbps: 1600
+`)
+
+	m := LoadConfig(path).Model()
+	require.Equal(t, 800e9/8, m.IntraBytesPerSec)
+	require.Equal(t, 1600e9/8, m.InterBytesPerSec)
+}
+
+func TestHCAsPerGPUFallback(t *testing.T) {
+	path := writeProfile(t, `
+infiniband:
+  rate_gbps: 400
+  hcas_per_gpu: 2
+`)
+
+	m := LoadConfig(path).Model()
+	require.Equal(t, 400e9/8*2, m.InterBytesPerSec)
+}
+
+func TestEnabledTriState(t *testing.T) {
+	t.Run("explicitly disabled", func(t *testing.T) {
+		path := writeProfile(t, `
+nccl:
+  enabled: false
+`)
+		require.False(t, LoadConfig(path).Enabled)
+	})
+
+	t.Run("omitted defaults to enabled", func(t *testing.T) {
+		path := writeProfile(t, `
+nccl:
+  latency_us: 5
+`)
+		require.True(t, LoadConfig(path).Enabled)
+	})
+}

--- a/pkg/gpu/mocknccl/engine/model.go
+++ b/pkg/gpu/mocknccl/engine/model.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import "time"
+
+// Model holds resolved cost-model parameters. Bandwidths are in bytes/sec.
+type Model struct {
+	LatencyUS        float64
+	Efficiency       float64
+	IntraBytesPerSec float64 // NVLink aggregate per GPU
+	InterBytesPerSec float64 // IB-derived (rate_gbps * hca_count)
+}
+
+// EffectiveBusBW is the target bus bandwidth (bytes/sec) for the scope, after
+// applying efficiency. interNode selects the IB bottleneck; otherwise NVLink.
+func (m Model) EffectiveBusBW(interNode bool) float64 {
+	if interNode {
+		return m.InterBytesPerSec * m.Efficiency
+	}
+	return m.IntraBytesPerSec * m.Efficiency
+}
+
+// OpTime returns the modeled duration of one collective call:
+//
+//	time = latency + msgBytes / algbw,  algbw = EffectiveBusBW / busbwFactor
+//
+// so a caller computing busbw = (msgBytes/time) * busbwFactor recovers
+// EffectiveBusBW for large messages and is latency-bound for small ones.
+// When the factor is 0 (n<=1), msgBytes<=0, or the effective bandwidth is 0,
+// only latency applies.
+func (m Model) OpTime(op Collective, msgBytes int64, n int, interNode bool) time.Duration {
+	latency := time.Duration(m.LatencyUS * float64(time.Microsecond))
+	factor := BusBWFactor(op, n)
+	bus := m.EffectiveBusBW(interNode)
+	if factor <= 0 || msgBytes <= 0 || bus <= 0 {
+		return latency
+	}
+	algbw := bus / factor // bytes/sec
+	transfer := time.Duration(float64(msgBytes) / algbw * float64(time.Second))
+	return latency + transfer
+}

--- a/pkg/gpu/mocknccl/engine/model_test.go
+++ b/pkg/gpu/mocknccl/engine/model_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpTimeLatencyBound(t *testing.T) {
+	// Tiny message: dominated by latency (~10us).
+	m := Model{LatencyUS: 10, Efficiency: 1.0, InterBytesPerSec: 50e9}
+	got := m.OpTime(AllReduce, 8, 2, true)
+	require.InDelta(t, 10e-6, got.Seconds(), 2e-6)
+}
+
+func TestBusBWAsymptote(t *testing.T) {
+	// Large message: measured busbw -> EffectiveBusBW.
+	m := Model{LatencyUS: 5, Efficiency: 0.9, InterBytesPerSec: 50e9} // 50 GB/s line
+	const n = 2
+	size := int64(1 << 30) // 1 GiB
+	d := m.OpTime(AllReduce, size, n, true)
+	algbw := float64(size) / d.Seconds()
+	busbw := algbw * BusBWFactor(AllReduce, n)
+	want := m.EffectiveBusBW(true) // 45 GB/s
+	require.InEpsilon(t, want, busbw, 0.01)
+}
+
+func TestEffectiveBusBWScope(t *testing.T) {
+	m := Model{Efficiency: 0.5, IntraBytesPerSec: 100, InterBytesPerSec: 10}
+	require.Equal(t, 50.0, m.EffectiveBusBW(false))
+	require.Equal(t, 5.0, m.EffectiveBusBW(true))
+}
+
+func TestOpTimeIntraNode(t *testing.T) {
+	// Intra-node uses IntraBytesPerSec. 1 GiB at 100 GB/s line, factor(AllReduce,2)=1.
+	m := Model{LatencyUS: 0, Efficiency: 1.0, IntraBytesPerSec: 100e9, InterBytesPerSec: 1e9}
+	size := int64(1 << 30)
+	d := m.OpTime(AllReduce, size, 2, false)
+	algbw := float64(size) / d.Seconds()
+	busbw := algbw * BusBWFactor(AllReduce, 2)
+	require.InEpsilon(t, m.EffectiveBusBW(false), busbw, 0.01)
+}
+
+func TestOpTimeZeroFactorIsLatency(t *testing.T) {
+	m := Model{LatencyUS: 7, Efficiency: 1, InterBytesPerSec: 1e9}
+	got := m.OpTime(AllReduce, 1024, 1, true) // n=1 => factor 0
+	require.Equal(t, 7*time.Microsecond, got)
+}

--- a/pkg/gpu/mocknccl/engine/rendezvous.go
+++ b/pkg/gpu/mocknccl/engine/rendezvous.go
@@ -1,0 +1,220 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"sort"
+	"time"
+)
+
+const (
+	// dialRetryInterval is the pause between dial attempts while rank 0 is
+	// not yet listening.
+	dialRetryInterval = 50 * time.Millisecond
+	// maxFrameSize bounds a single length-prefixed JSON frame.
+	maxFrameSize = 1 << 20
+)
+
+// Peer is one participant's identity in the comm roster.
+type Peer struct {
+	Rank int    `json:"rank"`
+	Addr string `json:"addr"`
+}
+
+// RendezvousResult is the agreed comm membership returned to every rank.
+type RendezvousResult struct {
+	Rank      int
+	WorldSize int
+	Peers     []Peer
+	InterNode bool
+}
+
+// Listener wraps a TCP listener so tests can grab the bound port.
+type Listener struct{ ln net.Listener }
+
+// Listen binds addr ("host:port"; port 0 = ephemeral).
+func Listen(addr string) (Listener, error) {
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return Listener{}, err
+	}
+	return Listener{ln: l}, nil
+}
+
+// Port returns the bound TCP port.
+func (l Listener) Port() int { return l.ln.Addr().(*net.TCPAddr).Port }
+
+// Close closes the listener.
+func (l Listener) Close() error { return l.ln.Close() }
+
+// Accept waits for and returns the next connection to the listener.
+func (l Listener) Accept() (net.Conn, error) { return l.ln.Accept() }
+
+func computeInterNode(peers []Peer) bool {
+	seen := map[string]struct{}{}
+	for _, p := range peers {
+		seen[p.Addr] = struct{}{}
+	}
+	return len(seen) > 1
+}
+
+// Rendezvous performs the barrier. Rank 0 binds rdzvAddr and serves; other
+// ranks dial it. selfAddr is this rank's reported pod IP (drives inter-node
+// detection). It blocks until worldSize ranks have registered.
+func Rendezvous(ctx context.Context, rank, worldSize int, rdzvAddr, selfAddr string) (*RendezvousResult, error) {
+	if worldSize <= 1 {
+		return &RendezvousResult{Rank: rank, WorldSize: worldSize,
+			Peers: []Peer{{Rank: rank, Addr: selfAddr}}, InterNode: false}, nil
+	}
+	if rank == 0 {
+		ln, err := Listen(rdzvAddr)
+		if err != nil {
+			return nil, fmt.Errorf("rank0 listen %s: %w", rdzvAddr, err)
+		}
+		defer ln.Close()
+		return rendezvousServe(ctx, ln, rank, worldSize, selfAddr)
+	}
+	return rendezvousDial(ctx, rdzvAddr, rank, worldSize, selfAddr)
+}
+
+func rendezvousServe(ctx context.Context, ln Listener, rank, worldSize int, selfAddr string) (*RendezvousResult, error) {
+	type reg struct {
+		peer Peer
+		conn net.Conn
+	}
+	regs := []reg{{peer: Peer{Rank: rank, Addr: selfAddr}}}
+
+	// Unblock a pending Accept when ctx is cancelled; tie the watcher's
+	// lifetime to this function so it never parks forever on normal return.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = ln.Close()
+		case <-done:
+		}
+	}()
+
+	// Close any still-open accepted conns on every return path so an
+	// early error (Accept/readJSON/writeJSON) doesn't leak fds.
+	defer func() {
+		for _, r := range regs {
+			if r.conn != nil {
+				_ = r.conn.Close()
+			}
+		}
+	}()
+
+	for len(regs) < worldSize {
+		c, err := ln.Accept()
+		if err != nil {
+			return nil, fmt.Errorf("accept: %w", err)
+		}
+		var p Peer
+		if err := readJSON(c, &p); err != nil {
+			_ = c.Close()
+			return nil, fmt.Errorf("read peer: %w", err)
+		}
+		regs = append(regs, reg{peer: p, conn: c})
+	}
+
+	peers := make([]Peer, 0, len(regs))
+	for _, r := range regs {
+		peers = append(peers, r.peer)
+	}
+	sort.Slice(peers, func(i, j int) bool { return peers[i].Rank < peers[j].Rank })
+	res := &RendezvousResult{Rank: rank, WorldSize: worldSize, Peers: peers, InterNode: computeInterNode(peers)}
+
+	for _, r := range regs {
+		if r.conn == nil {
+			continue
+		}
+		if err := writeJSON(r.conn, res); err != nil {
+			return nil, fmt.Errorf("send roster: %w", err)
+		}
+	}
+	return res, nil
+}
+
+func rendezvousDial(ctx context.Context, addr string, rank, worldSize int, selfAddr string) (*RendezvousResult, error) {
+	var d net.Dialer
+	var conn net.Conn
+	var err error
+	// Retry until ctx expires: rank 0 may not be listening yet.
+	for {
+		conn, err = d.DialContext(ctx, "tcp", addr)
+		if err == nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("dial %s: %w", addr, ctx.Err())
+		case <-time.After(dialRetryInterval):
+		}
+	}
+	defer conn.Close()
+	if err := writeJSON(conn, Peer{Rank: rank, Addr: selfAddr}); err != nil {
+		return nil, fmt.Errorf("send peer: %w", err)
+	}
+	var res RendezvousResult
+	if err := readJSON(conn, &res); err != nil {
+		return nil, fmt.Errorf("read roster: %w", err)
+	}
+	res.Rank = rank
+	// Deliberately recompute from the roster (the server also sets it) so the
+	// client agrees on scope without trusting the wire value.
+	res.InterNode = computeInterNode(res.Peers)
+	return &res, nil
+}
+
+// length-prefixed JSON framing (mirrors mockib's wire format).
+func writeJSON(w io.Writer, v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	if len(b) == 0 || len(b) > maxFrameSize {
+		return fmt.Errorf("bad frame length %d", len(b))
+	}
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(b)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err = w.Write(b)
+	return err
+}
+
+func readJSON(r io.Reader, v any) error {
+	var hdr [4]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return err
+	}
+	n := binary.BigEndian.Uint32(hdr[:])
+	if n == 0 || n > maxFrameSize {
+		return fmt.Errorf("bad frame length %d", n)
+	}
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return err
+	}
+	return json.Unmarshal(buf, v)
+}

--- a/pkg/gpu/mocknccl/engine/rendezvous.go
+++ b/pkg/gpu/mocknccl/engine/rendezvous.go
@@ -88,7 +88,7 @@ func Rendezvous(ctx context.Context, rank, worldSize int, rdzvAddr, selfAddr str
 		if err != nil {
 			return nil, fmt.Errorf("rank0 listen %s: %w", rdzvAddr, err)
 		}
-		defer ln.Close()
+		defer func() { _ = ln.Close() }()
 		return rendezvousServe(ctx, ln, rank, worldSize, selfAddr)
 	}
 	return rendezvousDial(ctx, rdzvAddr, rank, worldSize, selfAddr)
@@ -170,7 +170,7 @@ func rendezvousDial(ctx context.Context, addr string, rank, worldSize int, selfA
 		case <-time.After(dialRetryInterval):
 		}
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	if err := writeJSON(conn, Peer{Rank: rank, Addr: selfAddr}); err != nil {
 		return nil, fmt.Errorf("send peer: %w", err)
 	}

--- a/pkg/gpu/mocknccl/engine/rendezvous.go
+++ b/pkg/gpu/mocknccl/engine/rendezvous.go
@@ -84,9 +84,17 @@ func Rendezvous(ctx context.Context, rank, worldSize int, rdzvAddr, selfAddr str
 			Peers: []Peer{{Rank: rank, Addr: selfAddr}}, InterNode: false}, nil
 	}
 	if rank == 0 {
-		ln, err := Listen(rdzvAddr)
+		// rdzvAddr is the address other ranks DIAL (e.g. a Kubernetes Service
+		// DNS name); rank 0 cannot bind() that remote name, so it listens on
+		// the local wildcard interface for the same port.
+		_, port, err := net.SplitHostPort(rdzvAddr)
 		if err != nil {
-			return nil, fmt.Errorf("rank0 listen %s: %w", rdzvAddr, err)
+			return nil, fmt.Errorf("rank0 parse rdzv addr %q: %w", rdzvAddr, err)
+		}
+		bindAddr := net.JoinHostPort("", port)
+		ln, err := Listen(bindAddr)
+		if err != nil {
+			return nil, fmt.Errorf("rank0 listen %s: %w", bindAddr, err)
 		}
 		defer func() { _ = ln.Close() }()
 		return rendezvousServe(ctx, ln, rank, worldSize, selfAddr)

--- a/pkg/gpu/mocknccl/engine/rendezvous_test.go
+++ b/pkg/gpu/mocknccl/engine/rendezvous_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRendezvousBarrierTwoRanks(t *testing.T) {
+	// Rank 0 binds an ephemeral port; rank 1 dials it. Distinct selfAddrs
+	// make this an inter-node roster.
+	ln, addr := listenEphemeral(t)
+	results := make([]*RendezvousResult, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		r, err := rendezvousServe(ctx, ln, 0, 2, "10.0.0.1")
+		if err != nil {
+			t.Errorf("rank0: %v", err)
+			return
+		}
+		results[0] = r
+	}()
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		r, err := rendezvousDial(ctx, addr, 1, 2, "10.0.0.2")
+		if err != nil {
+			t.Errorf("rank1: %v", err)
+			return
+		}
+		results[1] = r
+	}()
+	wg.Wait()
+
+	for i, r := range results {
+		require.NotNilf(t, r, "rank %d nil result", i)
+		require.Equalf(t, 2, r.WorldSize, "rank %d worldsize", i)
+		require.Lenf(t, r.Peers, 2, "rank %d peers", i)
+		require.Truef(t, r.InterNode, "rank %d expected inter-node (distinct addrs)", i)
+	}
+}
+
+func TestInterNodeSingleAddr(t *testing.T) {
+	peers := []Peer{{Rank: 0, Addr: "10.0.0.1"}, {Rank: 1, Addr: "10.0.0.1"}}
+	require.False(t, computeInterNode(peers), "same addr should be intra-node")
+	peers[1].Addr = "10.0.0.2"
+	require.True(t, computeInterNode(peers), "distinct addrs should be inter-node")
+}
+
+func TestRendezvousDialRetryBeforeBind(t *testing.T) {
+	// Discover a free port by binding then immediately releasing it, so the
+	// dialer can target a known address before rank 0 actually serves.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := probe.Addr().String()
+	require.NoError(t, probe.Close())
+
+	results := make([]*RendezvousResult, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Rank 1 starts dialing before rank 0 binds; it must retry until serve.
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		r, err := rendezvousDial(ctx, addr, 1, 2, "10.0.0.2")
+		if err != nil {
+			t.Errorf("rank1: %v", err)
+			return
+		}
+		results[1] = r
+	}()
+
+	go func() {
+		defer wg.Done()
+		time.Sleep(150 * time.Millisecond)
+		ln, err := Listen(addr)
+		if err != nil {
+			t.Errorf("rank0 listen: %v", err)
+			return
+		}
+		defer func() { _ = ln.Close() }()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		r, err := rendezvousServe(ctx, ln, 0, 2, "10.0.0.1")
+		if err != nil {
+			t.Errorf("rank0: %v", err)
+			return
+		}
+		results[0] = r
+	}()
+	wg.Wait()
+
+	for i, r := range results {
+		require.NotNilf(t, r, "rank %d nil result", i)
+		require.Equalf(t, 2, r.WorldSize, "rank %d worldsize", i)
+		require.Lenf(t, r.Peers, 2, "rank %d peers", i)
+	}
+}
+
+func TestReadJSONFramingBounds(t *testing.T) {
+	frame := func(n uint32) []byte {
+		var buf bytes.Buffer
+		var hdr [4]byte
+		binary.BigEndian.PutUint32(hdr[:], n)
+		buf.Write(hdr[:])
+		return buf.Bytes()
+	}
+
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "zero length", data: frame(0)},
+		{name: "oversized", data: frame(maxFrameSize + 1)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var p Peer
+			err := readJSON(bytes.NewReader(tc.data), &p)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "bad frame length")
+		})
+	}
+}
+
+// helper using the package's own listener constructor (defined in rendezvous.go)
+func listenEphemeral(t *testing.T) (Listener, string) {
+	t.Helper()
+	ln, err := Listen("127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	return ln, fmt.Sprintf("127.0.0.1:%d", ln.Port())
+}

--- a/pkg/gpu/mocknccl/engine/rendezvous_test.go
+++ b/pkg/gpu/mocknccl/engine/rendezvous_test.go
@@ -125,6 +125,52 @@ func TestRendezvousDialRetryBeforeBind(t *testing.T) {
 	}
 }
 
+func TestRendezvousRank0BindsLocalPort(t *testing.T) {
+	// Exercises the top-level Rendezvous: rank 0 must bind the local wildcard
+	// for rdzvAddr's port (rdzvAddr is a dial-only Service name in k8s), while
+	// rank 1 dials the loopback host:port. Regression test for rank 0 trying
+	// to bind() the remote rendezvous address.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := probe.Addr().String()
+	require.NoError(t, probe.Close())
+
+	results := make([]*RendezvousResult, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		r, err := Rendezvous(ctx, 0, 2, addr, "10.0.0.1")
+		if err != nil {
+			t.Errorf("rank0: %v", err)
+			return
+		}
+		results[0] = r
+	}()
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		r, err := Rendezvous(ctx, 1, 2, addr, "10.0.0.2")
+		if err != nil {
+			t.Errorf("rank1: %v", err)
+			return
+		}
+		results[1] = r
+	}()
+	wg.Wait()
+
+	for i, r := range results {
+		require.NotNilf(t, r, "rank %d nil result", i)
+		require.Equalf(t, 2, r.WorldSize, "rank %d worldsize", i)
+		require.Lenf(t, r.Peers, 2, "rank %d peers", i)
+		require.Truef(t, r.InterNode, "rank %d expected inter-node (distinct addrs)", i)
+	}
+}
+
 func TestReadJSONFramingBounds(t *testing.T) {
 	frame := func(n uint32) []byte {
 		var buf bytes.Buffer

--- a/pkg/gpu/mocknccl/engine/types.go
+++ b/pkg/gpu/mocknccl/engine/types.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package engine implements the mock NCCL cost model, comm/rank state, and
+// MPI-free rendezvous backing libnccl.so.2.
+package engine
+
+import "strings"
+
+// Collective enumerates the supported collective operations.
+type Collective int
+
+const (
+	AllReduce Collective = iota
+	AllGather
+	ReduceScatter
+	Broadcast
+	Reduce
+)
+
+// ParseCollective maps an nccl-tests-style name to a Collective.
+func ParseCollective(s string) (Collective, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "all_reduce", "allreduce":
+		return AllReduce, true
+	case "all_gather", "allgather":
+		return AllGather, true
+	case "reduce_scatter", "reducescatter":
+		return ReduceScatter, true
+	case "broadcast", "bcast":
+		return Broadcast, true
+	case "reduce":
+		return Reduce, true
+	default:
+		return 0, false
+	}
+}
+
+// BusBWFactor returns the nccl-tests bus-bandwidth factor for op across n
+// ranks. AllReduce moves 2*(n-1)/n of the buffer; AllGather/ReduceScatter
+// move (n-1)/n; Broadcast/Reduce move the full buffer once. n<=1 yields 0
+// (no inter-rank traffic), matching real single-rank runs.
+func BusBWFactor(op Collective, n int) float64 {
+	if n <= 1 {
+		return 0
+	}
+	switch op {
+	case AllReduce:
+		return 2 * float64(n-1) / float64(n)
+	case AllGather, ReduceScatter:
+		return float64(n-1) / float64(n)
+	default: // Broadcast, Reduce
+		return 1
+	}
+}

--- a/pkg/gpu/mocknccl/engine/types_test.go
+++ b/pkg/gpu/mocknccl/engine/types_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBusBWFactor(t *testing.T) {
+	cases := []struct {
+		name string
+		op   Collective
+		n    int
+		want float64
+	}{
+		{"allreduce n=2", AllReduce, 2, 1.0},
+		{"allreduce n=8", AllReduce, 8, 1.75},
+		{"allgather n=8", AllGather, 8, 0.875},
+		{"reducescatter n=8", ReduceScatter, 8, 0.875},
+		{"broadcast n=8", Broadcast, 8, 1.0},
+		{"reduce n=8", Reduce, 8, 1.0},
+		{"allreduce n=1", AllReduce, 1, 0.0},
+		{"allreduce n=0", AllReduce, 0, 0.0},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			require.InDelta(t, c.want, BusBWFactor(c.op, c.n), 1e-9)
+		})
+	}
+}
+
+func TestParseCollective(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     string
+		want   Collective
+		wantOK bool
+	}{
+		{"all_reduce", "all_reduce", AllReduce, true},
+		{"allreduce", "allreduce", AllReduce, true},
+		{"all_gather", "all_gather", AllGather, true},
+		{"allgather", "allgather", AllGather, true},
+		{"reduce_scatter", "reduce_scatter", ReduceScatter, true},
+		{"reducescatter", "reducescatter", ReduceScatter, true},
+		{"broadcast", "broadcast", Broadcast, true},
+		{"bcast", "bcast", Broadcast, true},
+		{"reduce", "reduce", Reduce, true},
+		{"mixed case", "AllReduce", AllReduce, true},
+		{"whitespace padded", "  all_reduce  ", AllReduce, true},
+		{"empty string", "", 0, false},
+		{"unknown", "nonsense", 0, false},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := ParseCollective(c.in)
+			require.Equal(t, c.wantOK, ok)
+			if c.wantOK {
+				require.Equal(t, c.want, got)
+			}
+		})
+	}
+}

--- a/pkg/gpu/mocknccl/perf/mock-coll-perf.c
+++ b/pkg/gpu/mocknccl/perf/mock-coll-perf.c
@@ -1,0 +1,112 @@
+/* pkg/gpu/mocknccl/perf/mock-coll-perf.c
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Minimal nccl-tests-style driver for the mock libnccl + libcuda. MPI-free:
+ * rank/world come from RANK / WORLD_SIZE env; the comm rendezvous (when
+ * WORLD_SIZE>1) is handled inside mock ncclCommInitRank via MOCK_NCCL_RDZV.
+ *
+ * Usage: mock-coll-perf [all_reduce|all_gather|reduce_scatter|broadcast|reduce]
+ *                       -b <minBytes> -e <maxBytes> -f <factor> -n <iters>
+ */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <cuda_runtime.h>
+#include <nccl.h>
+
+static long env_long(const char *k, long def) {
+    const char *v = getenv(k);
+    return v && *v ? strtol(v, NULL, 10) : def;
+}
+
+static double busbw_factor(const char *op, int n) {
+    if (n <= 1) return 0.0;
+    if (!strcmp(op, "all_reduce")) return 2.0 * (n - 1) / n;
+    if (!strcmp(op, "all_gather") || !strcmp(op, "reduce_scatter")) return (double)(n - 1) / n;
+    return 1.0; /* broadcast, reduce */
+}
+
+static ncclResult_t run_one(const char *op, void *sbuf, void *rbuf,
+                            size_t count, ncclComm_t comm, cudaStream_t s) {
+    if (!strcmp(op, "all_reduce"))     return ncclAllReduce(sbuf, rbuf, count, ncclFloat32, ncclSum, comm, s);
+    if (!strcmp(op, "all_gather"))     return ncclAllGather(sbuf, rbuf, count, ncclFloat32, comm, s);
+    if (!strcmp(op, "reduce_scatter")) return ncclReduceScatter(sbuf, rbuf, count, ncclFloat32, ncclSum, comm, s);
+    if (!strcmp(op, "broadcast"))      return ncclBroadcast(sbuf, rbuf, count, ncclFloat32, 0, comm, s);
+    if (!strcmp(op, "reduce"))         return ncclReduce(sbuf, rbuf, count, ncclFloat32, ncclSum, 0, comm, s);
+    return ncclInvalidArgument;
+}
+
+int main(int argc, char **argv) {
+    const char *op = (argc > 1 && argv[1][0] != '-') ? argv[1] : "all_reduce";
+    long minB = 1024, maxB = 64L * 1024 * 1024, factor = 2, iters = 20;
+    for (int i = 1; i < argc - 1; i++) {
+        if (!strcmp(argv[i], "-b")) minB = strtol(argv[++i], NULL, 10);
+        else if (!strcmp(argv[i], "-e")) maxB = strtol(argv[++i], NULL, 10);
+        else if (!strcmp(argv[i], "-f")) factor = strtol(argv[++i], NULL, 10);
+        else if (!strcmp(argv[i], "-n")) iters = strtol(argv[++i], NULL, 10);
+    }
+    if (factor < 2) factor = 2; /* guard against a non-advancing size loop */
+
+    int rank = (int)env_long("RANK", 0);
+    int world = (int)env_long("WORLD_SIZE", 1);
+
+    cudaSetDevice(rank);
+    int ver = 0; ncclGetVersion(&ver);
+
+    ncclComm_t comm;
+    ncclUniqueId id;
+    ncclGetUniqueId(&id);
+    if (ncclCommInitRank(&comm, world, id, rank) != ncclSuccess) {
+        fprintf(stderr, "ncclCommInitRank failed\n");
+        return 1;
+    }
+
+    cudaStream_t stream; cudaStreamCreate(&stream);
+    cudaEvent_t start, stop; cudaEventCreate(&start); cudaEventCreate(&stop);
+
+    if (rank == 0) {
+        printf("# nReps %ld  nRanks %d  nccl %d  op %s\n", iters, world, ver, op);
+        printf("#%11s %11s %8s %8.8s %8s %9s\n",
+               "size(B)", "count", "type", "redop", "time(us)", "busbw(GB/s)");
+    }
+
+    double avg = 0.0; int rows = 0;
+    for (long bytes = minB; bytes <= maxB; bytes *= factor) {
+        size_t count = bytes / sizeof(float);
+        void *sbuf, *rbuf;
+        cudaMalloc(&sbuf, bytes);
+        cudaMalloc(&rbuf, bytes);
+
+        cudaEventRecord(start, stream);
+        for (long it = 0; it < iters; it++) {
+            if (run_one(op, sbuf, rbuf, count, comm, stream) != ncclSuccess) {
+                fprintf(stderr, "collective failed\n");
+                return 1;
+            }
+        }
+        cudaEventRecord(stop, stream);
+        cudaEventSynchronize(stop);
+
+        float ms = 0.0f; cudaEventElapsedTime(&ms, start, stop);
+        double t_us = (ms * 1000.0) / (double)iters;
+        double algbw = t_us > 0 ? (double)bytes / (t_us * 1e3) : 0.0; /* GB/s */
+        double busbw = algbw * busbw_factor(op, world);
+        if (rank == 0) {
+            printf("%12ld %11zu %8s %8s %8.1f %9.2f\n",
+                   bytes, count, "float", "sum", t_us, busbw);
+        }
+        avg += busbw; rows++;
+        cudaFree(sbuf); cudaFree(rbuf);
+    }
+
+    if (rank == 0 && rows > 0) {
+        printf("# Avg bus bandwidth : %.4f\n", avg / rows);
+    }
+
+    cudaEventDestroy(start); cudaEventDestroy(stop);
+    cudaStreamDestroy(stream);
+    ncclCommDestroy(comm);
+    return 0;
+}

--- a/tests/e2e/validate-nccl.sh
+++ b/tests/e2e/validate-nccl.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Validates the mock NCCL 2-pod collective-comms test Job: waits for the
+# Indexed Job to complete, then asserts the rank-0 pod reported a positive
+# "# Avg bus bandwidth" line (proves the cost model + mock CUDA-event timing
+# produced a non-zero busbw across the MPI-free rendezvous).
+#
+# Usage:
+#   validate-nccl.sh [namespace] [job-name]
+set -euo pipefail
+
+NS="${1:-default}"
+JOB="${2:-nvml-mock-nccl-test}"
+TIMEOUT="${NCCL_E2E_TIMEOUT:-180s}"
+
+echo "=== Validating mock NCCL job ns=$NS job=$JOB ==="
+
+echo "Waiting for Job/$JOB to complete (timeout $TIMEOUT)..."
+if ! kubectl -n "$NS" wait --for=condition=complete "job/$JOB" --timeout="$TIMEOUT"; then
+  echo "FAIL: Job/$JOB did not complete"
+  kubectl -n "$NS" describe "job/$JOB" || true
+  kubectl -n "$NS" logs -l "app.kubernetes.io/component=nccl-test" --tail=80 || true
+  exit 1
+fi
+
+# Rank-0 pod prints the nccl-tests-style table + the avg line. Scope the
+# selector to this Job's component so we never grab an index-0 pod from an
+# unrelated Indexed Job in the same namespace.
+POD="$(kubectl -n "$NS" get pods \
+        -l batch.kubernetes.io/job-completion-index=0,app.kubernetes.io/component=nccl-test \
+        -o jsonpath='{.items[0].metadata.name}')"
+if [ -z "$POD" ]; then
+  echo "FAIL: could not find rank-0 pod (batch.kubernetes.io/job-completion-index=0)"
+  exit 1
+fi
+echo "Rank-0 pod: $POD"
+
+if ! LOG="$(kubectl -n "$NS" logs "$POD")"; then
+  echo "FAIL: could not read logs from rank-0 pod $POD"
+  exit 1
+fi
+echo "=== rank-0 log ==="
+echo "$LOG"
+echo "=================="
+
+AVG="$(printf '%s\n' "$LOG" | sed -n 's/^# Avg bus bandwidth : //p')"
+if [ -z "$AVG" ]; then
+  echo "FAIL: no '# Avg bus bandwidth' line in rank-0 log" >&2
+  exit 1
+fi
+
+printf '%s\n' "$AVG" | awk '{
+  if ($1+0 > 0) { print "PASS: NCCL avg busbw = " $1 " GB/s" }
+  else { print "FAIL: NCCL busbw not positive (" $1 ")" > "/dev/stderr"; exit 1 }
+}'
+echo "=== mock NCCL validation PASSED ==="

--- a/tests/mocknccl/Makefile
+++ b/tests/mocknccl/Makefile
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: test
+test:
+	$(MAKE) -C ../../pkg/gpu/mocknccl
+	go test -tags=integration ./...

--- a/tests/mocknccl/abi_cgo.go
+++ b/tests/mocknccl/abi_cgo.go
@@ -1,0 +1,56 @@
+//go:build integration
+
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main holds the cgo bridge for the libnccl.so.2 ABI smoke test. Go
+// forbids `import "C"` inside *_test.go files, so the cgo preamble and thin Go
+// wrappers live here and are exercised by abi_test.go.
+package main
+
+/*
+#cgo LDFLAGS: -L${SRCDIR}/../../pkg/gpu/mocknccl -lnccl -Wl,-rpath,${SRCDIR}/../../pkg/gpu/mocknccl
+#include <stdlib.h>
+#include "../../pkg/gpu/mocknccl/bridge/nccl_types.h"
+extern int ncclGetVersion(int*);
+extern int ncclCommInitAll(ncclComm_t*, int, int*);
+extern int ncclAllReduce(void*, void*, size_t, ncclDataType_t, ncclRedOp_t, ncclComm_t, cudaStream_t);
+extern int ncclCommDestroy(ncclComm_t);
+*/
+import "C"
+import "unsafe"
+
+func getVersion() (rc int, version int) {
+	var ver C.int
+	rc = int(C.ncclGetVersion(&ver))
+	return rc, int(ver)
+}
+
+func commInitAll(n int) (rc int, comms []unsafe.Pointer) {
+	cComms := make([]C.ncclComm_t, n)
+	rc = int(C.ncclCommInitAll(&cComms[0], C.int(n), nil))
+	comms = make([]unsafe.Pointer, n)
+	for i := range cComms {
+		comms[i] = unsafe.Pointer(cComms[i])
+	}
+	return rc, comms
+}
+
+func allReduce(comm unsafe.Pointer) int {
+	return int(C.ncclAllReduce(nil, nil, C.size_t(1024), C.ncclFloat32, C.ncclSum,
+		C.ncclComm_t(comm), (C.cudaStream_t)(unsafe.Pointer(nil))))
+}
+
+func commDestroy(comm unsafe.Pointer) int {
+	return int(C.ncclCommDestroy(C.ncclComm_t(comm)))
+}

--- a/tests/mocknccl/abi_test.go
+++ b/tests/mocknccl/abi_test.go
@@ -1,0 +1,43 @@
+//go:build integration
+
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main loads the built libnccl.so.2 and exercises the C ABI:
+// version + a CommInitAll/AllReduce/CommDestroy round trip. The cgo bridge
+// lives in abi_cgo.go because Go forbids `import "C"` in *_test.go files.
+package main
+
+import "testing"
+
+func TestABIRoundTrip(t *testing.T) {
+	rc, ver := getVersion()
+	if rc != 0 || ver <= 0 {
+		t.Fatalf("ncclGetVersion -> rc=%d ver=%d", rc, ver)
+	}
+	const n = 2
+	rc, comms := commInitAll(n)
+	if rc != 0 {
+		t.Fatal("ncclCommInitAll failed")
+	}
+	for i := 0; i < n; i++ {
+		if rc := allReduce(comms[i]); rc != 0 {
+			t.Fatalf("allreduce rank %d -> %d", i, rc)
+		}
+	}
+	for i := 0; i < n; i++ {
+		if commDestroy(comms[i]) != 0 {
+			t.Fatalf("destroy %d failed", i)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Hardware-free NCCL collective-comms simulation so multi-node `nccl-tests`-style flows run on Kind without GPUs. A 2-pod `all_reduce`-style run completes and reports **non-zero algbw/busbw** derived from the topology (NVLink intra-node, InfiniBand `rate_gbps` inter-node). Closes #372.

### What's included
- **`pkg/gpu/mocknccl/engine`** — collective types + busbw factors, a linear cost model (`time = latency + size/effective_bw`), profile-YAML + `MOCK_NCCL_*` config resolution, an MPI-free TCP rendezvous barrier, and capped collective execution.
- **`pkg/gpu/mockcuda`** — host wall-clock CUDA stream/event timing engine + CGo exports (`cudaStreamCreate`, `cudaEvent*`, `cudaEventElapsedTime`, `cudaMemset`). This is the timing source the driver measures.
- **`libnccl.so.2` bridge** (`pkg/gpu/mocknccl/bridge`) — common NCCL ABI (version/init/comm-mgmt/group + AllReduce/AllGather/ReduceScatter/Broadcast/Reduce) delegating to the engine.
- **`mock-coll-perf`** nccl-tests-style C driver + driver-facing shim headers (`nccl.h`, `cuda_runtime.h`), `Makefile`, and a build-tagged ABI smoke test.
- **Packaging** — Dockerfile builds + installs the lib and driver into the `nvml-mock` image.
- **Chart** — optional 2-pod Indexed `Job` + headless rendezvous `Service` (`--set nccl.test.enabled=true`), `values.schema.json`, and helm unittests.
- **E2E** — `tests/e2e/validate-nccl.sh` + an `nccl-multinode` CI job; plus README/architecture/CHANGELOG docs.

### Design notes / deviations
- Opaque CUDA/NCCL handles are backed by real C memory (vet-clean) instead of fabricating pointers from integers.
- Driver prototypes live in dedicated shim headers (`nccl.h`/`cuda_runtime.h`) so the cgo-included `*_types.h` stay types-only and the bridge build is unaffected.
- E2E uses the branch's shell-validator + CI-job convention (the Go ginkgo harness lives in a separate, unmerged branch).

## Test plan
- [x] `go test` full suite — pass
- [x] `golangci-lint run` — 0 issues; `gofmt` clean
- [x] `helm lint` + `helm unittest` — 7 suites / 122 tests pass
- [x] Docker builder stage: `mock-coll-perf` links + runs on Linux (NCCL version `22304`, non-zero `time(us)`)
- [x] ABI smoke test links against `libnccl.so.2`
- [ ] Live `nccl-multinode` Kind job (runs in GitHub Actions; can't run on the macOS host)

🤖 Draft PR; opened for review/CI.