### PR TITLE
ci(e2e): build nvml-mock image once and share via ttl.sh

### DIFF
--- a/.github/workflows/nvml-mock-e2e-go.yaml
+++ b/.github/workflows/nvml-mock-e2e-go.yaml
@@ -19,8 +19,9 @@
 #
 # Image distribution: a single `build-image` job builds the nvml-mock image once
 # and pushes it to the ephemeral, auth-free ttl.sh registry (works on fork PRs)
-# as E2E_IMAGE. Every leg then pulls that ref and the harness kind-loads it
-# (E2E_SKIP_BUILD=true) instead of rebuilding per leg.
+# as E2E_IMAGE (24h TTL). Every leg then pulls that image by digest (immune to
+# tag overwrite on the anonymous registry), tags it to E2E_IMAGE, and the harness
+# kind-loads it (E2E_SKIP_BUILD=true) instead of rebuilding per leg.
 name: nvml-mock E2E (Go)
 
 permissions:
@@ -52,9 +53,11 @@ env:
   GO_VERSION: ${{ inputs.golang_version }}
   KIND_VERSION: "v0.31.0"
   KIND_AMD64_SHA256: "eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa"
-  # Per-commit, ephemeral (1h TTL) ttl.sh ref the build-image job publishes and
-  # every leg pulls. Auth-free, so it also works on fork PRs.
-  E2E_IMAGE: ttl.sh/nvml-mock-${{ github.sha }}:1h
+  # Per-commit, ephemeral (24h TTL) ttl.sh ref the build-image job publishes and
+  # every leg pulls (by digest, then tags locally to this ref for the harness).
+  # Auth-free, so it also works on fork PRs. 24h (ttl.sh max) keeps the image
+  # alive long enough to re-run individual failed legs without a full rebuild.
+  E2E_IMAGE: ttl.sh/nvml-mock-${{ github.sha }}:24h
   E2E_SKIP_BUILD: "true"
   E2E_ARTIFACTS: ${{ github.workspace }}/artifacts/e2e/go
 
@@ -63,6 +66,11 @@ jobs:
   # instead of rebuilding the image per job (see issue #460).
   build-image:
     runs-on: ubuntu-latest
+    outputs:
+      # Digest of the pushed image (sha256:...). Legs pull by digest so an
+      # anonymous ttl.sh tag overwrite cannot substitute the image between
+      # this push and their pulls.
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -71,6 +79,7 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Build and push nvml-mock image to ttl.sh
+        id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
@@ -101,8 +110,15 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
-      - name: Pull pre-built nvml-mock image from ttl.sh
-        run: docker pull "${{ env.E2E_IMAGE }}"
+      - name: Pull pre-built nvml-mock image from ttl.sh (pinned by digest)
+        run: |
+          # Content-addressed pull: even if the sha-derived tag is overwritten on
+          # the anonymous ttl.sh registry, the digest fetches exactly what
+          # build-image pushed. Re-tag to E2E_IMAGE for the harness kind-load and
+          # Helm repo:tag split.
+          pinned="ttl.sh/nvml-mock-${{ github.sha }}@${{ needs.build-image.outputs.digest }}"
+          docker pull "$pinned"
+          docker tag "$pinned" "${{ env.E2E_IMAGE }}"
 
       - name: Install Kind
         run: |
@@ -150,8 +166,15 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
-      - name: Pull pre-built nvml-mock image from ttl.sh
-        run: docker pull "${{ env.E2E_IMAGE }}"
+      - name: Pull pre-built nvml-mock image from ttl.sh (pinned by digest)
+        run: |
+          # Content-addressed pull: even if the sha-derived tag is overwritten on
+          # the anonymous ttl.sh registry, the digest fetches exactly what
+          # build-image pushed. Re-tag to E2E_IMAGE for the harness kind-load and
+          # Helm repo:tag split.
+          pinned="ttl.sh/nvml-mock-${{ github.sha }}@${{ needs.build-image.outputs.digest }}"
+          docker pull "$pinned"
+          docker tag "$pinned" "${{ env.E2E_IMAGE }}"
 
       - name: Install Kind
         run: |
@@ -197,8 +220,15 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
-      - name: Pull pre-built nvml-mock image from ttl.sh
-        run: docker pull "${{ env.E2E_IMAGE }}"
+      - name: Pull pre-built nvml-mock image from ttl.sh (pinned by digest)
+        run: |
+          # Content-addressed pull: even if the sha-derived tag is overwritten on
+          # the anonymous ttl.sh registry, the digest fetches exactly what
+          # build-image pushed. Re-tag to E2E_IMAGE for the harness kind-load and
+          # Helm repo:tag split.
+          pinned="ttl.sh/nvml-mock-${{ github.sha }}@${{ needs.build-image.outputs.digest }}"
+          docker pull "$pinned"
+          docker tag "$pinned" "${{ env.E2E_IMAGE }}"
 
       - name: Install Kind
         run: |
