### PR TITLE
chore: consolidate dependabot updates

### DIFF
--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -82,7 +82,7 @@ jobs:
       # `helm registry login` does not write; without this login the
       # signature blob upload is rejected with UNAUTHORIZED.
       - name: Log in to GHCR for cosign
-        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/nvml-mock-publish.yaml
+++ b/.github/workflows/nvml-mock-publish.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GHCR
         uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4

--- a/.github/workflows/nvml-mock-publish.yaml
+++ b/.github/workflows/nvml-mock-publish.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/nvml-mock-publish.yaml
+++ b/.github/workflows/nvml-mock-publish.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: deployments/nvml-mock/Dockerfile


### PR DESCRIPTION
## Problem

Multiple open dependabot PRs are queued against main, each needing its own review and CI cycle.

## Approach

Cherry-picked each dependabot commit onto a single branch cut from main, keeping dependabot authorship, with signed commits. One commit per bump:

- #427 — docker/setup-buildx-action 4.1.0 → 4.2.0
- #428 — docker/build-push-action 7.2.0 → 7.3.0
- #431 — docker/login-action 4.3.0 → 4.4.0

Deliberately excluded:

- #443 (golang 1.26.4 → 1.27rc2 in /deployments/devel) — release-candidate toolchain; will pick up 1.27.0 when it goes final.
- #430 (go-nvml 0.13.2-0 → 0.13.3-0) — initially included, then dropped: with the bump, all 4 e2e-gpu-operator profiles fail deterministically; nvidia-smi exits 12 (NVML library load failure) against the mock lib, and the GPU operator's toolkit-validation crash-loops with the same exit code. Main at the identical base (bd2459a9) is green. #430 never ran e2e on its own (dependabot PRs only trigger basic checks), so this was invisible until now. Needs a dedicated investigation before the bump can land.

Dependabot will close the three consolidated originals automatically once this merges.

## Testing done

- `make vendor` — clean, zero diff
- `make check-modules` — pass
- `go build ./...` / `go test ./...` — pass (18 packages)

## Breaking changes

None.
