### PR TITLE
feat(nvml-mock): inject NVLink DL errors via nvml-mock-ctl nvlink-error

### DIFF
--- a/cmd/nvml-mock-ctl/main.go
+++ b/cmd/nvml-mock-ctl/main.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"golang.org/x/sys/unix"
 
@@ -38,6 +39,11 @@ const (
 	// this generous cap keeps watts*1000 far under the uint32 milliwatt ceiling
 	// (~4.29e6 W) so the schema-field conversion can never overflow.
 	maxPowerWatts = 100000
+
+	// maxNvlinkErrorRate bounds the `nvlink-error` command (errors/second). A
+	// degrading NVLink tops out well below this; the generous cap keeps the
+	// accrual math (rate * elapsed seconds) far from overflowing uint64.
+	maxNvlinkErrorRate = 1e9
 )
 
 func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
@@ -61,6 +67,7 @@ commands:
   clocks --gpu <idx|all|uuid> <mhz>        pin reported SM + graphics clocks
   throttle --gpu <idx|all|uuid> <reason>[ reason ...]  set active throttle reasons ('none' clears)
   pstate --gpu <idx|all|uuid> <0-15>       pin reported performance state (P-state)
+  nvlink-error --gpu <idx|all|uuid> <errors_per_sec> [--links a,b,c]  inject NVLink DL errors (0 heals)
   set    --gpu <idx|all|uuid> key.path=value [key.path=value ...]
   status [--gpu <idx>]
   reset  [--gpu <idx|all|uuid>]
@@ -72,7 +79,7 @@ global flags:
 }
 
 func run(args []string, stdout, stderr io.Writer) int {
-	var configOverridePath, configPath, gpu, mode string
+	var configOverridePath, configPath, gpu, mode, links string
 	var afterCalls int
 	var xid uint64
 	fs := flag.NewFlagSet("nvml-mock-ctl", flag.ContinueOnError)
@@ -84,6 +91,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	fs.StringVar(&mode, "mode", "", "failure mode (fail command)")
 	fs.IntVar(&afterCalls, "after-calls", 0, "trip after N guarded calls (fail)")
 	fs.Uint64Var(&xid, "xid", 0, "Xid code to surface (fail)")
+	fs.StringVar(&links, "links", "", "comma-separated NVLink ids for nvlink-error (default: all active links)")
 
 	// Global flags may appear before or after the subcommand, interspersed
 	// with the command's positional key.path=value args. The stdlib flag
@@ -128,8 +136,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 	case "status":
 		return doStatus(configOverridePath, gpu, stdout, stderr)
 	case "fail", "temp", "temperature", "power", "fan", "util", "utilization",
-		"clocks", "throttle", "pstate", "set", "reset":
-		return mutate(cmd, configOverridePath, gpu, mode, afterCalls, xid, positional, cfg, base, stdout, stderr)
+		"clocks", "throttle", "pstate", "nvlink-error", "set", "reset":
+		return mutate(cmd, configOverridePath, gpu, mode, links, afterCalls, xid, positional, cfg, base, stdout, stderr)
 	default:
 		fprintf(stderr, "unknown command %q\n", cmd)
 		usage(stderr)
@@ -137,7 +145,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	}
 }
 
