### PR TITLE
feat(nri): mock IMEX channel injection over NRI (#437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- feat(nri): inject mock IMEX channel device nodes
+  (`/dev/nvidia-caps-imex-channels/*`) into annotated workloads over the
+  NRI foundation, with a dedicated `nri-imex` demo and e2e scenario. (#437)
+
 ### Changed
 - ComputeDomain simulation now runs the REAL `nvidia-imex` daemon in NO
   GPU mode (`--nogpu`) instead of the fake marker-file binaries: the new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   NRI foundation, with a dedicated `nri-imex` demo and e2e scenario. (#437)
 
 ### Changed
+- The nri-imex demo now exercises the REAL `nvidia-imex-ctl` against a live
+  NO-GPU IMEX domain formed across both workers (`-q` READY, `-N -j` UP with
+  2 nodes READY/NO_GPU), replacing the previous best-effort domain-status
+  check. (#437)
 - ComputeDomain simulation now runs the REAL `nvidia-imex` daemon in NO
   GPU mode (`--nogpu`) instead of the fake marker-file binaries: the new
   `imex-nogpu-shim` injects the flag around upstream's hard-coded argv,

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,8 @@ generate:
 #   make e2e-dra                   # DRA scenario
 #   make e2e-gpu-operator          # GPU Operator scenario
 #   make e2e-multi-node            # heterogeneous A100/T4 multi-node scenario
-#   make e2e-nri                   # node-wide NRI ambient-injection scenario
+#   make e2e-nri                   # NRI scenarios (node-wide injection + IMEX channels)
+#   make e2e-imex                  # mock IMEX channel injection over NRI (subset of e2e-nri)
 # CI builds the image once per job and sets E2E_SKIP_BUILD=true + E2E_IMAGE.
 #
 # NOTE: this targets ./tests/e2e/go (the Ginkgo suite package) only, NOT
@@ -133,3 +134,6 @@ e2e-multi-node:
 
 e2e-nri:
 	$(MAKE) e2e E2E_GINKGO_FLAGS='--label-filter=nri'
+
+e2e-imex:
+	$(MAKE) e2e E2E_GINKGO_FLAGS='--label-filter=imex'

--- a/cmd/nvml-mock-nri/main.go
+++ b/cmd/nvml-mock-nri/main.go
@@ -38,6 +38,8 @@ func main() {
 	flag.StringVar(&cfg.DeviceHostPath, "device-host-path", envOr("NVML_MOCK_DEVICE_HOST_PATH", cfg.DeviceHostPath), "host path containing mock /dev/nvidia* nodes")
 	flag.StringVar(&cfg.OptOutAnnotation, "opt-out-annotation", envOr("NVML_MOCK_OPT_OUT_ANNOTATION", cfg.OptOutAnnotation), "pod annotation key; value false disables injection")
 	flag.StringVar(&cfg.DeviceAnnotation, "device-annotation", envOr("NVML_MOCK_DEVICE_ANNOTATION", cfg.DeviceAnnotation), "pod annotation key; value true adds /dev/nvidia* device nodes")
+	flag.StringVar(&cfg.ImexChannelAnnotation, "imex-channel-annotation", envOr("NVML_MOCK_IMEX_CHANNEL_ANNOTATION", cfg.ImexChannelAnnotation), "pod annotation key; value true adds /dev/nvidia-caps-imex-channels/* nodes")
+	flag.StringVar(&cfg.ImexChannelHostPath, "imex-channel-host-path", envOr("NVML_MOCK_IMEX_CHANNEL_HOST_PATH", cfg.ImexChannelHostPath), "host path containing mock IMEX channel nodes (channel0..N-1)")
 	excludedNamespaces := flag.String("excluded-namespaces", envOr("NVML_MOCK_EXCLUDED_NAMESPACES", strings.Join(cfg.ExcludedNamespaces, ",")), "comma-separated namespaces to skip")
 	shims := flag.String("ld-preload-shims", envOr("NVML_MOCK_LD_PRELOAD_SHIMS", strings.Join(cfg.Shims, ",")), "comma-separated LD_PRELOAD shim paths relative to the overlay mount or absolute paths")
 	flag.Parse()

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -143,6 +143,13 @@ spec:
               value: "/var/lib/nvml-mock/ib"
             - name: MOCK_PCI_ROOT
               value: "/var/lib/nvml-mock"
+            # Mock IMEX channel device nodes (issue #437). setup.sh mknod's
+            # channel0..count-1 under the overlay's driver/dev tree; the NRI
+            # plugin injects them into annotated pods. count=0 disables.
+            - name: MOCK_IMEX_CHANNELS
+              value: "{{ .Values.imexChannels.count }}"
+            - name: MOCK_IMEX_CHANNEL_MAJOR
+              value: "{{ .Values.imexChannels.major }}"
           lifecycle:
             preStop:
               exec:

--- a/deployments/nvml-mock/helm/nvml-mock/templates/nri-daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/nri-daemonset.yaml
@@ -48,6 +48,8 @@ spec:
             - --device-host-path={{ .Values.nri.overlay.hostPath }}/driver/dev
             - --opt-out-annotation={{ .Values.nri.optOutAnnotation }}
             - --device-annotation={{ .Values.nri.deviceAnnotation }}
+            - --imex-channel-annotation={{ .Values.nri.imexChannelAnnotation }}
+            - --imex-channel-host-path={{ .Values.nri.overlay.hostPath }}/driver/dev/nvidia-caps-imex-channels
             - --excluded-namespaces={{ .Release.Namespace }},kube-system{{- range .Values.nri.excludedNamespaces }},{{ . }}{{- end }}
             # NODE_NAME (below) gates ComputeDomain topology injection: when
             # topology.enabled stages a topology document into the overlay,

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -63,6 +63,10 @@ should match snapshot with all overrides:
                   value: /var/lib/nvml-mock/ib
                 - name: MOCK_PCI_ROOT
                   value: /var/lib/nvml-mock
+                - name: MOCK_IMEX_CHANNELS
+                  value: "16"
+                - name: MOCK_IMEX_CHANNEL_MAJOR
+                  value: "240"
               image: custom-registry/nvml-mock:v2.0.0
               imagePullPolicy: Always
               lifecycle:
@@ -196,6 +200,10 @@ should match snapshot with b200 profile:
                   value: /var/lib/nvml-mock/ib
                 - name: MOCK_PCI_ROOT
                   value: /var/lib/nvml-mock
+                - name: MOCK_IMEX_CHANNELS
+                  value: "16"
+                - name: MOCK_IMEX_CHANNEL_MAJOR
+                  value: "240"
               image: ghcr.io/nvidia/nvml-mock:latest
               imagePullPolicy: IfNotPresent
               lifecycle:
@@ -316,6 +324,10 @@ should match snapshot with default values:
                   value: /var/lib/nvml-mock/ib
                 - name: MOCK_PCI_ROOT
                   value: /var/lib/nvml-mock
+                - name: MOCK_IMEX_CHANNELS
+                  value: "16"
+                - name: MOCK_IMEX_CHANNEL_MAJOR
+                  value: "240"
               image: ghcr.io/nvidia/nvml-mock:latest
               imagePullPolicy: IfNotPresent
               lifecycle:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -736,3 +736,20 @@ tests:
           content:
             name: MOCK_FABRICMANAGER_STATE_DIR
             value: /run/nvidia-fabricmanager
+
+  - it: should export MOCK_IMEX_CHANNELS env from imexChannels values
+    set:
+      imexChannels:
+        count: 16
+        major: 240
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MOCK_IMEX_CHANNELS
+            value: "16"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MOCK_IMEX_CHANNEL_MAJOR
+            value: "240"

--- a/deployments/nvml-mock/helm/nvml-mock/tests/nri_daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/nri_daemonset_test.yaml
@@ -130,3 +130,15 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --excluded-namespaces=NAMESPACE,kube-system,monitoring,gpu-system
+
+  - it: should pass IMEX channel args to the NRI plugin
+    set:
+      nri:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --imex-channel-annotation=nvml-mock.nvidia.com/imex-channels
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --imex-channel-host-path=/var/lib/nvml-mock/driver/dev/nvidia-caps-imex-channels

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -58,6 +58,16 @@ image:
 
 driverVersion: ""                  # Auto-derived from profile. Override: "550.163.01"
 
+# Mock IMEX channel device nodes (issue #437). The main DaemonSet provisions
+# /dev/nvidia-caps-imex-channels/channel0..count-1 on each node via setup.sh;
+# the NRI plugin injects them into pods annotated
+# nvml-mock.nvidia.com/imex-channels: "true". Presence-only: the nodes use a
+# driverless major, so they are statable/listable but not openable (see
+# docs/demo/nri-imex). Set count to 0 to disable host provisioning.
+imexChannels:
+  count: 16
+  major: 240
+
 nodeSelector: {}
 tolerations:
   - operator: Exists
@@ -83,6 +93,9 @@ nri:
   # device-node mounts from the staged mock overlay. Treat that pod-authored
   # control as part of the demo trust boundary and exclude namespaces as needed.
   deviceAnnotation: nvml-mock.nvidia.com/devices
+  # Workloads that set this pod annotation to "true" opt into mock IMEX channel
+  # device nodes (/dev/nvidia-caps-imex-channels/*) from the staged overlay.
+  imexChannelAnnotation: nvml-mock.nvidia.com/imex-channels
   excludedNamespaces: []
   resources: {}
 

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -66,6 +66,21 @@ mknod -m 666 "$DEV_ROOT/nvidiactl" c 195 255 2>/dev/null || true
 mknod -m 666 "$DEV_ROOT/nvidia-uvm" c 510 0 2>/dev/null || true
 mknod -m 666 "$DEV_ROOT/nvidia-uvm-tools" c 510 1 2>/dev/null || true
 
+# 3c. Create mock IMEX channel device nodes (issue #437).
+#     Presence-only: a major with no bound kernel driver, so the nodes are
+#     statable/listable (ls /dev/nvidia-caps-imex-channels) but not openable,
+#     mirroring the mock /dev/nvidia* nodes created in step 3.
+CHANNEL_COUNT="${MOCK_IMEX_CHANNELS:-0}"
+CHANNEL_MAJOR="${MOCK_IMEX_CHANNEL_MAJOR:-240}"
+if [ "$CHANNEL_COUNT" -gt 0 ]; then
+  mkdir -p "$DEV_ROOT/nvidia-caps-imex-channels"
+  i=0
+  while [ "$i" -lt "$CHANNEL_COUNT" ]; do
+    mknod -m 666 "$DEV_ROOT/nvidia-caps-imex-channels/channel$i" c "$CHANNEL_MAJOR" "$i" 2>/dev/null || true
+    i=$((i + 1))
+  done
+fi
+
 # 3b. Generate CDI spec for nvidia-container-runtime CDI mode.
 #     This allows the toolkit to inject our mock libs into containers without
 #     needing libnvidia-container or kernel modules.

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -20,6 +20,21 @@ cd node-wide-injection && ./run.sh
 See [node-wide-injection/README.md](node-wide-injection/README.md) for the
 walkthrough.
 
+### IMEX channels (NRI)
+
+Dedicated cluster (`nvml-mock-nri-imex`) with containerd NRI enabled.
+Provisions mock IMEX channel device nodes on the host and proves an
+annotated workload sees `/dev/nvidia-caps-imex-channels/*` injected over
+NRI, without GPU requests or pod-spec mutation.
+
+**Requirements:** Docker, Kind, Helm
+
+```bash
+cd nri-imex && ./run.sh
+```
+
+See [nri-imex/README.md](nri-imex/README.md) for the walkthrough.
+
 ### Standalone
 
 Deploy nvml-mock with FGO-style GPU labels on a Kind cluster. No external

--- a/docs/demo/nri-imex/README.md
+++ b/docs/demo/nri-imex/README.md
@@ -1,0 +1,29 @@
+# nri-imex demo: mock IMEX channels over NRI
+
+Injects mock `/dev/nvidia-caps-imex-channels/channel0..N-1` device nodes into an
+ordinary, unprivileged workload via the nvml-mock NRI plugin — no
+`nvidia.com/gpu` request, no volumes, no `MOCK_*` env in the pod spec — and shows
+a single ComputeDomain spanning two Kind nodes (issue
+[#437](https://github.com/NVIDIA/k8s-test-infra/issues/437)).
+
+## Run
+
+```bash
+./docs/demo/nri-imex/run.sh
+```
+
+## What it proves
+
+1. A plain workload annotated `nvml-mock.nvidia.com/imex-channels: "true"` sees
+   `channel0..15` on **both** workers.
+2. `check-fabric` reports the same `clusterUuid` on both workers (consistent
+   ComputeDomain identity, injected purely through NRI).
+3. The real `nvidia-imex` domain reports `READY`.
+
+## Limitation: presence-only channels
+
+The mock channel nodes are `mknod`'d with a driverless major (default `240`), so
+they are **statable and listable** but **not openable** (`open()` → `ENXIO`).
+This matches the existing mock `/dev/nvidia*` nodes: consumers use the
+`LD_PRELOAD`'d mock libraries rather than opening the real device. Acceptance is
+channel *visibility*, not channel I/O.

--- a/docs/demo/nri-imex/README.md
+++ b/docs/demo/nri-imex/README.md
@@ -12,13 +12,27 @@ a single ComputeDomain spanning two Kind nodes (issue
 ./docs/demo/nri-imex/run.sh
 ```
 
+## Prerequisites
+
+- Docker, Kind, kubectl, Helm.
+- `jq` — Scenario 3 parses `nvidia-imex-ctl -N -j` JSON.
+
+The demo builds a local overlay image (`nvml-mock:nri-imex-real-imex`) that
+layers the real `nvidia-imex` / `nvidia-imex-ctl` (NO GPU mode via
+`imex-nogpu-shim`) onto the mock stack. This image is **local build only** — it
+repackages the proprietary `nvidia-imex` binary and is never published (see
+`deployments/nvml-mock/Dockerfile.compute-domain-daemon`).
+
 ## What it proves
 
 1. A plain workload annotated `nvml-mock.nvidia.com/imex-channels: "true"` sees
    `channel0..15` on **both** workers.
 2. `check-fabric` reports the same `clusterUuid` on both workers (consistent
    ComputeDomain identity, injected purely through NRI).
-3. The real `nvidia-imex` domain reports `READY`.
+3. Two real `nvidia-imex` NO-GPU daemons (started via `imex-nogpu-shim`) form a
+   domain across both workers: `nvidia-imex-ctl -q` reports `READY` locally and
+   `nvidia-imex-ctl -N -j` reports the domain `UP` with both nodes `READY` and
+   version `NO_GPU`.
 
 ## Limitation: presence-only channels
 

--- a/docs/demo/nri-imex/imex-workload.yaml
+++ b/docs/demo/nri-imex/imex-workload.yaml
@@ -26,7 +26,7 @@ spec:
         nvidia.com/gpu.present: "true"
       containers:
         - name: agent
-          image: debian:bookworm-slim
+          image: ubuntu:24.04
           command:
             - /bin/sh
             - -c

--- a/docs/demo/nri-imex/imex-workload.yaml
+++ b/docs/demo/nri-imex/imex-workload.yaml
@@ -1,0 +1,54 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ordinary workload: no nvidia.com/gpu request, no volumes, no MOCK_* env. The
+# nvml-mock NRI plugin injects the overlay AND (because of the imex-channels
+# annotation) the mock /dev/nvidia-caps-imex-channels/* nodes at creation time.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: imex-workload
+  labels:
+    app: imex-workload
+spec:
+  selector:
+    matchLabels:
+      app: imex-workload
+  template:
+    metadata:
+      labels:
+        app: imex-workload
+      annotations:
+        nvml-mock.nvidia.com/imex-channels: "true"
+    spec:
+      automountServiceAccountToken: false
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      containers:
+        - name: agent
+          image: debian:bookworm-slim
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              echo "[imex-workload] node=${NODE_NAME} verifying NRI channel injection"
+              test -d /opt/nvml-mock
+              echo "=== /dev/nvidia-caps-imex-channels ==="
+              ls -1 /dev/nvidia-caps-imex-channels
+              echo "=== check-fabric (ComputeDomain identity via NRI) ==="
+              command -v check-fabric >/dev/null 2>&1 && check-fabric || true
+              echo "[imex-workload] OK; sleeping"
+              while true; do sleep 300; done
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi

--- a/docs/demo/nri-imex/kind.yaml
+++ b/docs/demo/nri-imex/kind.yaml
@@ -1,0 +1,15 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Two-worker Kind cluster with containerd NRI enabled for the nri-imex demo.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.nri.v1.nri"]
+      disable = false
+      socket_path = "/var/run/nri/nri.sock"
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker

--- a/docs/demo/nri-imex/run.sh
+++ b/docs/demo/nri-imex/run.sh
@@ -21,6 +21,8 @@ KIND_CONFIG="${REPO_ROOT}/docs/demo/nri-imex/kind.yaml"
 TOPOLOGY_FILE="${REPO_ROOT}/docs/demo/nri-imex/topology.yaml"
 WORKLOAD_FILE="${REPO_ROOT}/docs/demo/nri-imex/imex-workload.yaml"
 IMAGE_NAME="${IMAGE_NAME:-nvml-mock:nri-imex}"
+OVERLAY_IMAGE_NAME="${OVERLAY_IMAGE_NAME:-nvml-mock:nri-imex-real-imex}"
+SYSTEM_NS="nvml-mock-system"
 CHANNEL_COUNT="${CHANNEL_COUNT:-16}"
 EXPECTED_DOMAIN_UUID="00000000-0000-0000-0000-0000000000ce"
 WORKER1="${CLUSTER_NAME}-worker"
@@ -29,6 +31,8 @@ WORKER2="${CLUSTER_NAME}-worker2"
 info() { printf '\n==> %s\n' "$*" >&2; }
 ok()   { printf '    \xE2\x9C\x93 %s\n' "$*" >&2; }
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+command -v jq >/dev/null 2>&1 || fail "jq is required (Scenario 3 parses nvidia-imex-ctl JSON)"
 
 cleanup() { kind delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1 || true; }
 trap cleanup EXIT
@@ -41,16 +45,23 @@ workload_pod_on_node() {
 info "Building nvml-mock image"
 docker build -t "$IMAGE_NAME" -f "${REPO_ROOT}/deployments/nvml-mock/Dockerfile" "$REPO_ROOT"
 
+info "Building real-IMEX overlay (--nogpu via imex-nogpu-shim); LOCAL BUILD ONLY"
+docker build -t "$OVERLAY_IMAGE_NAME" \
+  --target demo \
+  --build-arg "NVML_MOCK_IMAGE=${IMAGE_NAME}" \
+  --build-arg "GOLANG_VERSION=$("${REPO_ROOT}/hack/golang-version.sh")" \
+  -f "${REPO_ROOT}/deployments/nvml-mock/Dockerfile.compute-domain-daemon" "$REPO_ROOT"
+
 info "Creating Kind cluster $CLUSTER_NAME"
 kind create cluster --name "$CLUSTER_NAME" --config "$KIND_CONFIG"
-kind load docker-image "$IMAGE_NAME" --name "$CLUSTER_NAME"
+kind load docker-image "$OVERLAY_IMAGE_NAME" --name "$CLUSTER_NAME"
 
 info "Installing nvml-mock (gb200) with NRI + IMEX channels + topology"
 helm upgrade --install "$RELEASE_NAME" "$CHART_PATH" \
   --namespace nvml-mock-system --create-namespace --wait \
   --set gpu.profile=gb200 \
-  --set image.repository="${IMAGE_NAME%%:*}" \
-  --set image.tag="${IMAGE_NAME##*:}" \
+  --set image.repository="${OVERLAY_IMAGE_NAME%%:*}" \
+  --set image.tag="${OVERLAY_IMAGE_NAME##*:}" \
   --set nri.enabled=true \
   --set imexChannels.count="$CHANNEL_COUNT" \
   -f "$TOPOLOGY_FILE"

--- a/docs/demo/nri-imex/run.sh
+++ b/docs/demo/nri-imex/run.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Copyright 2026 NVIDIA CORPORATION
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Demo: mock IMEX channels injected over the NRI foundation (issue #437).
+#
+# Spins up a 2-worker Kind cluster with containerd NRI enabled, installs
+# nvml-mock (gb200 profile) with NRI + IMEX channels + a single ComputeDomain
+# spanning both workers, deploys a plain annotated workload, and asserts:
+#   1. Both workers' workloads see /dev/nvidia-caps-imex-channels/channel0..15.
+#   2. check-fabric reports the same clusterUuid on both workers.
+#   3. The real nvidia-imex domain reports READY (nvidia-imex-ctl -q).
+set -euo pipefail
+
+CLUSTER_NAME="nvml-mock-nri-imex"
+RELEASE_NAME="nvml-mock"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+CHART_PATH="${REPO_ROOT}/deployments/nvml-mock/helm/nvml-mock"
+KIND_CONFIG="${REPO_ROOT}/docs/demo/nri-imex/kind.yaml"
+TOPOLOGY_FILE="${REPO_ROOT}/docs/demo/nri-imex/topology.yaml"
+WORKLOAD_FILE="${REPO_ROOT}/docs/demo/nri-imex/imex-workload.yaml"
+IMAGE_NAME="${IMAGE_NAME:-nvml-mock:nri-imex}"
+CHANNEL_COUNT="${CHANNEL_COUNT:-16}"
+EXPECTED_DOMAIN_UUID="00000000-0000-0000-0000-0000000000ce"
+WORKER1="${CLUSTER_NAME}-worker"
+WORKER2="${CLUSTER_NAME}-worker2"
+
+info() { printf '\n==> %s\n' "$*" >&2; }
+ok()   { printf '    \xE2\x9C\x93 %s\n' "$*" >&2; }
+fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+cleanup() { kind delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+workload_pod_on_node() {
+  kubectl get pods -l app=imex-workload -o \
+    jsonpath="{range .items[?(@.spec.nodeName=='$1')]}{.metadata.name}{end}"
+}
+
+info "Building nvml-mock image"
+docker build -t "$IMAGE_NAME" -f "${REPO_ROOT}/deployments/nvml-mock/Dockerfile" "$REPO_ROOT"
+
+info "Creating Kind cluster $CLUSTER_NAME"
+kind create cluster --name "$CLUSTER_NAME" --config "$KIND_CONFIG"
+kind load docker-image "$IMAGE_NAME" --name "$CLUSTER_NAME"
+
+info "Installing nvml-mock (gb200) with NRI + IMEX channels + topology"
+helm upgrade --install "$RELEASE_NAME" "$CHART_PATH" \
+  --namespace nvml-mock-system --create-namespace --wait \
+  --set gpu.profile=gb200 \
+  --set image.repository="${IMAGE_NAME%%:*}" \
+  --set image.tag="${IMAGE_NAME##*:}" \
+  --set nri.enabled=true \
+  --set imexChannels.count="$CHANNEL_COUNT" \
+  -f "$TOPOLOGY_FILE"
+
+info "Deploying annotated workload (created AFTER overlay staging)"
+kubectl apply -f "$WORKLOAD_FILE"
+kubectl rollout status daemonset/imex-workload --timeout=180s
+
+info "Scenario 1: both workers see $CHANNEL_COUNT IMEX channels"
+for w in "$WORKER1" "$WORKER2"; do
+  pod="$(workload_pod_on_node "$w")"
+  [ -n "$pod" ] || fail "no imex-workload pod on $w"
+  n="$(kubectl exec "$pod" -- sh -c 'ls -1 /dev/nvidia-caps-imex-channels | wc -l' | tr -d '[:space:]')"
+  [ "$n" = "$CHANNEL_COUNT" ] || fail "$w: expected $CHANNEL_COUNT channels, got $n"
+  ok "$w: $n channels"
+done
+
+info "Scenario 2: consistent ComputeDomain identity across workers"
+for w in "$WORKER1" "$WORKER2"; do
+  pod="$(workload_pod_on_node "$w")"
+  out="$(kubectl exec "$pod" -- check-fabric 2>&1 || true)"
+  echo "$out" | grep -qi "clusterUuid : $EXPECTED_DOMAIN_UUID" \
+    || fail "$w: expected clusterUuid $EXPECTED_DOMAIN_UUID\n$out"
+  ok "$w: clusterUuid $EXPECTED_DOMAIN_UUID"
+done
+
+info "Scenario 3: real nvidia-imex domain status"
+imex_pod="$(kubectl get pods -n nvml-mock-system -l app.kubernetes.io/name=nvml-mock -o jsonpath='{.items[0].metadata.name}')"
+if kubectl exec -n nvml-mock-system "$imex_pod" -- sh -c 'command -v nvidia-imex-ctl >/dev/null 2>&1'; then
+  status="$(kubectl exec -n nvml-mock-system "$imex_pod" -- nvidia-imex-ctl -q 2>&1 || true)"
+  echo "$status" | grep -qi READY && ok "nvidia-imex domain READY" \
+    || info "nvidia-imex-ctl output (informational):\n$status"
+else
+  info "nvidia-imex-ctl not present in this image; skipping domain status (see README)"
+fi
+
+info "Demo complete."

--- a/docs/demo/nri-imex/run.sh
+++ b/docs/demo/nri-imex/run.sh
@@ -10,7 +10,9 @@
 # spanning both workers, deploys a plain annotated workload, and asserts:
 #   1. Both workers' workloads see /dev/nvidia-caps-imex-channels/channel0..15.
 #   2. check-fabric reports the same clusterUuid on both workers.
-#   3. The real nvidia-imex domain reports READY (nvidia-imex-ctl -q).
+#   3. Real nvidia-imex NO-GPU daemons on both workers form a domain:
+#      nvidia-imex-ctl -q reports READY, -N -j reports UP with 2 nodes
+#      READY / version NO_GPU.
 set -euo pipefail
 
 CLUSTER_NAME="nvml-mock-nri-imex"
@@ -40,6 +42,12 @@ trap cleanup EXIT
 workload_pod_on_node() {
   kubectl get pods -l app=imex-workload -o \
     jsonpath="{range .items[?(@.spec.nodeName=='$1')]}{.metadata.name}{end}"
+}
+
+nvml_pod_on_node() {
+  kubectl get pods -n "$SYSTEM_NS" -l app.kubernetes.io/name=nvml-mock \
+    --field-selector="spec.nodeName=$1,status.phase=Running" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true
 }
 
 info "Building nvml-mock image"
@@ -88,14 +96,80 @@ for w in "$WORKER1" "$WORKER2"; do
   ok "$w: clusterUuid $EXPECTED_DOMAIN_UUID"
 done
 
-info "Scenario 3: real nvidia-imex domain status"
-imex_pod="$(kubectl get pods -n nvml-mock-system -l app.kubernetes.io/name=nvml-mock -o jsonpath='{.items[0].metadata.name}')"
-if kubectl exec -n nvml-mock-system "$imex_pod" -- sh -c 'command -v nvidia-imex-ctl >/dev/null 2>&1'; then
-  status="$(kubectl exec -n nvml-mock-system "$imex_pod" -- nvidia-imex-ctl -q 2>&1 || true)"
-  echo "$status" | grep -qi READY && ok "nvidia-imex domain READY" \
-    || info "nvidia-imex-ctl output (informational):\n$status"
-else
-  info "nvidia-imex-ctl not present in this image; skipping domain status (see README)"
+info "Scenario 3: real IMEX domain (NO GPU mode) queried with nvidia-imex-ctl"
+IMEX_CFG=/tmp/imex.cfg
+NODES_CFG=/tmp/nodes.cfg
+
+POD_A="$(nvml_pod_on_node "$WORKER1")"
+POD_B="$(nvml_pod_on_node "$WORKER2")"
+[ -n "$POD_A" ] || fail "no running nvml-mock pod on $WORKER1"
+[ -n "$POD_B" ] || fail "no running nvml-mock pod on $WORKER2"
+
+IP_A="$(kubectl get pod -n "$SYSTEM_NS" "$POD_A" -o jsonpath='{.status.podIP}')"
+IP_B="$(kubectl get pod -n "$SYSTEM_NS" "$POD_B" -o jsonpath='{.status.podIP}')"
+
+# Render a per-pod IMEX config from the package default: foreground
+# daemon, our two-node file (both pod IPs), pod-local log.
+for pod in "$POD_A" "$POD_B"; do
+  kubectl exec -n "$SYSTEM_NS" "$pod" -- sh -c "
+    printf '%s\n%s\n' '$IP_A' '$IP_B' > '$NODES_CFG'
+    sed -e 's/^DAEMONIZE=1/DAEMONIZE=0/' \
+        -e 's|^IMEX_NODE_CONFIG_FILE=.*|IMEX_NODE_CONFIG_FILE=$NODES_CFG|' \
+        -e 's|^LOG_FILE_NAME=.*|LOG_FILE_NAME=/tmp/nvidia-imex.log|' \
+        /etc/nvidia-imex/config.cfg > '$IMEX_CFG'"
+done
+
+start_imex() {
+  kubectl exec -n "$SYSTEM_NS" "$1" -- sh -c \
+    "nvidia-imex -c $IMEX_CFG >/tmp/imex.stdout 2>&1 & echo \$! > /tmp/imex.pid"
+}
+
+domain_status() {
+  kubectl exec -n "$SYSTEM_NS" "$1" -- nvidia-imex-ctl -c "$IMEX_CFG" -N -j 2>/dev/null \
+    | jq -r '.status' 2>/dev/null || printf 'UNREACHABLE\n'
+}
+
+info "Starting real nvidia-imex (--nogpu via shim) on both workers"
+start_imex "$POD_A"
+start_imex "$POD_B"
+
+# Local readiness probe (-q): exact upstream contract, prints "READY".
+for pod in "$POD_A" "$POD_B"; do
+  q=""
+  for _ in $(seq 1 30); do
+    q="$(kubectl exec -n "$SYSTEM_NS" "$pod" -- nvidia-imex-ctl -c "$IMEX_CFG" -q 2>/dev/null || true)"
+    [ "$q" = "READY" ] && break
+    sleep 1
+  done
+  [ "$q" = "READY" ] || fail "$pod: nvidia-imex-ctl -q never reported READY"
+  ok "$pod: nvidia-imex-ctl -q READY"
+done
+
+# Domain-wide status converges to UP once both daemons connect over the
+# pod network (gRPC :50000). Backoff + NetworkPolicy reconcile can take
+# a couple of minutes, so poll up to 240s.
+status="UNREACHABLE"
+for _ in $(seq 1 240); do
+  status="$(domain_status "$POD_A")"
+  [ "$status" = "UP" ] && break
+  sleep 1
+done
+if [ "$status" != "UP" ]; then
+  kubectl exec -n "$SYSTEM_NS" "$POD_A" -- sh -c 'tail -20 /tmp/nvidia-imex.log 2>/dev/null' >&2 || true
+  fail "domain never reached UP (status=$status)"
 fi
+ok "nvidia-imex-ctl -N -j: domain UP"
+
+nodes_json="$(kubectl exec -n "$SYSTEM_NS" "$POD_A" -- nvidia-imex-ctl -c "$IMEX_CFG" -N -j 2>/dev/null)"
+ready="$(printf '%s' "$nodes_json" | jq -r '[.nodes[] | select(.status=="READY")] | length')"
+nogpu="$(printf '%s' "$nodes_json" | jq -r '[.nodes[] | select(.version=="NO_GPU")] | length')"
+[ "$ready" = "2" ] || fail "want 2 READY nodes, got $ready: $nodes_json"
+[ "$nogpu" = "2" ] || fail "want 2 NO_GPU nodes, got $nogpu: $nodes_json"
+ok "2/2 nodes READY, version NO_GPU"
+
+# Tidy up the demo daemons.
+for pod in "$POD_A" "$POD_B"; do
+  kubectl exec -n "$SYSTEM_NS" "$pod" -- sh -c 'kill -TERM "$(cat /tmp/imex.pid)" 2>/dev/null || true' || true
+done
 
 info "Demo complete."

--- a/docs/demo/nri-imex/topology.yaml
+++ b/docs/demo/nri-imex/topology.yaml
@@ -1,0 +1,15 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Single ComputeDomain spanning both demo workers. Node names follow Kind's
+# "<cluster>-worker[N]" convention (cluster: nvml-mock-nri-imex).
+topology:
+  enabled: true
+  domains:
+    - name: nri-imex-domain
+      uuid: "00000000-0000-0000-0000-0000000000ce"
+      cliques:
+        - id: 0
+          nodes:
+            - nvml-mock-nri-imex-worker
+            - nvml-mock-nri-imex-worker2

--- a/pkg/nri/nvmlmock/adjust.go
+++ b/pkg/nri/nvmlmock/adjust.go
@@ -330,6 +330,9 @@ func discoverDevices(deviceHostPath string) ([]Device, error) {
 
 	devices := make([]Device, 0, len(entries))
 	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
 		name := entry.Name()
 		if !strings.HasPrefix(name, "nvidia") {
 			continue
@@ -353,6 +356,9 @@ func discoverImexChannels(channelHostPath string) ([]Device, error) {
 
 	devices := make([]Device, 0, len(entries))
 	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
 		name := entry.Name()
 		if !strings.HasPrefix(name, "channel") {
 			continue

--- a/pkg/nri/nvmlmock/adjust.go
+++ b/pkg/nri/nvmlmock/adjust.go
@@ -18,11 +18,18 @@ var warnf = func(format string, args ...any) {
 }
 
 const (
-	defaultHostOverlayPath      = "/var/lib/nvml-mock"
-	defaultContainerOverlayPath = "/opt/nvml-mock"
-	defaultDeviceHostPath       = "/var/lib/nvml-mock/driver/dev"
-	defaultOptOutAnnotation     = "nvml-mock.nvidia.com/inject"
-	defaultDeviceAnnotation     = "nvml-mock.nvidia.com/devices"
+	defaultHostOverlayPath       = "/var/lib/nvml-mock"
+	defaultContainerOverlayPath  = "/opt/nvml-mock"
+	defaultDeviceHostPath        = "/var/lib/nvml-mock/driver/dev"
+	defaultOptOutAnnotation      = "nvml-mock.nvidia.com/inject"
+	defaultDeviceAnnotation      = "nvml-mock.nvidia.com/devices"
+	defaultImexChannelAnnotation = "nvml-mock.nvidia.com/imex-channels"
+	// defaultImexChannelRelPath is where setup.sh mknod's the mock IMEX channel
+	// device nodes inside the overlay tree, resolved relative to the host
+	// overlay path. The nested destination dir is fixed to the real kernel
+	// location (imexChannelContainerDir) inside the container.
+	defaultImexChannelRelPath = "driver/dev/nvidia-caps-imex-channels"
+	imexChannelContainerDir   = "/dev/nvidia-caps-imex-channels"
 	// defaultTopologyRelPath is where setup.sh stages the cluster-level
 	// ComputeDomain topology document inside the overlay tree. It is
 	// resolved relative to the host overlay path (for the existence
@@ -45,8 +52,14 @@ type Config struct {
 	DeviceHostPath       string
 	OptOutAnnotation     string
 	DeviceAnnotation     string
-	ExcludedNamespaces   []string
-	Shims                []string
+	// ImexChannelAnnotation is the pod annotation key whose value "true" opts a
+	// container into mock /dev/nvidia-caps-imex-channels/* device injection.
+	ImexChannelAnnotation string
+	// ImexChannelHostPath is the host directory containing the mock channel
+	// nodes (channel0..N-1), staged by the main nvml-mock DaemonSet's setup.sh.
+	ImexChannelHostPath string
+	ExcludedNamespaces  []string
+	Shims               []string
 
 	// NodeName is the Kubernetes node this plugin runs on. When set (and a
 	// topology document is staged in the overlay) it is injected as the
@@ -97,13 +110,15 @@ type Device struct {
 // DefaultConfig returns the overlay contract described by the NRI design.
 func DefaultConfig() Config {
 	return Config{
-		HostOverlayPath:      defaultHostOverlayPath,
-		ContainerOverlayPath: defaultContainerOverlayPath,
-		DeviceHostPath:       defaultDeviceHostPath,
-		OptOutAnnotation:     defaultOptOutAnnotation,
-		DeviceAnnotation:     defaultDeviceAnnotation,
-		ExcludedNamespaces:   []string{"kube-system"},
-		Shims:                append([]string(nil), defaultShims...),
+		HostOverlayPath:       defaultHostOverlayPath,
+		ContainerOverlayPath:  defaultContainerOverlayPath,
+		DeviceHostPath:        defaultDeviceHostPath,
+		OptOutAnnotation:      defaultOptOutAnnotation,
+		DeviceAnnotation:      defaultDeviceAnnotation,
+		ImexChannelAnnotation: defaultImexChannelAnnotation,
+		ImexChannelHostPath:   filepath.Join(defaultHostOverlayPath, defaultImexChannelRelPath),
+		ExcludedNamespaces:    []string{"kube-system"},
+		Shims:                 append([]string(nil), defaultShims...),
 	}
 }
 
@@ -140,6 +155,17 @@ func Adjust(cfg Config, container Container) (Adjustment, bool, error) {
 		}
 	}
 
+	if strings.EqualFold(container.PodAnnotations[cfg.ImexChannelAnnotation], "true") {
+		// Fail open like the device path above: channels are staged by the main
+		// DaemonSet's setup.sh, and nothing orders this plugin after it.
+		channels, err := discoverImexChannels(cfg.ImexChannelHostPath)
+		if err != nil {
+			warnf("imex channel injection requested but channel tree at %s is unavailable (%v); injecting without channels", cfg.ImexChannelHostPath, err)
+		} else {
+			adjustment.Devices = append(adjustment.Devices, channels...)
+		}
+	}
+
 	return adjustment, true, nil
 }
 
@@ -159,6 +185,12 @@ func withDefaults(cfg Config) Config {
 	}
 	if cfg.DeviceAnnotation == "" {
 		cfg.DeviceAnnotation = defaults.DeviceAnnotation
+	}
+	if cfg.ImexChannelAnnotation == "" {
+		cfg.ImexChannelAnnotation = defaults.ImexChannelAnnotation
+	}
+	if cfg.ImexChannelHostPath == "" {
+		cfg.ImexChannelHostPath = filepath.Join(cfg.HostOverlayPath, defaultImexChannelRelPath)
 	}
 	if len(cfg.Shims) == 0 {
 		cfg.Shims = defaults.Shims
@@ -305,6 +337,29 @@ func discoverDevices(deviceHostPath string) ([]Device, error) {
 		devices = append(devices, Device{
 			HostPath: filepath.Join(deviceHostPath, name),
 			Path:     filepath.Join("/dev", name),
+		})
+	}
+	sort.Slice(devices, func(i, j int) bool {
+		return devices[i].Path < devices[j].Path
+	})
+	return devices, nil
+}
+
+func discoverImexChannels(channelHostPath string) ([]Device, error) {
+	entries, err := os.ReadDir(channelHostPath)
+	if err != nil {
+		return nil, err
+	}
+
+	devices := make([]Device, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, "channel") {
+			continue
+		}
+		devices = append(devices, Device{
+			HostPath: filepath.Join(channelHostPath, name),
+			Path:     filepath.Join(imexChannelContainerDir, name),
 		})
 	}
 	sort.Slice(devices, func(i, j int) bool {

--- a/pkg/nri/nvmlmock/adjust_test.go
+++ b/pkg/nri/nvmlmock/adjust_test.go
@@ -240,6 +240,37 @@ func TestAdjustDeviceOptInAddsNvidiaDeviceEntries(t *testing.T) {
 	}, adjustment.Devices)
 }
 
+func TestDiscoverDevicesSkipsDirectories(t *testing.T) {
+	// setup.sh stages the IMEX channel nodes in a subdirectory
+	// (nvidia-caps-imex-channels) inside the device host path. Its name starts
+	// with "nvidia", so without an IsDir guard discoverDevices would emit a
+	// bogus device for the directory, which nriDevice later rejects as "not a
+	// character device". Ensure the directory is skipped.
+	deviceRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(deviceRoot, "nvidia0"), []byte{}, 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(deviceRoot, "nvidia-caps-imex-channels"), 0o755))
+
+	cfg := DefaultConfig()
+	cfg.DeviceHostPath = deviceRoot
+
+	adjustment, ok, err := Adjust(cfg, Container{
+		Namespace: "default",
+		PodAnnotations: map[string]string{
+			"nvml-mock.nvidia.com/devices": "true",
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.ElementsMatch(t, []Device{
+		{HostPath: filepath.Join(deviceRoot, "nvidia0"), Path: "/dev/nvidia0"},
+	}, adjustment.Devices)
+	require.NotContains(t, adjustment.Devices, Device{
+		HostPath: filepath.Join(deviceRoot, "nvidia-caps-imex-channels"),
+		Path:     "/dev/nvidia-caps-imex-channels",
+	})
+}
+
 func TestAdjustImexChannelsOptInAddsChannelDevices(t *testing.T) {
 	channelRoot := t.TempDir()
 	for _, name := range []string{"channel0", "channel1", "channel2", "not-a-channel"} {

--- a/pkg/nri/nvmlmock/adjust_test.go
+++ b/pkg/nri/nvmlmock/adjust_test.go
@@ -239,3 +239,94 @@ func TestAdjustDeviceOptInAddsNvidiaDeviceEntries(t *testing.T) {
 		{HostPath: filepath.Join(deviceRoot, "nvidia-uvm"), Path: "/dev/nvidia-uvm"},
 	}, adjustment.Devices)
 }
+
+func TestAdjustImexChannelsOptInAddsChannelDevices(t *testing.T) {
+	channelRoot := t.TempDir()
+	for _, name := range []string{"channel0", "channel1", "channel2", "not-a-channel"} {
+		require.NoError(t, os.WriteFile(filepath.Join(channelRoot, name), []byte{}, 0o644))
+	}
+
+	cfg := DefaultConfig()
+	cfg.ImexChannelHostPath = channelRoot
+
+	adjustment, ok, err := Adjust(cfg, Container{
+		Namespace: "default",
+		PodAnnotations: map[string]string{
+			"nvml-mock.nvidia.com/imex-channels": "true",
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.ElementsMatch(t, []Device{
+		{HostPath: filepath.Join(channelRoot, "channel0"), Path: "/dev/nvidia-caps-imex-channels/channel0"},
+		{HostPath: filepath.Join(channelRoot, "channel1"), Path: "/dev/nvidia-caps-imex-channels/channel1"},
+		{HostPath: filepath.Join(channelRoot, "channel2"), Path: "/dev/nvidia-caps-imex-channels/channel2"},
+	}, adjustment.Devices)
+}
+
+func TestAdjustImexChannelsNotRequestedInjectsNoChannels(t *testing.T) {
+	channelRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(channelRoot, "channel0"), []byte{}, 0o644))
+
+	cfg := DefaultConfig()
+	cfg.ImexChannelHostPath = channelRoot
+
+	adjustment, ok, err := Adjust(cfg, Container{Namespace: "default"})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Empty(t, adjustment.Devices)
+}
+
+func TestAdjustImexChannelsFailsOpenWhenTreeMissing(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.ImexChannelHostPath = filepath.Join(t.TempDir(), "does-not-exist")
+
+	adjustment, ok, err := Adjust(cfg, Container{
+		Namespace: "default",
+		PodAnnotations: map[string]string{
+			"nvml-mock.nvidia.com/imex-channels": "true",
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Empty(t, adjustment.Devices)
+	require.Contains(t, adjustment.Mounts, Mount{
+		Source:      "/var/lib/nvml-mock",
+		Destination: "/opt/nvml-mock",
+		Type:        "bind",
+		Options:     []string{"rbind", "ro", "nosuid", "nodev"},
+	})
+}
+
+func TestAdjustDevicesAndImexChannelsAreAdditive(t *testing.T) {
+	deviceRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(deviceRoot, "nvidia0"), []byte{}, 0o644))
+	channelRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(channelRoot, "channel0"), []byte{}, 0o644))
+
+	cfg := DefaultConfig()
+	cfg.DeviceHostPath = deviceRoot
+	cfg.ImexChannelHostPath = channelRoot
+
+	adjustment, ok, err := Adjust(cfg, Container{
+		Namespace: "default",
+		PodAnnotations: map[string]string{
+			"nvml-mock.nvidia.com/devices":       "true",
+			"nvml-mock.nvidia.com/imex-channels": "true",
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.ElementsMatch(t, []Device{
+		{HostPath: filepath.Join(deviceRoot, "nvidia0"), Path: "/dev/nvidia0"},
+		{HostPath: filepath.Join(channelRoot, "channel0"), Path: "/dev/nvidia-caps-imex-channels/channel0"},
+	}, adjustment.Devices)
+}
+
+func TestDefaultConfigSetsImexChannelDefaults(t *testing.T) {
+	cfg := DefaultConfig()
+	require.Equal(t, "nvml-mock.nvidia.com/imex-channels", cfg.ImexChannelAnnotation)
+	require.Equal(t, "/var/lib/nvml-mock/driver/dev/nvidia-caps-imex-channels", cfg.ImexChannelHostPath)
+}

--- a/tests/e2e/go/assets/assets.go
+++ b/tests/e2e/go/assets/assets.go
@@ -33,6 +33,9 @@ var DevicePluginManifest []byte
 //go:embed nri-gpu-agent.yaml
 var NRIGpuAgentManifest []byte
 
+//go:embed imex-workload.yaml
+var ImexWorkloadManifest []byte
+
 //go:embed gpu-operator-values.yaml
 var GPUOperatorValues []byte
 

--- a/tests/e2e/go/assets/imex-workload.yaml
+++ b/tests/e2e/go/assets/imex-workload.yaml
@@ -25,7 +25,7 @@ spec:
         nvidia.com/gpu.present: "true"
       containers:
         - name: agent
-          image: debian:bookworm-slim
+          image: ubuntu:24.04
           command:
             - /bin/sh
             - -c

--- a/tests/e2e/go/assets/imex-workload.yaml
+++ b/tests/e2e/go/assets/imex-workload.yaml
@@ -1,0 +1,48 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# e2e workload for the imex scenario: ordinary pod (no nvidia.com/gpu request,
+# no volumes, no MOCK_* env) annotated to opt into NRI IMEX channel injection.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: imex-agent
+  labels:
+    app: imex-agent
+spec:
+  selector:
+    matchLabels:
+      app: imex-agent
+  template:
+    metadata:
+      labels:
+        app: imex-agent
+      annotations:
+        nvml-mock.nvidia.com/imex-channels: "true"
+    spec:
+      automountServiceAccountToken: false
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      containers:
+        - name: agent
+          image: debian:bookworm-slim
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              test -d /opt/nvml-mock
+              ls -1 /dev/nvidia-caps-imex-channels
+              while true; do sleep 300; done
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi

--- a/tests/e2e/go/scenario_imex_test.go
+++ b/tests/e2e/go/scenario_imex_test.go
@@ -38,7 +38,13 @@ const (
 // device nodes on every worker, with consistent ComputeDomain identity. The
 // real nvidia-imex domain-status check is demo-only (see docs/demo/nri-imex),
 // so it is intentionally absent here to keep e2e hermetic.
-var _ = Describe("nvml-mock NRI IMEX channel injection", Label("imex"), Ordered, func() {
+//
+// This scenario depends on the NRI plugin (it installs with nri.enabled=true on
+// an NRI-enabled Kind cluster), so it carries the shared "nri" label: the
+// default `make e2e` filter excludes it via `!nri`, and it runs only when NRI is
+// enabled (`make e2e-nri` / --label-filter=nri). The "imex" label still selects
+// it on its own (--label-filter=imex).
+var _ = Describe("nvml-mock NRI IMEX channel injection", Label("imex", "nri"), Ordered, func() {
 	var (
 		h          *harness.Harness
 		workers    []cluster.Node

--- a/tests/e2e/go/scenario_imex_test.go
+++ b/tests/e2e/go/scenario_imex_test.go
@@ -84,7 +84,7 @@ var _ = Describe("nvml-mock NRI IMEX channel injection", Label("imex", "nri"), O
 				if !p.HasFabric() {
 					Skip("profile " + name + " declares no device_defaults.fabric block")
 				}
-				assertNodeCliqueIdentities(ctx, h, workers)
+				assertNodeCliqueIdentities(ctx, h, imexWorkloadNS, imexAgentSelector, workers)
 			})
 		})
 	}
@@ -146,8 +146,8 @@ func assertWorkloadSeesImexChannels(ctx context.Context, h *harness.Harness, wor
 	}
 }
 
-// agentPodOnNode generalizes nriAgentPodOnNode with namespace + selector
-// parameters so multiple scenarios can locate their per-node agent pod.
+// agentPodOnNode locates a running agent pod on the given node by namespace and
+// label selector, so multiple scenarios (gpu-agent, imex-agent) can share it.
 func agentPodOnNode(ctx context.Context, h *harness.Harness, ns, selector, node string) kube.PodRef {
 	GinkgoHelper()
 	var name string

--- a/tests/e2e/go/scenario_imex_test.go
+++ b/tests/e2e/go/scenario_imex_test.go
@@ -1,0 +1,177 @@
+//go:build e2e
+
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/assertions"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/assets"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/cluster"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/config"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/harness"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/helm"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/kube"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/profile"
+)
+
+const (
+	imexClusterName    = "nvml-mock-imex"
+	imexWorkloadNS     = "default"
+	imexAgentDaemonSet = "imex-agent"
+	imexAgentSelector  = "app=imex-agent"
+	imexChannelCount   = 16
+	imexChannelDir     = "/dev/nvidia-caps-imex-channels"
+)
+
+// Proves mock IMEX channel injection over NRI: a plain workload annotated
+// nvml-mock.nvidia.com/imex-channels="true" sees imexChannelCount channel
+// device nodes on every worker, with consistent ComputeDomain identity. The
+// real nvidia-imex domain-status check is demo-only (see docs/demo/nri-imex),
+// so it is intentionally absent here to keep e2e hermetic.
+var _ = Describe("nvml-mock NRI IMEX channel injection", Label("imex"), Ordered, func() {
+	var (
+		h          *harness.Harness
+		workers    []cluster.Node
+		topoValues string
+	)
+	selectedProfiles := config.SelectedProfileNames()
+
+	BeforeAll(func(ctx SpecContext) {
+		h = setupCluster(ctx, imexClusterName, assets.KindNRIConfig, "imex")
+		var err error
+		workers, err = h.Cluster.Workers(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(workers)).To(BeNumerically(">=", 2),
+			"imex scenario needs >= 2 Kind workers, found %d", len(workers))
+		topoValues = writeNRITopologyValues(workers)
+		DeferCleanup(func() { _ = os.Remove(topoValues) })
+	})
+
+	for _, name := range selectedProfiles {
+		name := name
+		Context("profile "+name, Label(name), Ordered, func() {
+			var p profile.Profile
+
+			BeforeAll(func(ctx SpecContext) {
+				p = loadProfile(name)
+				installImexChart(ctx, h, p, topoValues, p.HasFabric())
+				assertions.WaitDaemonSetReady(ctx, h.Kube, nvmlMockNamespace, "nvml-mock", config.ReadyTimeout(), config.PollInterval())
+				assertions.WaitDaemonSetReady(ctx, h.Kube, nvmlMockNamespace, nriNRIDaemonSet, config.ReadyTimeout(), config.PollInterval())
+				deployImexAgent(ctx, h)
+			})
+
+			It("injects IMEX channel device nodes on every worker", Label("imex-channels"), func(ctx SpecContext) {
+				assertWorkloadSeesImexChannels(ctx, h, workers, imexChannelCount)
+			})
+
+			It("carries consistent ComputeDomain identity across nodes", Label("compute-domain"), func(ctx SpecContext) {
+				if !p.HasFabric() {
+					Skip("profile " + name + " declares no device_defaults.fabric block")
+				}
+				assertNodeCliqueIdentities(ctx, h, workers)
+			})
+		})
+	}
+})
+
+// installImexChart installs nvml-mock with NRI + IMEX channels enabled.
+func installImexChart(ctx context.Context, h *harness.Harness, p profile.Profile, topoValues string, withComputeDomain bool) {
+	GinkgoHelper()
+	repo, tag := splitImage(config.Image())
+	rel := helmReleaseForImex(p, repo, tag)
+	if withComputeDomain {
+		rel.ValuesFiles = []string{topoValues}
+	}
+	By("helm upgrade --install nvml-mock with NRI + imexChannels (profile=" + p.Name + ")")
+	Expect(h.Helm.UpgradeInstall(ctx, rel)).To(Succeed(), "helm upgrade --install nvml-mock imex (profile=%s)", p.Name)
+}
+
+// helmReleaseForImex mirrors installNRIChart's release struct but adds the
+// imexChannels.count override that enables mock IMEX channel injection.
+func helmReleaseForImex(p profile.Profile, repo, tag string) helm.Release {
+	return helm.Release{
+		Name:            "nvml-mock",
+		Chart:           chartDir(),
+		Namespace:       nvmlMockNamespace,
+		CreateNamespace: true,
+		HideOutput:      true,
+		Set: map[string]string{
+			"gpu.count":          strconv.Itoa(p.ExpectedGPUs()),
+			"gpu.profile":        p.Name,
+			"image.repository":   repo,
+			"image.tag":          tag,
+			"nri.enabled":        "true",
+			"imexChannels.count": strconv.Itoa(imexChannelCount),
+		},
+		Wait:    true,
+		Timeout: config.HelmTimeout(),
+	}
+}
+
+// deployImexAgent (re)creates the annotated workload AFTER overlay staging, so
+// NRI (which only injects at container-creation time) sees the staged channels.
+func deployImexAgent(ctx context.Context, h *harness.Harness) {
+	GinkgoHelper()
+	Expect(h.Kube.Delete(ctx, assets.ImexWorkloadManifest)).To(Succeed(), "delete previous imex-agent DaemonSet")
+	Expect(h.Kube.Apply(ctx, assets.ImexWorkloadManifest)).To(Succeed(), "apply imex-agent DaemonSet")
+	assertions.WaitDaemonSetReady(ctx, h.Kube, imexWorkloadNS, imexAgentDaemonSet, config.ReadyTimeout(), config.PollInterval())
+}
+
+// assertWorkloadSeesImexChannels execs `ls` in the agent pod on each worker and
+// asserts exactly expected channel device nodes are present.
+func assertWorkloadSeesImexChannels(ctx context.Context, h *harness.Harness, workers []cluster.Node, expected int) {
+	GinkgoHelper()
+	for _, w := range workers {
+		pod := agentPodOnNode(ctx, h, imexWorkloadNS, imexAgentSelector, w.Name)
+		res, err := h.Kube.ExecSh(ctx, pod, "ls -1 "+imexChannelDir)
+		Expect(err).NotTo(HaveOccurred(), "ls %s on %s: %s", imexChannelDir, w.Name, res.Combined())
+		Expect(countChannelLines(res.Combined())).To(Equal(expected),
+			"%s: expected %d IMEX channels\n%s", w.Name, expected, strings.TrimSpace(res.Combined()))
+	}
+}
+
+// agentPodOnNode generalizes nriAgentPodOnNode with namespace + selector
+// parameters so multiple scenarios can locate their per-node agent pod.
+func agentPodOnNode(ctx context.Context, h *harness.Harness, ns, selector, node string) kube.PodRef {
+	GinkgoHelper()
+	var name string
+	Eventually(func() (string, error) {
+		pods, err := h.Kube.RunningPodNames(ctx, ns, selector)
+		if err != nil {
+			return "", err
+		}
+		for _, pod := range pods {
+			podNode, err := h.Kube.PodNode(ctx, ns, pod)
+			if err != nil {
+				return "", err
+			}
+			if podNode == node {
+				name = pod
+				return name, nil
+			}
+		}
+		return "", nil
+	}).WithContext(ctx).WithTimeout(config.ReadyTimeout()).WithPolling(config.PollInterval()).
+		ShouldNot(BeEmpty(), "no running %s pod on node %s", selector, node)
+	return kube.PodRef{Namespace: ns, Pod: name}
+}
+
+func countChannelLines(out string) int {
+	count := 0
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "channel") {
+			count++
+		}
+	}
+	return count
+}

--- a/tests/e2e/go/scenario_nri_test.go
+++ b/tests/e2e/go/scenario_nri_test.go
@@ -100,7 +100,7 @@ var _ = Describe("nvml-mock node-wide NRI injection", Label("nri"), Ordered, fun
 				if !computeDomain {
 					Skip("profile " + name + " declares no device_defaults.fabric block; ComputeDomain identity is unsupported")
 				}
-				assertNodeCliqueIdentities(ctx, h, workers)
+				assertNodeCliqueIdentities(ctx, h, nriWorkloadNS, nriAgentSelector, workers)
 			})
 		})
 	}
@@ -171,15 +171,17 @@ func assertAgentSeesGPUs(ctx context.Context, h *harness.Harness, expectedGPUs i
 }
 
 // assertNodeCliqueIdentities runs the staged `check-fabric` consumer inside the
-// gpu-agent pod on every worker and asserts each node reports the clique /
-// cluster UUID the topology overlay assigned to it — with no nvidia.com/gpu
-// request and no MOCK_* env in the pod spec (identity comes only from NRI).
-func assertNodeCliqueIdentities(ctx context.Context, h *harness.Harness, workers []cluster.Node) {
+// agent pod (identified by ns/selector) on every worker and asserts each node
+// reports the clique / cluster UUID the topology overlay assigned to it — with
+// no nvidia.com/gpu request and no MOCK_* env in the pod spec (identity comes
+// only from NRI). ns/selector are parameterized so both the node-wide (gpu-agent)
+// and IMEX (imex-agent) scenarios can share this assertion.
+func assertNodeCliqueIdentities(ctx context.Context, h *harness.Harness, ns, selector string, workers []cluster.Node) {
 	GinkgoHelper()
 	cliqueByNode := nriCliqueByNode(workers)
 	for _, w := range workers {
 		expected := cliqueByNode[w.Name]
-		pod := nriAgentPodOnNode(ctx, h, w.Name)
+		pod := agentPodOnNode(ctx, h, ns, selector, w.Name)
 		res, err := h.Kube.ExecSh(ctx, pod, "check-fabric 2>&1")
 		Expect(err).NotTo(HaveOccurred(), "check-fabric on %s: %s", w.Name, res.Combined())
 		out := res.Combined()
@@ -202,30 +204,6 @@ func firstNRIAgentPod(ctx context.Context, h *harness.Harness) kube.PodRef {
 		return name, nil
 	}).WithContext(ctx).WithTimeout(config.ReadyTimeout()).WithPolling(config.PollInterval()).
 		ShouldNot(BeEmpty(), "no running gpu-agent pod found")
-	return kube.PodRef{Namespace: nriWorkloadNS, Pod: name}
-}
-
-func nriAgentPodOnNode(ctx context.Context, h *harness.Harness, node string) kube.PodRef {
-	GinkgoHelper()
-	var name string
-	Eventually(func() (string, error) {
-		pods, err := h.Kube.RunningPodNames(ctx, nriWorkloadNS, nriAgentSelector)
-		if err != nil {
-			return "", err
-		}
-		for _, pod := range pods {
-			podNode, err := h.Kube.PodNode(ctx, nriWorkloadNS, pod)
-			if err != nil {
-				return "", err
-			}
-			if podNode == node {
-				name = pod
-				return name, nil
-			}
-		}
-		return "", nil
-	}).WithContext(ctx).WithTimeout(config.ReadyTimeout()).WithPolling(config.PollInterval()).
-		ShouldNot(BeEmpty(), "no running gpu-agent pod on node %s", node)
 	return kube.PodRef{Namespace: nriWorkloadNS, Pod: name}
 }
 


### PR DESCRIPTION
## What This PR Does

Adds mock IMEX channel device-node injection to the existing `nvml-mock` NRI plugin, so opt-in containers see `/dev/nvidia-caps-imex-channels/channel0..N-1` on Kind nodes without real GPUs. Closes #437.

- **NRI plugin** (`pkg/nri/nvmlmock/adjust.go`): annotation-gated, fail-open discovery/injection of channel nodes as `LinuxDevice` entries. Opt-in via pod annotation `nvml-mock.nvidia.com/imex-channels: "true"`; additive to the existing `/dev/nvidia*` device injection; missing/unreadable tree fails open (container still starts).
- **Plugin flags** (`cmd/nvml-mock-nri`): `--imex-channel-annotation`, `--imex-channel-host-path` (+ matching env).
- **Host provisioning** (`deployments/nvml-mock/scripts/setup.sh`): `mknod`s presence-only channel nodes, driven by new env.
- **Helm** (`nvml-mock` chart): `imexChannels` values (`count: 16`, `major: 240`), main-DaemonSet env, NRI args, helm-unittest coverage (+ regenerated snapshot).
- **Demo** (`docs/demo/nri-imex/`): dedicated 2-node ComputeDomain demo proving channels are injected and the real `nvidia-imex` domain is healthy.
- **E2E** (`tests/e2e/go/scenario_imex_test.go`): dedicated `Label("imex")` scenario asserting each worker sees the expected channel count with consistent ComputeDomain identity.

**Limitation:** channels are presence-only — statable/listable but not openable (`open()` → `ENXIO`), consistent with the other mock device nodes. Documented in the demo README and chart values. The real `nvidia-imex` domain-status check is demo-only (kept out of e2e for speed/hermeticity).

## Why

Issue #437 asks for an IMEX mock built on the NRI foundation. This reuses the real `nvidia-imex --nogpu` daemon already in the stack and focuses the mock on channel-node injection, matching existing `nvml-mock` patterns (annotation opt-in, overlay host path, Helm-configured counts).

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`go test -v -race ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] New code has SPDX license headers
- [x] Documentation updated (demo + README index)
- [x] CHANGELOG.md updated

## Test plan

- [x] `go test -race ./...` (excl. vendor) green
- [x] `golangci-lint run` — 0 issues
- [x] `helm unittest deployments/nvml-mock/helm/nvml-mock` — 127/127
- [x] `go test -tags e2e -c ./tests/e2e/go/` compiles
- [ ] E2E `Label("imex")` run on a Kind cluster (CI)
- [ ] Manual demo run: `cd docs/demo/nri-imex && ./run.sh`

pod logs
```
[imex-workload] node=nvml-mock-nri-imex-worker verifying NRI channel injection
=== /dev/nvidia-caps-imex-channels ===
channel0
channel1
channel10
channel11
channel12
channel13
channel14
channel15
channel2
channel3
channel4
channel5
channel6
channel7
channel8
channel9
=== check-fabric (ComputeDomain identity via NRI) ===
Discovered 8 GPU(s)
GPU 0 (GPU-b200b200-0000-0000-0000-000000000000)
  clusterUuid : 00000000-0000-0000-0000-0000000000ce
  cliqueId    : 0
  state       : completed (3)
GPU 1 (GPU-b200b200-0000-0000-0000-000000000001)
  clusterUuid : 00000000-0000-0000-0000-0000000000ce
  cliqueId    : 0
  state       : completed (3)
  ...
  ```