### PR TITLE
fix(nvml-mock): regenerate bridge stubs for go-nvml 0.13.2 + scope e2e device plugin

### DIFF
--- a/pkg/gpu/mocknvml/bridge/nvml_types.h
+++ b/pkg/gpu/mocknvml/bridge/nvml_types.h
@@ -468,6 +468,17 @@ typedef struct nvmlRusdSettings_v1_st                       nvmlRusdSettings_v1_
 typedef struct nvmlUnrepairableMemoryStatus_v1_st           nvmlUnrepairableMemoryStatus_v1_t;
 typedef struct nvmlWorkloadPowerProfileUpdateProfiles_v1_st nvmlWorkloadPowerProfileUpdateProfiles_v1_t;
 
+/*
+ * NVML additions (go-nvml v0.13.2-0, #410). Versioned _v2 info structs for
+ * remapped rows and the vGPU scheduler APIs. Only ever passed by pointer
+ * through NOT_SUPPORTED stubs, so opaque forward declarations are sufficient
+ * and ABI-safe.
+ */
+typedef struct nvmlRemappedRowsInfo_v2_st                   nvmlRemappedRowsInfo_v2_t;
+typedef struct nvmlVgpuSchedulerLogInfo_v2_st               nvmlVgpuSchedulerLogInfo_v2_t;
+typedef struct nvmlVgpuSchedulerStateInfo_v2_st             nvmlVgpuSchedulerStateInfo_v2_t;
+typedef struct nvmlVgpuSchedulerState_v2_st                 nvmlVgpuSchedulerState_v2_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/pkg/gpu/mocknvml/bridge/stubs_generated.go
+++ b/pkg/gpu/mocknvml/bridge/stubs_generated.go
@@ -21,7 +21,7 @@ package main
 */
 import "C"
 
-// 279 stub functions for unimplemented NVML functions.
+// 287 stub functions for unimplemented NVML functions.
 // These return NVML_ERROR_NOT_SUPPORTED (3).
 
 //export nvmlComputeInstanceDestroy
@@ -519,6 +519,11 @@ func nvmlDeviceGetProcessesUtilizationInfo(device C.nvmlDevice_t, procesesUtilIn
 	return stubReturn("nvmlDeviceGetProcessesUtilizationInfo")
 }
 
+//export nvmlDeviceGetRemappedRows_v2
+func nvmlDeviceGetRemappedRows_v2(device C.nvmlDevice_t, info *C.nvmlRemappedRowsInfo_v2_t) C.nvmlReturn_t {
+	return stubReturn("nvmlDeviceGetRemappedRows_v2")
+}
+
 //export nvmlDeviceGetRepairStatus
 func nvmlDeviceGetRepairStatus(device C.nvmlDevice_t, repairStatus *C.nvmlRepairStatus_t) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetRepairStatus")
@@ -634,9 +639,19 @@ func nvmlDeviceGetVgpuSchedulerLog(device C.nvmlDevice_t, pSchedulerLog *C.nvmlV
 	return stubReturn("nvmlDeviceGetVgpuSchedulerLog")
 }
 
+//export nvmlDeviceGetVgpuSchedulerLog_v2
+func nvmlDeviceGetVgpuSchedulerLog_v2(device C.nvmlDevice_t, pSchedulerLogInfo *C.nvmlVgpuSchedulerLogInfo_v2_t) C.nvmlReturn_t {
+	return stubReturn("nvmlDeviceGetVgpuSchedulerLog_v2")
+}
+
 //export nvmlDeviceGetVgpuSchedulerState
 func nvmlDeviceGetVgpuSchedulerState(device C.nvmlDevice_t, pSchedulerState *C.nvmlVgpuSchedulerGetState_t) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetVgpuSchedulerState")
+}
+
+//export nvmlDeviceGetVgpuSchedulerState_v2
+func nvmlDeviceGetVgpuSchedulerState_v2(device C.nvmlDevice_t, pSchedulerStateInfo *C.nvmlVgpuSchedulerStateInfo_v2_t) C.nvmlReturn_t {
+	return stubReturn("nvmlDeviceGetVgpuSchedulerState_v2")
 }
 
 //export nvmlDeviceGetVgpuTypeCreatablePlacements
