### PR TITLE
feat(imex): run the real nvidia-imex in NO GPU mode instead of the fake marker protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- ComputeDomain simulation now runs the REAL `nvidia-imex` daemon in NO
+  GPU mode (`--nogpu`) instead of the fake marker-file binaries: the new
+  `imex-nogpu-shim` injects the flag around upstream's hard-coded argv,
+  `Dockerfile.compute-domain-daemon` installs the 595-branch package
+  from Ubuntu jammy multiverse at LOCAL build time (never published),
+  and the compute-domain demo asserts real gRPC domain readiness over
+  the pod network, including peer-death detection. (#304)
+
+### Deprecated
+- The fake `nvidia-imex` / `nvidia-imex-ctl` binaries, `pkg/imexcoord`,
+  and the chart's `imex.enabled` hostPath coordination — superseded by
+  the real daemon's NO GPU mode; removal in a follow-up release. Both
+  fakes print a deprecation notice (the ctl only on non-READY paths, to
+  preserve the upstream `CombinedOutput == "READY\n"` probe contract). (#304)
+
 ## [0.2.1] - 2026-06-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from Ubuntu jammy multiverse at LOCAL build time (never published),
   and the compute-domain demo asserts real gRPC domain readiness over
   the pod network, including peer-death detection. (#304) The chart's
-  ibping NetworkPolicy now also admits the IMEX peer port between
-  nvml-mock pods (kind's kindnetd enforces NetworkPolicy on current
+  ibping NetworkPolicy now also admits the IMEX peer and command ports
+  between nvml-mock pods (kind's kindnetd enforces NetworkPolicy on current
   releases, so the allow-list is load-bearing on Kind).
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Dockerfile.compute-domain-daemon` installs the 595-branch package
   from Ubuntu jammy multiverse at LOCAL build time (never published),
   and the compute-domain demo asserts real gRPC domain readiness over
-  the pod network, including peer-death detection. (#304)
+  the pod network, including peer-death detection. (#304) The chart's
+  ibping NetworkPolicy now also admits the IMEX peer port between
+  nvml-mock pods (kind's kindnetd enforces NetworkPolicy on current
+  releases, so the allow-list is load-bearing on Kind).
 
 ### Deprecated
 - The fake `nvidia-imex` / `nvidia-imex-ctl` binaries, `pkg/imexcoord`,

--- a/cmd/fake-imex/ctl/main.go
+++ b/cmd/fake-imex/ctl/main.go
@@ -26,6 +26,16 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/pkg/imexcoord"
 )
 
+// deprecationNotice is printed on non-success paths ONLY: the upstream
+// compute-domain-daemon readiness check compares CombinedOutput()
+// against exactly "READY\n", so the success path must stay silent on
+// both stdout and stderr.
+func deprecationNotice() {
+	fmt.Fprintln(os.Stderr, "fake-imex-ctl: DEPRECATED — this fake nvidia-imex-ctl "+
+		"will be removed in a follow-up release; the ComputeDomain simulation now "+
+		"runs the real nvidia-imex daemon in NO GPU mode (--nogpu) via imex-nogpu-shim.")
+}
+
 func main() {
 	cfg := flag.String("c", "", "imexd config file (ignored)")
 	query := flag.Bool("q", false, "query readiness (only supported mode)")
@@ -34,6 +44,7 @@ func main() {
 
 	if !*query {
 		fmt.Fprintln(os.Stderr, "fake-imex-ctl: only -q (query) mode is supported")
+		deprecationNotice()
 		os.Exit(2)
 	}
 
@@ -44,6 +55,7 @@ func main() {
 		// READY. Avoids a race where the controller marks a domain
 		// ready before its members have actually started.
 		fmt.Fprintf(os.Stderr, "fake-imex-ctl: read nodes.cfg: %v\n", err)
+		deprecationNotice()
 		os.Exit(1)
 	}
 
@@ -55,6 +67,7 @@ func main() {
 	ready, missing := imexcoord.AllPeersReady(imexcoord.StateDir(), expected)
 	if !ready {
 		fmt.Fprintf(os.Stderr, "fake-imex-ctl: peer %s not ready\n", missing)
+		deprecationNotice()
 		os.Exit(1)
 	}
 	fmt.Print("READY\n")

--- a/cmd/fake-imex/ctl/main.go
+++ b/cmd/fake-imex/ctl/main.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/NVIDIA/k8s-test-infra/pkg/imexcoord"
+	"github.com/NVIDIA/k8s-test-infra/pkg/imexcoord" //nolint:staticcheck // the fakes ARE the deprecated subsystem; removed together with imexcoord (#304)
 )
 
 // deprecationNotice is printed on non-success paths ONLY: the upstream

--- a/cmd/fake-imex/daemon/main.go
+++ b/cmd/fake-imex/daemon/main.go
@@ -39,6 +39,11 @@ func main() {
 	flag.Parse()
 	_ = cfg
 
+	log.Printf("fake-imex: DEPRECATED — this fake nvidia-imex will be removed " +
+		"in a follow-up release; the ComputeDomain simulation now runs the real " +
+		"nvidia-imex daemon in NO GPU mode (--nogpu) via imex-nogpu-shim. See " +
+		"NVIDIA/k8s-test-infra#304.")
+
 	podIP := os.Getenv(imexcoord.EnvPodIP)
 	if podIP == "" {
 		log.Fatalf("fake-imex: %s is required (set via downward API)", imexcoord.EnvPodIP)

--- a/cmd/fake-imex/daemon/main.go
+++ b/cmd/fake-imex/daemon/main.go
@@ -29,7 +29,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/NVIDIA/k8s-test-infra/pkg/imexcoord"
+	"github.com/NVIDIA/k8s-test-infra/pkg/imexcoord" //nolint:staticcheck // the fakes ARE the deprecated subsystem; removed together with imexcoord (#304)
 )
 
 func main() {

--- a/cmd/fake-imex/integration_test.go
+++ b/cmd/fake-imex/integration_test.go
@@ -14,6 +14,7 @@
 package fakeimex_test
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"os/exec"
@@ -192,4 +193,73 @@ func waitForNoMarker(t *testing.T, dir, ip string) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	require.FailNowf(t, "marker did not disappear", "marker %s did not disappear within deadline", ip)
+}
+
+// TestFakeImex_ProbeContractAndDeprecation guards two contracts.
+// (1) The ctl success path prints EXACTLY "READY\n" on stdout and
+// NOTHING on stderr: the upstream compute-domain-daemon compares
+// CombinedOutput() to that exact string, so a deprecation banner on
+// the success path would break the real daemon while the fakes are in
+// their deprecation release. (2) The daemon startup log and the ctl
+// failure paths announce the deprecation and its reason (replaced by
+// the real nvidia-imex in NO GPU mode).
+func TestFakeImex_ProbeContractAndDeprecation(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, "state")
+	require.NoError(t, os.MkdirAll(stateDir, 0o755))
+	nodesCfg := filepath.Join(tmp, "nodes.cfg")
+	require.NoError(t, os.WriteFile(nodesCfg, []byte("10.0.0.1\n"), 0o644))
+
+	daemonBin := build(t, "./cmd/fake-imex/daemon", filepath.Join(tmp, "nvidia-imex"))
+	ctlBin := build(t, "./cmd/fake-imex/ctl", filepath.Join(tmp, "nvidia-imex-ctl"))
+
+	env := []string{
+		"IMEX_STATE_DIR=" + stateDir,
+		"IMEX_NODES_CONFIG=" + nodesCfg,
+	}
+
+	// Failure path (no marker yet): deprecation notice on stderr.
+	var stdout, stderr bytes.Buffer
+	ctl := exec.Command(ctlBin, "-c", "/dev/null", "-q")
+	ctl.Env = env
+	ctl.Stdout, ctl.Stderr = &stdout, &stderr
+	err := ctl.Run()
+	var ee *exec.ExitError
+	require.ErrorAs(t, err, &ee)
+	require.Equal(t, 1, ee.ExitCode())
+	require.Contains(t, stderr.String(), "DEPRECATED", "ctl failure path must announce deprecation")
+	require.Contains(t, stderr.String(), "--nogpu", "notice must state the replacement")
+
+	// Daemon startup log (written to a file to avoid racing the pipe
+	// copier; the notice is logged before WriteMarker, so the marker's
+	// existence implies the notice is on disk).
+	logPath := filepath.Join(tmp, "daemon.log")
+	logFile, err := os.Create(logPath)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	daemon := exec.CommandContext(ctx, daemonBin, "-c", "/dev/null")
+	daemon.Env = append(append([]string{}, env...), "POD_IP=10.0.0.1")
+	daemon.Stderr = logFile
+	daemon.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	require.NoError(t, daemon.Start())
+	t.Cleanup(func() {
+		cancel()
+		_ = daemon.Wait()
+		_ = logFile.Close()
+	})
+	waitForMarker(t, stateDir, "10.0.0.1")
+	logged, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	require.Contains(t, string(logged), "DEPRECATED", "daemon startup must announce deprecation")
+	require.Contains(t, string(logged), "--nogpu", "notice must state the replacement")
+
+	// Success path: EXACT stdout, EMPTY stderr.
+	stdout.Reset()
+	stderr.Reset()
+	ctl = exec.Command(ctlBin, "-c", "/dev/null", "-q")
+	ctl.Env = env
+	ctl.Stdout, ctl.Stderr = &stdout, &stderr
+	require.NoError(t, ctl.Run())
+	require.Equal(t, "READY\n", stdout.String(), "upstream compares CombinedOutput to exactly READY\\n")
+	require.Empty(t, stderr.String(), "success path must stay silent or the upstream probe contract breaks")
 }

--- a/cmd/fake-imex/integration_test.go
+++ b/cmd/fake-imex/integration_test.go
@@ -230,6 +230,28 @@ func TestFakeImex_ProbeContractAndDeprecation(t *testing.T) {
 	require.Contains(t, stderr.String(), "DEPRECATED", "ctl failure path must announce deprecation")
 	require.Contains(t, stderr.String(), "--nogpu", "notice must state the replacement")
 
+	// Usage-error path (no -q): exit 2 + deprecation notice.
+	stdout.Reset()
+	stderr.Reset()
+	ctl = exec.Command(ctlBin, "-c", "/dev/null")
+	ctl.Env = env
+	ctl.Stdout, ctl.Stderr = &stdout, &stderr
+	err = ctl.Run()
+	require.ErrorAs(t, err, &ee)
+	require.Equal(t, 2, ee.ExitCode())
+	require.Contains(t, stderr.String(), "DEPRECATED", "usage-error path must announce deprecation")
+
+	// nodes.cfg read-error path: exit 1 + deprecation notice.
+	stdout.Reset()
+	stderr.Reset()
+	ctl = exec.Command(ctlBin, "-c", "/dev/null", "-q")
+	ctl.Env = append(append([]string{}, env...), "IMEX_NODES_CONFIG="+filepath.Join(tmp, "missing-nodes.cfg"))
+	ctl.Stdout, ctl.Stderr = &stdout, &stderr
+	err = ctl.Run()
+	require.ErrorAs(t, err, &ee)
+	require.Equal(t, 1, ee.ExitCode())
+	require.Contains(t, stderr.String(), "DEPRECATED", "read-error path must announce deprecation")
+
 	// Daemon startup log (written to a file to avoid racing the pipe
 	// copier; the notice is logged before WriteMarker, so the marker's
 	// existence implies the notice is on disk).

--- a/cmd/imex-nogpu-shim/exec_test.go
+++ b/cmd/imex-nogpu-shim/exec_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func buildShim(t *testing.T, out string) string {
+	t.Helper()
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available")
+	}
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skipf("unsupported GOOS=%s for build/exec integration", runtime.GOOS)
+	}
+	cmd := exec.Command("go", "build", "-mod=vendor", "-o", out, "./cmd/imex-nogpu-shim")
+	cmd.Dir = shimRepoRoot(t)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "build shim: %s", output)
+	return out
+}
+
+func shimRepoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	for cur := wd; cur != "/"; cur = filepath.Dir(cur) {
+		if _, err := os.Stat(filepath.Join(cur, "go.mod")); err == nil {
+			return cur
+		}
+	}
+	require.FailNow(t, "could not locate repo root")
+	return ""
+}
+
+// writeStub creates a fake "real" nvidia-imex that prints its argv and
+// an env probe, then exits 7 — so the test can independently verify
+// argv construction, environment passthrough, and exit-code
+// transparency of the exec.
+func writeStub(t *testing.T, dir string) string {
+	t.Helper()
+	stub := filepath.Join(dir, "nvidia-imex.real")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\"\nprintf 'ENV_PROBE=%s\\n' \"$ENV_PROBE\"\nexit 7\n"
+	require.NoError(t, os.WriteFile(stub, []byte(script), 0o755))
+	return stub
+}
+
+func TestShimExecsRealWithNogpu(t *testing.T) {
+	tmp := t.TempDir()
+	shim := buildShim(t, filepath.Join(tmp, "shim"))
+	stub := writeStub(t, tmp)
+
+	cmd := exec.Command(shim, "-c", "/imexd/imexd.cfg")
+	cmd.Env = append(os.Environ(), envRealBin+"="+stub, "ENV_PROBE=carried-through")
+	out, err := cmd.Output()
+
+	var ee *exec.ExitError
+	require.ErrorAs(t, err, &ee, "stub exits 7; shim must surface the real binary's exit code")
+	assert.Equal(t, 7, ee.ExitCode(), "exit code must pass through exec")
+	assert.Equal(t, "-c\n/imexd/imexd.cfg\n--nogpu\nENV_PROBE=carried-through\n", string(out))
+}
+
+func TestShimMissingRealBinary(t *testing.T) {
+	tmp := t.TempDir()
+	shim := buildShim(t, filepath.Join(tmp, "shim"))
+
+	cmd := exec.Command(shim, "-c", "/cfg")
+	cmd.Env = append(os.Environ(), envRealBin+"=/nonexistent/nvidia-imex.real")
+	out, err := cmd.CombinedOutput()
+
+	var ee *exec.ExitError
+	require.ErrorAs(t, err, &ee)
+	assert.Equal(t, 127, ee.ExitCode(), "conventional command-not-found code")
+	assert.Contains(t, string(out), "imex-nogpu-shim: exec /nonexistent/nvidia-imex.real")
+}

--- a/cmd/imex-nogpu-shim/main.go
+++ b/cmd/imex-nogpu-shim/main.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// imex-nogpu-shim is a drop-in argv wrapper for the real `nvidia-imex`
+// daemon. The upstream compute-domain-daemon hard-codes the daemon
+// command line (`nvidia-imex -c /imexd/imexd.cfg`) with no
+// flag passthrough, so GPU-less environments install this shim at
+// /usr/bin/nvidia-imex and the real binary at
+// /usr/bin/nvidia-imex.real: the shim exec's the real daemon with
+// `--nogpu` (NO GPU mode) appended, preserving all caller arguments,
+// environment, stdio, and the process image (exec replaces the shim —
+// no wrapper process lingers, signals reach the daemon directly).
+// Remove once upstream supports passing extra IMEX daemon args. See
+// NVIDIA/k8s-test-infra#304.
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// envRealBin overrides the real binary location; used by tests and as
+// an escape hatch for non-standard installs.
+const envRealBin = "IMEX_SHIM_REAL_BIN"
+
+const defaultRealBin = "/usr/bin/nvidia-imex.real"
+
+// realBin returns the path of the real nvidia-imex binary.
+func realBin() string {
+	if v := os.Getenv(envRealBin); v != "" {
+		return v
+	}
+	return defaultRealBin
+}
+
+// buildArgv assembles the exec argv: argv[0] is the real binary path,
+// caller args follow unchanged, and --nogpu is appended unless the
+// caller already passed it (either spelling the daemon accepts).
+func buildArgv(realPath string, args []string) []string {
+	argv := append([]string{realPath}, args...)
+	for _, a := range args {
+		if a == "--nogpu" || a == "-nogpu" {
+			return argv
+		}
+	}
+	return append(argv, "--nogpu")
+}
+
+func main() {
+	bin := realBin()
+	if err := syscall.Exec(bin, buildArgv(bin, os.Args[1:]), os.Environ()); err != nil {
+		fmt.Fprintf(os.Stderr, "imex-nogpu-shim: exec %s: %v\n", bin, err)
+		os.Exit(127)
+	}
+}

--- a/cmd/imex-nogpu-shim/main_test.go
+++ b/cmd/imex-nogpu-shim/main_test.go
@@ -69,6 +69,6 @@ func TestRealBin(t *testing.T) {
 	})
 	t.Run("constant pins the documented literal", func(t *testing.T) {
 		assert.Equal(t, "IMEX_SHIM_REAL_BIN", envRealBin,
-			"deployment manifests set this exact name; the constant must match")
+			"documented escape hatch (README/Dockerfile contract); the constant must match")
 	})
 }

--- a/cmd/imex-nogpu-shim/main_test.go
+++ b/cmd/imex-nogpu-shim/main_test.go
@@ -69,6 +69,6 @@ func TestRealBin(t *testing.T) {
 	})
 	t.Run("constant pins the documented literal", func(t *testing.T) {
 		assert.Equal(t, "IMEX_SHIM_REAL_BIN", envRealBin,
-			"documented escape hatch (README/Dockerfile contract); the constant must match")
+			"documented in Dockerfile.compute-domain-daemon's shim stage; the constant must match")
 	})
 }

--- a/cmd/imex-nogpu-shim/main_test.go
+++ b/cmd/imex-nogpu-shim/main_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildArgv(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "no args appends nogpu",
+			args: nil,
+			want: []string{"/usr/bin/nvidia-imex.real", "--nogpu"},
+		},
+		{
+			name: "upstream invocation preserved and nogpu appended",
+			args: []string{"-c", "/etc/nvidia-imex/imexd.cfg"},
+			want: []string{"/usr/bin/nvidia-imex.real", "-c", "/etc/nvidia-imex/imexd.cfg", "--nogpu"},
+		},
+		{
+			name: "existing --nogpu not duplicated",
+			args: []string{"-c", "/cfg", "--nogpu"},
+			want: []string{"/usr/bin/nvidia-imex.real", "-c", "/cfg", "--nogpu"},
+		},
+		{
+			name: "existing single-dash -nogpu not duplicated",
+			args: []string{"-nogpu", "-c", "/cfg"},
+			want: []string{"/usr/bin/nvidia-imex.real", "-nogpu", "-c", "/cfg"},
+		},
+		{
+			name: "nogpu-prefixed value is not the flag",
+			args: []string{"-c", "--nogpufoo"},
+			want: []string{"/usr/bin/nvidia-imex.real", "-c", "--nogpufoo", "--nogpu"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, buildArgv("/usr/bin/nvidia-imex.real", tt.args))
+		})
+	}
+}
+
+func TestRealBin(t *testing.T) {
+	t.Run("default when env unset", func(t *testing.T) {
+		t.Setenv(envRealBin, "")
+		assert.Equal(t, "/usr/bin/nvidia-imex.real", realBin())
+	})
+	t.Run("env override wins", func(t *testing.T) {
+		t.Setenv(envRealBin, "/opt/imex/nvidia-imex")
+		assert.Equal(t, "/opt/imex/nvidia-imex", realBin())
+	})
+	t.Run("constant pins the documented literal", func(t *testing.T) {
+		assert.Equal(t, "IMEX_SHIM_REAL_BIN", envRealBin,
+			"deployment manifests set this exact name; the constant must match")
+	})
+}

--- a/deployments/nvml-mock/Dockerfile.compute-domain-daemon
+++ b/deployments/nvml-mock/Dockerfile.compute-domain-daemon
@@ -12,18 +12,69 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Thin overlay on the upstream compute-domain-daemon image that swaps in
-# the fake nvidia-imex / nvidia-imex-ctl binaries from the nvml-mock
-# image. With this image deployed (via the upstream Helm chart's image
-# override), the real compute-domain-controller and -daemon run
-# unmodified against the mock NVML fabric APIs on a hardware-free KIND
-# cluster. See NVIDIA/k8s-test-infra#304.
+# Overlay images pairing the REAL nvidia-imex (NO GPU mode) with the
+# mock stack. Two targets:
+#
+#   daemon (default) — the upstream compute-domain-daemon image with
+#       the real nvidia-imex / nvidia-imex-ctl and the imex-nogpu-shim
+#       swapped in. Upstream spawns `nvidia-imex -c /imexd/imexd.cfg`
+#       with a hard-coded argv (no flag passthrough), so the shim at
+#       /usr/bin/nvidia-imex exec's /usr/bin/nvidia-imex.real with
+#       --nogpu appended: the real daemon then runs the real gRPC peer
+#       protocol without GPUs.
+#
+#   demo — the same real-IMEX trio layered onto the nvml-mock image;
+#       used by docs/demo/compute-domain/run.sh Scenario 2.
+#
+# LOCAL BUILD ONLY — never publish these images: they repackage the
+# proprietary nvidia-imex binary (installed from Ubuntu jammy
+# multiverse at build time).
+#
+# See NVIDIA/k8s-test-infra#304.
 
 ARG NVML_MOCK_IMAGE=ghcr.io/nvidia/nvml-mock:latest
-ARG COMPUTE_DOMAIN_DAEMON_IMAGE=registry.k8s.io/dra-driver-nvidia-gpu/compute-domain-daemon:latest
+# Upstream ships ONE image for all DRA driver components (the chart's
+# image.repository); there is no per-component compute-domain-daemon
+# image on registry.k8s.io (that path exists but has zero tags).
+# Verified live 2026-07-03. No `latest` tag is published — bump the
+# pinned version deliberately.
+ARG COMPUTE_DOMAIN_DAEMON_IMAGE=registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu:v0.4.1
+ARG GOLANG_VERSION=1.26
 
-FROM ${NVML_MOCK_IMAGE} AS imex
+# Real IMEX daemon + ctl. Ubuntu redistributes the NVIDIA driver stack
+# in multiverse; nvidia-imex-595 is the 595-branch package (same
+# version on amd64 and arm64: 595.71.05-0ubuntu0.22.04.1 as of
+# 2026-07-03), so no external repo and no arch mapping are needed. The
+# branch NAME is the pin — jammy only ever carries 595.x under it —
+# and the grep makes a packaging surprise fail the build loudly.
+FROM ubuntu:22.04 AS imex
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends nvidia-imex-595 \
+ && rm -rf /var/lib/apt/lists/* \
+ && dpkg-query -W -f='${Version}\n' nvidia-imex-595 | tee /imex-version \
+ && grep -q '^595\.' /imex-version
 
+FROM golang:${GOLANG_VERSION} AS shim
+WORKDIR /src
+COPY go.mod go.sum ./
+COPY vendor/ vendor/
+COPY cmd/imex-nogpu-shim/ cmd/imex-nogpu-shim/
+RUN CGO_ENABLED=0 go build -mod=vendor -o /out/imex-nogpu-shim ./cmd/imex-nogpu-shim
+
+# demo: real IMEX on top of the nvml-mock image, replacing the
+# deprecated fakes at their canonical paths. The package's default
+# config.cfg ships too — the demo renders its per-pod config from it.
+FROM ${NVML_MOCK_IMAGE} AS demo
+COPY --from=imex /usr/bin/nvidia-imex         /usr/bin/nvidia-imex.real
+COPY --from=imex /usr/bin/nvidia-imex-ctl     /usr/bin/nvidia-imex-ctl
+COPY --from=imex /etc/nvidia-imex/config.cfg  /etc/nvidia-imex/config.cfg
+COPY --from=shim /out/imex-nogpu-shim         /usr/bin/nvidia-imex
+
+# daemon (default target): real IMEX on top of the upstream
+# compute-domain-daemon image. Upstream renders its own imexd.cfg from
+# its template, so no config.cfg is copied here.
 FROM ${COMPUTE_DOMAIN_DAEMON_IMAGE}
-COPY --from=imex /usr/bin/nvidia-imex     /usr/bin/nvidia-imex
-COPY --from=imex /usr/bin/nvidia-imex-ctl /usr/bin/nvidia-imex-ctl
+COPY --from=imex /usr/bin/nvidia-imex         /usr/bin/nvidia-imex.real
+COPY --from=imex /usr/bin/nvidia-imex-ctl     /usr/bin/nvidia-imex-ctl
+COPY --from=shim /out/imex-nogpu-shim         /usr/bin/nvidia-imex

--- a/deployments/nvml-mock/Dockerfile.compute-domain-daemon
+++ b/deployments/nvml-mock/Dockerfile.compute-domain-daemon
@@ -39,7 +39,10 @@ ARG NVML_MOCK_IMAGE=ghcr.io/nvidia/nvml-mock:latest
 # Verified live 2026-07-03. No `latest` tag is published — bump the
 # pinned version deliberately.
 ARG COMPUTE_DOMAIN_DAEMON_IMAGE=registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu:v0.4.1
-ARG GOLANG_VERSION=1.26
+# Default kept in lockstep with hack/golang-version.sh (repo-wide pin,
+# see the #394 CVE refresh); the demo script overrides it with the
+# script's output anyway.
+ARG GOLANG_VERSION=1.26.4
 
 # Real IMEX daemon + ctl. Ubuntu redistributes the NVIDIA driver stack
 # in multiverse; nvidia-imex-595 is the 595-branch package (same
@@ -55,6 +58,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
  && dpkg-query -W -f='${Version}\n' nvidia-imex-595 | tee /imex-version \
  && grep -q '^595\.' /imex-version
 
+# imex-nogpu-shim (installed below as /usr/bin/nvidia-imex) execs
+# /usr/bin/nvidia-imex.real with --nogpu appended. Setting
+# IMEX_SHIM_REAL_BIN in the container environment overrides the
+# real-binary path for non-standard installs.
 FROM golang:${GOLANG_VERSION} AS shim
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -53,6 +53,12 @@ spec:
             - name: imex
               containerPort: 50000
               protocol: TCP
+            # IMEX command/status port — peers query each other's node
+            # status and version over it; without it the domain never
+            # converges past DEGRADED (see NVIDIA/k8s-test-infra#304).
+            - name: imex-cmd
+              containerPort: 50005
+              protocol: TCP
           {{- end }}
           command: ["/scripts/entrypoint.sh"]
           env:

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -47,6 +47,12 @@ spec:
             - name: ibping
               containerPort: {{ .Values.infiniband.ping.port }}
               protocol: TCP
+            # Real nvidia-imex (NO GPU mode) gRPC peer port — used by the
+            # ComputeDomain demo (see NVIDIA/k8s-test-infra#304). Declared
+            # here so the ibping NetworkPolicy's named-port entry resolves.
+            - name: imex
+              containerPort: 50000
+              protocol: TCP
           {{- end }}
           command: ["/scripts/entrypoint.sh"]
           env:

--- a/deployments/nvml-mock/helm/nvml-mock/templates/network-policy-ibping.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/network-policy-ibping.yaml
@@ -4,13 +4,16 @@
 # The mock-ib TCP fabric listener binds 0.0.0.0:{{ .Values.infiniband.ping.port }}
 # with no authentication, and the DaemonSet runs privileged. This policy
 # limits the blast radius by allowing inbound fabric traffic only from peer
-# nvml-mock pods (the only legitimate clients). Egress is left unrestricted
-# so DNS-based peer discovery and registration keep working.
+# nvml-mock pods (the only legitimate clients) — it also admits the real
+# nvidia-imex NO GPU mode gRPC peer traffic (port 50000) between those same
+# pods. Egress is left unrestricted so DNS-based peer discovery and
+# registration keep working.
 #
-# NOTE: NetworkPolicy is only enforced by CNIs that implement it (Calico,
-# Cilium, ...). Kind's default CNI (kindnet) ignores NetworkPolicy, so this
-# is a no-op in the typical Kind fixture and matters on policy-enforcing
-# clusters. Harmless either way.
+# NOTE: kind's kindnetd ENFORCES NetworkPolicy on current kind releases, so
+# this allow-list is load-bearing on Kind, not just on Calico/Cilium clusters.
+# Any new pod-to-pod listener added to the mock stack must be allowed here —
+# the imex port below is required by the ComputeDomain demo's real
+# nvidia-imex daemons (NVIDIA/k8s-test-infra#304).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -41,5 +44,7 @@ spec:
               app.kubernetes.io/name: {{ include "nvml-mock.name" . }}
       ports:
         - port: ibping
+          protocol: TCP
+        - port: imex
           protocol: TCP
 {{- end }}

--- a/deployments/nvml-mock/helm/nvml-mock/templates/network-policy-ibping.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/network-policy-ibping.yaml
@@ -5,9 +5,9 @@
 # with no authentication, and the DaemonSet runs privileged. This policy
 # limits the blast radius by allowing inbound fabric traffic only from peer
 # nvml-mock pods (the only legitimate clients) — it also admits the real
-# nvidia-imex NO GPU mode gRPC peer traffic (port 50000) between those same
-# pods. Egress is left unrestricted so DNS-based peer discovery and
-# registration keep working.
+# nvidia-imex NO GPU mode gRPC peer traffic (port 50000) and command/status
+# traffic (port 50005) between those same pods. Egress is left unrestricted
+# so DNS-based peer discovery and registration keep working.
 #
 # NOTE: kind's kindnetd ENFORCES NetworkPolicy on current kind releases, so
 # this allow-list is load-bearing on Kind, not just on Calico/Cilium clusters.
@@ -46,5 +46,7 @@ spec:
         - port: ibping
           protocol: TCP
         - port: imex
+          protocol: TCP
+        - port: imex-cmd
           protocol: TCP
 {{- end }}

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -72,6 +72,9 @@ should match snapshot with all overrides:
                 - containerPort: 50000
                   name: imex
                   protocol: TCP
+                - containerPort: 50005
+                  name: imex-cmd
+                  protocol: TCP
               resources:
                 limits:
                   cpu: 500m
@@ -196,6 +199,9 @@ should match snapshot with b200 profile:
                 - containerPort: 50000
                   name: imex
                   protocol: TCP
+                - containerPort: 50005
+                  name: imex-cmd
+                  protocol: TCP
               securityContext:
                 privileged: true
               volumeMounts:
@@ -306,6 +312,9 @@ should match snapshot with default values:
                   protocol: TCP
                 - containerPort: 50000
                   name: imex
+                  protocol: TCP
+                - containerPort: 50005
+                  name: imex-cmd
                   protocol: TCP
               securityContext:
                 privileged: true

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -69,6 +69,9 @@ should match snapshot with all overrides:
                 - containerPort: 18515
                   name: ibping
                   protocol: TCP
+                - containerPort: 50000
+                  name: imex
+                  protocol: TCP
               resources:
                 limits:
                   cpu: 500m
@@ -190,6 +193,9 @@ should match snapshot with b200 profile:
                 - containerPort: 18515
                   name: ibping
                   protocol: TCP
+                - containerPort: 50000
+                  name: imex
+                  protocol: TCP
               securityContext:
                 privileged: true
               volumeMounts:
@@ -297,6 +303,9 @@ should match snapshot with default values:
               ports:
                 - containerPort: 18515
                   name: ibping
+                  protocol: TCP
+                - containerPort: 50000
+                  name: imex
                   protocol: TCP
               securityContext:
                 privileged: true

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -572,6 +572,15 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports[0].protocol
           value: TCP
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].name
+          value: imex
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].containerPort
+          value: 50000
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].protocol
+          value: TCP
 
   - it: should disable ping mock (but keep sysfs masking) for profiles without InfiniBand
     set:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -581,6 +581,15 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports[1].protocol
           value: TCP
+      - equal:
+          path: spec.template.spec.containers[0].ports[2].name
+          value: imex-cmd
+      - equal:
+          path: spec.template.spec.containers[0].ports[2].containerPort
+          value: 50005
+      - equal:
+          path: spec.template.spec.containers[0].ports[2].protocol
+          value: TCP
 
   - it: should disable ping mock (but keep sysfs masking) for profiles without InfiniBand
     set:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/network_policy_ibping_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/network_policy_ibping_test.yaml
@@ -39,6 +39,12 @@ tests:
       - equal:
           path: spec.ingress[0].ports[1].protocol
           value: TCP
+      - equal:
+          path: spec.ingress[0].ports[2].port
+          value: imex-cmd
+      - equal:
+          path: spec.ingress[0].ports[2].protocol
+          value: TCP
 
   - it: should not render when disabled
     set:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/network_policy_ibping_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/network_policy_ibping_test.yaml
@@ -33,6 +33,12 @@ tests:
       - equal:
           path: spec.ingress[0].ports[0].protocol
           value: TCP
+      - equal:
+          path: spec.ingress[0].ports[1].port
+          value: imex
+      - equal:
+          path: spec.ingress[0].ports[1].protocol
+          value: TCP
 
   - it: should not render when disabled
     set:

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -123,8 +123,9 @@ infiniband:
     # the DaemonSet runs privileged. This NetworkPolicy restricts inbound
     # access to that port to peer nvml-mock pods (the only legitimate
     # clients), limiting the blast radius on clusters whose CNI enforces
-    # NetworkPolicy. NOTE: Kind's default CNI (kindnet) does NOT enforce
-    # NetworkPolicy, so this is a no-op there; it matters on Calico/Cilium.
+    # NetworkPolicy. NOTE: Kind's default CNI (kindnet) ENFORCES
+    # NetworkPolicy on current releases, so this allow-list is load-bearing
+    # there; it also matters on Calico/Cilium.
     networkPolicy:
       enabled: true
 

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -128,12 +128,13 @@ infiniband:
     networkPolicy:
       enabled: true
 
-# Fake IMEX coordination. When `imex.enabled` is true the chart mounts a
-# hostPath state directory into the nvml-mock pod so the fake nvidia-imex
-# / nvidia-imex-ctl binaries (compiled into the image) can coordinate
-# peer readiness via marker files. Real compute-domain-daemon pods reuse
-# the same hostPath via a thin image layer (see
-# deployments/nvml-mock/Dockerfile.compute-domain-daemon).
+# DEPRECATED — fake IMEX coordination, removed in a follow-up release.
+# The fake nvidia-imex / nvidia-imex-ctl marker protocol is superseded
+# by the REAL nvidia-imex daemon running in NO GPU mode (--nogpu) via
+# imex-nogpu-shim; real daemons coordinate over the pod network and
+# need no hostPath (see deployments/nvml-mock/Dockerfile.compute-domain-daemon
+# and NVIDIA/k8s-test-infra#304). While deprecated, `imex.enabled: true`
+# still mounts the hostPath state directory the fakes' marker files use.
 imex:
   enabled: false
   stateDir: /var/lib/nvml-mock/imex-state

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -46,15 +46,17 @@ walkthrough.
 
 ### ComputeDomain (NVLink fabric)
 
-Dedicated cluster (`nvml-mock-compute-domain`) with 4 workers sharing a
-hostPath state directory. Exercises the mock NVML fabric APIs
-(`nvmlDeviceGetGpuFabricInfo` / `…InfoV`) driven by a cluster-level
-topology ConfigMap, plus the fake `nvidia-imex` /
-`nvidia-imex-ctl` binaries coordinating peer readiness through marker
-files on the shared volume. Concludes with a `helm upgrade` that
-rebinds every node into a new clique without rebuilding the image.
+Dedicated cluster (`nvml-mock-compute-domain`) with 4 workers.
+Exercises the mock NVML fabric APIs (`nvmlDeviceGetGpuFabricInfo` /
+`…InfoV`) driven by a cluster-level topology ConfigMap, plus the REAL
+`nvidia-imex` daemon in NO GPU mode (`--nogpu`, injected by
+`imex-nogpu-shim`) forming a live gRPC IMEX domain over the pod
+network — readiness, version handshake, and peer-death detection are
+the real protocol, not a simulation. Concludes with a `helm upgrade`
+that rebinds every node into a new clique without rebuilding the
+image.
 
-**Requirements:** Docker, Kind, Helm
+**Requirements:** Docker, Kind, Helm, kubectl, jq
 
 ```bash
 cd compute-domain && ./run.sh

--- a/docs/demo/compute-domain/README.md
+++ b/docs/demo/compute-domain/README.md
@@ -29,7 +29,7 @@ The demo expects the following tools on `$PATH`:
 
 | Tool      | Tested version | Notes |
 |---        |---             |---    |
-| `docker`  | 24+            | Daemon must be running. Multi-stage build uses Go 1.25 base. |
+| `docker`  | 24+            | Daemon must be running. Multi-stage builds use the repo's pinned Go base (hack/golang-version.sh). |
 | `kind`    | v0.24+         | Provisions the demo's dedicated 4-worker cluster. |
 | `kubectl` | v1.30+         | Used for `exec`, `rollout`, `get` against the in-cluster pods. |
 | `helm`    | v3.13+         | Chart install + `helm upgrade --reuse-values`. |

--- a/docs/demo/compute-domain/README.md
+++ b/docs/demo/compute-domain/README.md
@@ -32,7 +32,7 @@ The demo expects the following tools on `$PATH`:
 | `docker`  | 24+            | Daemon must be running. Multi-stage builds use the repo's pinned Go base (hack/golang-version.sh). |
 | `kind`    | v0.24+         | Provisions the demo's dedicated 4-worker cluster. |
 | `kubectl` | v1.30+         | Used for `exec`, `rollout`, `get` against the in-cluster pods. |
-| `helm`    | v3.13+         | Chart install + `helm upgrade --reuse-values`. |
+| `helm`    | v3.13+ (v4 works) | Chart install + `helm upgrade --reuse-values`. |
 | `bash`    | 3.2+           | `run.sh` uses `set -euo pipefail` — no bash 4+ features. |
 | `jq`      | any recent     | Scenario 2 parses `nvidia-imex-ctl -N -j` JSON. |
 
@@ -125,8 +125,10 @@ kind create cluster --name nvml-mock-compute-domain \
 
 # 2. Build the demo image (bundles check-fabric on top of the standard
 #    nvml-mock image), then layer the REAL nvidia-imex (NO GPU mode
-#    via imex-nogpu-shim) on top. Local build only — this image
-#    repackages the proprietary nvidia-imex.
+#    via imex-nogpu-shim) on top. nvidia-imex is proprietary but comes
+#    from the PUBLIC Ubuntu 22.04 multiverse repo (nvidia-imex-595) —
+#    no NVIDIA credentials or internal access needed. Local build only:
+#    never publish the resulting image.
 docker build -t nvml-mock:compute-domain -f deployments/nvml-mock/Dockerfile .
 docker build -t nvml-mock:compute-domain-imex \
     --target demo \

--- a/docs/demo/compute-domain/README.md
+++ b/docs/demo/compute-domain/README.md
@@ -12,17 +12,16 @@ introduced by [NVIDIA/k8s-test-infra#304](https://github.com/NVIDIA/k8s-test-inf
   domains and which Kubernetes nodes belong to which clique. The mock
   NVML library overlays it on top of the per-profile YAML at
   `LoadConfig()` time.
-* **Fake `nvidia-imex` / `nvidia-imex-ctl`** — file-based readiness
-  protocol over a shared hostPath. `nvidia-imex-ctl` exits 0 + prints
-  `READY` only when every peer in `nodes.cfg` has dropped a marker
-  file; SIGTERM-ing a daemon removes its marker and trips the probe.
+* **Real `nvidia-imex` in NO GPU mode** — the demo overlay image fronts
+  the real daemon with `imex-nogpu-shim` (`/usr/bin/nvidia-imex` exec's
+  `/usr/bin/nvidia-imex.real --nogpu`), so IMEX readiness is the real
+  gRPC peer protocol over the pod network: `nvidia-imex-ctl -q` prints
+  `READY`, `-N -j` reports the domain `UP` with version `NO_GPU`, and
+  killing a peer daemon degrades the domain.
 
 The demo lives in its own cluster (`nvml-mock-compute-domain`) and its
 own 4-worker Kind topology
-([`tests/e2e/kind-compute-domain-config.yaml`](../../../tests/e2e/kind-compute-domain-config.yaml))
-that mounts `/tmp/nvml-mock-imex-state` from the host into every worker
-node container — the cross-node shared volume the real
-compute-domain-daemon would normally get from a CSI driver.
+([`tests/e2e/kind-compute-domain-config.yaml`](../../../tests/e2e/kind-compute-domain-config.yaml)).
 
 ## Prerequisites
 
@@ -31,37 +30,33 @@ The demo expects the following tools on `$PATH`:
 | Tool      | Tested version | Notes |
 |---        |---             |---    |
 | `docker`  | 24+            | Daemon must be running. Multi-stage build uses Go 1.25 base. |
-| `kind`    | v0.24+         | Kind clusters mount a shared hostPath via `extraMounts`. |
+| `kind`    | v0.24+         | Provisions the demo's dedicated 4-worker cluster. |
 | `kubectl` | v1.30+         | Used for `exec`, `rollout`, `get` against the in-cluster pods. |
 | `helm`    | v3.13+         | Chart install + `helm upgrade --reuse-values`. |
 | `bash`    | 3.2+           | `run.sh` uses `set -euo pipefail` — no bash 4+ features. |
-
-If you intend to follow the manual reproduction below instead of running
-the script, you'll also want `kubectl-cp` (bundled with `kubectl`) for
-copying `nodes.cfg` into pods.
+| `jq`      | any recent     | Scenario 2 parses `nvidia-imex-ctl -N -j` JSON. |
 
 ## What the script does
 
 1. (Re)creates the dedicated Kind cluster (idempotent: an existing
-   `nvml-mock-compute-domain` cluster is reused) and clears
-   `/tmp/nvml-mock-imex-state` so the IMEX assertions start from a
-   clean slate.
-2. Builds and loads the `nvml-mock:compute-domain` image, which
-   bundles three new binaries on top of the standard nvml-mock image:
-   `/usr/bin/nvidia-imex`, `/usr/bin/nvidia-imex-ctl`, and
-   `/usr/local/bin/check-fabric`.
+   `nvml-mock-compute-domain` cluster is reused).
+2. Builds and loads the `nvml-mock:compute-domain` image (bundles
+   `/usr/local/bin/check-fabric` on top of the standard nvml-mock
+   image), then builds the `nvml-mock:compute-domain-imex` overlay via
+   the `demo` target of
+   [`Dockerfile.compute-domain-daemon`](../../../deployments/nvml-mock/Dockerfile.compute-domain-daemon),
+   which layers the real `nvidia-imex` (NO GPU mode via
+   `imex-nogpu-shim`) on top — the image the DaemonSet actually runs.
 3. Installs the chart with:
 
    ```text
    gpu.profile=gb200
    topology.enabled=true
    topology.domains=<demo topology>
-   imex.enabled=true
    ```
 
    This renders both ConfigMaps (`nvml-mock-config` and
-   `nvml-mock-topology`) and mounts the shared hostPath state
-   directory into every pod.
+   `nvml-mock-topology`).
 
    The script intentionally does **not** pass `--set gpu.count=...`.
    That flag only sizes the host-side CDI spec produced by
@@ -78,16 +73,14 @@ copying `nodes.cfg` into pods.
    * `-worker3` / `-worker4` report **clique 1**,
    * every node reports the demo cluster UUID
      `00000000-0000-0000-0000-0000000000ab` and `state=completed`.
-5. **Scenario 2 — fake IMEX coordination**. Hand-writes a `nodes.cfg`
-   listing both clique-0 pod IPs and walks the readiness probe
-   through three transitions:
-   * 1 of 2 markers present → `nvidia-imex-ctl` exits 1,
-   * 2 of 2 markers present → `nvidia-imex-ctl` prints `READY`,
-   * peer SIGTERMed → marker removed → `nvidia-imex-ctl` exits 1.
-
-   The script reads the markers directly off the host filesystem
-   (`/tmp/nvml-mock-imex-state/<pod-ip>`) to prove the coordination
-   actually traverses the shared volume.
+5. **Scenario 2 — real IMEX domain (NO GPU mode)**. Renders a per-pod
+   IMEX config, starts the real `nvidia-imex` (the shim appends
+   `--nogpu`) in both clique-0 pods, and asserts three transitions:
+   * daemon A alone → local `-q` probe `READY`, domain not `UP`,
+   * daemon B joins → `-N -j` reports `UP`, 2/2 nodes `READY`,
+     version `NO_GPU` (real gRPC over the pod network),
+   * daemon B SIGTERMed → domain leaves `UP` (real liveness — the
+     deprecated marker files couldn't detect a dead peer).
 6. **Scenario 3 — topology rebinding (no image rebuild)**. A
    `helm upgrade --reuse-values` swaps the topology document so every
    node is now a member of clique 99 in a brand-new domain UUID. After
@@ -114,28 +107,33 @@ commands the script issues. They're written for the default
 note at the end of this section if you need to rename it.
 
 ```bash
-# 1. Create the dedicated cluster + shared hostPath.
-mkdir -p /tmp/nvml-mock-imex-state
+# 1. Create the dedicated cluster.
 kind create cluster --name nvml-mock-compute-domain \
     --config tests/e2e/kind-compute-domain-config.yaml
 
-# 2. Build the demo image (bundles fake-imex + check-fabric on top of
-#    the standard nvml-mock image).
+# 2. Build the demo image (bundles check-fabric on top of the standard
+#    nvml-mock image), then layer the REAL nvidia-imex (NO GPU mode
+#    via imex-nogpu-shim) on top. Local build only — this image
+#    repackages the proprietary nvidia-imex.
 docker build -t nvml-mock:compute-domain -f deployments/nvml-mock/Dockerfile .
+docker build -t nvml-mock:compute-domain-imex \
+    --target demo \
+    --build-arg NVML_MOCK_IMAGE=nvml-mock:compute-domain \
+    --build-arg GOLANG_VERSION=$(hack/golang-version.sh) \
+    -f deployments/nvml-mock/Dockerfile.compute-domain-daemon .
 
-# 3. Load the image into the Kind cluster.
-kind load docker-image nvml-mock:compute-domain --name nvml-mock-compute-domain
+# 3. Load the demo image into the Kind cluster.
+kind load docker-image nvml-mock:compute-domain-imex --name nvml-mock-compute-domain
 
 # 4. Install the chart. The --set image.* flags point the DaemonSet at
 #    the locally-loaded image (these are required — without them the
 #    chart pulls the default upstream image which does not have the
-#    fake binaries baked in).
+#    real IMEX layer baked in).
 helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
     -f docs/demo/compute-domain/topology.yaml \
     --set image.repository=nvml-mock \
-    --set image.tag=compute-domain \
+    --set image.tag=compute-domain-imex \
     --set gpu.profile=gb200 \
-    --set imex.enabled=true \
     --wait --timeout 180s
 
 # 5. Verify the per-node fabric overlay (Scenario 1).
@@ -155,39 +153,35 @@ demo `clusterUuid : 00000000-0000-0000-0000-0000000000ab` and
 `state : completed (3)`.
 
 Scenarios 2 and 3 are best read directly from
-[`run.sh`](./run.sh) — they involve writing a `nodes.cfg`,
-inspecting markers under `/tmp/nvml-mock-imex-state`, and a
+[`run.sh`](./run.sh) — they involve rendering a per-pod `nodes.cfg`,
+running the real `nvidia-imex` daemons, and a
 `helm upgrade --reuse-values` with a substituted topology. None of
 those steps are non-obvious once Scenario 1 works.
 
 **Custom cluster name.** If you rename the Kind cluster (e.g., to
-parallelise demos), three things need to change in lockstep:
+parallelise demos), two things need to change in lockstep:
 
 1. The `nodes:` lists in [`topology.yaml`](./topology.yaml) — each
    Kind worker is named `<cluster-name>-worker[N]`, so renaming the
    cluster renames every entry in the topology.
-2. The `hostPath:` under `extraMounts:` in
-   [`tests/e2e/kind-compute-domain-config.yaml`](../../../tests/e2e/kind-compute-domain-config.yaml)
-   if you also want an isolated state directory — otherwise the new
-   cluster shares `/tmp/nvml-mock-imex-state` with whatever else is
-   running.
-3. Cluster name in every `kind` / `kubectl --context` / `kind load`
+2. Cluster name in every `kind` / `kubectl --context` / `kind load`
    call below.
 
 The script doesn't expose this as a flag because the demo is
 documentation-by-example; the canonical name keeps the example
 faithful to what's checked in.
 
-## How the fakes fit alongside the real compute-domain-daemon
+## How the real IMEX fits alongside the compute-domain-daemon
 
-The upstream daemon spawns `nvidia-imex` as a subprocess and runs
-`nvidia-imex-ctl -c /imexd/imexd.cfg -q` from its readiness probe. With
-this demo's image installed, both binaries are already in `$PATH` at
-the canonical locations. To run the real daemon against this cluster
-without modifying it, point its container image at
-[`deployments/nvml-mock/Dockerfile.compute-domain-daemon`](../../../deployments/nvml-mock/Dockerfile.compute-domain-daemon),
-which is a 2-line `FROM upstream-daemon` overlay that copies in the
-fakes from the nvml-mock image.
+The upstream daemon spawns `nvidia-imex` as a subprocess and probes
+readiness with `nvidia-imex-ctl -c /imexd/imexd.cfg -q`,
+comparing the combined output to exactly `READY`. With this demo's
+overlay installed both paths hold the real binaries: the shim at
+`/usr/bin/nvidia-imex` execs `/usr/bin/nvidia-imex.real --nogpu`, so
+the upstream daemon runs unmodified — same argv, same probe, real
+protocol, no GPUs. Point its container image at the default (`daemon`)
+target of
+[`deployments/nvml-mock/Dockerfile.compute-domain-daemon`](../../../deployments/nvml-mock/Dockerfile.compute-domain-daemon).
 
 > **Heads up — patching the upstream chart.** The nvml-mock chart wires
 > `NODE_NAME` (downward API), `MOCK_TOPOLOGY_CONFIG`, and the topology
@@ -230,5 +224,4 @@ list).
 
 ```bash
 kind delete cluster --name nvml-mock-compute-domain
-rm -rf /tmp/nvml-mock-imex-state
 ```

--- a/docs/demo/compute-domain/README.md
+++ b/docs/demo/compute-domain/README.md
@@ -91,12 +91,24 @@ The demo expects the following tools on `$PATH`:
 ## Quick start
 
 ```bash
-./run.sh
+./docs/demo/compute-domain/run.sh
 ```
 
-The script is idempotent — rerun it as often as you like; the
-existing cluster is reused and `helm upgrade --install` covers both
-first-time install and follow-up upgrades.
+The script locates the repository itself, so it works from any
+directory; the **manual-reproduction commands below assume you run
+them from the repository root**.
+
+Expect roughly 10–20 minutes on a first run (Kind cluster creation
+plus two image builds dominate; Scenario 2's domain convergence alone
+may legitimately take up to 4 minutes — see Troubleshooting). Reruns
+are much faster: the script is idempotent, the existing cluster is
+reused, and `helm upgrade --install` covers both first-time install
+and follow-up upgrades.
+
+> **One runner per host.** The cluster name, Helm release, and image
+> tags are fixed, so two concurrent runs of this demo on the same
+> machine will corrupt each other's Helm revisions and topology
+> assertions. Run one at a time.
 
 ## Manual reproduction
 
@@ -220,8 +232,39 @@ and is passed to Helm with `-f topology.yaml` (not `--set-file`, which
 would inline the file as a string literal rather than as a parsed
 list).
 
+## Troubleshooting
+
+* **Scenario 2 seems stuck on "domain status UP".** First convergence
+  after a fresh rollout can take a few minutes: kind's CNI (kindnetd)
+  reconciles NetworkPolicy asynchronously, and the IMEX daemon retries
+  failed peer connections with exponential backoff (15s, 31s, 62s,
+  125s…). The script already waits up to 240s — let it finish before
+  concluding failure. On timeout it prints the daemon log tail.
+* **Peers never connect at all.** The nvml-mock chart ships a
+  NetworkPolicy that allow-lists pod-to-pod ingress between nvml-mock
+  pods (TCP 18515 ibping, 50000 IMEX gRPC peer, 50005 IMEX
+  command/status). kindnetd **enforces** NetworkPolicy on current kind
+  releases, so if you add any new pod-to-pod listener to the stack it
+  must also be admitted in
+  `deployments/nvml-mock/helm/nvml-mock/templates/network-policy-ibping.yaml`
+  — otherwise its SYNs are silently dropped.
+* **Rerunning after a failed Scenario 2.** A run that dies mid-scenario
+  leaves real `nvidia-imex` daemons holding port 50000 inside the pods,
+  and a rerun's daemons will fail to bind. Recycle the pods first:
+  `kubectl delete pods -l app.kubernetes.io/name=nvml-mock` (the
+  DaemonSet recreates them clean), or delete the cluster for a truly
+  fresh start. Successful runs clean up after themselves.
+* **`nvidia-imex-ctl -N -j` shows the peer `UNAVAILABLE` with an empty
+  version while connections look established.** Node status and version
+  are exchanged over the IMEX *command* port (50005), separate from the
+  gRPC peer port (50000). If only 50000 is reachable the domain sticks
+  at `DEGRADED` — check that both ports are admitted (see the
+  NetworkPolicy bullet above).
+
 ## Clean up
 
 ```bash
 kind delete cluster --name nvml-mock-compute-domain
+# Optional: also remove the locally built demo images.
+docker rmi nvml-mock:compute-domain nvml-mock:compute-domain-imex
 ```

--- a/docs/demo/compute-domain/run.sh
+++ b/docs/demo/compute-domain/run.sh
@@ -378,6 +378,6 @@ cat <<EOF
     deployments/nvml-mock/Dockerfile.compute-domain-daemon for the
     thin overlay that runs the real IMEX daemon with --nogpu).
 
-==> Tear down
+==> The cluster is left running for inspection. To tear it down:
     kind delete cluster --name ${CLUSTER_NAME}
 EOF

--- a/docs/demo/compute-domain/run.sh
+++ b/docs/demo/compute-domain/run.sh
@@ -6,10 +6,9 @@
 # End-to-end demo of nvml-mock ComputeDomain simulation
 # (NVIDIA/k8s-test-infra#304).
 #
-# Spins up a dedicated 4-worker Kind cluster wired with extraMounts
-# that share a hostPath (/tmp/nvml-mock-imex-state) across every
-# worker, installs nvml-mock with the gb200 profile + topology overlay
-# + fake IMEX coordination, and walks through four assertions:
+# Spins up a dedicated 4-worker Kind cluster, installs nvml-mock with
+# the gb200 profile + topology overlay, and walks through four
+# assertions:
 #
 #   1. Mock NVML fabric API
 #      Each pod's nvmlDeviceGetGpuFabricInfo (via the bundled
@@ -21,11 +20,13 @@
 #      kind-compute-domain-worker / -worker2 report clique 0;
 #      -worker3 / -worker4 report clique 1.
 #
-#   3. Fake IMEX peer coordination
-#      With a hand-written nodes.cfg listing every pod IP in a clique,
-#      nvidia-imex-ctl prints `READY` once the fake nvidia-imex daemon
-#      has dropped a marker file for every peer; it exits 1 as soon as
-#      one peer's marker is removed.
+#   3. Real IMEX domain formation (NO GPU mode)
+#      Two real nvidia-imex daemons (started via imex-nogpu-shim, which
+#      execs nvidia-imex.real --nogpu) form a domain over the pod
+#      network: nvidia-imex-ctl -q reports READY for a single daemon's
+#      local probe, -N -j reports the domain UP with every peer READY
+#      and version NO_GPU once both daemons are running, and killing a
+#      peer degrades the domain.
 #
 #   4. Topology rebinding without rebuilding the image
 #      `helm upgrade --reuse-values` with a different topology document
@@ -40,12 +41,12 @@ set -euo pipefail
 ###############################################################################
 CLUSTER_NAME="nvml-mock-compute-domain"
 IMAGE_NAME="nvml-mock:compute-domain"
+DEMO_IMAGE_NAME="nvml-mock:compute-domain-imex"
 RELEASE_NAME="nvml-mock"
 CHART_PATH="deployments/nvml-mock/helm/nvml-mock"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 KIND_CONFIG="${REPO_ROOT}/tests/e2e/kind-compute-domain-config.yaml"
 TOPOLOGY_FILE="${REPO_ROOT}/docs/demo/compute-domain/topology.yaml"
-HOST_STATE_DIR="/tmp/nvml-mock-imex-state"
 EXPECTED_DOMAIN_UUID="00000000-0000-0000-0000-0000000000ab"
 # Kind names worker nodes "<cluster>-worker[N]". Keep these in sync
 # with the node lists in topology.yaml and tests/e2e/kind-compute-domain-config.yaml.
@@ -61,6 +62,8 @@ info() { printf '\n==> %s\n' "$*" >&2; }
 sub()  { printf '    %s\n' "$*" >&2; }
 ok()   { printf '    \xE2\x9C\x93 %s\n' "$*" >&2; }
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+command -v jq >/dev/null 2>&1 || fail "jq is required (Scenario 2 parses nvidia-imex-ctl JSON)"
 
 # pod_on_node: echo the name of the running nvml-mock pod scheduled on
 # the given Kubernetes node. Used both to query fabric info per node
@@ -119,42 +122,9 @@ assert_clique() {
   ok "${node}: clique=${expected_clique} uuid=${expected_uuid} state=completed"
 }
 
-# expect_ctl_not_ready: run nvidia-imex-ctl inside `pod` and assert it
-# exits 1 (the "peer not ready" path). Stdout/stderr are captured and
-# replayed as a single indented status line so the demo log stays
-# legible — without this helper kubectl spills both
-# `fake-imex-ctl: peer X not ready` and `command terminated with exit
-# code 1` onto separate lines, which is technically correct but reads
-# like an error from the demo itself.
-expect_ctl_not_ready() {
-  local pod=$1 reason=$2
-  local out rc
-  set +e
-  out=$(kubectl exec "${pod}" -- env "IMEX_NODES_CONFIG=${NODES_CFG}" \
-    nvidia-imex-ctl -c /dev/null -q 2>&1)
-  rc=$?
-  set -e
-  if [[ "${rc}" -ne 1 ]]; then
-    printf '%s\n' "${out}" | sed 's/^/      /' >&2
-    fail "nvidia-imex-ctl ${reason}: rc=${rc} (want 1), out=${out}"
-  fi
-  # Surface only the informative line from fake-imex-ctl's stderr
-  # (drops the trailing "command terminated with exit code 1" that
-  # kubectl injects after the container exits non-zero).
-  local detail
-  detail=$(printf '%s\n' "${out}" | grep -E '^fake-imex-ctl:' | head -1)
-  ok "nvidia-imex-ctl ${reason} (rc=1) — ${detail:-peer not ready}"
-}
-
 ###############################################################################
-# Step 1 — Kind cluster (with shared hostPath for IMEX state)
+# Step 1 — Kind cluster
 ###############################################################################
-info "Preparing shared hostPath: ${HOST_STATE_DIR}"
-mkdir -p "${HOST_STATE_DIR}"
-# Wipe stale markers from a previous run so the IMEX assertions below
-# can rely on a clean baseline.
-rm -f "${HOST_STATE_DIR}"/* 2>/dev/null || true
-
 info "Creating Kind cluster: ${CLUSTER_NAME}"
 if kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
   sub "Cluster already exists, reusing it"
@@ -169,8 +139,17 @@ info "Building image: ${IMAGE_NAME}"
 docker build -t "${IMAGE_NAME}" \
   -f "${REPO_ROOT}/deployments/nvml-mock/Dockerfile" "${REPO_ROOT}"
 
+# Layer the REAL nvidia-imex (NO GPU mode via imex-nogpu-shim) on top.
+# Local build only — this image repackages the proprietary nvidia-imex.
+info "Building demo overlay with real nvidia-imex: ${DEMO_IMAGE_NAME}"
+docker build -t "${DEMO_IMAGE_NAME}" \
+  --target demo \
+  --build-arg "NVML_MOCK_IMAGE=${IMAGE_NAME}" \
+  --build-arg "GOLANG_VERSION=$("${REPO_ROOT}/hack/golang-version.sh")" \
+  -f "${REPO_ROOT}/deployments/nvml-mock/Dockerfile.compute-domain-daemon" "${REPO_ROOT}"
+
 info "Loading image into Kind"
-kind load docker-image "${IMAGE_NAME}" --name "${CLUSTER_NAME}"
+kind load docker-image "${DEMO_IMAGE_NAME}" --name "${CLUSTER_NAME}"
 
 ###############################################################################
 # Step 3 — Install nvml-mock with gb200 + topology + IMEX
@@ -194,9 +173,8 @@ info "Installing chart (gb200 + topology + IMEX)"
 helm upgrade --install "${RELEASE_NAME}" "${REPO_ROOT}/${CHART_PATH}" \
   -f "${TOPOLOGY_FILE}" \
   --set image.repository=nvml-mock \
-  --set image.tag=compute-domain \
+  --set image.tag=compute-domain-imex \
   --set gpu.profile=gb200 \
-  --set imex.enabled=true \
   --set-string updateStrategy.rollingUpdate.maxUnavailable=100% \
   --set terminationGracePeriodSeconds=1 \
   --wait --timeout 180s >/dev/null
@@ -221,93 +199,113 @@ assert_clique "${WORKER3}" 1 "${EXPECTED_DOMAIN_UUID}"
 assert_clique "${WORKER4}" 1 "${EXPECTED_DOMAIN_UUID}"
 
 ###############################################################################
-# Scenario 2 — Fake IMEX peer coordination (shared hostPath markers)
+# Scenario 2 — Real IMEX domain (NO GPU mode) over the pod network
 ###############################################################################
-# Each nvml-mock pod's entrypoint does NOT start nvidia-imex
-# automatically — the real compute-domain-daemon would. To exercise
-# the coordination protocol without deploying upstream, we run the
-# fake daemon ad-hoc inside one pod per clique-0 worker and verify
-# nvidia-imex-ctl from a peer.
-info "Scenario 2: fake IMEX peer coordination"
+# The demo image carries the real nvidia-imex behind imex-nogpu-shim:
+# /usr/bin/nvidia-imex exec's /usr/bin/nvidia-imex.real --nogpu. The
+# daemons below speak the real gRPC peer protocol (port 50000) across
+# pods — no shared hostPath, no marker files. This is the protocol the
+# upstream compute-domain-daemon drives; the fake marker binaries it
+# replaces are deprecated.
+info "Scenario 2: real IMEX domain (NO GPU mode) over the pod network"
 
 POD_A=$(pod_on_node "${WORKER1}")
 POD_B=$(pod_on_node "${WORKER2}")
 sub "clique 0 pods: ${POD_A}, ${POD_B}"
 
-# Read both pod IPs so we can write a synthetic nodes.cfg.
 IP_A=$(kubectl get pod "${POD_A}" -o jsonpath='{.status.podIP}')
 IP_B=$(kubectl get pod "${POD_B}" -o jsonpath='{.status.podIP}')
 sub "pod IPs: ${POD_A}=${IP_A}  ${POD_B}=${IP_B}"
 
-# Write nodes.cfg into both pods. The chart already mounts the shared
-# state dir at /var/lib/nvml-mock/imex-state; the fakes read
-# IMEX_NODES_CONFIG with default /imexd/nodes.cfg, so we override
-# with a writable path inside /tmp.
+# Render a per-pod IMEX config: foreground daemon, our nodes file, a
+# pod-local log. Everything else keeps the package defaults.
+IMEX_CFG=/tmp/imex.cfg
 NODES_CFG=/tmp/nodes.cfg
 for pod in "${POD_A}" "${POD_B}"; do
-  kubectl exec "${pod}" -- sh -c "printf '%s\n%s\n' '${IP_A}' '${IP_B}' > ${NODES_CFG}"
+  kubectl exec "${pod}" -- sh -c "
+    printf '%s\n%s\n' '${IP_A}' '${IP_B}' > '${NODES_CFG}'
+    sed -e 's/^DAEMONIZE=1/DAEMONIZE=0/' \
+        -e 's|^IMEX_NODE_CONFIG_FILE=.*|IMEX_NODE_CONFIG_FILE=${NODES_CFG}|' \
+        -e 's|^LOG_FILE_NAME=.*|LOG_FILE_NAME=/tmp/nvidia-imex.log|' \
+        /etc/nvidia-imex/config.cfg > '${IMEX_CFG}'"
 done
 
-# Start the fake daemon in pod A and check from pod B. We background
-# the daemon and capture its PID so we can SIGTERM it later.
-sub "starting fake nvidia-imex in ${POD_A}"
-kubectl exec "${POD_A}" -- sh -c \
-  "POD_IP=${IP_A} IMEX_NODES_CONFIG=${NODES_CFG} \
-   nvidia-imex -c /dev/null >/tmp/imex.log 2>&1 &
-   echo \$! > /tmp/imex.pid"
+start_imex() {
+  local pod=$1
+  kubectl exec "${pod}" -- sh -c \
+    "nvidia-imex -c ${IMEX_CFG} >/tmp/imex.stdout 2>&1 & echo \$! > /tmp/imex.pid"
+}
 
-# Poll up to 5s for the marker to appear under the shared hostPath.
-sub "waiting for marker ${IP_A} under ${HOST_STATE_DIR}"
-for _ in $(seq 1 25); do
-  if [[ -f "${HOST_STATE_DIR}/${IP_A}" ]]; then break; fi
-  sleep 0.2
+# imex_domain_status: the ctl's JSON domain status ("UP", "DEGRADED",
+# ...) as seen from `pod`; "UNREACHABLE" while the local daemon is
+# still coming up.
+imex_domain_status() {
+  local pod=$1
+  kubectl exec "${pod}" -- nvidia-imex-ctl -c "${IMEX_CFG}" -N -j 2>/dev/null \
+    | jq -r '.status' 2>/dev/null || printf 'UNREACHABLE\n'
+}
+
+wait_domain_status() {
+  local pod=$1 want=$2 reason=$3
+  for _ in $(seq 1 60); do
+    if [[ "$(imex_domain_status "${pod}")" == "${want}" ]]; then
+      ok "domain status ${want} ${reason}"
+      return 0
+    fi
+    sleep 1
+  done
+  kubectl exec "${pod}" -- sh -c 'tail -20 /tmp/nvidia-imex.log 2>/dev/null' >&2 || true
+  fail "domain status never became ${want} ${reason}"
+}
+
+# Start the daemon in pod A only. Its local probe (-q) must go READY —
+# upstream probes local readiness, not the whole domain — while the
+# domain-wide status stays degraded because pod B never connected.
+sub "starting real nvidia-imex (--nogpu via shim) in ${POD_A}"
+start_imex "${POD_A}"
+Q_OUT=""
+for _ in $(seq 1 30); do
+  Q_OUT=$(kubectl exec "${POD_A}" -- nvidia-imex-ctl -c "${IMEX_CFG}" -q 2>/dev/null || true)
+  [[ "${Q_OUT}" == "READY" ]] && break
+  sleep 1
 done
-[[ -f "${HOST_STATE_DIR}/${IP_A}" ]] || fail "marker ${IP_A} never appeared"
-ok "marker for ${IP_A} present on host"
+[[ "${Q_OUT}" == "READY" ]] || fail "nvidia-imex-ctl -q never reported READY in ${POD_A}"
+ok "local probe READY in ${POD_A} (real ctl, exact upstream contract)"
 
-# 1 of 2 markers → ctl exits 1.
-expect_ctl_not_ready "${POD_B}" "with 1/2 markers"
+STATUS_ONE=$(imex_domain_status "${POD_A}")
+[[ "${STATUS_ONE}" != "UP" ]] || fail "domain claims UP with 1/2 daemons (want degraded)"
+ok "domain not UP with 1/2 daemons (status=${STATUS_ONE})"
 
-# Bring up pod B's daemon → 2/2 markers → ctl prints READY.
-sub "starting fake nvidia-imex in ${POD_B}"
-kubectl exec "${POD_B}" -- sh -c \
-  "POD_IP=${IP_B} IMEX_NODES_CONFIG=${NODES_CFG} \
-   nvidia-imex -c /dev/null >/tmp/imex.log 2>&1 &
-   echo \$! > /tmp/imex.pid"
+# Start pod B's daemon: the daemons find each other over the pod
+# network and the domain converges to UP.
+sub "starting real nvidia-imex (--nogpu via shim) in ${POD_B}"
+start_imex "${POD_B}"
+wait_domain_status "${POD_A}" "UP" "after both daemons started (real cross-node gRPC)"
 
-for _ in $(seq 1 25); do
-  if [[ -f "${HOST_STATE_DIR}/${IP_B}" ]]; then break; fi
-  sleep 0.2
+# Every member must be READY and report the NO_GPU version handshake.
+NODES_JSON=$(kubectl exec "${POD_A}" -- nvidia-imex-ctl -c "${IMEX_CFG}" -N -j 2>/dev/null)
+READY_NODES=$(printf '%s' "${NODES_JSON}" | jq -r '[.nodes[] | select(.status=="READY")] | length')
+NOGPU_NODES=$(printf '%s' "${NODES_JSON}" | jq -r '[.nodes[] | select(.version=="NO_GPU")] | length')
+[[ "${READY_NODES}" == "2" ]] || fail "want 2 READY nodes, got ${READY_NODES}: ${NODES_JSON}"
+[[ "${NOGPU_NODES}" == "2" ]] || fail "want 2 NO_GPU-version nodes, got ${NOGPU_NODES}: ${NODES_JSON}"
+ok "2/2 nodes READY, version NO_GPU — real IMEX domain over the pod network"
+
+# Kill pod B's daemon: pod A's view must degrade. This is real
+# liveness detection — the property the deprecated marker files could
+# not provide (a SIGKILLed fake left its marker behind).
+sub "killing nvidia-imex in ${POD_B}"
+kubectl exec "${POD_B}" -- sh -c 'kill -TERM "$(cat /tmp/imex.pid)" 2>/dev/null || true'
+STATUS_AFTER="UP"
+for _ in $(seq 1 60); do
+  STATUS_AFTER=$(imex_domain_status "${POD_A}")
+  [[ "${STATUS_AFTER}" != "UP" ]] && break
+  sleep 1
 done
-[[ -f "${HOST_STATE_DIR}/${IP_B}" ]] || fail "marker ${IP_B} never appeared"
+[[ "${STATUS_AFTER}" != "UP" ]] || fail "domain still UP after peer daemon died"
+ok "peer death detected: domain status=${STATUS_AFTER} (real liveness)"
 
-CTL_OUT=$(kubectl exec "${POD_B}" -- env "IMEX_NODES_CONFIG=${NODES_CFG}" \
-  nvidia-imex-ctl -c /dev/null -q 2>/dev/null)
-if [[ "${CTL_OUT}" == "READY" ]]; then
-  ok "nvidia-imex-ctl prints READY with 2/2 markers"
-else
-  fail "nvidia-imex-ctl with 2/2 markers printed '${CTL_OUT}' (want READY)"
-fi
-
-# SIGTERM the daemon in pod A → marker removed → ctl exits 1 again.
-sub "killing nvidia-imex in ${POD_A}"
-kubectl exec "${POD_A}" -- sh -c \
-  'kill -TERM "$(cat /tmp/imex.pid)"; sleep 1' || true
-
-for _ in $(seq 1 25); do
-  if [[ ! -f "${HOST_STATE_DIR}/${IP_A}" ]]; then break; fi
-  sleep 0.2
-done
-[[ ! -f "${HOST_STATE_DIR}/${IP_A}" ]] || fail "marker ${IP_A} did not get cleaned up"
-ok "marker for ${IP_A} removed by SIGTERM"
-
-expect_ctl_not_ready "${POD_B}" "after peer SIGTERM"
-
-# Tidy up the surviving daemon so the rollout in Scenario 3 doesn't
-# inherit stale state.
-kubectl exec "${POD_B}" -- sh -c \
-  'kill -TERM "$(cat /tmp/imex.pid)" 2>/dev/null || true' || true
-rm -f "${HOST_STATE_DIR}"/* 2>/dev/null || true
+# Tidy up daemon A so Scenario 3's rollout starts clean.
+kubectl exec "${POD_A}" -- sh -c 'kill -TERM "$(cat /tmp/imex.pid)" 2>/dev/null || true' || true
 
 ###############################################################################
 # Scenario 3 — Topology rebinding (helm upgrade, no image rebuild)
@@ -360,9 +358,12 @@ cat <<EOF
    Scenario 1  fabric API     : every node reports its assigned clique
                                 (workers 1-2 -> clique 0, workers 3-4 -> clique 1)
                                 via nvmlDeviceGetGpuFabricInfo.
-   Scenario 2  fake IMEX      : nvidia-imex-ctl transitions
-                                NOT-READY -> READY -> NOT-READY in lockstep
-                                with marker files on the shared hostPath.
+   Scenario 2  real IMEX      : two real nvidia-imex daemons (NO GPU
+                                mode via imex-nogpu-shim) formed a
+                                domain over the pod network; ctl -q
+                                printed READY, -N -j reported UP with
+                                version NO_GPU, and killing a peer
+                                degraded the domain (real liveness).
    Scenario 3  rebind         : helm upgrade + DaemonSet rollout promoted
                                 every node to clique 99 with a new cluster
                                 UUID — no image rebuild required.
@@ -376,5 +377,4 @@ cat <<EOF
 
 ==> Tear down
     kind delete cluster --name ${CLUSTER_NAME}
-    rm -rf ${HOST_STATE_DIR}
 EOF

--- a/docs/demo/compute-domain/run.sh
+++ b/docs/demo/compute-domain/run.sh
@@ -152,7 +152,7 @@ info "Loading image into Kind"
 kind load docker-image "${DEMO_IMAGE_NAME}" --name "${CLUSTER_NAME}"
 
 ###############################################################################
-# Step 3 — Install nvml-mock with gb200 + topology + IMEX
+# Step 3 — Install nvml-mock with gb200 + topology (real IMEX via demo image)
 ###############################################################################
 # NOTE: `--set-file topology.domains=...` cannot be used here. That
 # flag stuffs the raw file bytes in as a string literal, which would
@@ -160,7 +160,7 @@ kind load docker-image "${DEMO_IMAGE_NAME}" --name "${CLUSTER_NAME}"
 # as an indented block scalar instead of the structured array the
 # engine expects. Using `-f <values-file>` lets helm parse the file
 # normally and deep-merge it with the defaults.
-info "Installing chart (gb200 + topology + IMEX)"
+info "Installing chart (gb200 + topology; real IMEX via demo image)"
 # NOTE: `--set gpu.count=...` is intentionally NOT passed. The flag
 # only controls the host-side CDI spec / /dev/nvidia* device nodes
 # emitted by setup.sh; the in-pod ConfigMap mounted at
@@ -373,10 +373,10 @@ cat <<EOF
 
 ==> The upstream compute-domain-controller and compute-domain-daemon
     can now run unmodified against this cluster: their NVML calls land
-    on the mock library, and their fork of nvidia-imex / nvidia-imex-ctl
-    is shadowed by the fakes shipped in the nvml-mock image (see
+    on the mock library, and the real nvidia-imex / nvidia-imex-ctl are
+    fronted by the imex-nogpu-shim overlay image (see
     deployments/nvml-mock/Dockerfile.compute-domain-daemon for the
-    thin overlay image).
+    thin overlay that runs the real IMEX daemon with --nogpu).
 
 ==> Tear down
     kind delete cluster --name ${CLUSTER_NAME}

--- a/docs/demo/compute-domain/run.sh
+++ b/docs/demo/compute-domain/run.sh
@@ -247,7 +247,10 @@ imex_domain_status() {
 
 wait_domain_status() {
   local pod=$1 want=$2 reason=$3
-  for _ in $(seq 1 60); do
+  # 240s: after a fresh rollout, kindnetd's NetworkPolicy dataplane
+  # reconcile plus the daemon's exponential reconnect backoff (15s,
+  # 31s, 62s, 125s...) can push first convergence past 60s.
+  for _ in $(seq 1 240); do
     if [[ "$(imex_domain_status "${pod}")" == "${want}" ]]; then
       ok "domain status ${want} ${reason}"
       return 0

--- a/pkg/imexcoord/coord.go
+++ b/pkg/imexcoord/coord.go
@@ -16,6 +16,11 @@
 // simulate ComputeDomain peer discovery on KIND clusters without real
 // GB200 hardware. See NVIDIA/k8s-test-infra#304 for the full design.
 //
+// Deprecated: the fake IMEX marker protocol is superseded by the real
+// nvidia-imex daemon running in NO GPU mode (--nogpu) via imex-nogpu-shim;
+// this package will be removed in a follow-up release. See
+// NVIDIA/k8s-test-infra#304.
+//
 // Protocol (single-clique view; the real compute-domain-daemon writes a
 // per-clique nodes.cfg so the fake never has to know cliques itself):
 //
@@ -66,8 +71,9 @@ import (
 )
 
 // DefaultStateDir is the canonical hostPath shared between KIND
-// workers. KIND mounts /tmp/nvml-mock-imex-state on the host to this
-// path inside each node container via extraMounts.
+// workers. This constant is retained for the deprecated imex.enabled
+// toggle; KIND's extraMounts wiring was removed with the real-IMEX
+// migration, but the hostPath path remains for backward compatibility.
 const DefaultStateDir = "/var/lib/nvml-mock/imex-state"
 
 // DefaultNodesConfig matches the path the upstream compute-domain-daemon

--- a/tests/e2e/kind-compute-domain-config.yaml
+++ b/tests/e2e/kind-compute-domain-config.yaml
@@ -3,29 +3,21 @@
 #
 # Kind cluster config for ComputeDomain (NVLink fabric) simulation.
 #
-# Each worker mounts the same hostPath into /var/lib/nvml-mock/imex-state
-# so the fake nvidia-imex daemons on every node coordinate readiness via
-# shared marker files. The mock NVML library reads the topology overlay
-# (Helm value topology.enabled=true) to learn its clique / cluster UUID.
+# The real nvidia-imex daemons (NO GPU mode via imex-nogpu-shim)
+# coordinate over the pod network, so no shared hostPath is required.
+# The mock NVML library reads the topology overlay (Helm value
+# topology.enabled=true) to learn its clique / cluster UUID.
 #
 # Pair with the gb200 profile and topology enabled:
 #   helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
 #     --set gpu.profile=gb200 \
-#     --set gpu.count=4 \
 #     --set topology.enabled=true \
-#     --set imex.enabled=true \
 #     -f docs/demo/compute-domain/topology.yaml
-#
-# Usage:
-#   mkdir -p /tmp/nvml-mock-imex-state
-#   kind create cluster --name nvml-mock-compute-domain \
-#       --config tests/e2e/kind-compute-domain-config.yaml
 #
 # Cluster-name convention: Kind names each worker
 # `<cluster-name>-worker[N]`. The demo's topology.yaml lists nodes as
 # `nvml-mock-compute-domain-worker[2..4]`, so renaming the cluster
-# requires updating the node names in topology.yaml in lockstep (and
-# changing the hostPath below if you also want an isolated state dir).
+# requires updating the node names in topology.yaml in lockstep.
 #
 # See NVIDIA/k8s-test-infra#304 for the full design.
 kind: Cluster
@@ -39,24 +31,12 @@ nodes:
   - role: worker
     labels:
       nvml-mock/clique: "0"
-    extraMounts:
-      - hostPath: /tmp/nvml-mock-imex-state
-        containerPath: /var/lib/nvml-mock/imex-state
   - role: worker
     labels:
       nvml-mock/clique: "0"
-    extraMounts:
-      - hostPath: /tmp/nvml-mock-imex-state
-        containerPath: /var/lib/nvml-mock/imex-state
   - role: worker
     labels:
       nvml-mock/clique: "1"
-    extraMounts:
-      - hostPath: /tmp/nvml-mock-imex-state
-        containerPath: /var/lib/nvml-mock/imex-state
   - role: worker
     labels:
       nvml-mock/clique: "1"
-    extraMounts:
-      - hostPath: /tmp/nvml-mock-imex-state
-        containerPath: /var/lib/nvml-mock/imex-state


### PR DESCRIPTION
## Problem

The ComputeDomain simulation (#304) ships fake `nvidia-imex` / `nvidia-imex-ctl` binaries implementing a file-marker readiness protocol over a shared hostPath. The fake has documented fidelity limits (no liveness signal — SIGKILLed peers leave stale markers; pod-IP recycling is undefined) and drifts from the real binary's behavior by construction. An IMEX developer pointed out the real daemon has a NO GPU mode (`--nogpu`) built exactly for running the real protocol without GPUs.

## Approach

Run the **real** `nvidia-imex` in NO GPU mode instead of faking it:

- **`cmd/imex-nogpu-shim`** — upstream's compute-domain-daemon hard-codes `nvidia-imex -c /imexd/imexd.cfg` (no flag passthrough), so a small exec-wrapper installed at `/usr/bin/nvidia-imex` execs `/usr/bin/nvidia-imex.real --nogpu`, preserving argv/env/stdio/exit codes (process image is replaced; signals reach the daemon directly). A follow-up upstream contribution to make the argv extensible will retire the shim.
- **`Dockerfile.compute-domain-daemon`** — rewritten multi-target: `daemon` (default; upstream image + real IMEX + shim) and `demo` (nvml-mock image + the same trio). The real package installs from the **public Ubuntu jammy multiverse** (`nvidia-imex-595`, same version on amd64/arm64 — no NVIDIA repo, no credentials). **Local build only — never published** (repackages a proprietary binary). The upstream image default was corrected to the only live reference (`registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu:v0.4.1`; the per-component path has zero tags).
- **Demo migration** — Scenario 2 now asserts the real protocol over the pod network: local `-q` probe `READY` (the exact upstream probe contract), domain `UP` with 2/2 nodes `READY` version `NO_GPU`, and real peer-death degradation the markers could never show.
- **Deprecation (one release)** — the fakes log removal notices. The ctl prints its notice on non-READY paths only: upstream compares the probe's `CombinedOutput()` to exactly `READY\n`, and a test now pins that contract (exact stdout, empty stderr).
- **NetworkPolicy fix (found by the E2E)** — kind's kindnetd **enforces** NetworkPolicy on current releases, so the chart's ibping allow-list silently dropped everything else pod-to-pod. It now admits both IMEX ports: 50000 (gRPC peers) and 50005 (command/status — without it the domain sticks at `DEGRADED` with versionless peers). The stale "kindnet ignores NetworkPolicy" comments were corrected.

## Testing

- TDD throughout (tests and implementation in separate commits; RED evidence recorded).
- Unit/integration: shim argv/env/exit-code passthrough via a stub binary; fake-ctl probe-contract + deprecation-path coverage (mutation-checked); `go test ./cmd/... ./pkg/...` green; `golangci-lint` 0 issues; helm-unittest 120 tests + 15 snapshots.
- Container smoke: `demo`-target image runs shim → real daemon → real ctl in a GPU-less container (`READY`, log confirms NO GPU MODE, `/proc/<pid>/cmdline` confirms in-place exec).
- Live E2E on a fresh 4-worker Kind cluster: all three demo scenarios green, including real cross-node domain formation and peer-death detection.
- Docs blind-validated: an independent agent ran the demo zero-to-hero from the docs alone (no help) — passed first try; its friction findings are folded in.

## Breaking changes

None. `imex.enabled` (hostPath marker coordination) is deprecated but still functional for one release.

## Follow-ups (tracked, not in this PR)

- Upstream argv-extensibility contribution (retires the shim).
- Remove `cmd/fake-imex` + `pkg/imexcoord` + `imex.enabled` after the deprecation release.
- Demo hardening: pin `DEGRADED` in negative assertions; daemon-target E2E with the upstream chart; CI tripwire against ever publishing the overlay Dockerfile.

Part of #304.