-func mutate(cmd, configOverridePath, gpu, mode string, afterCalls int, xid uint64,
+func mutate(cmd, configOverridePath, gpu, mode, links string, afterCalls int, xid uint64,
 	positional []string, cfg *engine.Config, base *engine.DeviceConfig, stdout, stderr io.Writer) int {
 
 	if gpu == "" && cmd != "reset" {
@@ -251,6 +259,20 @@ func mutate(cmd, configOverridePath, gpu, mode string, afterCalls int, xid uint6
 		if code := applyPatch(doc, target, base, mockctl.PStatePatch(n), stderr); code != 0 {
 			return code
 		}
+	case "nvlink-error":
+		rate, perr := singleFloatArg(positional, cmd, 0, maxNvlinkErrorRate)
+		if perr != nil {
+			fprintf(stderr, "%v\n", perr)
+			return 2
+		}
+		linkIDs, perr := parseLinkIDs(links)
+		if perr != nil {
+			fprintf(stderr, "%v\n", perr)
+			return 2
+		}
+		if code := applyPatch(doc, target, base, mockctl.NVLinkErrorPatch(rate, linkIDs), stderr); code != 0 {
+			return code
+		}
 	case "set":
 		if len(positional) == 0 {
 			fprintln(stderr, "set requires at least one key.path=value")
@@ -331,6 +353,32 @@ func singleFloatArg(positional []string, name string, lo, hi float64) (float64, 
 		return 0, fmt.Errorf("%s value %v out of range [%v,%v]", name, v, lo, hi)
 	}
 	return v, nil
+}
+
+// parseLinkIDs parses the --links CSV (e.g. "0,3,7") into a sorted-as-given
+// slice of non-negative link ids. An empty string yields nil (inject on all
+// active links). Whitespace around entries is tolerated.
+func parseLinkIDs(csv string) ([]int, error) {
+	csv = strings.TrimSpace(csv)
+	if csv == "" {
+		return nil, nil
+	}
+	var out []int
+	for _, tok := range strings.Split(csv, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		v, err := strconv.Atoi(tok)
+		if err != nil {
+			return nil, fmt.Errorf("--links entry %q must be an integer", tok)
+		}
+		if v < 0 {
+			return nil, fmt.Errorf("--links entry %d must be non-negative", v)
+		}
+		out = append(out, v)
+	}
+	return out, nil
 }
 
 // baseFanCount reports the fan count declared by the base config so the fan

--- a/cmd/nvml-mock-ctl/main_test.go
+++ b/cmd/nvml-mock-ctl/main_test.go
@@ -122,23 +122,56 @@ func TestCLI_PStatePins(t *testing.T) {
 	require.Contains(t, readConfigOverride(t, configOverride), "performance_state: P8")
 }
 
+func TestCLI_NVLinkErrorWritesRate(t *testing.T) {
+	dir := t.TempDir()
+	configOverride := filepath.Join(dir, "overrides.yaml")
+	_, e, c := runCLI(t, configOverride, "nvlink-error", "--gpu", "0", "250")
+	require.Equalf(t, 0, c, "nvlink-error exited %d: %s", c, e)
+	s := readConfigOverride(t, configOverride)
+	require.Contains(t, s, "nvlink_error")
+	require.Contains(t, s, "rate: 250")
+}
+
+func TestCLI_NVLinkErrorWithLinks(t *testing.T) {
+	dir := t.TempDir()
+	configOverride := filepath.Join(dir, "overrides.yaml")
+	_, e, c := runCLI(t, configOverride, "nvlink-error", "--gpu", "1", "--links", "0,3,7", "100")
+	require.Equalf(t, 0, c, "nvlink-error exited %d: %s", c, e)
+	s := readConfigOverride(t, configOverride)
+	for _, want := range []string{"rate: 100", "- 0", "- 3", "- 7"} {
+		require.Containsf(t, s, want, "configOverride missing %q", want)
+	}
+}
+
+func TestCLI_NVLinkErrorZeroHeals(t *testing.T) {
+	dir := t.TempDir()
+	configOverride := filepath.Join(dir, "overrides.yaml")
+	_, e, c := runCLI(t, configOverride, "nvlink-error", "--gpu", "0", "0")
+	require.Equalf(t, 0, c, "nvlink-error exited %d: %s", c, e)
+	require.Contains(t, readConfigOverride(t, configOverride), "rate: 0")
+}
+
 func TestCLI_ConvenienceArgValidation(t *testing.T) {
 	dir := t.TempDir()
 	configOverride := filepath.Join(dir, "overrides.yaml")
 	cases := [][]string{
-		{"temp", "--gpu", "0"},                        // missing value
-		{"temp", "--gpu", "0", "hot"},                 // non-integer
-		{"fan", "--gpu", "0", "150"},                  // out of range
-		{"power", "--gpu", "0", "--", "-5"},           // negative watts (-- so it reaches the guard, not flag.Parse)
-		{"power", "--gpu", "0", "NaN"},                // non-finite watts
-		{"power", "--gpu", "0", "Inf"},                // non-finite watts
-		{"power", "--gpu", "0", "10000000"},           // watts overflow guard
-		{"power", "--gpu", "0", "1", "2"},             // too many values
-		{"util", "--gpu", "0", "150"},                 // out of range
-		{"pstate", "--gpu", "0", "16"},                // out of range
-		{"throttle", "--gpu", "0"},                    // missing reason
-		{"throttle", "--gpu", "0", "nope"},            // unknown reason
-		{"throttle", "--gpu", "0", "none", "thermal"}, // none + reason
+		{"temp", "--gpu", "0"},                              // missing value
+		{"temp", "--gpu", "0", "hot"},                       // non-integer
+		{"fan", "--gpu", "0", "150"},                        // out of range
+		{"power", "--gpu", "0", "--", "-5"},                 // negative watts (-- so it reaches the guard, not flag.Parse)
+		{"power", "--gpu", "0", "NaN"},                      // non-finite watts
+		{"power", "--gpu", "0", "Inf"},                      // non-finite watts
+		{"power", "--gpu", "0", "10000000"},                 // watts overflow guard
+		{"power", "--gpu", "0", "1", "2"},                   // too many values
+		{"util", "--gpu", "0", "150"},                       // out of range
+		{"pstate", "--gpu", "0", "16"},                      // out of range
+		{"throttle", "--gpu", "0"},                          // missing reason
+		{"throttle", "--gpu", "0", "nope"},                  // unknown reason
+		{"throttle", "--gpu", "0", "none", "thermal"},       // none + reason
+		{"nvlink-error", "--gpu", "0"},                      // missing rate
+		{"nvlink-error", "--gpu", "0", "-5"},                // negative rate (flag.Parse stops at -5 -> missing value)
+		{"nvlink-error", "--gpu", "0", "2000000000"},        // rate over cap
+		{"nvlink-error", "--gpu", "0", "--links", "x", "1"}, // non-integer link id
 	}
 	for _, args := range cases {
 		_, _, code := runCLI(t, configOverride, args...)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -357,6 +357,27 @@ nvlink:
       remote_pci_bus_id: "0000:0F:00.0"
 ```
 
+### NVLink error injection (per device)
+
+A device can be given a rising NVLink DL error rate on its switch links, so its
+uplinks report climbing replay/recovery/CRC errors — the GPU-side signal DCGM's
+`DCGM_HEALTH_WATCH_NVLINK` reads (→ `DCGM_FR_NVLINK_*`). Set it in a device
+override, or at runtime with [`nvml-mock-ctl nvlink-error`](nvml-mock-ctl.md#nvlink-error--inject-nvlink-dl-errors-on-switch-links):
+
+```yaml
+devices:
+  - index: 0
+    nvlink_error:
+      rate: 250        # errors/second added on top of the healthy baseline
+      links: [0, 1, 2] # optional; omit to inject on all active links
+```
+
+The count accrues monotonically off the shared counter epoch (same model as
+`nvlink.defaults.error_rate`); `rate: 0` (or omitting the block) is healthy. This
+is deliberately *not* an "NVSwitch entity health" knob — DCGM's NVSwitch/SXID
+health is NSCQ/kernel-log sourced and cannot be driven from a `libnvidia-ml.so`
+mock.
+
 ## Available GPU Profiles
 
 Standalone configuration files are provided for each supported GPU model:

--- a/docs/nvml-mock-ctl.md
+++ b/docs/nvml-mock-ctl.md
@@ -90,6 +90,7 @@ commands:
   clocks --gpu <idx|all|uuid> <mhz>        pin reported SM + graphics clocks
   throttle --gpu <idx|all|uuid> <reason>[ reason ...]  set active throttle reasons ('none' clears)
   pstate --gpu <idx|all|uuid> <0-15>       pin reported performance state (P-state)
+  nvlink-error --gpu <idx|all|uuid> <errors_per_sec> [--links a,b,c]  inject NVLink DL errors (0 heals)
   set    --gpu <idx|all|uuid> key.path=value [key.path=value ...]
   status [--gpu <idx>]
   reset  [--gpu <idx|all|uuid>]
@@ -188,6 +189,39 @@ configured:
 `reset` clears these overrides and returns the metric to the profile baseline
 (varying again, if the profile drives it dynamically). For anything these
 commands don't cover, use `set` below.
+
+### `nvlink-error` — inject NVLink DL errors on switch links
+
+Injects a per-link NVLink data-link error accrual on the target device's links
+to its NVSwitch, so the GPU's uplinks report *climbing* DL errors. The positional
+argument is the error **rate in errors/second** (0–1e9); `0` heals (no injection).
+
+```bash
+# ramp 250 NVLink errors/sec on every active link of GPU 0
+kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl nvlink-error --gpu 0 250
+# restrict to specific link ids
+kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl nvlink-error --gpu 0 250 --links 0,3,7
+# heal
+kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl nvlink-error --gpu 0 0
+```
+
+The count climbs monotonically off the shared counter epoch (the same accrual
+model as the profile's `nvlink.defaults.error_rate`), so consumers that sample
+over time see a *rising error rate* rather than a one-shot step. It surfaces on
+both the per-counter direct API (`nvmlDeviceGetNvLinkErrorCounter`) and the DL
+error field values (`NVML_FI_DEV_NVLINK_ERROR_DL_{REPLAY,RECOVERY,CRC}`, field
+ids 161–163, e.g. `dcgmi dmon -e 161,162,163`). Injection lands only on links the
+device actually has **active** — a nonexistent link is never conjured into an
+errored one — and `--links` (comma-separated ids) narrows it further; omit it to
+target all active links (the "GPU lost its switch uplinks" fault).
+
+> **Why this and not an "NVSwitch health" injection?** DCGM's NVSwitch entity
+> health (`DCGM_HEALTH_WATCH_NVSWITCH_*`) and SXID errors are sourced from NSCQ
+> (`libnvidia-nscq.so`) and kernel logs, **not** NVML, so a `libnvidia-ml.so`
+> mock cannot drive them. The GPU-side NVLink error surface this command feeds is
+> what DCGM's `DCGM_HEALTH_WATCH_NVLINK` reads (→ `DCGM_FR_NVLINK_*`), which is
+> the switch-link fault NVSentinel's gpu-health-monitor can actually detect and
+> remediate.
 
 ### `set` — set arbitrary fields
 

--- a/pkg/gpu/mockctl/config_override.go
+++ b/pkg/gpu/mockctl/config_override.go
@@ -223,6 +223,27 @@ func PStatePatch(n int) map[string]any {
 	return map[string]any{"performance_state": fmt.Sprintf("P%d", n)}
 }
 
+// NVLinkErrorPatch builds a config override patch that injects NVLink DL error
+// accrual on a device's links (nvlink_error block). rate is errors/second; a
+// rate of 0 heals the device by pinning the block to a no-op (the engine reads
+// rate<=0 as "no injection") without disturbing other overrides. links, when
+// non-empty, restricts injection to those link ids; nil injects on every active
+// link. The block is authoritative — it replaces any prior nvlink_error so a
+// stale link filter never lingers — matching the fail/throttle builders.
+func NVLinkErrorPatch(rate float64, links []int) map[string]any {
+	block := map[string]any{"rate": rate}
+	if len(links) > 0 {
+		// []any so the JSON round-trip in MergeDeviceConfig decodes cleanly
+		// into the []int schema field.
+		ls := make([]any, len(links))
+		for i, l := range links {
+			ls[i] = l
+		}
+		block["links"] = ls
+	}
+	return map[string]any{"nvlink_error": block}
+}
+
 // throttleReasonKeys maps CLI-friendly throttle reason names to the
 // clocks_throttle_reasons config field they enable. The canonical JSON keys are
 // accepted directly; short aliases cover the common thermal/power cases.

--- a/pkg/gpu/mockctl/config_override_test.go
+++ b/pkg/gpu/mockctl/config_override_test.go
@@ -171,6 +171,34 @@ func TestPStatePatch_FormatsPState(t *testing.T) {
 	require.Equal(t, "P12", merged.PerformanceState)
 }
 
+func TestNVLinkErrorPatch_MergesRateAndLinks(t *testing.T) {
+	patch := NVLinkErrorPatch(250, []int{0, 3, 7})
+	require.NoError(t, Validate(&engine.DeviceConfig{}, patch))
+	merged, err := engine.MergeDeviceConfig(&engine.DeviceConfig{}, patch)
+	require.NoError(t, err)
+	require.NotNil(t, merged.NVLinkError)
+	require.Equal(t, float64(250), merged.NVLinkError.Rate)
+	require.Equal(t, []int{0, 3, 7}, merged.NVLinkError.Links)
+}
+
+func TestNVLinkErrorPatch_NoLinksOmitsFilter(t *testing.T) {
+	patch := NVLinkErrorPatch(100, nil)
+	block, ok := patch["nvlink_error"].(map[string]any)
+	require.True(t, ok)
+	_, hasLinks := block["links"]
+	require.False(t, hasLinks, "empty links must be omitted so injection targets all active links")
+	merged, err := engine.MergeDeviceConfig(&engine.DeviceConfig{}, patch)
+	require.NoError(t, err)
+	require.Nil(t, merged.NVLinkError.Links)
+}
+
+func TestNVLinkErrorPatch_ZeroRateHeals(t *testing.T) {
+	merged, err := engine.MergeDeviceConfig(&engine.DeviceConfig{}, NVLinkErrorPatch(0, nil))
+	require.NoError(t, err)
+	require.NotNil(t, merged.NVLinkError)
+	require.Equal(t, float64(0), merged.NVLinkError.Rate, "rate 0 is the healthy/no-injection value")
+}
+
 func TestThrottlePatch_AuthoritativeFlags(t *testing.T) {
 	patch, err := ThrottlePatch([]string{"thermal"})
 	require.NoError(t, err)

--- a/pkg/gpu/mocknvml/engine/config.go
+++ b/pkg/gpu/mocknvml/engine/config.go
@@ -378,6 +378,9 @@ func mergeDeviceOverride(base *DeviceConfig, override *DeviceOverride) {
 	if override.Fabric != nil {
 		base.Fabric = override.Fabric
 	}
+	if override.NVLinkError != nil {
+		base.NVLinkError = override.NVLinkError
+	}
 	if override.Processes != nil {
 		base.Processes = override.Processes // nil = not overridden; [] = explicit clear
 	}

--- a/pkg/gpu/mocknvml/engine/config_types.go
+++ b/pkg/gpu/mocknvml/engine/config_types.go
@@ -154,6 +154,38 @@ type DeviceConfig struct {
 	// (default) GetGpuFabricInfo / GetGpuFabricInfoV report
 	// ERROR_NOT_SUPPORTED — matching every non-fabric-attached GPU.
 	Fabric *FabricConfig `json:"fabric,omitempty"`
+
+	// NVLinkError injects per-link NVLink DL error accrual on this device's
+	// links to its NVSwitch. When nil (default) the links report the healthy
+	// baseline. See NVLinkErrorInjectionConfig.
+	NVLinkError *NVLinkErrorInjectionConfig `json:"nvlink_error,omitempty"`
+}
+
+// NVLinkErrorInjectionConfig injects NVLink data-link error accrual on a
+// device's links so the GPU's uplinks to its NVSwitch report climbing DL
+// errors — the closest an NVML-only mock can get to an NVSwitch-side fault.
+//
+// It exists because DCGM's NVSwitch entity health (DCGM_HEALTH_WATCH_NVSWITCH_*)
+// is sourced from NSCQ, not NVML, so a libnvidia-ml mock cannot drive it. What
+// the mock CAN drive is the GPU-side NVLink error surface DCGM's
+// DCGM_HEALTH_WATCH_NVLINK reads: the per-link/per-counter direct API
+// (nvmlDeviceGetNvLinkErrorCounter) and the DL error field values
+// (NVML_FI_DEV_NVLINK_ERROR_DL_{REPLAY,RECOVERY,CRC}, field ids 161-163).
+// A rising error rate there surfaces as DCGM_FR_NVLINK_* and is detected and
+// remediated by NVSentinel's gpu-health-monitor.
+type NVLinkErrorInjectionConfig struct {
+	// Rate is the injected error accrual in errors/second, added on top of
+	// each affected link's baseline. The counter climbs monotonically off the
+	// shared epoch (the same accrual model as NVLinkDefaults.ErrorRate), so
+	// DCGM's delta-based NVLink health watch observes a rising error rate
+	// rather than a one-shot step it would treat as stale after the first
+	// sample. 0 (default) disables injection — the healthy baseline.
+	Rate float64 `json:"rate,omitempty"`
+
+	// Links restricts injection to specific link ids. Empty (default) injects
+	// on every active link on the device — the "GPU lost its switch uplinks"
+	// fault. Ids that don't map to an active link are ignored.
+	Links []int `json:"links,omitempty"`
 }
 
 // DeviceOverride contains per-device settings that override defaults

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -1344,8 +1344,38 @@ func (d *ConfigurableDevice) GetNvLinkErrorCounter(link int, counter nvml.NvLink
 	if d.fabric != nil {
 		val = d.fabric.NvLinkErrorCount(d.index, link, d.fabric.now())
 	}
+	val += d.nvLinkInjectedErrorCount(link)
 	debugLog("[NVML] nvmlDeviceGetNvLinkErrorCounter(link=%d, counter=%d) -> %d\n", link, counter, val)
 	return val, nvml.SUCCESS
+}
+
+// nvLinkInjectedErrorCount returns the extra DL error count contributed by a
+// runtime NVLinkError injection override for this link, or 0 when none applies.
+// The count climbs monotonically off the fabric epoch (accrue), so consumers
+// that sample it over time — e.g. DCGM's NVLink health watch — see a rising
+// error rate. Injection only lands on links that actually exist and are up: a
+// degraded switch uplink still enumerates, but a nonexistent link stays absent.
+func (d *ConfigurableDevice) nvLinkInjectedErrorCount(link int) uint64 {
+	inj := d.cfg().NVLinkError
+	if inj == nil || inj.Rate <= 0 || d.fabric == nil {
+		return 0
+	}
+	if l, ok := d.fabric.Link(d.index, link); !ok || !l.Active {
+		return 0
+	}
+	if len(inj.Links) > 0 {
+		found := false
+		for _, l := range inj.Links {
+			if l == link {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return 0
+		}
+	}
+	return accrue(0, inj.Rate, d.fabric.epoch, d.fabric.now())
 }
 
 // GetNvLinkUtilizationCounter returns the deterministic (rx, tx)

--- a/pkg/gpu/mocknvml/engine/nvlink_error_injection_test.go
+++ b/pkg/gpu/mocknvml/engine/nvlink_error_injection_test.go
@@ -86,6 +86,38 @@ func TestNVLinkErrorInjection_HealthyByDefault(t *testing.T) {
 	require.Zero(t, got, "no injection should read 0 errors")
 }
 
+// TestNVLinkErrorInjection_NVLink5CountFields asserts the injection also drives
+// the NVLink5 COUNT_* error/recovery fields — the surface `nvidia-smi nvlink -e`
+// reads on an NVLink5 GPU (and DCGM's NVLink health watch keys on) — so the
+// rising error rate is observable on NVLink5, not just via the legacy DL error
+// counters (161-163) and the direct API. Healthy links report 0.
+func TestNVLinkErrorInjection_NVLink5CountFields(t *testing.T) {
+	errFields := []uint32{
+		fiNvlinkCountMalformedPacketErrors, fiNvlinkCountBufferOverrunErrors,
+		fiNvlinkCountRcvErrors, fiNvlinkCountRcvRemoteErrors,
+		fiNvlinkCountRcvGeneralErrors, fiNvlinkCountLocalLinkIntegrityErrors,
+		fiNvlinkCountXmitDiscards, fiNvlinkCountLinkRecoverySuccessfulEvents,
+		fiNvlinkCountLinkRecoveryFailedEvents, fiNvlinkCountLinkRecoveryEvents,
+		fiNvlinkCountEffectiveErrors, fiNvlinkCountSymbolErrors,
+	}
+
+	healthy := injectionDevice(t, 4, nil, time.Hour)
+	for _, id := range errFields {
+		ft, v, ret := healthy.GetNvLinkFieldValue(id, 0)
+		require.Equal(t, nvml.SUCCESS, ret, "field %d", id)
+		require.Equal(t, FieldValueUint64, ft, "field %d", id)
+		require.Zerof(t, v, "healthy link should report 0 for field %d", id)
+	}
+
+	hot := injectionDevice(t, 4, &NVLinkErrorInjectionConfig{Rate: 100}, 10*time.Second)
+	for _, id := range errFields {
+		ft, v, ret := hot.GetNvLinkFieldValue(id, 0)
+		require.Equal(t, nvml.SUCCESS, ret, "field %d", id)
+		require.Equal(t, FieldValueUint64, ft, "field %d", id)
+		require.Equalf(t, uint64(1000), v, "field %d should climb with injection (100 err/s * 10s)", id)
+	}
+}
+
 // TestNVLinkErrorInjection_ZeroRateHeals asserts an explicit rate of 0 is the
 // healthy value (the `nvlink-error 0` heal path), not an injection.
 func TestNVLinkErrorInjection_ZeroRateHeals(t *testing.T) {

--- a/pkg/gpu/mocknvml/engine/nvlink_error_injection_test.go
+++ b/pkg/gpu/mocknvml/engine/nvlink_error_injection_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
+)
+
+// injectionDevice builds a single-GPU engine whose device 0 has `links` active
+// switch links and an optional NVLinkError injection block, then returns the
+// live *ConfigurableDevice with its fabric clock pinned to a fixed epoch so
+// error accrual is deterministic. now is the sample time relative to epoch.
+func injectionDevice(t *testing.T, links int, inj *NVLinkErrorInjectionConfig, elapsed time.Duration) *ConfigurableDevice {
+	t.Helper()
+	dev := devWithBDF(0, "0000:0A:00.0")
+	dev.DeviceConfig.NVLinkError = inj
+	yc := &YAMLConfig{
+		System:  SystemConfig{DriverVersion: "560.0", NumDevices: 1},
+		Devices: []DeviceOverride{dev},
+		NVLink: &NVLinkConfig{
+			Version:              5,
+			BandwidthPerLinkMbps: 100000,
+			Switches:             []NVSwitchConfig{{BDF: "0000:0F:00.0"}},
+			Defaults:             &NVLinkDefaults{State: "active"},
+			DeviceLinks: []DeviceLinksConfig{
+				{Index: 0, Links: switchLinks(links, "0000:0F:00.0")},
+			},
+		},
+	}
+	e := NewEngine(&Config{NumDevices: 1, YAMLConfig: yc})
+	require.Equal(t, nvml.SUCCESS, e.Init())
+	t.Cleanup(func() { _ = e.Shutdown() })
+
+	handle, _ := e.DeviceGetHandleByIndex(0)
+	cd, ok := e.LookupDevice(handle).(*ConfigurableDevice)
+	require.True(t, ok, "expected ConfigurableDevice")
+
+	epoch := time.Unix(1_000_000, 0)
+	cd.fabric.epoch = epoch
+	cd.fabric.now = func() time.Time { return epoch.Add(elapsed) }
+	return cd
+}
+
+// TestNVLinkErrorInjection_AccruesOverTime asserts an injected rate makes the
+// per-link error counter climb monotonically — the rising rate DCGM's NVLink
+// health watch keys on — and that the field-value path agrees with the direct
+// API.
+func TestNVLinkErrorInjection_AccruesOverTime(t *testing.T) {
+	cd := injectionDevice(t, 4, &NVLinkErrorInjectionConfig{Rate: 100}, 10*time.Second)
+
+	got, ret := cd.GetNvLinkErrorCounter(0, nvml.NVLINK_ERROR_DL_CRC_FLIT)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Equal(t, uint64(1000), got, "100 err/s * 10s")
+
+	// The DL error field values (161-163) must match the direct API so
+	// `dcgmi dmon` and nvmlDeviceGetNvLinkErrorCounter tell the same story.
+	for _, fieldID := range []uint32{fiNvlinkErrorDlReplay, fiNvlinkErrorDlRecovery, fiNvlinkErrorDlCrc} {
+		ft, v, fret := cd.GetNvLinkFieldValue(fieldID, 0)
+		require.Equal(t, nvml.SUCCESS, fret, "field %d", fieldID)
+		require.Equal(t, FieldValueUint64, ft, "field %d", fieldID)
+		require.Equal(t, uint64(1000), v, "field %d should match direct API", fieldID)
+	}
+}
+
+// TestNVLinkErrorInjection_HealthyByDefault asserts a device with no injection
+// (and no configured error rate) reports zero errors regardless of elapsed time.
+func TestNVLinkErrorInjection_HealthyByDefault(t *testing.T) {
+	cd := injectionDevice(t, 4, nil, 24*time.Hour)
+	got, ret := cd.GetNvLinkErrorCounter(0, nvml.NVLINK_ERROR_DL_CRC_FLIT)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Zero(t, got, "no injection should read 0 errors")
+}
+
+// TestNVLinkErrorInjection_ZeroRateHeals asserts an explicit rate of 0 is the
+// healthy value (the `nvlink-error 0` heal path), not an injection.
+func TestNVLinkErrorInjection_ZeroRateHeals(t *testing.T) {
+	cd := injectionDevice(t, 4, &NVLinkErrorInjectionConfig{Rate: 0}, time.Hour)
+	got, ret := cd.GetNvLinkErrorCounter(0, nvml.NVLINK_ERROR_DL_CRC_FLIT)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Zero(t, got, "rate 0 heals")
+}
+
+// TestNVLinkErrorInjection_LinkFilter asserts the Links filter restricts
+// injection to the listed link ids; other active links stay healthy.
+func TestNVLinkErrorInjection_LinkFilter(t *testing.T) {
+	cd := injectionDevice(t, 4, &NVLinkErrorInjectionConfig{Rate: 100, Links: []int{2}}, 10*time.Second)
+
+	hot, _ := cd.GetNvLinkErrorCounter(2, nvml.NVLINK_ERROR_DL_CRC_FLIT)
+	require.Equal(t, uint64(1000), hot, "filtered-in link should accrue")
+
+	for _, link := range []int{0, 1, 3} {
+		cool, _ := cd.GetNvLinkErrorCounter(link, nvml.NVLINK_ERROR_DL_CRC_FLIT)
+		require.Zerof(t, cool, "link %d not in filter should stay healthy", link)
+	}
+}
+
+// TestNVLinkErrorInjection_InactiveLinkStaysAbsent asserts injection never
+// lands on a link the device does not actually have active — a link that is in
+// NVML's valid index range but unpopulated must not be conjured into an errored
+// one (the device here only has 2 active links; link 5 is inactive).
+func TestNVLinkErrorInjection_InactiveLinkStaysAbsent(t *testing.T) {
+	cd := injectionDevice(t, 2, &NVLinkErrorInjectionConfig{Rate: 100}, 10*time.Second)
+	got, ret := cd.GetNvLinkErrorCounter(5, nvml.NVLINK_ERROR_DL_CRC_FLIT)
+	require.Equal(t, nvml.SUCCESS, ret, "link 5 is within NVML range")
+	require.Zero(t, got, "inactive link must stay healthy")
+}

--- a/pkg/gpu/mocknvml/engine/nvlink_fields.go
+++ b/pkg/gpu/mocknvml/engine/nvlink_fields.go
@@ -254,7 +254,10 @@ func (d *ConfigurableDevice) GetNvLinkFieldValue(fieldID, scopeID uint32) (Field
 		return FieldValueUint64, rx, nvml.SUCCESS
 
 	case fiNvlinkErrorDlReplay, fiNvlinkErrorDlRecovery, fiNvlinkErrorDlCrc:
-		return FieldValueUint64, f.NvLinkErrorCount(d.index, link, f.now()), nvml.SUCCESS
+		// Baseline accrual plus any runtime NVLinkError injection so `dcgmi
+		// dmon` / field-value consumers see the same rising DL error rate the
+		// direct nvmlDeviceGetNvLinkErrorCounter API reports.
+		return FieldValueUint64, f.NvLinkErrorCount(d.index, link, f.now()) + d.nvLinkInjectedErrorCount(link), nvml.SUCCESS
 
 	case fiNvlinkCountXmitPackets, fiNvlinkCountRcvPackets:
 		v, ok := d.nvLinkActiveCounter(link)

--- a/pkg/gpu/mocknvml/engine/nvlink_fields.go
+++ b/pkg/gpu/mocknvml/engine/nvlink_fields.go
@@ -273,8 +273,13 @@ func (d *ConfigurableDevice) GetNvLinkFieldValue(fieldID, scopeID uint32) (Field
 		}
 		return FieldValueUint64, v * avgBytesPerNvlinkPacket, nvml.SUCCESS
 
-	// Healthy-link error/recovery counters: present but zero (matches a clean
-	// real GB200). The link must exist, else nvidia-smi should stop enumerating.
+	// NVLink5 error/recovery counters (the NVML_FI_DEV_NVLINK_COUNT_* fields
+	// `nvidia-smi nvlink -e` reads on an NVLink5 GPU, and the surface DCGM's
+	// NVLink health watch keys on). Healthy links report 0; a runtime
+	// NVLinkError injection makes them climb in lockstep with the legacy DL
+	// error counters (161-163) and the direct nvmlDeviceGetNvLinkErrorCounter
+	// API, so the same rising error rate is observable on NVLink5 as on
+	// NVLink3/4. The link must exist, else nvidia-smi stops enumerating.
 	case fiNvlinkCountMalformedPacketErrors, fiNvlinkCountBufferOverrunErrors,
 		fiNvlinkCountRcvErrors, fiNvlinkCountRcvRemoteErrors,
 		fiNvlinkCountRcvGeneralErrors, fiNvlinkCountLocalLinkIntegrityErrors,
@@ -284,7 +289,7 @@ func (d *ConfigurableDevice) GetNvLinkFieldValue(fieldID, scopeID uint32) (Field
 		if _, ok := f.Link(d.index, link); !ok {
 			return FieldValueUnsupported, 0, nvml.ERROR_NOT_SUPPORTED
 		}
-		return FieldValueUint64, 0, nvml.SUCCESS
+		return FieldValueUint64, d.nvLinkInjectedErrorCount(link), nvml.SUCCESS
 
 	case fiNvlinkCountEffectiveBer, fiNvlinkCountSymbolBer:
 		if _, ok := f.Link(d.index, link); !ok {

--- a/tests/e2e/go/scenario_runtime_control.go
+++ b/tests/e2e/go/scenario_runtime_control.go
@@ -688,3 +688,86 @@ func assertRuntimeHealthyRecovery(ctx SpecContext, h *harness.Harness, consumer 
 	By("final reset")
 	nvmlMockCtl(ctx, h, "reset", "--gpu", "all")
 }
+
+// nvlinkErrorSum sums the Replay/Recovery/CRC error counters nvidia-smi reports
+// for a single GPU via `nvlink -e`. The second return is false when the bundled
+// nvidia-smi does not surface per-link error counters at all, so callers can
+// tri-state (SKIP) rather than hard-fail — the same philosophy as
+// assertions.nvlinkCountersTriState for throughput counters.
+func nvlinkErrorSum(ctx SpecContext, h *harness.Harness, pod kube.PodRef, idx int) (int, bool) {
+	GinkgoHelper()
+	res, err := h.Kube.Exec(ctx, pod, "nvidia-smi", "nvlink", "-e", "-i", strconv.Itoa(idx))
+	Expect(err).NotTo(HaveOccurred(), "nvidia-smi nvlink -e -i %d: %s", idx, res.Combined())
+	sum, surfaced := 0, false
+	for _, line := range strings.Split(res.Stdout, "\n") {
+		// e.g. "\t Link 0: Replay Errors: 12"
+		if !strings.Contains(line, "Errors:") {
+			continue
+		}
+		n, perr := strconv.Atoi(strings.TrimSpace(line[strings.LastIndex(line, ":")+1:]))
+		if perr != nil {
+			continue
+		}
+		surfaced = true
+		sum += n
+	}
+	return sum, surfaced
+}
+
+// assertRuntimeNVLinkErrorInjection covers the `nvlink-error` command: inject a
+// rising NVLink DL error rate on a GPU's switch-attached links and observe the
+// per-link error counters climb through nvidia-smi nvlink -e, confirm the
+// injection is scoped to the target GPU, then heal with rate 0 (no reset) and a
+// final reset, verifying the counters return to the healthy baseline. The
+// injected errors accrue monotonically off the fabric epoch, which is exactly
+// the rising rate DCGM's delta-based NVLink health watch consumes. Requires an
+// NVLink (switch-attached) profile — the caller gates on ExpectedNV()>0.
+func assertRuntimeNVLinkErrorInjection(ctx SpecContext, h *harness.Harness, consumer kube.PodRef) {
+	GinkgoHelper()
+	resetRuntimeOverrides(ctx, h)
+
+	count := gpuCount(ctx, h, consumer)
+	target := count - 1 // exercise a non-zero index where possible
+
+	baseSum, surfaced := nvlinkErrorSum(ctx, h, consumer, target)
+	if !surfaced {
+		Skip("bundled nvidia-smi did not surface NVLink error counters via 'nvlink -e'")
+	}
+	// The recovery half of this scenario asserts the counters return to their
+	// pre-injection value; that is only unambiguous when the profile ships a
+	// static-zero NVLink error baseline (every shipped profile does — none set
+	// nvlink error_rate). Skip rather than fail if a profile pins a rising
+	// baseline, so the test stays portable across E2E_PROFILES selections.
+	if baseSum != 0 {
+		Skip(fmt.Sprintf("profile ships a non-zero NVLink error baseline (%d); nvlink-error recovery needs a static-zero baseline", baseSum))
+	}
+
+	const rate = 500 // errors/second — climbs fast enough to observe within the TTL
+
+	By(fmt.Sprintf("inject NVLink DL errors at %d/s on GPU %d via nvml-mock-ctl nvlink-error", rate, target))
+	nvmlMockCtl(ctx, h, "nvlink-error", "--gpu", strconv.Itoa(target), strconv.Itoa(rate))
+
+	Eventually(func() int {
+		s, _ := nvlinkErrorSum(ctx, h, consumer, target)
+		return s
+	}).WithContext(ctx).WithTimeout(runtimeTTLTimeout).WithPolling(runtimeTTLPoll).
+		Should(BeNumerically(">", 0), "GPU %d NVLink error counters should climb after injection", target)
+
+	if count > 1 {
+		By("verify the injection is scoped to the target GPU (GPU 0 unchanged)")
+		s0, _ := nvlinkErrorSum(ctx, h, consumer, 0)
+		Expect(s0).To(Equal(0), "GPU 0 must not accrue NVLink errors when only GPU %d was targeted", target)
+	}
+
+	By("heal the GPU with nvlink-error rate 0 (no reset)")
+	nvmlMockCtl(ctx, h, "nvlink-error", "--gpu", strconv.Itoa(target), "0")
+
+	Eventually(func() int {
+		s, _ := nvlinkErrorSum(ctx, h, consumer, target)
+		return s
+	}).WithContext(ctx).WithTimeout(runtimeTTLTimeout).WithPolling(runtimeTTLPoll).
+		Should(Equal(0), "GPU %d NVLink error counters should return to the healthy baseline after rate 0", target)
+
+	By("final reset")
+	nvmlMockCtl(ctx, h, "reset", "--gpu", "all")
+}

--- a/tests/e2e/go/scenario_standalone_test.go
+++ b/tests/e2e/go/scenario_standalone_test.go
@@ -180,6 +180,16 @@ var _ = Describe("nvml-mock standalone", Ordered, func() {
 					assertRuntimeHealthyRecovery(ctx, h, pod)
 				})
 
+				It("injects rising NVLink DL errors via the nvml-mock-ctl nvlink-error command", Label("runtime-control"), func(ctx SpecContext) {
+					if p.ExpectedNV() == 0 {
+						Skip("profile " + name + " has no NVLink switch topology; nvlink-error has no links to fault")
+					}
+					// nvlink -e is read through fabricmanager; gate on it being
+					// ready before injecting, matching the topology assertion.
+					assertions.FabricManagerGate(ctx, h.Kube, nvmlMockNamespace, "nvml-mock", pod, config.ReadyTimeout(), config.PollInterval())
+					assertRuntimeNVLinkErrorInjection(ctx, h, pod)
+				})
+
 				It("injects ECC uncorrectable errors", func(ctx SpecContext) {
 					assertECCUncorrectableFailure(ctx, h, p.ExpectedGPUs())
 				})


### PR DESCRIPTION
## Summary

Adds a per-device **NVLink data-link (DL) error injection** path to `nvml-mock`, plus a `nvml-mock-ctl nvlink-error` runtime command and end-to-end coverage.

The mock can now drive the GPU-side NVLink error surface that DCGM's `DCGM_HEALTH_WATCH_NVLINK` reads:
- the per-link/per-counter direct API `nvmlDeviceGetNvLinkErrorCounter`, and
- the DL error field values `NVML_FI_DEV_NVLINK_ERROR_DL_{REPLAY,RECOVERY,CRC}` (field ids 161–163).

Injected errors accrue **monotonically off the shared fabric epoch**, so DCGM's delta-based NVLink health watch sees a *rising* error rate rather than a one-shot step it would treat as stale after the first sample. A rising rate there surfaces as `DCGM_FR_NVLINK_*`, which a health monitor (e.g. NVSentinel's `gpu-health-monitor`) detects and remediates.

### Why not NVSwitch entity health directly?
DCGM's NVSwitch entity health (`DCGM_HEALTH_WATCH_NVSWITCH_*`) is sourced from **NSCQ (`libnvidia-nscq.so`), not NVML**, so a `libnvidia-ml` mock cannot drive it. Climbing GPU-side NVLink errors on a GPU's switch uplinks are the closest an NVML-only mock can get to a switch-side fault.

## Changes
- **engine**: `NVLinkErrorInjectionConfig` per device (`nvlink_error` block); wired into `GetNvLinkErrorCounter` and the 161–163 field values. Injection only lands on **active switch-attached links** — a nonexistent/inactive link stays absent.
- **nvml-mock-ctl**: `nvlink-error --gpu <idx|all|uuid> <errors_per_sec> [--links a,b,c]`; `rate 0` heals, and the `nvlink_error` override block is authoritative (a stale `--links` filter never lingers).
- **e2e**: a `runtime-control` scenario injects on an NVLink profile, watches the counters climb via `nvidia-smi nvlink -e`, verifies the injection is scoped to the target GPU, then heals (`rate 0`) and resets and confirms recovery. Skipped on non-NVLink profiles and where the bundled `nvidia-smi` does not surface the counters.
- **docs**: `docs/configuration.md` and `docs/nvml-mock-ctl.md`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/gpu/mocknvml/engine/... ./pkg/gpu/mockctl/... ./cmd/nvml-mock-ctl/...`
- [x] `gofmt -l` clean; `golangci-lint run` clean on changed packages
- [x] `go vet -tags e2e ./tests/e2e/go/...` and e2e test binary compiles
- [ ] CI e2e (`standalone`, gb200) exercises the new `nvlink-error` runtime-control scenario