### PR TITLE
docs(demo): add topograph network-topology discovery demo

### DIFF
--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -62,3 +62,23 @@ cd compute-domain && ./run.sh
 
 See [compute-domain/README.md](compute-domain/README.md) for the
 walkthrough.
+
+### Topograph (network topology discovery)
+
+Dedicated cluster (`nvml-mock-topograph`, 1 control-plane + 4 workers) that
+runs [NVIDIA/topograph](https://github.com/NVIDIA/topograph) against an
+nvml-mock-simulated GB200 cluster. topograph's node-data-broker reads each
+node's NVLink clique from the mock `nvidia-smi -q` and the server applies
+`network.topology.nvidia.com/accelerator` labels that partition the workers
+into two NVLink accelerator domains — all without real GPUs, HCAs, or
+switches. (nvml-mock's fabric is switchless, so only the `accelerator` label
+is produced, not `leaf`/`spine`/`core`; see the README for the documented
+follow-up.)
+
+**Requirements:** Docker, Kind, Helm (+ network access to the topograph chart)
+
+```bash
+cd topograph && ./run.sh
+```
+
+See [topograph/README.md](topograph/README.md) for the walkthrough.

--- a/docs/demo/topograph/README.md
+++ b/docs/demo/topograph/README.md
@@ -70,7 +70,7 @@ start clean. Env knobs:
 | `GPU_PROFILE` | `gb200` | nvml-mock GPU profile. |
 | `TOPOGRAPH_NS` | `topograph` | Namespace for the topograph release. |
 | `TOPOGRAPH_GIT` | `https://github.com/NVIDIA/topograph.git` | topograph source repo. |
-| `TOPOGRAPH_REF` | `v0.4.0` | Git ref to build (kept in lockstep with the vendored chart). |
+| `TOPOGRAPH_REF` | `main` | Git ref to build; the chart vendored in that checkout is installed too. |
 | `TOPOGRAPH_SRC` | `$TMPDIR/topograph-src` | Local checkout dir (reused across runs). |
 | `TOPOGRAPH_IMAGE_REPO` / `TOPOGRAPH_IMAGE_TAG` | `topograph` / `source-demo` | Locally built image loaded into Kind. |
 | `FORCE_RECREATE` | `false` | Tear down an existing cluster first. |
@@ -97,12 +97,14 @@ hardware identity; topograph's **node-data-broker** harvests it; topograph's
 
 2. **topograph's node-data-broker reads it and annotates the node.** The
    broker runs as a DaemonSet pinned to GPU nodes
-   (`nodeSelector: nvidia.com/gpu.present=true`). Its init container is told
-   where to find the device-plugin DaemonSet
-   (`device-plugin-daemonset=nvml-mock`,
-   `gpu-operator-namespace=default`), execs `nvidia-smi -q` in the
-   co-located nvml-mock pod, and writes the discovered clique onto the node
-   as the annotation `topograph.nvidia.com/cluster-id=<ClusterUUID>.<CliqueId>`.
+   (`nodeSelector: nvidia.com/gpu.present=true`). It is told where to find the
+   device-plugin DaemonSet via `node-data-broker.extraArgs`
+   (`device-plugin-daemonset=nvml-mock`, `gpu-operator-namespace=default`),
+   execs `nvidia-smi -q | grep "ClusterUUID\|CliqueId"` in the co-located
+   nvml-mock pod, and writes the discovered clique onto the node as the
+   annotation `topograph.nvidia.com/cluster-id=<ClusterUUID>.<CliqueId>`. The
+   broker applies the annotation on startup (and re-applies it every
+   `refreshInterval`) before it begins serving `/healthz`.
    See [`topograph-values.yaml`](./topograph-values.yaml).
 
 3. **topograph's server labels the node.** The `node-observer` triggers a
@@ -175,7 +177,7 @@ POD=$(kubectl get pods -l app.kubernetes.io/name=nvml-mock \
 kubectl exec "$POD" -- nvidia-smi -q | grep -E 'ClusterUUID|CliqueId'
 
 # 5. Build topograph from source and load the image into Kind.
-git clone --depth 1 --branch v0.4.0 \
+git clone --depth 1 --branch main \
     https://github.com/NVIDIA/topograph.git /tmp/topograph-src
 # topograph's Makefile defaults GOOS to the host OS; force linux for the image.
 make -C /tmp/topograph-src image-build \

--- a/docs/demo/topograph/README.md
+++ b/docs/demo/topograph/README.md
@@ -1,0 +1,200 @@
+# nvml-mock + topograph Demo
+
+End-to-end walkthrough of [NVIDIA/topograph](https://github.com/NVIDIA/topograph)
+performing **in-cluster topology discovery** against an nvml-mock-simulated
+GPU cluster on Kind — **no physical GPUs, HCAs, or switches**.
+
+topograph reads each node's NVLink **accelerator domain** (NVLink clique)
+straight out of the mock `nvidia-smi -q` output, then writes the standard
+`network.topology.nvidia.com/accelerator` label that topology-aware schedulers
+(e.g. the Kueue topology-aware scheduling plugin) consume.
+
+The demo runs on its own cluster (`nvml-mock-topograph`, 1 control-plane +
+4 workers) and partitions the workers into two NVLink cliques:
+
+```text
+domain "demo-domain"              uuid 00000000-0000-0000-0000-0000000000ab
+  clique 0:
+    - nvml-mock-topograph-worker
+    - nvml-mock-topograph-worker2
+  clique 1:
+    - nvml-mock-topograph-worker3
+    - nvml-mock-topograph-worker4
+```
+
+After the run, the four workers carry:
+
+```text
+nvml-mock-topograph-worker    network.topology.nvidia.com/accelerator=00000000-0000-0000-0000-0000000000ab.0
+nvml-mock-topograph-worker2   network.topology.nvidia.com/accelerator=00000000-0000-0000-0000-0000000000ab.0
+nvml-mock-topograph-worker3   network.topology.nvidia.com/accelerator=00000000-0000-0000-0000-0000000000ab.1
+nvml-mock-topograph-worker4   network.topology.nvidia.com/accelerator=00000000-0000-0000-0000-0000000000ab.1
+```
+
+— i.e. the label value is `<ClusterUUID>.<CliqueId>`, and the two cliques
+land in two distinct accelerator domains.
+
+## Prerequisites
+
+The demo expects the following tools on `$PATH`:
+
+| Tool      | Tested version | Notes |
+|---        |---             |---    |
+| `docker`  | 24+            | Daemon must be running. Multi-stage build uses the Go base image. |
+| `kind`    | v0.24+         | Creates the `nvml-mock-topograph` cluster (1 cp + 4 workers). |
+| `kubectl` | v1.30+         | Used for `exec`, `rollout`, `get`/`label` against in-cluster pods. |
+| `helm`    | v3.13+         | Installs the nvml-mock chart and the topograph chart `0.4.0`. |
+| `bash`    | 3.2+           | `run.sh` uses `set -euo pipefail` — no bash 4+ features. |
+
+Network access is required to pull the topograph Helm chart from
+`https://NVIDIA.github.io/topograph` and the topograph container images.
+
+## Quick start
+
+```bash
+./run.sh
+```
+
+The script is idempotent. By default an existing `nvml-mock-topograph`
+cluster is reused; pass `FORCE_RECREATE=true ./run.sh` to tear it down and
+start clean. Other env knobs: `GPU_PROFILE` (default `gb200`),
+`TOPOGRAPH_CHART_VERSION` (default `0.4.0`), `TOPOGRAPH_NS` (default
+`topograph`).
+
+## How it works
+
+The integration has three moving parts. nvml-mock supplies the simulated
+hardware identity; topograph's **node-data-broker** harvests it; topograph's
+**server** turns it into a node label.
+
+1. **nvml-mock advertises the NVLink clique.** The chart is installed with
+   `topology.enabled=true` and a two-clique topology document
+   ([`clique-topology.yaml`](./clique-topology.yaml)). The mock
+   `libnvidia-ml.so` overlays that document on the per-profile YAML at
+   `LoadConfig()` time (keyed by `NODE_NAME`), so `nvidia-smi -q` inside each
+   worker pod reports the per-node `Fabric → ClusterUUID` /
+   `Fabric → CliqueId`:
+
+   ```text
+   Fabric
+       CliqueId                          : 0
+       ClusterUUID                       : 00000000-0000-0000-0000-0000000000ab
+   ```
+
+2. **topograph's node-data-broker reads it and annotates the node.** The
+   broker runs as a DaemonSet pinned to GPU nodes
+   (`nodeSelector: nvidia.com/gpu.present=true`). Its init container is told
+   where to find the device-plugin DaemonSet
+   (`device-plugin-daemonset=nvml-mock`,
+   `gpu-operator-namespace=default`), execs `nvidia-smi -q` in the
+   co-located nvml-mock pod, and writes the discovered clique onto the node
+   as the annotation `topograph.nvidia.com/cluster-id=<ClusterUUID>.<CliqueId>`.
+   See [`topograph-values.yaml`](./topograph-values.yaml).
+
+3. **topograph's server labels the node.** The `node-observer` triggers a
+   topology generation; the server runs the `infiniband-k8s` provider with
+   `useGpuCliqueLabel=false` and the `k8s` engine, which turns the
+   `cluster-id` annotation into the
+   `network.topology.nvidia.com/accelerator` label.
+
+`run.sh` then asserts that both clique-0 workers share one accelerator value,
+both clique-1 workers share another, and the two values differ.
+
+### Why `useGpuCliqueLabel: false`
+
+topograph can also read the clique from a pre-existing
+`nvidia.com/gpu.clique` **node label** (the path the real GPU Operator
+populates). When that label is present, topograph deliberately *skips*
+writing its own `accelerator` label — it assumes the scheduler already keys
+off `nvidia.com/gpu.clique`. To demonstrate topograph producing the
+`accelerator` label itself, this demo uses the annotation path
+(`useGpuCliqueLabel: false`): the broker collects the clique via
+`nvidia-smi -q` and topograph writes the label.
+
+## Known limitation — switchless fabric (no leaf/spine/core)
+
+topograph's full value is building a multi-tier network tree
+(`accelerator` → `leaf` → `spine` → `core`) from the InfiniBand fabric via
+`ibnetdiscover`. **nvml-mock's simulated fabric is switchless** — it models
+point-to-point HCAs with no managed switches — so `ibnetdiscover` surfaces no
+switch hierarchy. topograph's broker still attempts IB discovery (and that
+attempt is tolerated/ignored), but only the **NVLink accelerator domain** is
+derived. You will therefore see the `accelerator` label but **no**
+`leaf` / `spine` / `core` labels; `run.sh` prints a `NOTE` to that effect at
+the end.
+
+**Follow-up:** to exercise topograph's switch-tier discovery against
+nvml-mock, the mock `ibnetdiscover` would need to expose a leaf/spine switch
+topology. That is tracked as a future enhancement to the mock InfiniBand
+subnet-manager.
+
+## Manual reproduction
+
+The commands below mirror what `run.sh` issues, for the default
+`nvml-mock-topograph` cluster name.
+
+```bash
+# 1. Create the cluster (1 control-plane + 4 workers).
+kind create cluster --name nvml-mock-topograph \
+    --config docs/demo/topograph/kind.yaml
+
+# 2. Build + load the nvml-mock image.
+docker build -t nvml-mock:topograph-demo -f deployments/nvml-mock/Dockerfile .
+kind load docker-image nvml-mock:topograph-demo --name nvml-mock-topograph
+
+# 3. Install nvml-mock (gb200 + two NVLink cliques + FGO labels).
+helm upgrade --install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+    -f docs/demo/topograph/clique-topology.yaml \
+    --set image.repository=nvml-mock \
+    --set image.tag=topograph-demo \
+    --set integrations.fakeGpuOperator.enabled=true \
+    --set gpu.profile=gb200 \
+    --wait --timeout 180s
+# Recycle so the freshly built (same-tagged) image is the one running.
+kubectl rollout restart daemonset/nvml-mock
+kubectl rollout status  daemonset/nvml-mock --timeout=120s
+
+# 4. Sanity check: nvml-mock exposes the clique to nvidia-smi -q.
+POD=$(kubectl get pods -l app.kubernetes.io/name=nvml-mock \
+    --field-selector spec.nodeName=nvml-mock-topograph-worker \
+    -o jsonpath='{.items[0].metadata.name}')
+kubectl exec "$POD" -- nvidia-smi -q | grep -E 'ClusterUUID|CliqueId'
+
+# 5. Install topograph (infiniband-k8s provider + k8s engine).
+helm repo add topograph https://NVIDIA.github.io/topograph
+helm repo update
+helm upgrade --install topograph topograph/topograph --version 0.4.0 \
+    --namespace topograph --create-namespace \
+    -f docs/demo/topograph/topograph-values.yaml \
+    --wait --timeout 180s
+
+# 6. Inspect the result.
+kubectl get nodes -L network.topology.nvidia.com/accelerator
+```
+
+`-worker` / `-worker2` should report accelerator
+`00000000-0000-0000-0000-0000000000ab.0`; `-worker3` / `-worker4` should
+report `…ab.1`.
+
+> **Image tag gotcha.** The demo always tags the image
+> `nvml-mock:topograph-demo`. When you reuse an existing cluster, a rebuilt
+> image keeps the same tag, so `helm upgrade` leaves the DaemonSet pod
+> template untouched and Kubernetes never recycles the pods — they keep the
+> previously loaded image. `run.sh` issues an explicit
+> `kubectl rollout restart daemonset/nvml-mock` after the install to force
+> the freshly built image into the running pods.
+
+## Custom cluster name
+
+If you rename the Kind cluster, the worker names in
+[`clique-topology.yaml`](./clique-topology.yaml) must change in lockstep —
+each Kind worker is named `<cluster-name>-worker[N]`, and the topology
+document keys cliques by node name. `run.sh` derives the clique node arrays
+from `CLUSTER_NAME`, but the checked-in `clique-topology.yaml` hard-codes the
+default `nvml-mock-topograph-*` names to keep the example faithful.
+
+## Clean up
+
+```bash
+kind delete cluster --name nvml-mock-topograph
+```

--- a/docs/demo/topograph/README.md
+++ b/docs/demo/topograph/README.md
@@ -43,11 +43,17 @@ The demo expects the following tools on `$PATH`:
 | `docker`  | 24+            | Daemon must be running. Multi-stage build uses the Go base image. |
 | `kind`    | v0.24+         | Creates the `nvml-mock-topograph` cluster (1 cp + 4 workers). |
 | `kubectl` | v1.30+         | Used for `exec`, `rollout`, `get`/`label` against in-cluster pods. |
-| `helm`    | v3.13+         | Installs the nvml-mock chart and the topograph chart `0.4.0`. |
+| `helm`    | v3.13+         | Installs the nvml-mock chart and the topograph chart (from source). |
+| `git`     | 2.x            | Clones the topograph source at `TOPOGRAPH_REF` for the build. |
+| `make`    | any            | Drives topograph's `image-build` target. |
 | `bash`    | 3.2+           | `run.sh` uses `set -euo pipefail` — no bash 4+ features. |
 
-Network access is required to pull the topograph Helm chart from
-`https://NVIDIA.github.io/topograph` and the topograph container images.
+**topograph is built from source, not pulled from the published chart/images.**
+`run.sh` clones [`NVIDIA/topograph`](https://github.com/NVIDIA/topograph) at a
+pinned ref, builds the single topograph image (server + node-observer +
+node-data-broker), loads it into Kind, and installs the chart vendored in that
+checkout. Network access is therefore required to clone the repo and to
+download Go modules / base images during the build (not to reach a Helm repo).
 
 ## Quick start
 
@@ -57,9 +63,17 @@ Network access is required to pull the topograph Helm chart from
 
 The script is idempotent. By default an existing `nvml-mock-topograph`
 cluster is reused; pass `FORCE_RECREATE=true ./run.sh` to tear it down and
-start clean. Other env knobs: `GPU_PROFILE` (default `gb200`),
-`TOPOGRAPH_CHART_VERSION` (default `0.4.0`), `TOPOGRAPH_NS` (default
-`topograph`).
+start clean. Env knobs:
+
+| Variable | Default | Purpose |
+|---       |---      |---      |
+| `GPU_PROFILE` | `gb200` | nvml-mock GPU profile. |
+| `TOPOGRAPH_NS` | `topograph` | Namespace for the topograph release. |
+| `TOPOGRAPH_GIT` | `https://github.com/NVIDIA/topograph.git` | topograph source repo. |
+| `TOPOGRAPH_REF` | `v0.4.0` | Git ref to build (kept in lockstep with the vendored chart). |
+| `TOPOGRAPH_SRC` | `$TMPDIR/topograph-src` | Local checkout dir (reused across runs). |
+| `TOPOGRAPH_IMAGE_REPO` / `TOPOGRAPH_IMAGE_TAG` | `topograph` / `source-demo` | Locally built image loaded into Kind. |
+| `FORCE_RECREATE` | `false` | Tear down an existing cluster first. |
 
 ## How it works
 
@@ -160,15 +174,28 @@ POD=$(kubectl get pods -l app.kubernetes.io/name=nvml-mock \
     -o jsonpath='{.items[0].metadata.name}')
 kubectl exec "$POD" -- nvidia-smi -q | grep -E 'ClusterUUID|CliqueId'
 
-# 5. Install topograph (infiniband-k8s provider + k8s engine).
-helm repo add topograph https://NVIDIA.github.io/topograph
-helm repo update
-helm upgrade --install topograph topograph/topograph --version 0.4.0 \
+# 5. Build topograph from source and load the image into Kind.
+git clone --depth 1 --branch v0.4.0 \
+    https://github.com/NVIDIA/topograph.git /tmp/topograph-src
+# topograph's Makefile defaults GOOS to the host OS; force linux for the image.
+make -C /tmp/topograph-src image-build \
+    IMAGE_REPO=topograph IMAGE_TAG=source-demo \
+    GOOS=linux GOARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')"
+kind load docker-image topograph:source-demo --name nvml-mock-topograph
+
+# 6. Install topograph's in-repo chart, pointing every component at the
+#    locally built image (server, node-data-broker, node-observer share it).
+helm upgrade --install topograph /tmp/topograph-src/charts/topograph \
     --namespace topograph --create-namespace \
     -f docs/demo/topograph/topograph-values.yaml \
+    --set image.repository=topograph --set image.tag=source-demo \
+    --set node-data-broker.image.repository=topograph \
+    --set node-data-broker.image.tag=source-demo \
+    --set node-observer.image.repository=topograph \
+    --set node-observer.image.tag=source-demo \
     --wait --timeout 180s
 
-# 6. Inspect the result.
+# 7. Inspect the result.
 kubectl get nodes -L network.topology.nvidia.com/accelerator
 ```
 

--- a/docs/demo/topograph/clique-topology.yaml
+++ b/docs/demo/topograph/clique-topology.yaml
@@ -1,0 +1,22 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# nvml-mock Helm values fragment: declare one NVLink domain split into two
+# cliques. The mock NVML engine looks up each pod's NODE_NAME and overrides its
+# GPUs' clique_id / cluster_uuid accordingly, so `nvidia-smi -q` on each node
+# reports the clique below. Node names follow Kind's `<cluster>-worker[N]`
+# scheme for cluster name `nvml-mock-topograph`.
+topology:
+  enabled: true
+  domains:
+    - name: "demo-domain"
+      uuid: "00000000-0000-0000-0000-0000000000ab"
+      cliques:
+        - id: 0
+          nodes:
+            - nvml-mock-topograph-worker
+            - nvml-mock-topograph-worker2
+        - id: 1
+          nodes:
+            - nvml-mock-topograph-worker3
+            - nvml-mock-topograph-worker4

--- a/docs/demo/topograph/kind.yaml
+++ b/docs/demo/topograph/kind.yaml
@@ -1,0 +1,13 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Kind topology for the topograph demo: one control-plane plus four workers,
+# arranged as two NVLink cliques of two nodes each (see clique-topology.yaml).
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker
+  - role: worker
+  - role: worker

--- a/docs/demo/topograph/run.sh
+++ b/docs/demo/topograph/run.sh
@@ -24,9 +24,6 @@ DEMO_DIR="${REPO_ROOT}/docs/demo/topograph"
 : "${TOPOGRAPH_NS:=topograph}"
 # FORCE_RECREATE=true tears down an existing cluster of the same name first.
 : "${FORCE_RECREATE:=false}"
-# ENABLE_IB_REDIRECT=true also redirects topograph's ibnetdiscover exec into the
-# nvml-mock pods (best-effort; the mock fabric is switchless so it adds no tiers).
-: "${ENABLE_IB_REDIRECT:=true}"
 
 CLIQUE0_NODES=("${CLUSTER_NAME}-worker" "${CLUSTER_NAME}-worker2")
 CLIQUE1_NODES=("${CLUSTER_NAME}-worker3" "${CLUSTER_NAME}-worker4")
@@ -81,6 +78,12 @@ helm upgrade --install nvml-mock "${REPO_ROOT}/${CHART_PATH}" \
   --set "gpu.profile=${GPU_PROFILE}" \
   --wait --timeout 180s
 
+# Force a pod recycle: when an existing cluster is reused, the image tag is
+# unchanged (nvml-mock:topograph-demo), so `helm upgrade` leaves the DaemonSet
+# template untouched and Kubernetes keeps the previously loaded (possibly stale)
+# image. Restarting guarantees the freshly built image is the one running.
+info "Restarting nvml-mock DaemonSet to pick up the freshly built image"
+kubectl rollout restart daemonset/nvml-mock
 info "Waiting for nvml-mock DaemonSet rollout"
 kubectl rollout status daemonset/nvml-mock --timeout=120s
 
@@ -115,19 +118,14 @@ helm upgrade --install topograph topograph/topograph \
   --wait --timeout 180s
 
 ###############################################################################
-# Step 6 -- (Optional) redirect topograph's ibnetdiscover into nvml-mock pods
-###############################################################################
-if [[ "${ENABLE_IB_REDIRECT}" == "true" ]]; then
-  info "Redirecting topograph ibnetdiscover exec into nvml-mock DaemonSet"
-  DEPLOY=$(kubectl get deploy -n "${TOPOGRAPH_NS}" \
-    -l app.kubernetes.io/name=topograph -o jsonpath='{.items[0].metadata.name}')
-  kubectl set env "deployment/${DEPLOY}" -n "${TOPOGRAPH_NS}" \
-    NODE_DATA_BROKER_NAME=nvml-mock NODE_DATA_BROKER_NAMESPACE=default
-  kubectl rollout status "deployment/${DEPLOY}" -n "${TOPOGRAPH_NS}" --timeout=120s
-fi
-
-###############################################################################
-# Step 7 -- Wait for topograph to label the nodes
+# Step 6 -- Wait for topograph to label the nodes
+#
+# topograph's node-data-broker init container reads each node's NVLink clique
+# (`nvidia-smi -q` in the nvml-mock pod) and annotates the node with
+# `topograph.nvidia.com/cluster-id=<ClusterUUID>.<CliqueId>`. The topograph
+# server's k8s engine then turns that annotation into the accelerator label.
+# (The broker also attempts `ibnetdiscover`, but nvml-mock's fabric is
+# switchless, so it contributes no switch tiers -- see Step 8.)
 ###############################################################################
 info "Waiting for topograph to apply network.topology.nvidia.com/accelerator labels"
 DEADLINE=$(( $(date +%s) + 180 ))
@@ -147,7 +145,7 @@ done
 info "All 4 worker nodes carry an accelerator label"
 
 ###############################################################################
-# Step 8 -- Verify: accelerator labels partition nodes by clique
+# Step 7 -- Verify: accelerator labels partition nodes by clique
 ###############################################################################
 A0=$(accel_label "${CLIQUE0_NODES[0]}")
 A0b=$(accel_label "${CLIQUE0_NODES[1]}")
@@ -162,7 +160,7 @@ info "clique1: ${CLIQUE1_NODES[0]}=${A1} ${CLIQUE1_NODES[1]}=${A1b}"
 info "Accelerator labels correctly partition the two NVLink cliques"
 
 ###############################################################################
-# Step 9 -- Document the switchless limitation (leaf/spine/core absent)
+# Step 8 -- Document the switchless limitation (leaf/spine/core absent)
 ###############################################################################
 LEAF=$(kubectl get node "${CLIQUE0_NODES[0]}" \
   -o jsonpath='{.metadata.labels.network\.topology\.nvidia\.com/leaf}' 2>/dev/null || true)
@@ -183,7 +181,6 @@ info "  Cluster      : ${CLUSTER_NAME}"
 info "  Profile      : ${GPU_PROFILE}"
 info "  Cliques      : 0=[${CLIQUE0_NODES[*]}] 1=[${CLIQUE1_NODES[*]}]"
 info "  Accelerator  : clique0=${A0} clique1=${A1}"
-info "  IB redirect  : ${ENABLE_IB_REDIRECT}"
 info ""
 info "Inspect labels: kubectl get nodes -L network.topology.nvidia.com/accelerator"
 info "To tear down  : kind delete cluster --name ${CLUSTER_NAME}"

--- a/docs/demo/topograph/run.sh
+++ b/docs/demo/topograph/run.sh
@@ -19,11 +19,24 @@ CHART_PATH="deployments/nvml-mock/helm/nvml-mock"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 DEMO_DIR="${REPO_ROOT}/docs/demo/topograph"
 : "${GPU_PROFILE:=gb200}"
-: "${TOPOGRAPH_REPO:=https://NVIDIA.github.io/topograph}"
-: "${TOPOGRAPH_CHART_VERSION:=0.4.0}"
 : "${TOPOGRAPH_NS:=topograph}"
+# topograph is built from source (not pulled from the published chart/images):
+#   TOPOGRAPH_GIT  -- source repository to clone
+#   TOPOGRAPH_REF  -- git ref (tag/branch/sha) to build; kept in lockstep with
+#                     the vendored chart version
+#   TOPOGRAPH_SRC  -- local checkout dir (reused across runs)
+#   TOPOGRAPH_IMAGE_REPO/TAG -- locally built image, loaded into Kind
+: "${TOPOGRAPH_GIT:=https://github.com/NVIDIA/topograph.git}"
+: "${TOPOGRAPH_REF:=main}"
+: "${TOPOGRAPH_SRC:=${TMPDIR:-/tmp}/topograph-src}"
+: "${TOPOGRAPH_IMAGE_REPO:=topograph}"
+: "${TOPOGRAPH_IMAGE_TAG:=source-demo}"
 # FORCE_RECREATE=true tears down an existing cluster of the same name first.
 : "${FORCE_RECREATE:=false}"
+
+# Container target arch (the Kind nodes' arch); topograph's Makefile defaults
+# GOOS to the host OS (e.g. darwin), so we force linux for the image build.
+TOPOGRAPH_ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')"
 
 CLIQUE0_NODES=("${CLUSTER_NAME}-worker" "${CLUSTER_NAME}-worker2")
 CLIQUE1_NODES=("${CLUSTER_NAME}-worker3" "${CLUSTER_NAME}-worker4")
@@ -105,16 +118,42 @@ fi
 info "nvidia-smi -q reports fabric clique identity (ClusterUUID/CliqueId present)"
 
 ###############################################################################
-# Step 5 -- Install topograph (infiniband-k8s provider + k8s engine)
+# Step 5 -- Build topograph from source, then install its in-repo chart
+#
+# We build topograph (server + node-observer + node-data-broker all ship in a
+# single image) from a pinned source ref instead of pulling the published
+# image/chart, and install the chart vendored in that same checkout. The image
+# tag is overridden onto every component so the DaemonSets/Deployment use the
+# locally loaded build rather than ghcr.io.
 ###############################################################################
-info "Adding topograph Helm repo"
-helm repo add topograph "${TOPOGRAPH_REPO}" >/dev/null 2>&1 || true
-helm repo update >/dev/null
-info "Installing topograph chart ${TOPOGRAPH_CHART_VERSION}"
-helm upgrade --install topograph topograph/topograph \
-  --version "${TOPOGRAPH_CHART_VERSION}" \
+info "Fetching topograph source (${TOPOGRAPH_REF}) into ${TOPOGRAPH_SRC}"
+if [[ -d "${TOPOGRAPH_SRC}/.git" ]]; then
+  git -C "${TOPOGRAPH_SRC}" fetch --depth 1 origin "${TOPOGRAPH_REF}"
+  git -C "${TOPOGRAPH_SRC}" checkout -q FETCH_HEAD
+else
+  rm -rf "${TOPOGRAPH_SRC}"
+  git clone --depth 1 --branch "${TOPOGRAPH_REF}" "${TOPOGRAPH_GIT}" "${TOPOGRAPH_SRC}"
+fi
+
+info "Building topograph image ${TOPOGRAPH_IMAGE_REPO}:${TOPOGRAPH_IMAGE_TAG} (linux/${TOPOGRAPH_ARCH})"
+make -C "${TOPOGRAPH_SRC}" image-build \
+  IMAGE_REPO="${TOPOGRAPH_IMAGE_REPO}" \
+  IMAGE_TAG="${TOPOGRAPH_IMAGE_TAG}" \
+  GOOS=linux GOARCH="${TOPOGRAPH_ARCH}"
+
+info "Loading topograph image into Kind cluster"
+kind load docker-image "${TOPOGRAPH_IMAGE_REPO}:${TOPOGRAPH_IMAGE_TAG}" --name "${CLUSTER_NAME}"
+
+info "Installing topograph chart from source (${TOPOGRAPH_SRC}/charts/topograph)"
+helm upgrade --install topograph "${TOPOGRAPH_SRC}/charts/topograph" \
   --namespace "${TOPOGRAPH_NS}" --create-namespace \
   -f "${DEMO_DIR}/topograph-values.yaml" \
+  --set "image.repository=${TOPOGRAPH_IMAGE_REPO}" \
+  --set "image.tag=${TOPOGRAPH_IMAGE_TAG}" \
+  --set "node-data-broker.image.repository=${TOPOGRAPH_IMAGE_REPO}" \
+  --set "node-data-broker.image.tag=${TOPOGRAPH_IMAGE_TAG}" \
+  --set "node-observer.image.repository=${TOPOGRAPH_IMAGE_REPO}" \
+  --set "node-observer.image.tag=${TOPOGRAPH_IMAGE_TAG}" \
   --wait --timeout 180s
 
 ###############################################################################
@@ -179,6 +218,7 @@ echo
 info "Demo complete."
 info "  Cluster      : ${CLUSTER_NAME}"
 info "  Profile      : ${GPU_PROFILE}"
+info "  topograph    : ${TOPOGRAPH_REF} (built from source -> ${TOPOGRAPH_IMAGE_REPO}:${TOPOGRAPH_IMAGE_TAG})"
 info "  Cliques      : 0=[${CLIQUE0_NODES[*]}] 1=[${CLIQUE1_NODES[*]}]"
 info "  Accelerator  : clique0=${A0} clique1=${A1}"
 info ""

--- a/docs/demo/topograph/run.sh
+++ b/docs/demo/topograph/run.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Copyright 2026 NVIDIA CORPORATION
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Demo: topograph derives NVLink accelerator-domain node labels from an
+# nvml-mock-simulated GB200 cluster on Kind. No real GPUs, HCAs, or switches.
+#
+# See README.md for the full walkthrough and the documented switchless-fabric
+# limitation (only the `accelerator` label is produced, not leaf/spine/core).
+set -euo pipefail
+
+###############################################################################
+# Configuration (env-overridable)
+###############################################################################
+CLUSTER_NAME="${CLUSTER_NAME:-nvml-mock-topograph}"
+IMAGE_NAME="nvml-mock:topograph-demo"
+CHART_PATH="deployments/nvml-mock/helm/nvml-mock"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+DEMO_DIR="${REPO_ROOT}/docs/demo/topograph"
+: "${GPU_PROFILE:=gb200}"
+: "${TOPOGRAPH_REPO:=https://NVIDIA.github.io/topograph}"
+: "${TOPOGRAPH_CHART_VERSION:=0.4.0}"
+: "${TOPOGRAPH_NS:=topograph}"
+# FORCE_RECREATE=true tears down an existing cluster of the same name first.
+: "${FORCE_RECREATE:=false}"
+# ENABLE_IB_REDIRECT=true also redirects topograph's ibnetdiscover exec into the
+# nvml-mock pods (best-effort; the mock fabric is switchless so it adds no tiers).
+: "${ENABLE_IB_REDIRECT:=true}"
+
+CLIQUE0_NODES=("${CLUSTER_NAME}-worker" "${CLUSTER_NAME}-worker2")
+CLIQUE1_NODES=("${CLUSTER_NAME}-worker3" "${CLUSTER_NAME}-worker4")
+
+###############################################################################
+# Helpers
+###############################################################################
+info() { echo "==> $*"; }
+fail() { echo "ERROR: $*" >&2; exit 1; }
+
+accel_label() {
+  # Print the topograph accelerator label value for a node (empty if unset).
+  kubectl get node "$1" \
+    -o jsonpath='{.metadata.labels.network\.topology\.nvidia\.com/accelerator}' \
+    2>/dev/null || true
+}
+
+###############################################################################
+# Step 1 -- Create (or reuse) the Kind cluster
+###############################################################################
+if kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
+  if [[ "${FORCE_RECREATE}" == "true" ]]; then
+    info "Deleting existing cluster '${CLUSTER_NAME}' (FORCE_RECREATE=true)"
+    kind delete cluster --name "${CLUSTER_NAME}"
+    info "Creating Kind cluster: ${CLUSTER_NAME}"
+    kind create cluster --name "${CLUSTER_NAME}" --config="${DEMO_DIR}/kind.yaml"
+  else
+    info "Reusing existing Kind cluster '${CLUSTER_NAME}' (FORCE_RECREATE=true to recreate)"
+  fi
+else
+  info "Creating Kind cluster: ${CLUSTER_NAME}"
+  kind create cluster --name "${CLUSTER_NAME}" --config="${DEMO_DIR}/kind.yaml"
+fi
+
+###############################################################################
+# Step 2 -- Build and load the nvml-mock image
+###############################################################################
+info "Building image: ${IMAGE_NAME}"
+docker build -t "${IMAGE_NAME}" -f "${REPO_ROOT}/deployments/nvml-mock/Dockerfile" "${REPO_ROOT}"
+info "Loading image into Kind cluster"
+kind load docker-image "${IMAGE_NAME}" --name "${CLUSTER_NAME}"
+
+###############################################################################
+# Step 3 -- Install nvml-mock (gb200 + two NVLink cliques)
+###############################################################################
+info "Installing nvml-mock (profile=${GPU_PROFILE}, two cliques)"
+helm upgrade --install nvml-mock "${REPO_ROOT}/${CHART_PATH}" \
+  -f "${DEMO_DIR}/clique-topology.yaml" \
+  --set image.repository=nvml-mock \
+  --set image.tag=topograph-demo \
+  --set integrations.fakeGpuOperator.enabled=true \
+  --set "gpu.profile=${GPU_PROFILE}" \
+  --wait --timeout 180s
+
+info "Waiting for nvml-mock DaemonSet rollout"
+kubectl rollout status daemonset/nvml-mock --timeout=120s
+
+###############################################################################
+# Step 4 -- Sanity check: nvml-mock exposes the clique to nvidia-smi -q
+#
+# topograph's node-data-broker reads the clique by running
+# `nvidia-smi -q | grep "ClusterUUID\|CliqueId"` in the nvml-mock pod. If those
+# strings are absent the whole integration cannot work, so fail fast.
+###############################################################################
+POD=$(kubectl get pods -l app.kubernetes.io/name=nvml-mock \
+  -o jsonpath='{.items[0].metadata.name}')
+info "Checking nvidia-smi -q clique output in pod ${POD}"
+SMI_Q=$(kubectl exec "${POD}" -- nvidia-smi -q)
+if ! grep -qE 'ClusterUUID|CliqueId' <<<"${SMI_Q}"; then
+  echo "${SMI_Q}" | grep -iE 'fabric|clique|cluster' || true
+  fail "nvml-mock nvidia-smi -q did not report ClusterUUID/CliqueId; topograph cannot derive the accelerator domain"
+fi
+info "nvidia-smi -q reports fabric clique identity (ClusterUUID/CliqueId present)"
+
+###############################################################################
+# Step 5 -- Install topograph (infiniband-k8s provider + k8s engine)
+###############################################################################
+info "Adding topograph Helm repo"
+helm repo add topograph "${TOPOGRAPH_REPO}" >/dev/null 2>&1 || true
+helm repo update >/dev/null
+info "Installing topograph chart ${TOPOGRAPH_CHART_VERSION}"
+helm upgrade --install topograph topograph/topograph \
+  --version "${TOPOGRAPH_CHART_VERSION}" \
+  --namespace "${TOPOGRAPH_NS}" --create-namespace \
+  -f "${DEMO_DIR}/topograph-values.yaml" \
+  --wait --timeout 180s
+
+###############################################################################
+# Step 6 -- (Optional) redirect topograph's ibnetdiscover into nvml-mock pods
+###############################################################################
+if [[ "${ENABLE_IB_REDIRECT}" == "true" ]]; then
+  info "Redirecting topograph ibnetdiscover exec into nvml-mock DaemonSet"
+  DEPLOY=$(kubectl get deploy -n "${TOPOGRAPH_NS}" \
+    -l app.kubernetes.io/name=topograph -o jsonpath='{.items[0].metadata.name}')
+  kubectl set env "deployment/${DEPLOY}" -n "${TOPOGRAPH_NS}" \
+    NODE_DATA_BROKER_NAME=nvml-mock NODE_DATA_BROKER_NAMESPACE=default
+  kubectl rollout status "deployment/${DEPLOY}" -n "${TOPOGRAPH_NS}" --timeout=120s
+fi
+
+###############################################################################
+# Step 7 -- Wait for topograph to label the nodes
+###############################################################################
+info "Waiting for topograph to apply network.topology.nvidia.com/accelerator labels"
+DEADLINE=$(( $(date +%s) + 180 ))
+while :; do
+  LABELED=0
+  for n in "${CLIQUE0_NODES[@]}" "${CLIQUE1_NODES[@]}"; do
+    [[ -n "$(accel_label "$n")" ]] && LABELED=$(( LABELED + 1 ))
+  done
+  [[ "${LABELED}" -eq 4 ]] && break
+  if [[ "$(date +%s)" -ge "${DEADLINE}" ]]; then
+    info "topograph server logs (last 60 lines):"
+    kubectl logs -n "${TOPOGRAPH_NS}" -l app.kubernetes.io/name=topograph --tail=60 || true
+    fail "timed out waiting for accelerator labels (${LABELED}/4 nodes labeled)"
+  fi
+  sleep 5
+done
+info "All 4 worker nodes carry an accelerator label"
+
+###############################################################################
+# Step 8 -- Verify: accelerator labels partition nodes by clique
+###############################################################################
+A0=$(accel_label "${CLIQUE0_NODES[0]}")
+A0b=$(accel_label "${CLIQUE0_NODES[1]}")
+A1=$(accel_label "${CLIQUE1_NODES[0]}")
+A1b=$(accel_label "${CLIQUE1_NODES[1]}")
+info "clique0: ${CLIQUE0_NODES[0]}=${A0} ${CLIQUE0_NODES[1]}=${A0b}"
+info "clique1: ${CLIQUE1_NODES[0]}=${A1} ${CLIQUE1_NODES[1]}=${A1b}"
+
+[[ "${A0}" == "${A0b}" ]] || fail "clique-0 nodes have different accelerator labels (${A0} vs ${A0b})"
+[[ "${A1}" == "${A1b}" ]] || fail "clique-1 nodes have different accelerator labels (${A1} vs ${A1b})"
+[[ "${A0}" != "${A1}" ]]  || fail "clique-0 and clique-1 share the same accelerator label (${A0}); cliques not distinguished"
+info "Accelerator labels correctly partition the two NVLink cliques"
+
+###############################################################################
+# Step 9 -- Document the switchless limitation (leaf/spine/core absent)
+###############################################################################
+LEAF=$(kubectl get node "${CLIQUE0_NODES[0]}" \
+  -o jsonpath='{.metadata.labels.network\.topology\.nvidia\.com/leaf}' 2>/dev/null || true)
+if [[ -n "${LEAF}" ]]; then
+  info "NOTE: a leaf label is present (${LEAF}) -- the fabric exposed switches"
+else
+  info "NOTE: no leaf/spine/core labels -- nvml-mock's fabric is switchless"
+  info "      (point-to-point); only the NVLink accelerator domain is derived."
+  info "      Follow-up: add mock leaf/spine switches to nvml-mock's ibnetdiscover."
+fi
+
+###############################################################################
+# Summary
+###############################################################################
+echo
+info "Demo complete."
+info "  Cluster      : ${CLUSTER_NAME}"
+info "  Profile      : ${GPU_PROFILE}"
+info "  Cliques      : 0=[${CLIQUE0_NODES[*]}] 1=[${CLIQUE1_NODES[*]}]"
+info "  Accelerator  : clique0=${A0} clique1=${A1}"
+info "  IB redirect  : ${ENABLE_IB_REDIRECT}"
+info ""
+info "Inspect labels: kubectl get nodes -L network.topology.nvidia.com/accelerator"
+info "To tear down  : kind delete cluster --name ${CLUSTER_NAME}"

--- a/docs/demo/topograph/topograph-values.yaml
+++ b/docs/demo/topograph/topograph-values.yaml
@@ -1,0 +1,51 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Topograph chart values for the nvml-mock demo. Adapted from the chart's
+# values.k8s.ib-example.yaml. The node-data-broker init container is redirected
+# from the GPU Operator's device plugin to the nvml-mock DaemonSet, so topograph
+# reads each node's NVLink clique from nvml-mock's `nvidia-smi -q`.
+global:
+  provider:
+    name: infiniband-k8s
+    params:
+      # Use the topograph.nvidia.com/cluster-id annotation (written by the
+      # node-data-broker) as the accelerator-domain source. Must stay false:
+      # with the nvidia.com/gpu.clique label path the k8s engine would defer to
+      # that label and NOT write its own network.topology.nvidia.com/accelerator
+      # label, which is exactly what this demo verifies.
+      useGpuCliqueLabel: false
+  engine:
+    name: k8s
+
+# Auto-trigger topology generation for the mock GPU nodes. setup.sh in the
+# nvml-mock chart labels those nodes nvidia.com/gpu.present=true.
+node-observer:
+  topograph:
+    trigger:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+
+node-data-broker:
+  securityContext:
+    privileged: true
+  nodeSelector:
+    nvidia.com/gpu.present: "true"
+  # Read NVLink clique IDs from the nvml-mock DaemonSet instead of the GPU
+  # Operator's device plugin. The init container execs `nvidia-smi -q` here.
+  initc:
+    extraArgs:
+      - gpu-operator-namespace=default
+      - device-plugin-daemonset=nvml-mock
+  # The broker's own pod (curl image) only hosts the init container above. The
+  # server's `ibnetdiscover` exec is redirected to the nvml-mock DaemonSet by
+  # run.sh (ENABLE_IB_REDIRECT). The mock fabric is switchless, so the switch
+  # tree is empty and only the accelerator (NVLink clique) label is produced.
+  volumeMounts:
+    - name: sys-class
+      mountPath: /sys/class
+  volumes:
+    - name: sys-class
+      hostPath:
+        path: /sys/class
+        type: Directory

--- a/docs/demo/topograph/topograph-values.yaml
+++ b/docs/demo/topograph/topograph-values.yaml
@@ -2,9 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Topograph chart values for the nvml-mock demo. Adapted from the chart's
-# values.k8s.ib-example.yaml. The node-data-broker init container is redirected
-# from the GPU Operator's device plugin to the nvml-mock DaemonSet, so topograph
-# reads each node's NVLink clique from nvml-mock's `nvidia-smi -q`.
+# values.k8s.ib-example.yaml.
+#
+# The node-data-broker (a per-node DaemonSet) is pointed at the nvml-mock
+# DaemonSet instead of the GPU Operator's device plugin: it execs
+# `nvidia-smi -q` inside the nvml-mock pod on its node, reads the NVLink clique
+# (ClusterUUID/CliqueId), and writes it onto the node as the
+# topograph.nvidia.com/cluster-id annotation. The k8s engine then turns that
+# annotation into the network.topology.nvidia.com/accelerator label.
 global:
   provider:
     name: infiniband-k8s
@@ -27,25 +32,16 @@ node-observer:
         nvidia.com/gpu.present: "true"
 
 node-data-broker:
-  securityContext:
-    privileged: true
+  # The broker runs as the main container (no init container in this version):
+  # it applies the cluster-id annotation on startup and re-applies it every
+  # refreshInterval. Pin it to the mock GPU nodes.
   nodeSelector:
     nvidia.com/gpu.present: "true"
-  # Read NVLink clique IDs from the nvml-mock DaemonSet instead of the GPU
-  # Operator's device plugin. The init container execs `nvidia-smi -q` here.
-  initc:
-    extraArgs:
-      - gpu-operator-namespace=default
-      - device-plugin-daemonset=nvml-mock
-  # The broker's own pod (curl image) only hosts the init container above. The
-  # server's `ibnetdiscover` exec is redirected to the nvml-mock DaemonSet by
-  # run.sh (ENABLE_IB_REDIRECT). The mock fabric is switchless, so the switch
-  # tree is empty and only the accelerator (NVLink clique) label is produced.
-  volumeMounts:
-    - name: sys-class
-      mountPath: /sys/class
-  volumes:
-    - name: sys-class
-      hostPath:
-        path: /sys/class
-        type: Directory
+  # Point the infiniband-k8s clique lookup at the nvml-mock DaemonSet in the
+  # default namespace. Each entry is passed to node-data-broker as --set=<entry>.
+  # The broker execs `nvidia-smi -q | grep "ClusterUUID\|CliqueId"` in the
+  # nvml-mock pod on its node (RBAC for pods/exec is granted by the chart when
+  # provider=infiniband-k8s and useGpuCliqueLabel=false).
+  extraArgs:
+    - gpu-operator-namespace=default
+    - device-plugin-daemonset=nvml-mock


### PR DESCRIPTION
## Summary

Adds a new end-to-end demo under `docs/demo/topograph/` showing
[NVIDIA/topograph](https://github.com/NVIDIA/topograph) performing in-cluster
topology discovery against an **nvml-mock-simulated** GPU cluster on Kind — no
physical GPUs, HCAs, or switches.

- nvml-mock advertises per-node NVLink cliques (gb200, two cliques) via
  `nvidia-smi -q` (`Fabric → ClusterUUID` / `CliqueId`).
- topograph's `node-data-broker` reads the clique from the co-located nvml-mock
  pod and annotates each node with `topograph.nvidia.com/cluster-id`.
- topograph's `k8s` engine turns that into the standard
  `network.topology.nvidia.com/accelerator` label, partitioning the four
  workers into two accelerator domains.
- **topograph is built from source** (cloned at a pinned ref, `make image-build`
  forcing `GOOS=linux`, loaded into Kind) and installed from its in-repo chart —
  no published chart/image pull.

Files:
- `docs/demo/topograph/{kind.yaml,clique-topology.yaml,topograph-values.yaml,run.sh,README.md}`
- index entry in `docs/demo/README.md`

### Known limitation (documented)
nvml-mock's simulated InfiniBand fabric is **switchless**, so topograph derives
only the NVLink `accelerator` domain — no `leaf`/`spine`/`core` labels. The
README and `run.sh` call this out and note the follow-up (mock leaf/spine
switches in nvml-mock's `ibnetdiscover`).

## Test plan

- [x] Core demo validated end-to-end on Kind (published chart path): all 4
      workers labeled, `clique0=…ab.0` / `clique1=…ab.1`, partitions verified.
- [ ] Re-validate the **build-from-source** Step 5 end-to-end (image build +
      local chart install). Draft until confirmed.
- [ ] `docs/demo/topograph/run.sh` passes `bash -n` / shellcheck in CI.

> Draft: opened for early review while the source-build path is re-validated locally.