### PR TITLE
chore(deps): bump github/codeql-action from 4.37.1 to 4.37.3

### DIFF
--- a/.github/workflows/code_scanning.yaml
+++ b/.github/workflows/code_scanning.yaml
@@ -40,7 +40,7 @@ jobs:
           go-version: ${{ inputs.golang_version }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: go
 
@@ -48,6 +48,6 @@ jobs:
         run: go mod download
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:go"

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -33,6 +33,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Consolidates dependabot PRs #483, #484 and #485 into a single bump, same pattern as #455.

- `github/codeql-action/init` 4.37.1 -> 4.37.3 (`code_scanning.yaml`)
- `github/codeql-action/analyze` 4.37.1 -> 4.37.3 (`code_scanning.yaml`)
- `github/codeql-action/upload-sarif` 4.37.1 -> 4.37.3 (`scorecard.yaml`)

The new pin `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` was verified to be the commit the annotated `v4.37.3` tag in github/codeql-action dereferences to.

Workflow-only change, no Go code touched. No breaking changes.

Supersedes #483, #484, #485.