@@ -894,6 +909,11 @@ func nvmlDeviceSetVgpuSchedulerState(device C.nvmlDevice_t, pSchedulerState *C.n
 	return stubReturn("nvmlDeviceSetVgpuSchedulerState")
 }
 
+//export nvmlDeviceSetVgpuSchedulerState_v2
+func nvmlDeviceSetVgpuSchedulerState_v2(device C.nvmlDevice_t, pSchedulerState *C.nvmlVgpuSchedulerState_v2_t) C.nvmlReturn_t {
+	return stubReturn("nvmlDeviceSetVgpuSchedulerState_v2")
+}
+
 //export nvmlDeviceSetVirtualizationMode
 func nvmlDeviceSetVirtualizationMode(device C.nvmlDevice_t, virtualMode C.nvmlGpuVirtualizationMode_t) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceSetVirtualizationMode")
@@ -902,6 +922,11 @@ func nvmlDeviceSetVirtualizationMode(device C.nvmlDevice_t, virtualMode C.nvmlGp
 //export nvmlDeviceValidateInforom
 func nvmlDeviceValidateInforom(device C.nvmlDevice_t) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceValidateInforom")
+}
+
+//export nvmlDeviceVgpuForceGspUnload
+func nvmlDeviceVgpuForceGspUnload(device C.nvmlDevice_t) C.nvmlReturn_t {
+	return stubReturn("nvmlDeviceVgpuForceGspUnload")
 }
 
 //export nvmlDeviceWorkloadPowerProfileClearRequestedProfiles
@@ -1059,9 +1084,19 @@ func nvmlGpuInstanceGetVgpuSchedulerLog(gpuInstance C.nvmlGpuInstance_t, pSchedu
 	return stubReturn("nvmlGpuInstanceGetVgpuSchedulerLog")
 }
 
+//export nvmlGpuInstanceGetVgpuSchedulerLog_v2
+func nvmlGpuInstanceGetVgpuSchedulerLog_v2(gpuInstance C.nvmlGpuInstance_t, pSchedulerLogInfo *C.nvmlVgpuSchedulerLogInfo_v2_t) C.nvmlReturn_t {
+	return stubReturn("nvmlGpuInstanceGetVgpuSchedulerLog_v2")
+}
+
 //export nvmlGpuInstanceGetVgpuSchedulerState
 func nvmlGpuInstanceGetVgpuSchedulerState(gpuInstance C.nvmlGpuInstance_t, pSchedulerStateInfo *C.nvmlVgpuSchedulerStateInfo_t) C.nvmlReturn_t {
 	return stubReturn("nvmlGpuInstanceGetVgpuSchedulerState")
+}
+
+//export nvmlGpuInstanceGetVgpuSchedulerState_v2
+func nvmlGpuInstanceGetVgpuSchedulerState_v2(gpuInstance C.nvmlGpuInstance_t, pSchedulerStateInfo *C.nvmlVgpuSchedulerStateInfo_v2_t) C.nvmlReturn_t {
+	return stubReturn("nvmlGpuInstanceGetVgpuSchedulerState_v2")
 }
 
 //export nvmlGpuInstanceGetVgpuTypeCreatablePlacements