@@ -240,8 +270,15 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
-      - name: Pull pre-built nvml-mock image from ttl.sh
-        run: docker pull "${{ env.E2E_IMAGE }}"
+      - name: Pull pre-built nvml-mock image from ttl.sh (pinned by digest)
+        run: |
+          # Content-addressed pull: even if the sha-derived tag is overwritten on
+          # the anonymous ttl.sh registry, the digest fetches exactly what
+          # build-image pushed. Re-tag to E2E_IMAGE for the harness kind-load and
+          # Helm repo:tag split.
+          pinned="ttl.sh/nvml-mock-${{ github.sha }}@${{ needs.build-image.outputs.digest }}"
+          docker pull "$pinned"
+          docker tag "$pinned" "${{ env.E2E_IMAGE }}"
 
       - name: Install Kind
         run: |
@@ -285,8 +322,15 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
-      - name: Pull pre-built nvml-mock image from ttl.sh
-        run: docker pull "${{ env.E2E_IMAGE }}"
+      - name: Pull pre-built nvml-mock image from ttl.sh (pinned by digest)
+        run: |
+          # Content-addressed pull: even if the sha-derived tag is overwritten on
+          # the anonymous ttl.sh registry, the digest fetches exactly what
+          # build-image pushed. Re-tag to E2E_IMAGE for the harness kind-load and
+          # Helm repo:tag split.
+          pinned="ttl.sh/nvml-mock-${{ github.sha }}@${{ needs.build-image.outputs.digest }}"
+          docker pull "$pinned"
+          docker tag "$pinned" "${{ env.E2E_IMAGE }}"
 
       - name: Install Kind
         run: |

--- a/.github/workflows/nvml-mock-e2e-go.yaml
+++ b/.github/workflows/nvml-mock-e2e-go.yaml
@@ -17,9 +17,10 @@
 # entrypoint (`make e2e`) that runs identically locally and here. Jobs mirror the
 # legacy nvml-mock E2E workflow and select the related Go scenario by label.
 #
-# Image distribution: each leg builds nvml-mock:e2e once via buildx with the
-# GitHub Actions layer cache (no registry dependency -> works on fork PRs),
-# then the harness kind-loads it (E2E_SKIP_BUILD=true).
+# Image distribution: a single `build-image` job builds the nvml-mock image once
+# and pushes it to the ephemeral, auth-free ttl.sh registry (works on fork PRs)
+# as E2E_IMAGE. Every leg then pulls that ref and the harness kind-loads it
+# (E2E_SKIP_BUILD=true) instead of rebuilding per leg.
 name: nvml-mock E2E (Go)
 
 permissions:
@@ -51,12 +52,38 @@ env:
   GO_VERSION: ${{ inputs.golang_version }}
   KIND_VERSION: "v0.31.0"
   KIND_AMD64_SHA256: "eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa"
-  E2E_IMAGE: nvml-mock:e2e
+  # Per-commit, ephemeral (1h TTL) ttl.sh ref the build-image job publishes and
+  # every leg pulls. Auth-free, so it also works on fork PRs.
+  E2E_IMAGE: ttl.sh/nvml-mock-${{ github.sha }}:1h
   E2E_SKIP_BUILD: "true"
   E2E_ARTIFACTS: ${{ github.workspace }}/artifacts/e2e/go
 
 jobs:
