### PR TITLE
test(e2e): add Ginkgo skipped-spec summary report

### DIFF
--- a/tests/e2e/go/report_skips_test.go
+++ b/tests/e2e/go/report_skips_test.go
@@ -1,0 +1,50 @@
+//go:build e2e
+
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+// ReportAfterSuite prints a single, easy-to-find summary of every skipped spec
+// and its reason. Ginkgo scatters per-spec `S` markers through the verbose
+// multi-profile log; this consolidates them so it is obvious at a glance what
+// was skipped and why. It is purely informational and never fails the suite.
+var _ = ReportAfterSuite("skipped specs summary", func(report Report) {
+	// ReportAfterSuite runs once, but guard anyway so parallel runners never
+	// emit the block twice.
+	if GinkgoParallelProcess() != 1 {
+		return
+	}
+
+	var lines []string
+	for _, spec := range report.SpecReports {
+		if spec.State != types.SpecStateSkipped {
+			continue
+		}
+		reason := strings.TrimSpace(spec.Failure.Message)
+		if reason == "" {
+			reason = "(filtered: did not match label filter)"
+		}
+		lines = append(lines, fmt.Sprintf("- %s\n    reason: %s", spec.FullText(), reason))
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "\n========== SKIPPED SPECS (%d) ==========\n", len(lines))
+	if len(lines) == 0 {
+		b.WriteString("No specs skipped.\n")
+	} else {
+		b.WriteString(strings.Join(lines, "\n"))
+		b.WriteString("\n")
+	}
+	b.WriteString("=======================================\n")
+
+	fmt.Fprint(GinkgoWriter, b.String())
+})

--- a/tests/e2e/go/report_skips_test.go
+++ b/tests/e2e/go/report_skips_test.go
@@ -24,6 +24,13 @@ var _ = ReportAfterSuite("skipped specs summary", func(report Report) {
 		return
 	}
 
+	// A skipped spec with an empty Failure.Message was not skipped via a
+	// programmatic Skip("..."); it could be a label-filter/focus/skip-string
+	// exclusion, a suite-wide skip, an interrupt, or a deadline. We cannot tell
+	// these apart per spec, so fall back to a cause-neutral marker that only
+	// names the filters actually configured for this run.
+	fallback := emptySkipReason(report.SuiteConfig)
+
 	var lines []string
 	for _, spec := range report.SpecReports {
 		if spec.State != types.SpecStateSkipped {
@@ -31,7 +38,7 @@ var _ = ReportAfterSuite("skipped specs summary", func(report Report) {
 		}
 		reason := strings.TrimSpace(spec.Failure.Message)
 		if reason == "" {
-			reason = "(filtered: did not match label filter)"
+			reason = fallback
 		}
 		lines = append(lines, fmt.Sprintf("- %s\n    reason: %s", spec.FullText(), reason))
 	}
@@ -48,3 +55,24 @@ var _ = ReportAfterSuite("skipped specs summary", func(report Report) {
 
 	fmt.Fprint(GinkgoWriter, b.String())
 })
+
+// emptySkipReason returns a cause-neutral marker for skipped specs that carry no
+// Failure.Message. Such skips have no per-spec reason we can recover, so we only
+// hint at the filters actually configured for this run rather than asserting a
+// single cause.
+func emptySkipReason(cfg types.SuiteConfig) string {
+	var filters []string
+	if strings.TrimSpace(cfg.LabelFilter) != "" {
+		filters = append(filters, fmt.Sprintf("label-filter %q", cfg.LabelFilter))
+	}
+	if len(cfg.FocusStrings) > 0 {
+		filters = append(filters, fmt.Sprintf("focus %v", cfg.FocusStrings))
+	}
+	if len(cfg.SkipStrings) > 0 {
+		filters = append(filters, fmt.Sprintf("skip %v", cfg.SkipStrings))
+	}
+	if len(filters) == 0 {
+		return "(no skip reason reported)"
+	}
+	return fmt.Sprintf("(no skip reason reported; possibly excluded by %s)", strings.Join(filters, ", "))
+}


### PR DESCRIPTION
## Summary

- Adds a `ReportAfterSuite("skipped specs summary", ...)` node to the Go/Ginkgo e2e suite that prints one consolidated, easy-to-find block at the end of a run listing every skipped spec and its reason.
- Programmatic `Skip("...")` reasons are read from `Failure.Message`; specs excluded by `--label-filter`/focus get a distinct `(filtered: did not match label filter)` marker so the two buckets are visually separable.
- Always prints the block (shows `No specs skipped.` when none), emits only on parallel process 1, and is purely informational — it never fails the suite.

Motivation: under `-v` multi-profile output the per-spec `S` markers scatter through a long log, making it hard to see at a glance what was skipped and why (IB disabled per profile, no `device_defaults.fabric` block, the `E2E_RUN_NGC` validator gate, label-filter exclusions).

Example output:

```
========== SKIPPED SPECS (2) ==========
- ... nvidia-smi ... [profile a100]
    reason: IB disabled for profile a100
- ... validator scenario
    reason: set E2E_RUN_NGC=true to run nvcr.io-backed validator scenario; see #446
=======================================
```

## Test plan

- [x] `go vet -tags e2e ./tests/e2e/go`
- [x] `ginkgo --tags e2e --dry-run ./tests/e2e/go` (suite compiles and outlines, 26/26 specs)
- [ ] Full `make e2e E2E_PROFILES=a100` run to confirm the block renders with real skip reasons (requires Kind/Docker)