@@ -1077,6 +1112,11 @@ func nvmlGpuInstanceSetVgpuHeterogeneousMode(gpuInstance C.nvmlGpuInstance_t, pH
 //export nvmlGpuInstanceSetVgpuSchedulerState
 func nvmlGpuInstanceSetVgpuSchedulerState(gpuInstance C.nvmlGpuInstance_t, pScheduler *C.nvmlVgpuSchedulerState_t) C.nvmlReturn_t {
 	return stubReturn("nvmlGpuInstanceSetVgpuSchedulerState")
+}
+
+//export nvmlGpuInstanceSetVgpuSchedulerState_v2
+func nvmlGpuInstanceSetVgpuSchedulerState_v2(gpuInstance C.nvmlGpuInstance_t, pSchedulerState *C.nvmlVgpuSchedulerState_v2_t) C.nvmlReturn_t {
+	return stubReturn("nvmlGpuInstanceSetVgpuSchedulerState_v2")
 }
 
 //export nvmlSetVgpuVersion

--- a/tests/e2e/device-plugin-mock.yaml
+++ b/tests/e2e/device-plugin-mock.yaml
@@ -20,6 +20,14 @@ spec:
       labels:
         name: nvidia-device-plugin-mock
     spec:
+      # Only schedule where the nvml-mock chart actually installed the driver.
+      # setup.sh labels those nodes nvidia.com/gpu.present=true; without this
+      # the DaemonSet (which tolerates all taints) also lands on the multi-node
+      # control-plane, where /var/lib/nvml-mock/driver is absent, so NVML init
+      # fails with ERROR_LIBRARY_NOT_FOUND and the rollout never completes.
+      # Single-node clusters label their control-plane too, so it still runs there.
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
       tolerations:
         - operator: Exists
       containers:


### PR DESCRIPTION
Two fixes that unblock the nvml-mock e2e matrix on `main`.

## 1. Regenerate bridge stubs for go-nvml 0.13.2 symbols

Every `e2e-device-plugin`, `e2e-dra`, and `e2e-gpu-operator` job was **red on `main`** (all GPU profiles) with:

```
NVIDIA-SMI couldn't find libnvidia-ml.so library in your system.
```

even though the mock `libnvidia-ml.so.1` is present in `lib64`.

**Root cause (reproduced locally):** the go-nvml **0.13.2-0** bump (#410) added new NVML entry points, but the generated bridge stubs were **not regenerated**, leaving 8 symbols undefined in the mock `libnvidia-ml.so`:

```
nvmlDeviceGetRemappedRows_v2
nvmlDeviceGetVgpuSchedulerLog_v2 / State_v2 / SetState_v2
nvmlDeviceVgpuForceGspUnload
nvmlGpuInstanceGetVgpuSchedulerLog_v2 / State_v2 / SetState_v2
```

`nvidia-smi` `dlopen()`s the library with `RTLD_NOW`, which resolves **every** symbol eagerly, so the first undefined symbol made the whole load fatal — surfaced as the misleading *"couldn't find libnvidia-ml.so"*. `LD_PRELOAD` paths kept working (a preloaded library is reused without re-resolution), masking it. Confirmed via `LD_DEBUG`:
```
libnvidia-ml.so.1: error: symbol lookup error: undefined symbol: nvmlDeviceGetRemappedRows_v2 (fatal)
```

**Fix:** regenerate `stubs_generated.go` (`go generate ./pkg/gpu/mocknvml/bridge/`) + add opaque forward declarations for the 4 new `_v2` info structs to `nvml_types.h` (matching the #400 pattern; pointer-only through `NOT_SUPPORTED` stubs, so ABI-safe).

**Verified (local Docker build):** rebuilt lib has no undefined `nvml` symbols; `nvidia-smi -L` succeeds via embedded RUNPATH alone (no `LD_PRELOAD`/`LD_LIBRARY_PATH`), exit 0.

## 2. Scope the mock device-plugin DaemonSet to mock-GPU nodes

`e2e-multi-node` failed at *Deploy NVIDIA device plugin* (rollout stuck at "2 of 3 pods available"). The DaemonSet tolerates all taints and had no `nodeSelector`, so it also scheduled on the **control-plane** node — where the `nvml-mock` chart is never installed (only the labeled workers get it). That pod mounts an empty `/var/lib/nvml-mock` and fails NVML init with `ERROR_LIBRARY_NOT_FOUND`. Looked flaky because the pod can briefly satisfy readiness before crashing.

**Fix:** add `nodeSelector: nvidia.com/gpu.present=true` (the label `setup.sh` applies to every node the chart provisions). Excludes the multi-node control-plane while still covering single-node clusters (whose control-plane is labeled). Race-safe: the label is set during the chart's `--wait` install, which always precedes applying this manifest.

## Related

- #410 — the go-nvml 0.13.2-0 bump that introduced the new symbols.
- #411 — separate pre-existing `main` breakage in the same go-nvml-drift family (`make check-modules` / `tests/mocknvml` go.mod). Not fixed here.

## Test plan

- [ ] `e2e-device-plugin`, `e2e-dra`, `e2e-gpu-operator` (all profiles) green
- [ ] `e2e-multi-node` green (rollout 2/2, control-plane excluded)