### PR TITLE
refactor(chart): Autodiscover available GPU profiles in the Helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+
 # Build artifacts
 *.so
 *.dll

--- a/deployments/nvml-mock/helm/nvml-mock/templates/_helpers.tpl
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/_helpers.tpl
@@ -102,23 +102,18 @@ and key order) or round-trip it through fromYaml/toYaml for overlays.
 {{- define "nvml-mock.gpuConfigBase" -}}
 {{- if .Values.gpu.customConfig }}
 {{- .Values.gpu.customConfig }}
-{{- else if eq .Values.gpu.profile "a100" }}
-{{- .Files.Get "profiles/a100.yaml" }}
-{{- else if eq .Values.gpu.profile "h100" }}
-{{- .Files.Get "profiles/h100.yaml" }}
-{{- else if eq .Values.gpu.profile "b200" }}
-{{- .Files.Get "profiles/b200.yaml" }}
-{{- else if eq .Values.gpu.profile "gb200" }}
-{{- .Files.Get "profiles/gb200.yaml" }}
-{{- else if eq .Values.gpu.profile "gb300" }}
-{{- .Files.Get "profiles/gb300.yaml" }}
-{{- else if eq .Values.gpu.profile "l40s" }}
-{{- .Files.Get "profiles/l40s.yaml" }}
-{{- else if eq .Values.gpu.profile "t4" }}
-{{- .Files.Get "profiles/t4.yaml" }}
-{{- else }}
-{{- fail (printf "Unknown GPU profile %q. Supported profiles: a100, h100, b200, gb200, gb300, l40s, t4. Or set gpu.customConfig with inline YAML." .Values.gpu.profile) }}
-{{- end }}
+{{- else -}}
+{{- $profilePath := printf "profiles/%s.yaml" .Values.gpu.profile -}}
+{{- $content := .Files.Get $profilePath -}}
+{{- if not $content -}}
+{{- $available := list -}}
+{{- range $path, $_ := .Files.Glob "profiles/*.yaml" -}}
+{{- $available = append $available ($path | base | trimSuffix ".yaml") -}}
+{{- end -}}
+{{- fail (printf "Unknown GPU profile %q: %s not found in chart. Available profiles: %s. Or set gpu.customConfig with inline YAML." .Values.gpu.profile $profilePath (join ", " ($available | sortAlpha))) -}}
+{{- end -}}
+{{- $content -}}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/deployments/nvml-mock/helm/nvml-mock/tests/configmap_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/configmap_test.yaml
@@ -216,7 +216,7 @@ tests:
         count: 1
     asserts:
       - failedTemplate:
-          errorMessage: 'Unknown GPU profile "invalid-gpu". Supported profiles: a100, h100, b200, gb200, gb300, l40s, t4. Or set gpu.customConfig with inline YAML.'
+          errorMessage: 'Unknown GPU profile "invalid-gpu": profiles/invalid-gpu.yaml not found in chart. Available profiles: a100, b200, gb200, gb300, h100, l40s, t4. Or set gpu.customConfig with inline YAML.'
 
   - it: should respect fullnameOverride in ConfigMap name
     set:

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 gpu:
-  profile: a100           # a100 | h100 | b200 | gb200 | gb300 | l40s | t4
+  profile: a100           # any *.yaml basename under profiles/ (e.g. a100, h100, b200, gb200, gb300, l40s, t4)
   # Number of GPUs to expose. Empty (default) derives the count from the
   # selected profile's `devices:` list (t4 -> 4, all NVSwitch baseboards/NVL
   # slices -> 8), so the profile is the single source of truth. Set to a


### PR DESCRIPTION
## What This PR Does

Autodiscover available GPU profiles in the Helm chart instead of hardcoding them.

## Why

Will make it easier to add new GPU profile without a need to update Helm chart much.

## Checklist

- [ ] Commits are signed off (`git commit -s`)
- [ ] Tests pass (`go test -v -race ./...`)
- [ ] Linter passes (`golangci-lint run`)
- [ ] New code has SPDX license headers
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (if user-facing change)