+  # Build nvml-mock once and publish to ttl.sh; all legs consume this artifact
+  # instead of rebuilding the image per job (see issue #460).
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Build and push nvml-mock image to ttl.sh
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: .
+          file: deployments/nvml-mock/Dockerfile
+          tags: ${{ env.E2E_IMAGE }}
+          push: true
+          build-args: |
+            GOLANG_VERSION=${{ env.GO_VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   e2e:
+    needs: build-image
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -73,20 +100,8 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
-
-      - name: Build nvml-mock image (buildx + GHA cache)
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-        with:
-          context: .
-          file: deployments/nvml-mock/Dockerfile
-          tags: ${{ env.E2E_IMAGE }}
-          load: true
-          build-args: |
-            GOLANG_VERSION=${{ env.GO_VERSION }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Pull pre-built nvml-mock image from ttl.sh
+        run: docker pull "${{ env.E2E_IMAGE }}"
 
       - name: Install Kind
         run: |
@@ -116,6 +131,7 @@ jobs:
           fi
 
   e2e-dra:
+    needs: build-image
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -132,20 +148,8 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
-
-      - name: Build nvml-mock image (buildx + GHA cache)
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-        with:
-          context: .
-          file: deployments/nvml-mock/Dockerfile
-          tags: ${{ env.E2E_IMAGE }}
-          load: true
-          build-args: |
-            GOLANG_VERSION=${{ env.GO_VERSION }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Pull pre-built nvml-mock image from ttl.sh
+        run: docker pull "${{ env.E2E_IMAGE }}"
 
       - name: Install Kind
         run: |
@@ -173,6 +177,7 @@ jobs:
           fi
 
   e2e-gpu-operator:
+    needs: build-image
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -189,20 +194,8 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
-
-      - name: Build nvml-mock image (buildx + GHA cache)
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-        with:
-          context: .
-          file: deployments/nvml-mock/Dockerfile
-          tags: ${{ env.E2E_IMAGE }}
-          load: true
-          build-args: |
-            GOLANG_VERSION=${{ env.GO_VERSION }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Pull pre-built nvml-mock image from ttl.sh
+        run: docker pull "${{ env.E2E_IMAGE }}"
 
       - name: Install Kind
         run: |
@@ -230,6 +223,7 @@ jobs:
           fi
 
   e2e-multi-node:
+    needs: build-image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -242,20 +236,8 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
-
-      - name: Build nvml-mock image (buildx + GHA cache)
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-        with:
-          context: .
-          file: deployments/nvml-mock/Dockerfile
-          tags: ${{ env.E2E_IMAGE }}
-          load: true
-          build-args: |
-            GOLANG_VERSION=${{ env.GO_VERSION }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Pull pre-built nvml-mock image from ttl.sh
+        run: docker pull "${{ env.E2E_IMAGE }}"
 
       - name: Install Kind
         run: |
@@ -281,6 +263,7 @@ jobs:
           fi
 
   e2e-nri:
+    needs: build-image
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -297,20 +280,8 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
-
-      - name: Build nvml-mock image (buildx + GHA cache)
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-        with:
-          context: .
-          file: deployments/nvml-mock/Dockerfile
-          tags: ${{ env.E2E_IMAGE }}
-          load: true
-          build-args: |
-            GOLANG_VERSION=${{ env.GO_VERSION }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Pull pre-built nvml-mock image from ttl.sh
+        run: docker pull "${{ env.E2E_IMAGE }}"
 
       - name: Install Kind
         run: |

--- a/.github/workflows/nvml-mock-e2e-go.yaml
+++ b/.github/workflows/nvml-mock-e2e-go.yaml
@@ -90,7 +90,8 @@ jobs:
       matrix:
         gpu-profile: ${{ fromJson(inputs.gpu_profiles) }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -138,7 +139,8 @@ jobs:
       matrix:
         gpu-profile: ${{ fromJson(inputs.gpu_profiles) }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -184,7 +186,8 @@ jobs:
       matrix:
         gpu-profile: ${{ fromJson(inputs.gpu_profiles) }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -226,7 +229,8 @@ jobs:
     needs: build-image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -270,7 +274,8 @@ jobs:
       matrix:
         gpu-profile: ${{ fromJson(inputs.gpu_profiles) }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -303,11 +303,15 @@ The workflow:
 1. Detects the project Go version unless one is explicitly provided.
 2. Builds the `nvml-mock` image exactly once in a dedicated `build-image` job
    (buildx + GHA cache) and pushes it to the ephemeral, auth-free `ttl.sh`
-   registry as `E2E_IMAGE` (`ttl.sh/nvml-mock-<sha>:1h`). Using `ttl.sh` keeps
-   this working on fork PRs, which cannot access authenticated registries.
-3. Makes every leg `needs: build-image`, pulls that pre-built ref, and sets
-   `E2E_SKIP_BUILD=true` so the harness Kind-loads it instead of rebuilding the
-   image per leg.
+   registry as `E2E_IMAGE` (`ttl.sh/nvml-mock-<sha>:24h`), exposing the pushed
+   image digest as a job output. Using `ttl.sh` keeps this working on fork PRs,
+   which cannot access authenticated registries; the 24h TTL (ttl.sh max) keeps
+   the image available long enough to re-run an individual failed leg.
+3. Makes every leg `needs: build-image`, pulls the image **by digest**
+   (`ttl.sh/nvml-mock-<sha>@sha256:<digest>`, so a third-party tag overwrite on
+   the anonymous registry cannot substitute it), tags it back to `E2E_IMAGE`,
+   and sets `E2E_SKIP_BUILD=true` so the harness Kind-loads it instead of
+   rebuilding the image per leg.
 4. Runs one GPU profile per matrix job.
 5. Prints collected diagnostics if the job fails.
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -301,8 +301,13 @@ CI runs the harness through
 The workflow:
 
 1. Detects the project Go version unless one is explicitly provided.
-2. Builds `nvml-mock:e2e` once per matrix leg with buildx and GHA cache.
-3. Sets `E2E_SKIP_BUILD=true` so the harness reuses that image.
+2. Builds the `nvml-mock` image exactly once in a dedicated `build-image` job
+   (buildx + GHA cache) and pushes it to the ephemeral, auth-free `ttl.sh`
+   registry as `E2E_IMAGE` (`ttl.sh/nvml-mock-<sha>:1h`). Using `ttl.sh` keeps
+   this working on fork PRs, which cannot access authenticated registries.
+3. Makes every leg `needs: build-image`, pulls that pre-built ref, and sets
+   `E2E_SKIP_BUILD=true` so the harness Kind-loads it instead of rebuilding the
+   image per leg.
 4. Runs one GPU profile per matrix job.
 5. Prints collected diagnostics if the job fails.
 


### PR DESCRIPTION
## Summary

Closes #460.

Builds the `nvml-mock` E2E image **once** instead of rebuilding it in every matrix leg (`e2e`, `e2e-dra`, `e2e-gpu-operator`, `e2e-multi-node`, `e2e-nri`), and hardens the hand-off between the build and the legs:

- **Build once:** a new `build-image` job builds `nvml-mock` a single time (buildx + GHA cache) and pushes it to the ephemeral, auth-free **ttl.sh** registry as `E2E_IMAGE`. Every leg `needs: build-image` and `docker pull`s it (`E2E_SKIP_BUILD=true`, then kind-loads) instead of rebuilding. ttl.sh is auth-free, so this also works on fork PRs.
- **Digest-pinned pull (integrity):** `build-image` exposes the pushed image digest as a job output, and each leg pulls `ttl.sh/nvml-mock-<sha>@sha256:<digest>` (content-addressed), then re-tags it to `E2E_IMAGE`. This closes the window where a third party could overwrite the sha-derived tag on the anonymous registry between push and pull.
- **24h TTL:** the ttl.sh tag uses a `24h` TTL (ttl.sh max) so re-running a single failed leg within the day still finds the image, instead of hitting an expired `1h` tag and being forced into a full rebuild.
- `tests/e2e/README.md` "CI Behavior" updated to match.

No Go harness or `Makefile` changes are needed: the leg re-tags the digest-pinned image back to `E2E_IMAGE`, which already flows through both `kind load docker-image` and the Helm `image.repository`/`image.tag` split.

_The digest-pinning and 24h-TTL items above address review feedback from @ArangoGutierrez._

## Timing comparison

Comparing a full old per-leg-build run against this PR's build-once + digest-pull run (both `success`, 25 profile legs each):

| Metric | Old — per-leg build ([#458](https://github.com/NVIDIA/k8s-test-infra/actions/runs/29486704680)) | New — build-once + digest ([#465](https://github.com/NVIDIA/k8s-test-infra/actions/runs/29487761864)) | Δ |
|---|---:|---:|---:|
| **Total runner-minutes** (legs + build-image) | 186.3 min | 58.1 min | **−128 min (−69%)** |
| Per-leg avg duration | 447 s | 138 s | −309 s (−69%) |
| Per-leg min / max | 334 s / 592 s | 104 s / 187 s | much faster |
| `build-image` job | — | 31 s (once) | +1 job |
| **Wall-clock span** (first start → last finish) | 593 s (9.88 min) | 220 s (3.67 min) | **−373 s (−63%)** |

**Takeaway:** dropping the per-leg buildx step is the dominant win — every leg now just `docker pull`s the pre-built image, so aggregate runner-minutes fall ~69% and wall-clock ~63%. The cleanest isolation of the build change is the plain `e2e` leg's min duration (**334 s → 104 s**), which has no extra scenario work and is purely rebuild vs `docker pull`. Caveat: the old baseline (#458) also ports DCGM validation, so its `gpu-operator` legs run extra scraping work that inflates the old max; and each side is a single run, so numbers include normal noise (runner scheduling, cache warmth, ttl.sh latency).

## Test plan

- [ ] CI: `build-image` job builds + pushes to ttl.sh once and exposes the digest output.
- [ ] CI: all five E2E legs pull by digest, re-tag, and pass (harness kind-loads it, no per-leg rebuild).
- [ ] Confirm fork-PR runs work (no registry auth needed).

