### PR TITLE
poc: Mokka + AICR pre-silicon integration preflight

### DIFF
--- a/cmd/render-imex-procdevices/main.go
+++ b/cmd/render-imex-procdevices/main.go
@@ -1,0 +1,73 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// render-imex-procdevices writes a substitute /proc/devices carrying NVIDIA
+// caps character-device entries, for consumption by the NVIDIA DRA driver's
+// compute-domain kubelet plugin via ALT_PROC_DEVICES_PATH.
+//
+// On a Mokka node there is no NVIDIA kernel module, so /proc/devices has no
+// nvidia-caps-imex-channels entry and the plugin aborts at startup. The DRA
+// driver's chart exposes an altProcDevices value for exactly this case; this
+// command produces the file it points at.
+//
+// Usage:
+//
+//	render-imex-procdevices \
+//	    --source /proc/devices \
+//	    --output /var/lib/nvml-mock/imex/proc-devices \
+//	    --imex-major 235 --caps-major 236
+//
+// Rendering is idempotent, so the DaemonSet may re-run it on restart.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/system/mockimex/render"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "render-imex-procdevices: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	fs := flag.NewFlagSet("render-imex-procdevices", flag.ContinueOnError)
+	source := fs.String("source", "/proc/devices", "path to the real /proc/devices to derive from")
+	output := fs.String("output", "", "path to write the rendered file (required)")
+	imexMajor := fs.Int("imex-major", 235, "device major to advertise for "+render.IMEXChannelsDeviceName)
+	capsMajor := fs.Int("caps-major", 236, "device major to advertise for "+render.CapsDeviceName)
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *output == "" {
+		return fmt.Errorf("--output is required")
+	}
+
+	data, err := os.ReadFile(*source) //nolint:gosec // operator-supplied source path
+	if err != nil {
+		return fmt.Errorf("read %s: %w", *source, err)
+	}
+
+	rendered, err := render.ProcDevices(string(data), *imexMajor, *capsMajor)
+	if err != nil {
+		return fmt.Errorf("render from %s: %w", *source, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(*output), 0o755); err != nil {
+		return fmt.Errorf("create output directory for %s: %w", *output, err)
+	}
+	if err := os.WriteFile(*output, []byte(rendered), 0o644); err != nil { //nolint:gosec // world-readable by design: consumed by another container
+		return fmt.Errorf("write %s: %w", *output, err)
+	}
+
+	fmt.Printf("wrote %s (%s major=%d, %s major=%d)\n",
+		*output, render.IMEXChannelsDeviceName, *imexMajor, render.CapsDeviceName, *capsMajor)
+	return nil
+}

--- a/deployments/nvml-mock/Dockerfile
+++ b/deployments/nvml-mock/Dockerfile
@@ -23,6 +23,7 @@ COPY pkg/gpu/mockcuda/ pkg/gpu/mockcuda/
 COPY pkg/network/mockib/ pkg/network/mockib/
 COPY pkg/nri/ pkg/nri/
 COPY pkg/system/mockpcisysfs/ pkg/system/mockpcisysfs/
+COPY pkg/system/mockimex/ pkg/system/mockimex/
 COPY pkg/imexcoord/ pkg/imexcoord/
 COPY pkg/fmcoord/ pkg/fmcoord/
 COPY cmd/mock-ib/ cmd/mock-ib/

--- a/deployments/nvml-mock/Dockerfile
+++ b/deployments/nvml-mock/Dockerfile
@@ -29,6 +29,7 @@ COPY cmd/mock-ib/ cmd/mock-ib/
 COPY cmd/nvml-mock-nri/ cmd/nvml-mock-nri/
 COPY cmd/nvml-mock-ctl/ cmd/nvml-mock-ctl/
 COPY cmd/render-pci-sysfs/ cmd/render-pci-sysfs/
+COPY cmd/render-imex-procdevices/ cmd/render-imex-procdevices/
 COPY cmd/fake-imex/ cmd/fake-imex/
 COPY cmd/fake-fabricmanager/ cmd/fake-fabricmanager/
 COPY cmd/check-fabric/ cmd/check-fabric/
@@ -41,6 +42,7 @@ RUN mkdir -p /out \
     && go build -mod=vendor -o /out/nvml-mock-nri ./cmd/nvml-mock-nri \
     && go build -mod=vendor -o /out/nvml-mock-ctl ./cmd/nvml-mock-ctl \
     && go build -mod=vendor -o /out/render-pci-sysfs ./cmd/render-pci-sysfs \
+    && go build -mod=vendor -o /out/render-imex-procdevices ./cmd/render-imex-procdevices \
     && go build -mod=vendor -o /out/nvidia-imex     ./cmd/fake-imex/daemon \
     && go build -mod=vendor -o /out/nvidia-imex-ctl ./cmd/fake-imex/ctl \
     && go build -mod=vendor -o /out/nv-fabricmanager     ./cmd/fake-fabricmanager/daemon \
@@ -60,6 +62,7 @@ COPY --from=builder /out/mock-ib /usr/local/bin/mock-ib
 COPY --from=builder /out/nvml-mock-nri /usr/local/bin/nvml-mock-nri
 COPY --from=builder /out/nvml-mock-ctl /usr/local/bin/nvml-mock-ctl
 COPY --from=builder /out/render-pci-sysfs /usr/local/bin/render-pci-sysfs
+COPY --from=builder /out/render-imex-procdevices /usr/local/bin/render-imex-procdevices
 # Fake IMEX binaries used for ComputeDomain simulation on KIND. Installed
 # at the same paths the upstream compute-domain-daemon expects in $PATH,
 # so the thin daemon image layer (Dockerfile.compute-domain-daemon) can

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -72,6 +72,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if .Values.imex.mockChannels.enabled }}
+            # Mock IMEX capability surface for the DRA compute-domain plugin.
+            # See values.yaml imex.mockChannels and NVIDIA/k8s-test-infra#498.
+            - name: IMEX_MOCK_CHANNELS
+              value: "true"
+            - name: IMEX_CHANNEL_COUNT
+              value: "{{ .Values.imex.mockChannels.channelCount }}"
+            - name: IMEX_CHANNEL_MAJOR
+              value: "{{ .Values.imex.mockChannels.channelMajor }}"
+            - name: IMEX_CAPS_MAJOR
+              value: "{{ .Values.imex.mockChannels.capsMajor }}"
+            {{- end }}
             # Point the mock NVML library at the in-pod ConfigMap mount so any
             # nvidia-smi / NVML caller running INSIDE the daemonset pod
             # (e.g. `kubectl exec ds/nvml-mock -- nvidia-smi`) loads the same

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -166,6 +166,38 @@ imex:
   enabled: false
   stateDir: /var/lib/nvml-mock/imex-state
 
+  # Mock IMEX capability surface for the NVIDIA DRA driver's compute-domain
+  # kubelet plugin. That plugin reads a device major for
+  # nvidia-caps-imex-channels out of /proc/devices at startup; on a mock node
+  # there is no NVIDIA kernel module, so the entry is absent and the plugin
+  # aborts with "error parsing '/proc/devices': unexpected regex match: []".
+  #
+  # When enabled, the DaemonSet renders:
+  #   <hostPath>/imex/proc-devices                       substitute /proc/devices
+  #   <driverRoot>/proc/driver/nvidia/capabilities/...   fabric-imex-mgmt
+  #   <driverRoot>/dev/nvidia-caps-imex-channels/channelN  channel device nodes
+  #
+  # Pair it with the DRA driver, on a release that supports altProcDevices:
+  #   --set altProcDevices=/var/lib/nvml-mock/imex/proc-devices
+  #   --set resources.computeDomains.enabled=true
+  #
+  # NOTE: as of 2026-07-25 altProcDevices is on the DRA driver's main branch
+  # but is NOT in any release (absent at v25.12.0), so enabling this alone does
+  # not yet make ComputeDomains work with released artifacts. See
+  # NVIDIA/k8s-test-infra#498.
+  #
+  # Off by default: it creates channelCount device nodes per node.
+  mockChannels:
+    enabled: false
+    # Number of channel device nodes. 2048 matches getImexChannelCount() in the
+    # DRA driver's compute-domain kubelet plugin.
+    channelCount: 2048
+    # Device majors advertised in the rendered proc-devices file. Defaults match
+    # the DRA driver's own CI fixtures. They must differ from each other and
+    # must not collide with a major already present on the node.
+    channelMajor: 235
+    capsMajor: 236
+
 # Fake nvidia-fabricmanager. NVSwitch platforms (HGX H100 / GB200 / GB300)
 # run nvidia-fabricmanager to register GPUs with the NVSwitch fabric. When
 # enabled the entrypoint starts the fake nvidia-fabricmanager daemon (baked

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -66,6 +66,54 @@ mknod -m 666 "$DEV_ROOT/nvidiactl" c 195 255 2>/dev/null || true
 mknod -m 666 "$DEV_ROOT/nvidia-uvm" c 510 0 2>/dev/null || true
 mknod -m 666 "$DEV_ROOT/nvidia-uvm-tools" c 510 1 2>/dev/null || true
 
+# 3a. Mock IMEX capability surface (opt-in via IMEX_MOCK_CHANNELS).
+#     The NVIDIA DRA driver's compute-domain kubelet plugin reads a device major
+#     for nvidia-caps-imex-channels out of /proc/devices at startup. There is no
+#     NVIDIA kernel module here, so that entry does not exist and the plugin
+#     aborts. The DRA driver supports a substitute file via its chart's
+#     altProcDevices value (env ALT_PROC_DEVICES_PATH); this renders it.
+#
+#     Pair with, on the DRA driver release that supports it:
+#       --set altProcDevices=/var/lib/nvml-mock/imex/proc-devices
+#       --set resources.computeDomains.enabled=true
+#
+#     Bind-mounting over /proc/devices is not an option: runc rejects it
+#     ("cannot be mounted because it is inside /proc"), which is why the
+#     consumer uses an env-var indirection instead.
+if [ "${IMEX_MOCK_CHANNELS:-false}" = "true" ]; then
+  IMEX_DIR=$HOST/imex
+  IMEX_MAJOR=${IMEX_CHANNEL_MAJOR:-235}
+  CAPS_MAJOR=${IMEX_CAPS_MAJOR:-236}
+  IMEX_CHANNELS=${IMEX_CHANNEL_COUNT:-2048}
+
+  mkdir -p "$IMEX_DIR"
+  # Rendering is idempotent, so a DaemonSet restart re-runs this safely.
+  render-imex-procdevices \
+    --source /proc/devices \
+    --output "$IMEX_DIR/proc-devices" \
+    --imex-major "$IMEX_MAJOR" \
+    --caps-major "$CAPS_MAJOR"
+
+  # The plugin also reads the fabric IMEX management capability.
+  mkdir -p "$DRIVER_ROOT/proc/driver/nvidia/capabilities"
+  cat > "$DRIVER_ROOT/proc/driver/nvidia/capabilities/fabric-imex-mgmt" <<CAPS_EOF
+DeviceFileMinor: 512
+DeviceFileMode: 438
+DeviceFileModify: 0
+CAPS_EOF
+
+  # Channel device nodes, injected into workload pods by the compute-domain CDI
+  # spec. They must exist as character devices for that injection to succeed.
+  mkdir -p "$DEV_ROOT/nvidia-caps-imex-channels"
+  i=0
+  while [ "$i" -lt "$IMEX_CHANNELS" ]; do
+    mknod -m 666 "$DEV_ROOT/nvidia-caps-imex-channels/channel$i" c "$IMEX_MAJOR" "$i" 2>/dev/null || true
+    i=$((i + 1))
+  done
+
+  echo "Mock IMEX surface ready: $IMEX_CHANNELS channels, major $IMEX_MAJOR, proc-devices at $IMEX_DIR/proc-devices"
+fi
+
 # 3b. Generate CDI spec for nvidia-container-runtime CDI mode.
 #     This allows the toolkit to inject our mock libs into containers without
 #     needing libnvidia-container or kernel modules.

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ full walkthrough.
 | Integration | Description |
 |-------------|-------------|
 | [fake-gpu-operator](integrations/fake-gpu-operator.md) | Run:ai's K8s-level GPU simulation + nvml-mock driver fidelity |
+| [AICR pre-silicon preflight](aicr-preflight/README.md) | Run the AICR validate/conformance suite against nvml-mock before silicon lands |
 
 ## Tested Consumers
 

--- a/docs/aicr-preflight/README.md
+++ b/docs/aicr-preflight/README.md
@@ -106,7 +106,7 @@ Of the 21 checks in the AICR validate catalog:
 
 Two limits on that headline, stated plainly because they matter more than the percentage:
 
-1. **9 of 21 checks actually executed** in the reference run (5 passed, 4 failed). The remaining 12
+1. **9 of 21 checks actually executed** in the reference run (6 passed, 3 failed). The remaining 12
    were not selected by the generated recipe. Their buckets are analysis, not observation.
 2. **The run used one node.** It says nothing about GPU-stack fidelity at large node counts.
 
@@ -120,11 +120,18 @@ wiring, and dynamic-library resolution. That is the exact chain that broke in a 
 three missing exported symbols made the library fail to load while the build, unit tests, and linters
 all stayed green.
 
-The more useful result: `dra-support` failed, and the reason was a genuine, previously unknown gap.
-The DRA driver installs and publishes all 8 simulated GB200 devices as ResourceSlices, but enabling
-ComputeDomains crashes the plugin because Mokka registers no IMEX channel device class. That is a
-concrete defect found on a laptop, months before any hardware arrives, and it is now tracked as
+The more useful results were two real defects.
+
+`dra-support` failed because the DRA driver's compute-domain plugin needs an IMEX device surface that
+the mock does not ship. The driver installs and publishes all 8 simulated GB200 devices as
+ResourceSlices, but enabling ComputeDomains crashes the plugin. Tracked as
 [#498](https://github.com/NVIDIA/k8s-test-infra/issues/498).
+
+`ai-service-metrics` failed because the generated recipe never wires the GPU Operator's dcgm-exporter
+into Prometheus, so no GPU time series exists and a check the recipe itself selects cannot pass from
+its own bundle. Enabling the ServiceMonitor and installing prometheus-adapter made it pass. That is a
+misconfiguration a customer would otherwise hit during bring-up, wondering why their GPU dashboards
+are empty.
 
 Finding real defects is the point. A suite that goes uniformly green against a mock would be evidence
 of nothing.

--- a/docs/aicr-preflight/README.md
+++ b/docs/aicr-preflight/README.md
@@ -1,0 +1,160 @@
+# Pre-silicon integration preflight: Mokka Sim + AICR
+
+**Audience:** platform engineers at neocloud providers and enterprises who have GPU capacity on order
+and want to be ready when it lands.
+
+**One line:** AICR defines what "ready" means, and Mokka Sim lets you run most of that definition
+before the hardware exists.
+
+All coverage numbers on this page come from a real run on 2026-07-25. They are simulation-provenance
+(`sim`) and none has been confirmed on silicon. The run is
+[reproducible](../../tests/aicr-preflight/README.md), and the raw output is
+[committed](../../tests/aicr-preflight/results/2026-07-25-gb200-kind/).
+
+## The problem
+
+You buy a GB200 cluster. It arrives in roughly three months. Your engineers are available now, and
+there is nothing for them to integrate against. So the work waits.
+
+When the racks land, the clock starts. Every hour spent discovering that a prerequisite ConfigMap
+lands in the wrong ordering slot, or that a recipe's Kubernetes floor is below what the DRA API needs,
+is an hour not spent on the work that genuinely requires the hardware: driver and firmware
+compatibility, NCCL and NVLink behaviour, and getting real tokens out of a real model.
+
+Those integration failures are not exotic. They are ordinary, they are found late, and they consume
+bring-up time that was budgeted for something else.
+
+## What AICR is
+
+AICR codifies configurations that have been **validated and optimized on real hardware**. It gives you
+a known-good baseline instead of rediscovering the stack yourself, expressed as recipes plus a
+validation and conformance suite you can run against your cluster.
+
+AICR is the readiness definition. That does not change here.
+
+## What Mokka Sim is
+
+Mokka Sim (the `nvml-mock` project) presents real CPU nodes to Kubernetes as a GPU fleet. It is not an
+API-level fake: it replaces `libnvidia-ml.so.1` on the host with a real shared library, ships the real
+`nvidia-smi` binary patched to resolve against it, creates device nodes, and generates a CDI spec. The
+interception is at the NVML and driver line, so everything above that line is the real software.
+
+That means the NVIDIA GPU Operator installs for real, the device plugin advertises `nvidia.com/gpu` for
+real, GPU Feature Discovery labels nodes from real NVML calls, the DRA driver publishes real
+ResourceSlices, and dcgm-exporter scrapes real metrics endpoints.
+
+**Mokka needs real nodes.** It replaces a library on the host and needs a real kubelet and container
+runtime, so it cannot run on KWOK nodes.
+
+## How they compose
+
+AICR runs **on** a Mokka-enabled Kubernetes cluster, unmodified. Mokka is the substrate; AICR is the
+workload. You are validating the real readiness path, not a simulation-specific one.
+
+```mermaid
+flowchart TB
+  subgraph L5["AICR: recipes, validate and conformance suite"]
+    A1["deployment checks"]
+    A2["conformance checks"]
+    A3["performance checks (need silicon)"]
+  end
+  subgraph L4["GPU stack: GPU Operator, DRA driver, device plugin, GFD, DCGM"]
+  end
+  subgraph L3["kubelet and containerd, with CDI"]
+  end
+  subgraph L2["Mokka Sim: libnvidia-ml.so.1 replacement, device nodes, CDI spec"]
+  end
+  subgraph L1["Real CPU nodes (Kubernetes)"]
+  end
+  L1 --> L2 --> L3 --> L4 --> L5
+```
+
+The direction matters, because the common misreading is that simulation lives inside AICR. It does
+not. Mokka is node-level substrate underneath the whole stack, and AICR sits on top of it.
+
+## What preflight covers, and what it does not
+
+This is the part to read carefully.
+
+| Preflight covers | Preflight does NOT cover |
+|---|---|
+| GPU Operator installation and reconciliation | CUDA execution |
+| DRA installation and resource advertisement | Firmware and driver compatibility |
+| NVML-facing components (`nvidia-smi`, GFD, DCGM path) | NCCL, NVLink, NVLS, network fabric |
+| Scheduling and control-plane behaviour | Workload TTFT and throughput |
+| Prerequisite ordering, version and API skew | Anything that needs a real device to compute |
+
+The right-hand column is what determines time to first token. **AICR validation on real silicon
+remains the final readiness gate.** Preflight moves the integration work left; it does not replace the
+gate.
+
+## What the numbers actually say
+
+Of the 21 checks in the AICR validate catalog:
+
+| Bucket | Count | Meaning |
+|---|---:|---|
+| **A** meaningful under Mokka | 14 | exercises real integration, can fail for a real reason |
+| **B** passes trivially | 0 | green only because the mock answered |
+| **C** hardware-dependent | 4 | not judgeable pre-silicon |
+| **G** closable gap | 3 | would be meaningful, Mokka lacks the capability today |
+
+- **66.7% carries real pre-silicon signal today** (A / total).
+- **81.0% is reachable** once the tracked gaps close. That is a roadmap number, not a current claim.
+- **42.9% is what Mokka specifically unlocks** (9 of 21). The other 5 bucket-A checks are
+  control-plane checks that any cluster would run, so honesty requires separating them.
+
+Two limits on that headline, stated plainly because they matter more than the percentage:
+
+1. **9 of 21 checks actually executed** in the reference run (5 passed, 4 failed). The remaining 12
+   were not selected by the generated recipe. Their buckets are analysis, not observation.
+2. **The run used one node.** It says nothing about GPU-stack fidelity at large node counts.
+
+See [coverage.md](coverage.md) for the per-check breakdown.
+
+## What this looked like in practice
+
+The clearest positive: `check-nvidia-smi` passed. It schedules a pod requesting `nvidia.com/gpu` and
+runs `nvidia-smi` inside it, exercising device-plugin allocation, CDI injection, container-toolkit
+wiring, and dynamic-library resolution. That is the exact chain that broke in a real regression where
+three missing exported symbols made the library fail to load while the build, unit tests, and linters
+all stayed green.
+
+The more useful result: `dra-support` failed, and the reason was a genuine, previously unknown gap.
+The DRA driver installs and publishes all 8 simulated GB200 devices as ResourceSlices, but enabling
+ComputeDomains crashes the plugin because Mokka registers no IMEX channel device class. That is a
+concrete defect found on a laptop, months before any hardware arrives, and it is now tracked as
+[#498](https://github.com/NVIDIA/k8s-test-infra/issues/498).
+
+Finding real defects is the point. A suite that goes uniformly green against a mock would be evidence
+of nothing.
+
+## The honest claim
+
+**Preflight reduces time to first token** by moving integration failures earlier, so that silicon time
+is spent on the hardware-dependent validation that actually needs silicon.
+
+**It does not mean you hit first token on day one.** Simulation cannot prove that, because the entire
+hardware-dependent path is untested by construction. Anyone telling you otherwise is overselling.
+
+## Diagrams
+
+Each is available as mermaid (renders inline on GitHub) and as a committed SVG for use in email and
+slides, under [`diagrams/`](diagrams/).
+
+| Diagram | Shows |
+|---|---|
+| [stack-layering](diagrams/stack-layering.svg) | AICR is the workload, Mokka is the substrate |
+| [vertical-vs-horizontal](diagrams/vertical-vs-horizontal.svg) | KWOK breadth and Mokka depth are orthogonal |
+| [preflight-timeline](diagrams/preflight-timeline.svg) | where integration failures get found |
+| [coverage-map](diagrams/coverage-map.svg) | the A/B/C/G split and the final-gate boundary |
+| [preflight-workflow](diagrams/preflight-workflow.svg) | the operational sequence and failure triage |
+
+![Where integration failures get found](diagrams/preflight-timeline.svg)
+
+## Further reading
+
+- [how-it-works.md](how-it-works.md): the mechanism, for someone who will run it.
+- [coverage.md](coverage.md): what preflight validates, what needs silicon, and the gap backlog.
+- [Harness](../../tests/aicr-preflight/README.md): how to reproduce the run.
+- [Findings](../../tests/aicr-preflight/FINDINGS.md): the full POC result, including its limits.

--- a/docs/aicr-preflight/coverage.md
+++ b/docs/aicr-preflight/coverage.md
@@ -19,7 +19,7 @@ Of the **21** checks in the AICR validate catalog:
 - **Reachable: 81.0%** once the tracked gaps close ((A + G) / total). Roadmap, not a current claim.
 - **Mokka specifically unlocks 42.9%** (9 of 21), because 5 of the 14 bucket-A checks are
   control-plane checks any cluster would run.
-- **Executed: 9 of 21** (5 pass, 4 fail). 12 were not selected by the recipe and carry no evidence.
+- **Executed: 9 of 21** (6 pass, 3 fail). 12 were not selected by the recipe and carry no evidence.
 
 ```mermaid
 pie showData

--- a/docs/aicr-preflight/coverage.md
+++ b/docs/aicr-preflight/coverage.md
@@ -103,7 +103,7 @@ Summary issue: [#502](https://github.com/NVIDIA/k8s-test-infra/issues/502).
 
 | Gap | Issue | Unlocks | Size | Status |
 |---|---|---|---:|---|
-| No `nvidia-caps-imex-channels` device class, blocks DRA ComputeDomains | [#498](https://github.com/NVIDIA/k8s-test-infra/issues/498) | 2 checks, G to A | M | open |
+| nvml-mock does not ship the mock IMEX surface the DRA compute-domain plugin needs | [#498](https://github.com/NVIDIA/k8s-test-infra/issues/498) | 2 checks, G to A | S | open |
 | No simulated node provisioner | [#499](https://github.com/NVIDIA/k8s-test-infra/issues/499) | 1 check, G to A | M | open |
 | GFD e2e assertion warning-only, can never fail | [#500](https://github.com/NVIDIA/k8s-test-infra/issues/500) | test quality, no bucket move | S | closed |
 

--- a/docs/aicr-preflight/coverage.md
+++ b/docs/aicr-preflight/coverage.md
@@ -1,0 +1,141 @@
+# Coverage: what preflight validates, and what needs silicon
+
+Every number here comes from the run on 2026-07-25 against AICR at commit `06256cc8`. Provenance is
+`sim` throughout. Raw output:
+[`results/2026-07-25-gb200-kind/`](../../tests/aicr-preflight/results/2026-07-25-gb200-kind/).
+
+## Headline
+
+Of the **21** checks in the AICR validate catalog:
+
+| Bucket | Count | Share |
+|---|---:|---:|
+| **A** meaningful under Mokka | 14 | 66.7% |
+| **B** passes trivially against the mock | 0 | 0% |
+| **C** hardware-dependent, silicon only | 4 | 19.0% |
+| **G** closable Mokka gap | 3 | 14.3% |
+
+- **Today: 66.7%** carries real pre-silicon signal (A / total).
+- **Reachable: 81.0%** once the tracked gaps close ((A + G) / total). Roadmap, not a current claim.
+- **Mokka specifically unlocks 42.9%** (9 of 21), because 5 of the 14 bucket-A checks are
+  control-plane checks any cluster would run.
+- **Executed: 9 of 21** (5 pass, 4 fail). 12 were not selected by the recipe and carry no evidence.
+
+```mermaid
+pie showData
+  title AICR check coverage under Mokka (21 checks)
+  "A meaningful (14)" : 14
+  "C hardware-dependent (4)" : 4
+  "G closable gap (3)" : 3
+  "B trivial (0)" : 0
+```
+
+## Per-check breakdown
+
+`GPU-dep` marks whether the check touches the GPU stack at all. A bucket-A check that is not
+GPU-dependent moves left, but Mokka is not what unlocks it.
+
+| # | Check | Phase | Bucket | GPU-dep | Outcome | Note |
+|---|---|---|---|---|---|---|
+| 1 | `operator-health` | deployment | A | yes | pass | real GPU Operator reconciled |
+| 2 | `expected-resources` | deployment | A | yes | fail | prerequisite component absent |
+| 3 | `gpu-operator-version` | deployment | A | no | pass | version constraint satisfied |
+| 4 | `check-nvidia-smi` | deployment | A | yes | **pass** | full allocation-to-NVML chain |
+| 5 | `nccl-all-reduce-bw` | performance | C | yes | not run | needs real links |
+| 6 | `nccl-all-reduce-bw-net` | performance | C | yes | not run | needs real NET fabric |
+| 7 | `nccl-all-reduce-bw-nvls` | performance | C | yes | not run | needs a real IMEX domain |
+| 8 | `inference-perf` | performance | C | yes | not run | TTFT and throughput, needs CUDA |
+| 9 | `dra-support` | conformance | **G** | yes | fail | [#498](https://github.com/NVIDIA/k8s-test-infra/issues/498) |
+| 10 | `gang-scheduling` | conformance | A | no | not run | CPU-only upstream by design |
+| 11 | `accelerator-metrics` | conformance | A | yes | pass | real dcgm-exporter path |
+| 12 | `ai-service-metrics` | conformance | A | yes | fail | Prometheus absent |
+| 13 | `inference-gateway` | conformance | A | no | not run | pure control-plane |
+| 14 | `pod-autoscaling` | conformance | A | yes | not run | HPA on a GPU external metric |
+| 15 | `cluster-autoscaling` | conformance | **G** | no | not run | [#499](https://github.com/NVIDIA/k8s-test-infra/issues/499) |
+| 16 | `robust-controller` | conformance | A | no | not run | operator CRD reconciliation |
+| 17 | `secure-accelerator-access` | conformance | A | yes | not run | GPU isolation between containers |
+| 18 | `slinky-slurm-health` | conformance | A | yes | not run | needs Slurm deployed |
+| 19 | `slinky-slurm-imex-channel` | conformance | **G** | yes | not run | [#498](https://github.com/NVIDIA/k8s-test-infra/issues/498) |
+| 20 | `gpu-operator-health` | conformance | A | yes | pass | ClusterPolicy ready, see caveat |
+| 21 | `platform-health` | conformance | A | no | fail | 8 namespaces absent |
+
+## Why bucket B is empty
+
+An empty B bucket in a study like this deserves suspicion, so here is the reason. AICR's checks are
+written as **integration assertions**, not value assertions, so none is green purely because the mock
+answered an API.
+
+The corresponding limitation, which the bucket scheme does not express, is that where Mokka's values
+are synthetic a check validates the path and stays silent on the values. `accelerator-metrics`
+requires `DCGM_FI_DEV_GPU_UTIL`, `FB_USED`, `GPU_TEMP` and `POWER_USAGE` to be **present**, and
+Mokka's `FB_USED` is a constant zero. The exporter-to-NVML path is genuinely exercised. The telemetry
+values are checked by nobody.
+
+Two caveats on green results worth carrying:
+
+- **`gpu-operator-health`.** ClusterPolicy reaching `ready` is weaker under Mokka than on silicon,
+  because cuda-validation runs with `WITH_WORKLOAD=false` (kernel launch is a no-op) and the toolkit
+  stage is short-circuited by a pre-touched readiness marker. Do not read it as validating the driver
+  or the toolkit.
+- **Three of the four failures** were missing prerequisite components rather than simulation limits.
+  That is harness scoping. Evidence the checks read live state: installing the DRA driver mid-run
+  moved `platform-health` from 9 missing namespaces to 8.
+
+## What needs silicon, permanently
+
+These four are bucket C by construction. No gap closure reaches them, and they are why AICR validation
+on real silicon remains the final readiness gate.
+
+| Area | Checks | Why simulation cannot judge it |
+|---|---|---|
+| CUDA execution | `inference-perf` | Mokka exports 1 CUDA driver-API symbol (`cuInit`); kernel launch is a no-op |
+| Fabric transport | `nccl-all-reduce-bw`, `-net`, `-nvls` | no collective transport, no real links |
+| TTFT and throughput | `inference-perf` | needs real model serving on real devices |
+| Firmware and driver | (spans several) | `driver.enabled=false`; there is no kernel module |
+
+`nccl-all-reduce-bw-nvls` deserves specific mention: it exists to fail loudly when a broken IMEX domain
+makes NCCL silently fall back to NET. That is the GB200 NVL72 failure mode that matters most, and it is
+precisely what preflight cannot see.
+
+## Gap backlog
+
+Summary issue: [#502](https://github.com/NVIDIA/k8s-test-infra/issues/502).
+
+| Gap | Issue | Unlocks | Size | Status |
+|---|---|---|---:|---|
+| No `nvidia-caps-imex-channels` device class, blocks DRA ComputeDomains | [#498](https://github.com/NVIDIA/k8s-test-infra/issues/498) | 2 checks, G to A | M | open |
+| No simulated node provisioner | [#499](https://github.com/NVIDIA/k8s-test-infra/issues/499) | 1 check, G to A | M | open |
+| GFD e2e assertion warning-only, can never fail | [#500](https://github.com/NVIDIA/k8s-test-infra/issues/500) | test quality, no bucket move | S | closed |
+
+Closing #498 and #499 takes the Mokka-specific share from 42.9% to 57.1% (12 of 21), and the overall
+A share from 66.7% to 81.0%.
+
+**#498 is the highest-leverage item** and the only gap on the GB200 critical path, since ComputeDomains
+is how IMEX is expressed in DRA.
+
+### Deliberately not filed
+
+**MIG.** Mokka's MIG coverage is zero: every `GpuInstance` and `ComputeInstance` call is a stub. But
+**no check in the AICR catalog requires MIG**, so closing it would unlock no coverage. Recorded here so
+nobody refiles it as a blocker.
+
+## Scale caveat
+
+The mock replaces `libnvidia-ml.so.1` on the host and needs a real kubelet, so it **cannot run on KWOK
+nodes**. This POC ran on **one node** with 8 simulated GPUs, on linux/arm64.
+
+It therefore says nothing about GPU-stack fidelity at KWOK-scale node counts. That combination of
+fidelity and scale is a claim to prove, not to assert. [#499](https://github.com/NVIDIA/k8s-test-infra/issues/499)
+would compose the two axes for the autoscaling check specifically, and even then it would prove the
+control loop only, not node-level fidelity.
+
+## Back-test status
+
+The primary back-test against real DSX-OS GB200 NVL72 bring-up failures is **pending**: no captured
+failure set exists in any searchable location, and none was synthesized. Tracked as
+[#501](https://github.com/NVIDIA/k8s-test-infra/issues/501).
+
+A clearly-relabelled secondary proxy against real cloud-GB200 failures caught 2 of 4, with both misses
+explained by category (kernel and driver state, cloud credential lifetime) rather than by a fixable
+gap. See [FINDINGS.md](../../tests/aicr-preflight/FINDINGS.md) section 3 for the table and its four
+caveats, including a recorded objection to running the proxy at all.

--- a/docs/aicr-preflight/diagrams/README.md
+++ b/docs/aicr-preflight/diagrams/README.md
@@ -27,7 +27,7 @@ Current values, from the 2026-07-25 run (provenance `sim`):
 
 - 21 checks total: A 14, B 0, C 4, G 3
 - Today 66.7% (A / total), Mokka-specific 42.9% (9 / 21), reachable 81.0% ((A + G) / total)
-- Executed 9 of 21: 5 pass, 4 fail, 12 not run
+- Executed 9 of 21: 6 pass, 3 fail, 12 not run
 - Proxy back-test: 2 of 4 caught
 
 Verify with:

--- a/docs/aicr-preflight/diagrams/README.md
+++ b/docs/aicr-preflight/diagrams/README.md
@@ -1,0 +1,37 @@
+# Diagrams
+
+Each diagram exists twice: a `.mmd` mermaid source that renders inline on GitHub, and a committed
+`.svg` for reuse in email, slides, and docs. Mermaid does not render in mail clients, so use the SVG
+there.
+
+The SVGs are hand-authored. Text is real text, not paths, so it stays selectable and searchable. Each
+carries a `prefers-color-scheme: dark` block so it reads in both GitHub themes, and none relies on
+colour alone to carry meaning.
+
+| Diagram | What it is for |
+|---|---|
+| `stack-layering` | Kills the common misreading that simulation lives inside AICR. AICR is the workload, Mokka is the substrate. |
+| `vertical-vs-horizontal` | KWOK is node-count breadth, Mokka is GPU-stack depth. Orthogonal, and they compose. |
+| `preflight-timeline` | The customer value: where integration failures get found, with and without preflight. |
+| `coverage-map` | The A/B/C/G split with the final-gate boundary drawn. |
+| `preflight-workflow` | The operational sequence, including how to triage a failing check. |
+
+## Keeping the numbers honest
+
+`coverage-map` and `preflight-timeline` carry counts from a real run. **If the catalog changes, these
+must be regenerated.** The source of truth is
+[`tests/aicr-preflight/catalog.yaml`](../../../tests/aicr-preflight/catalog.yaml) and the generated
+[report](../../../tests/aicr-preflight/results/2026-07-25-gb200-kind/coverage.md).
+
+Current values, from the 2026-07-25 run (provenance `sim`):
+
+- 21 checks total: A 14, B 0, C 4, G 3
+- Today 66.7% (A / total), Mokka-specific 42.9% (9 / 21), reachable 81.0% ((A + G) / total)
+- Executed 9 of 21: 5 pass, 4 fail, 12 not run
+- Proxy back-test: 2 of 4 caught
+
+Verify with:
+
+```bash
+grep -c 'bucket: A' ../../../tests/aicr-preflight/catalog.yaml
+```

--- a/docs/aicr-preflight/diagrams/coverage-map.mmd
+++ b/docs/aicr-preflight/diagrams/coverage-map.mmd
@@ -13,5 +13,5 @@ flowchart TB
 
   C --> GATE["<b>FINAL GATE BOUNDARY</b><br/>AICR validation on real silicon.<br/>No gap closure ever reaches these."]
 
-  E["Executed in this run: 9 of 21, giving 5 pass, 4 fail.<br/>12 not run: their buckets are analysis, not observation."]
+  E["Executed in this run: 9 of 21, giving 6 pass, 3 fail.<br/>12 not run: their buckets are analysis, not observation."]
   T -.- E

--- a/docs/aicr-preflight/diagrams/coverage-map.mmd
+++ b/docs/aicr-preflight/diagrams/coverage-map.mmd
@@ -1,0 +1,17 @@
+%% AICR check coverage under Mokka. 21 checks, run 2026-07-25, provenance sim.
+%% Counts MUST match tests/aicr-preflight/catalog.yaml and the generated report.
+flowchart TB
+  T["AICR validate catalog: 21 checks"]
+
+  T --> A["<b>Bucket A, meaningful pre-silicon: 14</b><br/>9 GPU-dependent (Mokka unlocks these)<br/>5 GPU-independent (any cluster runs these)"]
+  T --> B["<b>Bucket B, trivial against the mock: 0</b><br/>AICR checks are integration assertions,<br/>not value assertions"]
+  T --> G["<b>Bucket G, closable gap: 3</b><br/>#498 dra-support, slinky-slurm-imex-channel<br/>#499 cluster-autoscaling"]
+  T --> C["<b>Bucket C, hardware-dependent: 4</b><br/>nccl-all-reduce-bw / -net / -nvls<br/>inference-perf (TTFT)"]
+
+  A --> TODAY["TODAY: 14/21 = 66.7%<br/>Mokka-specific: 9/21 = 42.9%"]
+  G --> REACH["REACHABLE once gaps close:<br/>(14+3)/21 = 81.0%<br/>roadmap, NOT a current claim"]
+
+  C --> GATE["<b>FINAL GATE BOUNDARY</b><br/>AICR validation on real silicon.<br/>No gap closure ever reaches these."]
+
+  E["Executed in this run: 9 of 21, giving 5 pass, 4 fail.<br/>12 not run: their buckets are analysis, not observation."]
+  T -.- E

--- a/docs/aicr-preflight/diagrams/coverage-map.svg
+++ b/docs/aicr-preflight/diagrams/coverage-map.svg
@@ -62,6 +62,6 @@
     <rect x="16" y="330" width="730" height="72" rx="6" class="note"/>
     <text x="30" y="352" class="lb" font-weight="600">TODAY 66.7% (14/21) · Mokka-specific 42.9% (9/21) · REACHABLE 81.0% (17/21)</text>
     <text x="30" y="372" class="cap">Reachable is the roadmap number once #498 and #499 close. It is never the current number.</text>
-    <text x="30" y="390" class="cap">Executed in this run: 9 of 21, 5 pass and 4 fail. The other 12 are analysis, not observation.</text>
+    <text x="30" y="390" class="cap">Executed in this run: 9 of 21, 6 pass and 3 fail. The other 12 are analysis, not observation.</text>
   </g>
 </svg>

--- a/docs/aicr-preflight/diagrams/coverage-map.svg
+++ b/docs/aicr-preflight/diagrams/coverage-map.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 420" width="760" height="420" role="img" aria-label="Coverage map of 21 AICR checks: 14 bucket A meaningful pre-silicon of which 9 are GPU-dependent, 0 bucket B, 3 bucket G closable gaps, 4 bucket C hardware-dependent behind the final gate boundary.">
+  <title>AICR check coverage under Mokka: 21 checks</title>
+  <style>
+    .t   { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .hd  { font-size: 15px; font-weight: 600; fill: #1f2328; }
+    .lb  { font-size: 12.5px; fill: #1f2328; }
+    .sm  { font-size: 11px; fill: #1f2328; }
+    .cap { font-size: 11px; fill: #57606a; }
+    .bA  { fill: #ffffff; stroke: #1a7f37; stroke-width: 2.5; }
+    .bB  { fill: #ffffff; stroke: #57606a; stroke-width: 1.5; stroke-dasharray: 5 4; }
+    .bG  { fill: #fff8e6; stroke: #9a6700; stroke-width: 2.5; }
+    .bC  { fill: #ffebe9; stroke: #cf222e; stroke-width: 2.5; }
+    .txA { fill: #0f5323; } .txG { fill: #7d4e00; } .txC { fill: #a40e26; }
+    .note { fill: #f6f8fa; stroke: #57606a; stroke-width: 1; }
+    .gate { stroke: #cf222e; stroke-width: 2.5; stroke-dasharray: 8 5; }
+    @media (prefers-color-scheme: dark) {
+      .hd, .lb, .sm { fill: #e6edf3; }
+      .cap { fill: #9198a1; }
+      .bA { fill: #161b22; stroke: #3fb950; }
+      .bB { fill: #161b22; stroke: #8b949e; }
+      .bG { fill: #2b2411; stroke: #d29922; }
+      .bC { fill: #3c1618; stroke: #f85149; }
+      .txA { fill: #7ee787; } .txG { fill: #e3b341; } .txC { fill: #ff9492; }
+      .note { fill: #21262d; stroke: #8b949e; }
+      .gate { stroke: #f85149; }
+    }
+  </style>
+  <g class="t">
+    <text x="16" y="22" class="hd">AICR check coverage under Mokka: 21 checks</text>
+    <text x="16" y="40" class="cap">Run 2026-07-25 · provenance: sim · counts match tests/aicr-preflight/catalog.yaml</text>
+
+    <rect x="16" y="56" width="352" height="96" rx="6" class="bA"/>
+    <text x="30" y="78" class="lb txA" font-weight="600">Bucket A, meaningful pre-silicon: 14 of 21</text>
+    <text x="30" y="99" class="sm">9 GPU-dependent, which is what Mokka unlocks</text>
+    <text x="30" y="117" class="sm">5 GPU-independent, which any cluster would run</text>
+    <text x="30" y="140" class="cap">operator-health · check-nvidia-smi · accelerator-metrics · gpu-operator-health · …</text>
+
+    <rect x="16" y="164" width="352" height="62" rx="6" class="bB"/>
+    <text x="30" y="186" class="lb" font-weight="600">Bucket B, trivial against the mock: 0</text>
+    <text x="30" y="206" class="cap">AICR checks are integration assertions, not value assertions,</text>
+    <text x="30" y="220" class="cap">so none is green purely because the mock answered.</text>
+
+    <rect x="16" y="238" width="352" height="76" rx="6" class="bG"/>
+    <text x="30" y="260" class="lb txG" font-weight="600">Bucket G, closable gap: 3</text>
+    <text x="30" y="280" class="sm">#498 dra-support, slinky-slurm-imex-channel</text>
+    <text x="30" y="297" class="sm">#499 cluster-autoscaling</text>
+
+    <line x1="392" y1="56" x2="392" y2="400" class="gate"/>
+    <text x="400" y="72" class="cap txC" font-weight="600">FINAL GATE BOUNDARY</text>
+
+    <rect x="408" y="86" width="338" height="112" rx="6" class="bC"/>
+    <text x="422" y="108" class="lb txC" font-weight="600">Bucket C, hardware-dependent: 4</text>
+    <text x="422" y="130" class="sm txC">nccl-all-reduce-bw</text>
+    <text x="422" y="147" class="sm txC">nccl-all-reduce-bw-net</text>
+    <text x="422" y="164" class="sm txC">nccl-all-reduce-bw-nvls</text>
+    <text x="422" y="181" class="sm txC">inference-perf (CUDA, TTFT, throughput)</text>
+
+    <rect x="408" y="212" width="338" height="52" rx="6" class="note"/>
+    <text x="422" y="233" class="lb" font-weight="600">AICR validation on real silicon</text>
+    <text x="422" y="252" class="cap">No gap closure ever reaches these. This is why the gate stays.</text>
+
+    <rect x="16" y="330" width="730" height="72" rx="6" class="note"/>
+    <text x="30" y="352" class="lb" font-weight="600">TODAY 66.7% (14/21) · Mokka-specific 42.9% (9/21) · REACHABLE 81.0% (17/21)</text>
+    <text x="30" y="372" class="cap">Reachable is the roadmap number once #498 and #499 close. It is never the current number.</text>
+    <text x="30" y="390" class="cap">Executed in this run: 9 of 21, 5 pass and 4 fail. The other 12 are analysis, not observation.</text>
+  </g>
+</svg>

--- a/docs/aicr-preflight/diagrams/preflight-timeline.mmd
+++ b/docs/aicr-preflight/diagrams/preflight-timeline.mmd
@@ -1,0 +1,25 @@
+%% The customer value, honestly drawn.
+%% NOTE: no "day-one first token" claim. Silicon time still ends with the
+%% hardware-dependent validation that actually needs silicon.
+flowchart TB
+  subgraph WITHOUT["WITHOUT preflight"]
+    direction LR
+    W1["~3 months procurement<br/>engineers idle,<br/>nothing to integrate against"]
+    W2["silicon arrives"]
+    W3["integration failures<br/>discovered HERE:<br/>prereq ordering, version skew,<br/>resource advertisement,<br/>driver-userspace resolution"]
+    W4["hardware-dependent validation<br/>CUDA, firmware, NCCL/NVLink, TTFT"]
+    W5["first token"]
+    W1 --> W2 --> W3 --> W4 --> W5
+  end
+
+  subgraph WITH["WITH preflight"]
+    direction LR
+    P1["~3 months procurement<br/>PREFLIGHT on Mokka:<br/>AICR runs unmodified,<br/>integration failures found and fixed"]
+    P2["silicon arrives"]
+    P3["hardware-dependent validation<br/>CUDA, firmware, NCCL/NVLink, TTFT<br/>AICR on silicon = FINAL GATE"]
+    P4["first token, sooner"]
+    P1 --> P2 --> P3 --> P4
+  end
+
+  N["Evidence, 2026-07-25 (sim, n=4 proxy on cloud GB200, NOT NVL72):<br/>2 of 4 real failures would have been caught pre-silicon.<br/>2 missed: kernel/driver state and cloud credential lifetime.<br/>Time saved per bring-up: NOT YET QUANTIFIED (see issue #501)."]
+  WITH -.- N

--- a/docs/aicr-preflight/diagrams/preflight-timeline.svg
+++ b/docs/aicr-preflight/diagrams/preflight-timeline.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 400" width="760" height="400" role="img" aria-label="Two tracks over the procurement window. Without preflight, engineers are idle then integration failures consume silicon time. With preflight, integration failures are found pre-silicon so silicon time goes to hardware-dependent validation. AICR on silicon remains the final gate.">
+  <title>Preflight timeline: where integration failures get found</title>
+  <style>
+    .t   { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .hd  { font-size: 15px; font-weight: 600; fill: #1f2328; }
+    .lb  { font-size: 12px; fill: #1f2328; }
+    .sm  { font-size: 10.5px; fill: #1f2328; }
+    .cap { font-size: 11px; fill: #57606a; }
+    .idle { fill: #ffffff; stroke: #57606a; stroke-width: 1.5; stroke-dasharray: 6 4; }
+    .work { fill: #f6f8fa; stroke: #57606a; stroke-width: 1.5; }
+    .bad  { fill: #ffebe9; stroke: #cf222e; stroke-width: 2; }
+    .badtx{ fill: #a40e26; }
+    .gate { fill: #ddf4ff; stroke: #0969da; stroke-width: 2.5; }
+    .gatetx { fill: #0a3069; }
+    .line { stroke: #57606a; stroke-width: 1.5; stroke-dasharray: 3 3; }
+    .note { fill: #ffffff; stroke: #57606a; stroke-width: 1; }
+    @media (prefers-color-scheme: dark) {
+      .hd, .lb, .sm { fill: #e6edf3; }
+      .cap { fill: #9198a1; }
+      .idle { fill: #161b22; stroke: #8b949e; }
+      .work { fill: #21262d; stroke: #8b949e; }
+      .bad  { fill: #3c1618; stroke: #f85149; }
+      .badtx{ fill: #ff9492; }
+      .gate { fill: #121d2f; stroke: #58a6ff; }
+      .gatetx { fill: #79c0ff; }
+      .line { stroke: #8b949e; }
+      .note { fill: #161b22; stroke: #8b949e; }
+    }
+  </style>
+  <g class="t">
+    <text x="16" y="22" class="hd">Where integration failures get found</text>
+
+    <line x1="404" y1="40" x2="404" y2="290" class="line"/>
+    <text x="404" y="54" class="cap" text-anchor="middle">silicon arrives</text>
+
+    <text x="16" y="86" class="lb" font-weight="600">WITHOUT preflight</text>
+    <rect x="16" y="96" width="384" height="52" rx="5" class="idle"/>
+    <text x="28" y="118" class="sm" font-weight="600">~3 months procurement</text>
+    <text x="28" y="136" class="cap">engineers idle, nothing to integrate against</text>
+
+    <rect x="408" y="96" width="184" height="52" rx="5" class="bad"/>
+    <text x="418" y="115" class="sm badtx" font-weight="600">integration failures</text>
+    <text x="418" y="130" class="sm badtx">prereq ordering, version skew,</text>
+    <text x="418" y="143" class="sm badtx">advertisement, lib resolution</text>
+
+    <rect x="596" y="96" width="150" height="52" rx="5" class="gate"/>
+    <text x="606" y="115" class="sm gatetx" font-weight="600">hardware-dependent</text>
+    <text x="606" y="130" class="sm gatetx">CUDA, firmware,</text>
+    <text x="606" y="143" class="sm gatetx">NCCL/NVLink, TTFT</text>
+
+    <text x="16" y="196" class="lb" font-weight="600">WITH preflight</text>
+    <rect x="16" y="206" width="384" height="60" rx="5" class="work"/>
+    <text x="28" y="226" class="sm" font-weight="600">~3 months procurement: PREFLIGHT on Mokka</text>
+    <text x="28" y="243" class="cap">AICR runs unmodified on simulated GPU nodes.</text>
+    <text x="28" y="258" class="cap">Integration failures found and fixed here.</text>
+
+    <rect x="408" y="206" width="338" height="60" rx="5" class="gate"/>
+    <text x="418" y="226" class="sm gatetx" font-weight="600">hardware-dependent validation only</text>
+    <text x="418" y="243" class="sm gatetx">CUDA, firmware and driver, NCCL / NVLink / NVLS, TTFT</text>
+    <text x="418" y="258" class="sm gatetx" font-weight="600">AICR on silicon = FINAL READINESS GATE</text>
+
+    <rect x="16" y="286" width="730" height="98" rx="5" class="note"/>
+    <text x="28" y="306" class="lb" font-weight="600">What the evidence actually shows (2026-07-25, provenance: sim)</text>
+    <text x="28" y="325" class="cap">2 of 4 real hardware-encountered failures would have been caught pre-silicon.</text>
+    <text x="28" y="341" class="cap">2 missed: kernel and driver state, and cloud credential lifetime. Neither is a closable gap.</text>
+    <text x="28" y="357" class="cap">Proxy set is cloud GB200, n=4, NOT a DSX-OS NVL72 rack bring-up. Too small to generalize.</text>
+    <text x="28" y="373" class="cap" font-weight="600">Time saved per bring-up is NOT YET QUANTIFIED. No "day one first token" claim is made.</text>
+  </g>
+</svg>

--- a/docs/aicr-preflight/diagrams/preflight-workflow.mmd
+++ b/docs/aicr-preflight/diagrams/preflight-workflow.mmd
@@ -1,0 +1,22 @@
+%% The operational sequence. Note the triage step: a failing check is not
+%% automatically a simulation limit.
+flowchart TB
+  S1["1. Stand up cluster<br/>real CPU nodes, containerd CDI enabled"]
+  S2["2. Install Mokka (nvml-mock)<br/>gb200 profile, driver overlay + device nodes + CDI spec"]
+  S3["3. Install GPU stack<br/>GPU Operator (driver.enabled=false) + DRA driver"]
+  S4["4. Generate recipe<br/>aicr recipe --service kind --accelerator gb200"]
+  S5["5. Run AICR<br/>aicr validate --phase deployment --phase conformance<br/>--fail-on-error=false"]
+  S6["6. Classify<br/>go run ./tests/aicr-preflight -ctrf ctrf<br/>emits provenance-labelled JSON + catalog table"]
+
+  S1 --> S2 --> S3 --> S4 --> S5 --> S6 --> T{"7. Triage each failure"}
+
+  T -->|"missing prerequisite<br/>component"| R1["harness scoping.<br/>Deploy it, re-run."]
+  T -->|"version or contract<br/>skew"| R2["REAL FINDING.<br/>Fix pre-silicon.<br/>This is the value."]
+  T -->|"Mokka capability<br/>missing"| R3["bucket G.<br/>File a tracked issue.<br/>Close if small."]
+
+  R1 --> S5
+  R2 --> FIX["8. Fix integration issues<br/>months before hardware lands"]
+  R3 --> FIX
+
+  FIX --> SIL["9. Silicon arrives"]
+  SIL --> GATE["10. AICR on real hardware<br/><b>FINAL READINESS GATE</b><br/>CUDA · firmware/driver · NCCL/NVLink/NVLS · TTFT"]

--- a/docs/aicr-preflight/diagrams/preflight-workflow.svg
+++ b/docs/aicr-preflight/diagrams/preflight-workflow.svg
@@ -1,0 +1,109 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 470" width="760" height="470" role="img" aria-label="Operational workflow: stand up cluster, install Mokka, install GPU stack, generate recipe, run AICR, classify, triage failures into three causes, fix integration issues pre-silicon, then AICR on real hardware as the final gate.">
+  <title>Preflight workflow: from cluster bring-up to the final gate</title>
+  <style>
+    .t   { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .hd  { font-size: 15px; font-weight: 600; fill: #1f2328; }
+    .lb  { font-size: 12px; fill: #1f2328; }
+    .sm  { font-size: 10.5px; fill: #1f2328; }
+    .cap { font-size: 10.5px; fill: #57606a; }
+    .box { fill: #ffffff; stroke: #57606a; stroke-width: 1.5; }
+    .tri { fill: #f6f8fa; stroke: #57606a; stroke-width: 2; }
+    .good{ fill: #dafbe1; stroke: #1a7f37; stroke-width: 2.5; }
+    .goodtx { fill: #0f5323; }
+    .gap { fill: #fff8e6; stroke: #9a6700; stroke-width: 2; }
+    .gaptx { fill: #7d4e00; }
+    .gate{ fill: #ddf4ff; stroke: #0969da; stroke-width: 2.5; }
+    .gatetx { fill: #0a3069; }
+    .arw { stroke: #57606a; stroke-width: 1.5; fill: none; }
+    @media (prefers-color-scheme: dark) {
+      .hd, .lb, .sm { fill: #e6edf3; }
+      .cap { fill: #9198a1; }
+      .box { fill: #161b22; stroke: #8b949e; }
+      .tri { fill: #21262d; stroke: #8b949e; }
+      .good{ fill: #12261a; stroke: #3fb950; } .goodtx { fill: #7ee787; }
+      .gap { fill: #2b2411; stroke: #d29922; } .gaptx { fill: #e3b341; }
+      .gate{ fill: #121d2f; stroke: #58a6ff; } .gatetx { fill: #79c0ff; }
+      .arw { stroke: #8b949e; }
+    }
+  </style>
+  <g class="t">
+    <text x="16" y="22" class="hd">Preflight workflow</text>
+
+    <rect x="16" y="38" width="200" height="40" rx="5" class="box"/>
+    <text x="26" y="56" class="sm" font-weight="600">1. Stand up cluster</text>
+    <text x="26" y="71" class="cap">real CPU nodes, containerd CDI</text>
+
+    <rect x="16" y="88" width="200" height="42" rx="5" class="box"/>
+    <text x="26" y="106" class="sm" font-weight="600">2. Install Mokka (gb200)</text>
+    <text x="26" y="121" class="cap">driver overlay, device nodes, CDI</text>
+
+    <rect x="16" y="140" width="200" height="42" rx="5" class="box"/>
+    <text x="26" y="158" class="sm" font-weight="600">3. Install GPU stack</text>
+    <text x="26" y="173" class="cap">GPU Operator + DRA driver</text>
+
+    <rect x="16" y="192" width="200" height="40" rx="5" class="box"/>
+    <text x="26" y="210" class="sm" font-weight="600">4. Generate recipe</text>
+    <text x="26" y="225" class="cap">aicr recipe --accelerator gb200</text>
+
+    <rect x="16" y="242" width="200" height="42" rx="5" class="box"/>
+    <text x="26" y="260" class="sm" font-weight="600">5. Run aicr validate</text>
+    <text x="26" y="275" class="cap">--fail-on-error=false</text>
+
+    <rect x="16" y="294" width="200" height="42" rx="5" class="box"/>
+    <text x="26" y="312" class="sm" font-weight="600">6. Classify</text>
+    <text x="26" y="327" class="cap">provenance-labelled JSON + table</text>
+
+    <rect x="16" y="346" width="200" height="34" rx="5" class="tri"/>
+    <text x="26" y="368" class="sm" font-weight="600">7. Triage each failure</text>
+
+    <path d="M116 78 L116 88"   class="arw" marker-end="url(#w)"/>
+    <path d="M116 130 L116 140" class="arw" marker-end="url(#w)"/>
+    <path d="M116 182 L116 192" class="arw" marker-end="url(#w)"/>
+    <path d="M116 232 L116 242" class="arw" marker-end="url(#w)"/>
+    <path d="M116 284 L116 294" class="arw" marker-end="url(#w)"/>
+    <path d="M116 336 L116 346" class="arw" marker-end="url(#w)"/>
+
+    <path d="M216 363 L252 363" class="arw" marker-end="url(#w)"/>
+
+    <rect x="256" y="228" width="228" height="46" rx="5" class="box"/>
+    <text x="266" y="246" class="sm" font-weight="600">missing prerequisite component</text>
+    <text x="266" y="263" class="cap">harness scoping. Deploy it and re-run.</text>
+
+    <rect x="256" y="286" width="228" height="60" rx="5" class="good"/>
+    <text x="266" y="305" class="sm goodtx" font-weight="600">version or contract skew</text>
+    <text x="266" y="322" class="cap goodtx">REAL FINDING. Fix pre-silicon.</text>
+    <text x="266" y="337" class="cap goodtx">This is the value of preflight.</text>
+
+    <rect x="256" y="358" width="228" height="60" rx="5" class="gap"/>
+    <text x="266" y="377" class="sm gaptx" font-weight="600">Mokka capability missing</text>
+    <text x="266" y="394" class="cap gaptx">bucket G. File a tracked issue.</text>
+    <text x="266" y="409" class="cap gaptx">Close it if small.</text>
+
+    <path d="M252 360 L256 274" class="arw" marker-end="url(#w)"/>
+    <path d="M252 363 L256 316" class="arw" marker-end="url(#w)"/>
+    <path d="M252 366 L256 388" class="arw" marker-end="url(#w)"/>
+
+    <rect x="516" y="286" width="230" height="52" rx="5" class="box"/>
+    <text x="526" y="306" class="sm" font-weight="600">8. Fix integration issues</text>
+    <text x="526" y="323" class="cap">months before hardware lands</text>
+
+    <path d="M484 316 L516 314" class="arw" marker-end="url(#w)"/>
+    <path d="M484 388 L516 330" class="arw" marker-end="url(#w)"/>
+
+    <rect x="516" y="222" width="230" height="34" rx="5" class="box"/>
+    <text x="526" y="244" class="sm" font-weight="600">9. Silicon arrives</text>
+    <path d="M631 286 L631 256" class="arw" marker-end="url(#w)"/>
+
+    <rect x="516" y="110" width="230" height="94" rx="5" class="gate"/>
+    <text x="526" y="132" class="lb gatetx" font-weight="600">10. AICR on real hardware</text>
+    <text x="526" y="151" class="sm gatetx" font-weight="600">FINAL READINESS GATE</text>
+    <text x="526" y="170" class="cap gatetx">CUDA · firmware and driver</text>
+    <text x="526" y="186" class="cap gatetx">NCCL / NVLink / NVLS · TTFT</text>
+    <path d="M631 222 L631 204" class="arw" marker-end="url(#w)"/>
+  </g>
+  <defs>
+    <marker id="w" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#57606a"/>
+    </marker>
+  </defs>
+</svg>

--- a/docs/aicr-preflight/diagrams/stack-layering.mmd
+++ b/docs/aicr-preflight/diagrams/stack-layering.mmd
@@ -1,0 +1,19 @@
+%% AICR runs ON a Mokka-enabled Kubernetes cluster.
+%% Direction matters: AICR is the workload, Mokka is the substrate.
+%% Simulation does NOT live "inside" AICR.
+flowchart TB
+  L5["<b>AICR</b><br/>recipes, validate and conformance suite<br/><i>runs unmodified</i>"]
+  L4["<b>GPU stack</b><br/>GPU Operator · DRA driver · device plugin · GFD · DCGM<br/><i>real software, unmodified</i>"]
+  L3["<b>kubelet + containerd</b><br/>CDI injection"]
+  L2["<b>Mokka Sim (nvml-mock)</b><br/>libnvidia-ml.so.1 replacement · /dev/nvidia* nodes · CDI spec<br/><i>THE SIMULATION BOUNDARY</i>"]
+  L1["<b>Real CPU nodes</b><br/>Kubernetes · real kubelet · real container runtime"]
+
+  L1 --> L2 --> L3 --> L4 --> L5
+
+  NOTE["No NVIDIA kernel module.<br/>Nothing below the boundary is simulated."]
+  NOTE -.- L2
+
+  classDef sim stroke-width:3px
+  classDef real stroke-width:1px
+  class L2 sim
+  class L1,L3,L4,L5 real

--- a/docs/aicr-preflight/diagrams/stack-layering.svg
+++ b/docs/aicr-preflight/diagrams/stack-layering.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 430" width="720" height="430" role="img" aria-label="AICR runs on a Mokka-enabled Kubernetes cluster. Layers from bottom: real CPU nodes, Mokka Sim simulation boundary, kubelet and containerd, GPU stack, AICR.">
+  <title>Stack layering: AICR runs on a Mokka-enabled cluster</title>
+  <style>
+    .t   { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .hd  { font-size: 15px; font-weight: 600; fill: #1f2328; }
+    .lb  { font-size: 12.5px; fill: #1f2328; }
+    .sub { font-size: 11.5px; fill: #57606a; font-style: italic; }
+    .cap { font-size: 11.5px; fill: #57606a; }
+    .box { fill: #ffffff; stroke: #57606a; stroke-width: 1.5; }
+    .simbox { fill: #fff8e6; stroke: #9a6700; stroke-width: 3; }
+    .arw { stroke: #57606a; stroke-width: 1.5; fill: none; }
+    .dash { stroke: #9a6700; stroke-width: 1.5; stroke-dasharray: 5 4; fill: none; }
+    @media (prefers-color-scheme: dark) {
+      .hd, .lb { fill: #e6edf3; }
+      .sub, .cap { fill: #9198a1; }
+      .box { fill: #161b22; stroke: #8b949e; }
+      .simbox { fill: #2b2411; stroke: #d29922; }
+      .arw { stroke: #8b949e; }
+      .dash { stroke: #d29922; }
+    }
+  </style>
+  <g class="t">
+    <text x="16" y="24" class="hd">AICR runs ON a Mokka-enabled cluster</text>
+    <text x="16" y="42" class="cap">Mokka is the substrate. AICR is the workload. Simulation does not live inside AICR.</text>
+
+    <rect x="16" y="58" width="470" height="54" rx="6" class="box"/>
+    <text x="30" y="79" class="lb" font-weight="600">AICR: recipes, validate and conformance suite</text>
+    <text x="30" y="98" class="sub">runs unmodified, same as it would on silicon</text>
+
+    <rect x="16" y="128" width="470" height="58" rx="6" class="box"/>
+    <text x="30" y="149" class="lb" font-weight="600">GPU stack</text>
+    <text x="30" y="167" class="lb">GPU Operator · DRA driver · device plugin · GFD · DCGM</text>
+    <text x="30" y="181" class="sub">real software, unmodified</text>
+
+    <rect x="16" y="202" width="470" height="44" rx="6" class="box"/>
+    <text x="30" y="222" class="lb" font-weight="600">kubelet + containerd</text>
+    <text x="30" y="238" class="sub">CDI injection</text>
+
+    <rect x="16" y="262" width="470" height="66" rx="6" class="simbox"/>
+    <text x="30" y="283" class="lb" font-weight="600">Mokka Sim (nvml-mock): SIMULATION BOUNDARY</text>
+    <text x="30" y="301" class="lb">libnvidia-ml.so.1 replacement · /dev/nvidia* nodes · CDI spec</text>
+    <text x="30" y="319" class="sub">interception is at the NVML and driver line</text>
+
+    <rect x="16" y="344" width="470" height="52" rx="6" class="box"/>
+    <text x="30" y="365" class="lb" font-weight="600">Real CPU nodes</text>
+    <text x="30" y="383" class="lb">Kubernetes · real kubelet · real container runtime</text>
+
+    <path d="M251 344 L251 328" class="arw" marker-end="url(#a)"/>
+    <path d="M251 262 L251 246" class="arw" marker-end="url(#a)"/>
+    <path d="M251 202 L251 186" class="arw" marker-end="url(#a)"/>
+    <path d="M251 128 L251 112" class="arw" marker-end="url(#a)"/>
+
+    <path d="M486 295 L520 295" class="dash"/>
+    <rect x="520" y="252" width="186" height="86" rx="6" class="box"/>
+    <text x="532" y="274" class="lb" font-weight="600">Below this line:</text>
+    <text x="532" y="293" class="cap">no NVIDIA kernel module,</text>
+    <text x="532" y="309" class="cap">no CUDA execution,</text>
+    <text x="532" y="325" class="cap">no fabric transport.</text>
+
+    <rect x="520" y="58" width="186" height="86" rx="6" class="box"/>
+    <text x="532" y="80" class="lb" font-weight="600">Above the line:</text>
+    <text x="532" y="99" class="cap">every component is the</text>
+    <text x="532" y="115" class="cap">real one, so you validate</text>
+    <text x="532" y="131" class="cap">the real readiness path.</text>
+  </g>
+  <defs>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#57606a"/>
+    </marker>
+  </defs>
+</svg>

--- a/docs/aicr-preflight/diagrams/vertical-vs-horizontal.mmd
+++ b/docs/aicr-preflight/diagrams/vertical-vs-horizontal.mmd
@@ -1,0 +1,26 @@
+%% KWOK and Mokka are orthogonal axes, not competitors.
+%% KWOK = horizontal (node-count breadth). Mokka = vertical (GPU-stack depth).
+%% Run:ai's fake-gpu-operator combines both per nodepool.
+flowchart LR
+  subgraph H["KWOK, HORIZONTAL: node-count breadth"]
+    H1["hollow nodes, no kubelet"]
+    H2["API and control-plane scale"]
+    H3["very cheap per node"]
+    H4["blind spot: no GPU stack exists"]
+  end
+
+  subgraph V["Mokka Sim, VERTICAL: GPU-stack depth"]
+    V1["real kubelet on real CPU nodes"]
+    V2["GPU Operator, DRA, NVML, DCGM all run"]
+    V3["one CPU node per simulated GPU node"]
+    V4["blind spot: not the cheapest way to add node count"]
+  end
+
+  H -.->|"orthogonal, they compose"| V
+
+  C["Run:ai fake-gpu-operator<br/>selects backend per nodepool:<br/>fake (KWOK-compatible) or mock (Mokka)"]
+  H --> C
+  V --> C
+
+  N["UNPROVEN: GPU-stack fidelity AT KWOK scale.<br/>Mokka cannot run on KWOK nodes: it replaces a<br/>host library and needs a real kubelet."]
+  C -.- N

--- a/docs/aicr-preflight/diagrams/vertical-vs-horizontal.svg
+++ b/docs/aicr-preflight/diagrams/vertical-vs-horizontal.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 430" width="720" height="430" role="img" aria-label="KWOK provides horizontal node-count breadth, Mokka provides vertical GPU-stack depth. They are orthogonal and compose. Fidelity at KWOK scale is unproven.">
+  <title>Vertical versus horizontal: Mokka and KWOK are orthogonal axes</title>
+  <style>
+    .t   { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .hd  { font-size: 15px; font-weight: 600; fill: #1f2328; }
+    .lb  { font-size: 12.5px; fill: #1f2328; }
+    .cap { font-size: 11.5px; fill: #57606a; }
+    .ax  { stroke: #57606a; stroke-width: 2; fill: none; }
+    .box { fill: #ffffff; stroke: #57606a; stroke-width: 1.5; }
+    .vbox { fill: #f6f8fa; stroke: #57606a; stroke-width: 2.5; }
+    .warn { fill: #fff8e6; stroke: #9a6700; stroke-width: 2; }
+    .warntx { fill: #7d4e00; font-size: 11.5px; }
+    @media (prefers-color-scheme: dark) {
+      .hd, .lb { fill: #e6edf3; }
+      .cap { fill: #9198a1; }
+      .ax { stroke: #8b949e; }
+      .box { fill: #161b22; stroke: #8b949e; }
+      .vbox { fill: #21262d; stroke: #8b949e; }
+      .warn { fill: #2b2411; stroke: #d29922; }
+      .warntx { fill: #e3b341; }
+    }
+  </style>
+  <g class="t">
+    <text x="16" y="24" class="hd">Orthogonal axes, not competitors</text>
+    <text x="16" y="42" class="cap">Combine them. Do not pick one.</text>
+
+    <path d="M70 330 L680 330" class="ax" marker-end="url(#b)"/>
+    <path d="M70 330 L70 62" class="ax" marker-end="url(#b)"/>
+    <text x="360" y="352" class="lb" text-anchor="middle" font-weight="600">HORIZONTAL: node count (KWOK)</text>
+    <text x="26" y="200" class="lb" font-weight="600" transform="rotate(-90 26 200)" text-anchor="middle">VERTICAL: stack depth (Mokka)</text>
+
+    <rect x="92" y="238" width="228" height="80" rx="6" class="box"/>
+    <text x="104" y="258" class="lb" font-weight="600">KWOK</text>
+    <text x="104" y="276" class="cap">hollow nodes, no kubelet</text>
+    <text x="104" y="292" class="cap">control-plane scale, very cheap</text>
+    <text x="104" y="308" class="cap">blind spot: no GPU stack exists</text>
+
+    <rect x="92" y="86" width="228" height="86" rx="6" class="vbox"/>
+    <text x="104" y="106" class="lb" font-weight="600">Mokka Sim</text>
+    <text x="104" y="124" class="cap">real kubelet on real CPU nodes</text>
+    <text x="104" y="140" class="cap">GPU Operator, DRA, NVML, DCGM run</text>
+    <text x="104" y="156" class="cap">blind spot: costliest way to add nodes</text>
+
+    <rect x="366" y="150" width="300" height="76" rx="6" class="box"/>
+    <text x="378" y="170" class="lb" font-weight="600">Run:ai fake-gpu-operator: combines both</text>
+    <text x="378" y="189" class="cap">selects a backend per nodepool.</text>
+    <text x="378" y="205" class="cap">fake = KWOK-compatible · mock = Mokka on real nodes</text>
+    <text x="378" y="220" class="cap">External adoption of this chart, merged upstream.</text>
+
+    <rect x="366" y="240" width="300" height="78" rx="6" class="warn"/>
+    <text x="378" y="260" class="lb" font-weight="600">UNPROVEN: fidelity AT scale</text>
+    <text x="378" y="279" class="warntx">Mokka cannot run on KWOK nodes. It replaces a</text>
+    <text x="378" y="295" class="warntx">host library and needs a real kubelet.</text>
+    <text x="378" y="311" class="warntx">This POC ran on 1 node. Do not assert otherwise.</text>
+  </g>
+  <defs>
+    <marker id="b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#57606a"/>
+    </marker>
+  </defs>
+</svg>

--- a/docs/aicr-preflight/how-it-works.md
+++ b/docs/aicr-preflight/how-it-works.md
@@ -1,0 +1,145 @@
+# How pre-silicon preflight works
+
+**Audience:** an engineer who will actually run this.
+
+For the reproducible commands see the [harness README](../../tests/aicr-preflight/README.md). This
+page explains the mechanism so the results are interpretable.
+
+## Where the simulation boundary sits
+
+Everything above the NVML and driver line is the real software. Mokka replaces the line itself.
+
+```mermaid
+flowchart TB
+  W["Workload pod: nvidia-smi, DCGM, device plugin, DRA driver"]
+  CDI["CDI injection by containerd"]
+  NVML["libnvidia-ml.so.1 -- REPLACED by Mokka"]
+  DEV["/dev/nvidia* device nodes -- created by Mokka"]
+  ENG["Mokka engine: YAML GPU profile (gb200)"]
+  KERNEL["Host kernel -- NO NVIDIA kernel module"]
+
+  W --> CDI --> NVML --> ENG
+  CDI --> DEV
+  KERNEL -.->|"nothing below this line is simulated"| DEV
+```
+
+Consequences worth internalising:
+
+- A consumer that calls NVML gets profile-derived answers. That is why GFD labels, device-plugin
+  counts, and DRA ResourceSlices are all real code paths producing correct-shaped data.
+- A consumer that needs a **kernel module** gets nothing. `driver.enabled=false` is not a workaround,
+  it is the boundary.
+- A consumer that needs to **compute** gets nothing. Mokka exports one CUDA driver-API symbol,
+  `cuInit`. Kernel launch is a documented no-op.
+
+## Bring-up order
+
+1. **Cluster.** Kind or real nodes, with containerd CDI enabled and the NVIDIA runtime handler
+   registered.
+2. **Container toolkit.** Installed into the node so CDI injection works.
+3. **Mokka.** The `nvml-mock` Helm chart with a GPU profile (`gb200`). A privileged DaemonSet writes
+   the host driver overlay at `/var/lib/nvml-mock`, creates device nodes, and generates the CDI spec.
+   It also labels the node `nvidia.com/gpu.present=true`.
+4. **GPU stack.** GPU Operator with `driver.enabled=false` and `toolkit.enabled=false`, since Mokka
+   supplies the driver userspace. Then the DRA driver.
+5. **AICR.** Generate a recipe, then `aicr validate`.
+
+Order matters: the GPU Operator's operands probe NVML on startup, so Mokka has to be in place first.
+
+## What AICR does when you run it
+
+`aicr validate` deploys containerized validator Jobs into the cluster, one per selected check, and
+emits a [CTRF](https://ctrf.io) JSON report. Checks are selected by the recipe, not by the CLI, so the
+recipe determines your coverage.
+
+```bash
+aicr recipe --service kind --accelerator gb200 --intent inference -o recipe.yaml
+aicr validate --recipe recipe.yaml --phase deployment --phase conformance --fail-on-error=false --output ctrf/validate.json
+```
+
+`--fail-on-error=false` matters. The goal is to record every outcome, not to stop at the first failure.
+
+Three phases exist:
+
+| Phase | What it covers | Preflight-relevant? |
+|---|---|---|
+| `deployment` | operator health, expected resources, version constraints, `nvidia-smi` | Yes, this is the core |
+| `conformance` | DRA, scheduling, metrics, gateway, autoscaling, isolation | Mostly, per check |
+| `performance` | NCCL bandwidth, inference throughput and TTFT | No, needs silicon |
+
+## How the classification works
+
+The harness joins two independent things:
+
+- **The catalog** (`tests/aicr-preflight/catalog.yaml`) carries the analytical judgment: which bucket
+  each check belongs in, why, and the source evidence. It is reviewable without running anything.
+- **The run** supplies only the observed outcome.
+
+The harness never edits a bucket. That separation is what makes the catalog auditable: you can
+disagree with a bucket assignment by reading the rationale, without re-running anything.
+
+```bash
+go run ./tests/aicr-preflight -ctrf ctrf -markdown coverage.md -json report.json -provenance sim
+```
+
+## Reading the buckets
+
+| Bucket | Question it answers | How to act on it |
+|---|---|---|
+| **A** | Does this exercise real integration that could fail for a real reason? | Fix failures now, pre-silicon |
+| **B** | Is this green only because the mock answered? | Ignore as coverage; it bounds the claim |
+| **C** | Does this need real hardware? | Schedule it for silicon; it is why the final gate exists |
+| **G** | Would this be meaningful, but Mokka lacks the capability? | Roadmap; every G row links a tracked issue |
+
+Bucket A is additionally split by `gpuDependent`. A bucket-A check that is GPU-independent
+(`gang-scheduling` is deliberately CPU-only upstream) still moves left, but any cluster runs it, so
+Mokka is not what unlocks it. Do not count those toward what simulation bought you.
+
+## Triaging a failure
+
+A failing check is not automatically a simulation limit. Separate three causes before concluding
+anything:
+
+1. **Missing prerequisite component.** A recipe declaring 14 components run against a cluster with 2
+   of them will fail `platform-health` on absent namespaces. That is your scoping, not Mokka's limit.
+2. **Version or contract skew** between AICR and the component it inspects. These are real integration
+   findings and are exactly what preflight is for.
+3. **A genuine Mokka capability gap.** Only these are bucket G, and each needs a tracked issue.
+
+A worked example of the third case, from the reference run. `dra-support` failed on a missing
+`nvidia-dra-driver-gpu-controller` Deployment. That Deployment is templated only when
+`resources.computeDomains.enabled=true`. Enabling it produced:
+
+```
+error getting nvcap for IMEX channel '0': error getting device major:
+error parsing '/proc/devices': unexpected regex match: []
+```
+
+Mokka registers no `nvidia-caps-imex-channels` char-device major. The check was right, the cluster was
+wrong, and the gap is closable because it is device-node plumbing rather than fabric transport. It is
+tracked as [#498](https://github.com/NVIDIA/k8s-test-infra/issues/498).
+
+Note the discipline in that conclusion: the first hypothesis (a stale expectation in AICR) was wrong,
+and checking the chart templates rather than assuming is what produced the correct one.
+
+## Guarantees the harness gives you
+
+Built in, and unit-tested:
+
+1. A check the run never reported is recorded `not-run`, never promoted to a pass.
+2. CTRF `pending` and `other` map to `not-run` rather than being laundered into a pass.
+3. A bucket-C check reporting green under `sim` provenance is flagged `suspect`.
+4. Every record carries `sim` or `silicon` provenance.
+5. A bucket-G row without a tracked issue fails catalog validation.
+6. A check in the run but absent from the catalog is reported as catalog drift.
+
+The intent is that an incomplete or broken run degrades to "not run" rather than to a favourable
+number.
+
+## Known operational notes
+
+- The reference run used linux/arm64, which is the correct architecture for GB200 since Grace is ARM.
+- A single-node cluster with roughly 8 GiB of container memory runs the GPU Operator plus the DRA
+  driver. The full 14-component recipe needs considerably more.
+- `expected-resources` can take several minutes and produced a transient `other` status on one run
+  before reporting a real verdict on the next. Treat `other` as "no verdict" and re-run.

--- a/docs/aicr-preflight/how-it-works.md
+++ b/docs/aicr-preflight/how-it-works.md
@@ -115,12 +115,20 @@ error getting nvcap for IMEX channel '0': error getting device major:
 error parsing '/proc/devices': unexpected regex match: []
 ```
 
-Mokka registers no `nvidia-caps-imex-channels` char-device major. The check was right, the cluster was
-wrong, and the gap is closable because it is device-node plumbing rather than fabric transport. It is
-tracked as [#498](https://github.com/NVIDIA/k8s-test-infra/issues/498).
+The check was right and the cluster was wrong. The gap is closable, and it is smaller than it first
+looks: the DRA driver already exposes an `altProcDevices` value (documented example path:
+`/var/lib/nvml-mock/imex/proc-devices`) that mounts an alternate file and passes
+`ALT_PROC_DEVICES_PATH`, and its own CI builds that surface against `nvml-mock`. What is missing is
+that `nvml-mock` does not ship the surface and the released NGC chart has no `altProcDevices` key.
+Tracked as [#498](https://github.com/NVIDIA/k8s-test-infra/issues/498).
 
-Note the discipline in that conclusion: the first hypothesis (a stale expectation in AICR) was wrong,
-and checking the chart templates rather than assuming is what produced the correct one.
+Two wrong hypotheses preceded that conclusion, which is the point of the triage step. The first was
+that AICR carried a stale expectation; checking the chart templates disproved it. The second was that
+Mokka needed a way to fake `/proc/devices` invented from scratch; reading the DRA driver's own CI
+disproved that too. Do not stop at the first plausible story.
+
+Also worth knowing: mounting a file over `/proc/devices` inside a container does not work, because
+runc rejects it. That is exactly why the `ALT_PROC_DEVICES_PATH` indirection exists.
 
 ## Guarantees the harness gives you
 

--- a/pkg/system/mockimex/render/procdevices.go
+++ b/pkg/system/mockimex/render/procdevices.go
@@ -1,0 +1,148 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// Package render generates the mock IMEX capability surface that the NVIDIA DRA
+// driver's compute-domain kubelet plugin needs on a node with no NVIDIA kernel
+// driver.
+//
+// The plugin reads a device major for "nvidia-caps-imex-channels" out of
+// /proc/devices at startup. On a Mokka node that entry does not exist, because
+// there is no kernel module, and the plugin aborts with:
+//
+//	error getting nvcap for IMEX channel '0': error getting device major:
+//	error parsing '/proc/devices': unexpected regex match: []
+//
+// The DRA driver supports pointing at a substitute file through the
+// ALT_PROC_DEVICES_PATH environment variable, wired by its chart's
+// altProcDevices value. This package renders that file.
+//
+// The output must satisfy the consumer's parser, which requires the entry to
+// appear between the "Character devices:" and "Block devices:" headers and to be
+// newline-terminated. See internal/common/nvcaps.go in
+// kubernetes-sigs/dra-driver-nvidia-gpu.
+package render
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Device names the DRA driver looks up.
+const (
+	IMEXChannelsDeviceName = "nvidia-caps-imex-channels"
+	CapsDeviceName         = "nvidia-caps"
+)
+
+const (
+	charDevicesHeader  = "Character devices:"
+	blockDevicesHeader = "Block devices:"
+
+	// maxDeviceMajor is the largest major this renderer will emit. Linux
+	// allocates majors well below this; keeping the bound tight makes a
+	// transposed or garbage value fail loudly rather than produce a file the
+	// consumer will parse into nonsense.
+	maxDeviceMajor = 4095
+)
+
+// entryPattern matches an existing "<major> <name>" line so re-rendering can
+// replace it instead of appending a duplicate.
+func entryPattern(name string) *regexp.Regexp {
+	return regexp.MustCompile(`(?m)^[ \t]*[0-9]+ ` + regexp.QuoteMeta(name) + `[ \t]*$` + "\n?")
+}
+
+// existingMajors returns every device major already listed in src.
+func existingMajors(src string) map[int]string {
+	majors := make(map[int]string)
+	re := regexp.MustCompile(`(?m)^[ \t]*([0-9]+) +(\S+)[ \t]*$`)
+	for _, m := range re.FindAllStringSubmatch(src, -1) {
+		major, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+		// Keep the first binding; a major can legitimately appear in both the
+		// character and block sections for different drivers.
+		if _, seen := majors[major]; !seen {
+			majors[major] = m[2]
+		}
+	}
+	return majors
+}
+
+// ProcDevices returns src with NVIDIA caps character-device entries inserted
+// into the character-devices section, so the DRA driver's compute-domain plugin
+// can resolve its majors.
+//
+// It is idempotent: rendering an already-rendered file is a no-op, and
+// re-rendering with a different major replaces the entry rather than appending
+// a second one.
+func ProcDevices(src string, imexMajor, capsMajor int) (string, error) {
+	if err := validateMajors(src, imexMajor, capsMajor); err != nil {
+		return "", err
+	}
+
+	charAt := strings.Index(src, charDevicesHeader)
+	if charAt < 0 {
+		return "", fmt.Errorf("input has no %q header, so the consumer's parser can never match", charDevicesHeader)
+	}
+	blockAt := strings.Index(src, blockDevicesHeader)
+	if blockAt < 0 {
+		return "", fmt.Errorf("input has no %q header, so the consumer's parser can never match", blockDevicesHeader)
+	}
+	if blockAt < charAt {
+		return "", fmt.Errorf("%q appears before %q, which is not a valid /proc/devices layout",
+			blockDevicesHeader, charDevicesHeader)
+	}
+
+	// Drop any previous rendering so a changed major replaces rather than
+	// duplicates. Only the character-devices section is rewritten.
+	charSection := src[:blockAt]
+	rest := src[blockAt:]
+	for _, name := range []string{IMEXChannelsDeviceName, CapsDeviceName} {
+		charSection = entryPattern(name).ReplaceAllString(charSection, "")
+	}
+
+	// Trim trailing blank lines from the character section, append the entries,
+	// then restore the blank-line separator before the block header.
+	charSection = strings.TrimRight(charSection, "\n \t")
+	entries := fmt.Sprintf("\n%3d %s\n%3d %s\n\n", imexMajor, IMEXChannelsDeviceName, capsMajor, CapsDeviceName)
+
+	return charSection + entries + rest, nil
+}
+
+func validateMajors(src string, imexMajor, capsMajor int) error {
+	for _, m := range []struct {
+		name  string
+		major int
+	}{
+		{IMEXChannelsDeviceName, imexMajor},
+		{CapsDeviceName, capsMajor},
+	} {
+		if m.major <= 0 || m.major > maxDeviceMajor {
+			return fmt.Errorf("device major %d for %s is out of range, want 1..%d",
+				m.major, m.name, maxDeviceMajor)
+		}
+	}
+
+	if imexMajor == capsMajor {
+		return fmt.Errorf("device majors for %s and %s must differ, both are %d",
+			IMEXChannelsDeviceName, CapsDeviceName, imexMajor)
+	}
+
+	inUse := existingMajors(src)
+	for _, m := range []struct {
+		name  string
+		major int
+	}{
+		{IMEXChannelsDeviceName, imexMajor},
+		{CapsDeviceName, capsMajor},
+	} {
+		if owner, taken := inUse[m.major]; taken && owner != m.name {
+			return fmt.Errorf("device major %d is already assigned to %q, refusing to reuse it for %s",
+				m.major, owner, m.name)
+		}
+	}
+
+	return nil
+}

--- a/pkg/system/mockimex/render/procdevices_test.go
+++ b/pkg/system/mockimex/render/procdevices_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package render
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// draParserOracle is a verbatim copy of the regex the NVIDIA DRA driver uses to
+// read a device major out of /proc/devices
+// (kubernetes-sigs/dra-driver-nvidia-gpu internal/common/nvcaps.go, getDeviceMajor).
+//
+// Using the consumer's own parser as the oracle is the point: it derives the
+// expected result by a different path from the implementation, so these tests
+// fail if the rendered file drifts out of the contract the DRA driver actually
+// enforces. Asserting only "the string contains nvidia-caps-imex-channels"
+// would pass against output the real parser rejects.
+func draParserOracle(t *testing.T, content, name string) (int, bool) {
+	t.Helper()
+
+	re := regexp.MustCompile(
+		"(?s)Character devices:.*?" +
+			"([0-9]+) " + regexp.QuoteMeta(name) +
+			"\n.*Block devices:",
+	)
+	matches := re.FindStringSubmatch(content)
+	if len(matches) != 2 {
+		return 0, false
+	}
+	major, err := strconv.Atoi(matches[1])
+	require.NoError(t, err)
+	return major, true
+}
+
+// realisticProcDevices mirrors the shape of a real /proc/devices on a node with
+// no NVIDIA kernel driver loaded, which is exactly the Mokka case.
+const realisticProcDevices = `Character devices:
+  1 mem
+  4 tty
+  5 /dev/tty
+ 10 misc
+ 13 input
+128 ptm
+136 pts
+
+Block devices:
+  7 loop
+  8 sd
+259 blkext
+`
+
+func TestProcDevicesOutputSatisfiesTheDRAParser(t *testing.T) {
+	t.Parallel()
+
+	out, err := ProcDevices(realisticProcDevices, 235, 236)
+	require.NoError(t, err)
+
+	major, ok := draParserOracle(t, out, IMEXChannelsDeviceName)
+	require.True(t, ok, "the DRA driver's own regex must find the IMEX channels entry")
+	assert.Equal(t, 235, major)
+
+	capsMajor, ok := draParserOracle(t, out, CapsDeviceName)
+	require.True(t, ok, "the DRA driver's own regex must also find the nvidia-caps entry")
+	assert.Equal(t, 236, capsMajor)
+}
+
+// The failure this reproduces is the one observed on the POC cluster:
+// "error parsing '/proc/devices': unexpected regex match: []".
+func TestUnmodifiedProcDevicesFailsTheDRAParser(t *testing.T) {
+	t.Parallel()
+
+	_, ok := draParserOracle(t, realisticProcDevices, IMEXChannelsDeviceName)
+
+	assert.False(t, ok,
+		"an unmodified /proc/devices must NOT satisfy the parser, otherwise this test proves nothing")
+}
+
+// The parser requires the entry to sit between the two section headers, so the
+// entry must land in the character-devices section and not be appended at the end.
+func TestEntriesLandBeforeTheBlockDevicesSection(t *testing.T) {
+	t.Parallel()
+
+	out, err := ProcDevices(realisticProcDevices, 235, 236)
+	require.NoError(t, err)
+
+	imexAt := strings.Index(out, IMEXChannelsDeviceName)
+	blockAt := strings.Index(out, "Block devices:")
+	require.NotEqual(t, -1, imexAt)
+	require.NotEqual(t, -1, blockAt)
+
+	assert.Less(t, imexAt, blockAt,
+		"the IMEX entry must precede the Block devices header or the parser will not match it")
+}
+
+func TestProcDevicesPreservesExistingEntries(t *testing.T) {
+	t.Parallel()
+
+	out, err := ProcDevices(realisticProcDevices, 235, 236)
+	require.NoError(t, err)
+
+	for _, keep := range []string{"1 mem", "4 tty", "136 pts", "7 loop", "259 blkext"} {
+		assert.Contains(t, out, keep, "existing entry %q must survive rendering", keep)
+	}
+}
+
+// setup.sh may re-run on DaemonSet restart, so rendering twice must not produce
+// a duplicate entry, which would make the parser's ".*?" match ambiguous.
+func TestProcDevicesIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	once, err := ProcDevices(realisticProcDevices, 235, 236)
+	require.NoError(t, err)
+	twice, err := ProcDevices(once, 235, 236)
+	require.NoError(t, err)
+
+	assert.Equal(t, once, twice, "rendering an already-rendered file must be a no-op")
+	assert.Equal(t, 1, strings.Count(twice, IMEXChannelsDeviceName),
+		"the IMEX entry must appear exactly once")
+}
+
+// Re-rendering with a different major must update rather than append, otherwise
+// the file would carry two conflicting majors.
+func TestProcDevicesReplacesAnExistingEntryWithADifferentMajor(t *testing.T) {
+	t.Parallel()
+
+	first, err := ProcDevices(realisticProcDevices, 235, 236)
+	require.NoError(t, err)
+	second, err := ProcDevices(first, 240, 241)
+	require.NoError(t, err)
+
+	major, ok := draParserOracle(t, second, IMEXChannelsDeviceName)
+	require.True(t, ok)
+	assert.Equal(t, 240, major, "the major must be updated, not duplicated")
+	assert.Equal(t, 1, strings.Count(second, IMEXChannelsDeviceName))
+}
+
+func TestProcDevicesRejectsInputWithoutBlockDevicesSection(t *testing.T) {
+	t.Parallel()
+
+	_, err := ProcDevices("Character devices:\n  1 mem\n", 235, 236)
+
+	require.Error(t, err, "without a Block devices section the DRA parser can never match")
+	assert.Contains(t, err.Error(), "Block devices")
+}
+
+func TestProcDevicesRejectsInputWithoutCharacterDevicesSection(t *testing.T) {
+	t.Parallel()
+
+	_, err := ProcDevices("Block devices:\n  7 loop\n", 235, 236)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Character devices")
+}
+
+func TestProcDevicesRejectsOutOfRangeMajors(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		imex, caps int
+	}{
+		{"imex zero", 0, 236},
+		{"imex negative", -1, 236},
+		{"caps zero", 235, 0},
+		{"imex too large", 1 << 20, 236},
+		{"imex equals caps", 235, 235},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := ProcDevices(realisticProcDevices, tc.imex, tc.caps)
+			assert.Error(t, err, "major pair (%d,%d) must be rejected", tc.imex, tc.caps)
+		})
+	}
+}
+
+// A major already claimed by another driver would make the mock entry collide
+// with a real device, so it must be refused rather than silently written.
+func TestProcDevicesRejectsAMajorAlreadyInUse(t *testing.T) {
+	t.Parallel()
+
+	_, err := ProcDevices(realisticProcDevices, 10, 236)
+
+	require.Error(t, err, "major 10 is already 'misc' in the fixture and must be refused")
+	assert.Contains(t, err.Error(), "10")
+}

--- a/tests/aicr-preflight/FINDINGS.md
+++ b/tests/aicr-preflight/FINDINGS.md
@@ -13,8 +13,9 @@ against mocked APIs? (Mark Chmarny, 2026-07-24.)
 ## Answer
 
 It does more than prove deployment against mocked APIs, but by less than the headline coverage number
-suggests, and the strongest single result is a real integration defect found pre-silicon rather than a
-green suite. Of 21 AICR checks, 14 are analytically meaningful under Mokka, but only 9 of those depend
+suggests, and the strongest results are two real integration defects found pre-silicon rather than a
+green suite: a missing IMEX device surface, and an AICR recipe that declares a conformance check its
+own bundle cannot satisfy. Of 21 AICR checks, 14 are analytically meaningful under Mokka, but only 9 of those depend
 on the GPU stack at all, and only 9 checks of the 21 actually executed in this run. The honest verdict
 is go-with-scope: preflight is real for operator install, NVML-facing components, resource
 advertisement and control-plane behaviour, and it is nothing at all for the hardware-dependent path
@@ -35,7 +36,7 @@ Two qualifications, both of which cut against the headline:
    `platform-health`) are control-plane checks that any cluster would run. `gang-scheduling` is
    deliberately CPU-only upstream. They move left, but Mokka is not what unlocks them. **The share
    Mokka specifically unlocks is 9/21, or 42.9%.**
-2. **Only 9 of 21 checks executed.** 5 passed, 4 failed, 12 were not run because the generated
+2. **Only 9 of 21 checks executed.** 6 passed, 3 failed, 12 were not run because the generated
    `kind` + `gb200` recipe did not select them. Bucket assignment is analysis over the whole catalog;
    it is not evidence that the other 12 would behave as classified.
 
@@ -65,19 +66,30 @@ Machine-readable: [`report.json`](results/2026-07-25-gb200-kind/report.json).
 | `operator-health` | deployment | A | pass | real operator reconciled against the mock |
 | `gpu-operator-version` | deployment | A | pass | constraint `>= v25.10.0` satisfied |
 | `check-nvidia-smi` | deployment | A | **pass** | device plugin, CDI, toolkit, `libnvidia-ml.so.1` resolution |
-| `expected-resources` | deployment | A | fail | missing `agentgateway` Deployment (prerequisite absent) |
+| `expected-resources` | deployment | A | fail | missing `agentgateway` Deployment (component not installed) |
 | `gpu-operator-health` | conformance | A | pass | ClusterPolicy `ready`, see caveat below |
 | `accelerator-metrics` | conformance | A | pass | real dcgm-exporter against mock NVML |
+| `ai-service-metrics` | conformance | A | **pass** | passes only after two real integration fixes, see below |
 | `dra-support` | conformance | G | fail | see gap #498 |
-| `ai-service-metrics` | conformance | A | fail | no Prometheus in `monitoring` (prerequisite absent) |
-| `platform-health` | conformance | A | fail | 8 namespaces absent (prerequisites) |
+| `platform-health` | conformance | A | fail | 5 namespaces absent (components not installed) |
 
-Three of the four failures are missing prerequisite components rather than simulation limits: this
-harness deployed the GPU Operator and the DRA driver, while the recipe declares 14 components. That is
-harness scoping, and it is recorded as such rather than counted against Mokka.
+Two of the three failures are components this harness did not install, not simulation limits: the
+recipe declares 14 components and this cluster ran 7. That is harness scoping and is recorded as such
+rather than counted against Mokka.
 
-Evidence that these checks read live state rather than passing trivially: installing the DRA driver
-mid-run moved `platform-health` from 9 missing namespaces to 8.
+**These checks demonstrably read live state.** Coverage improved monotonically as components were
+added, and each fix moved a check to its next real requirement rather than flipping it green:
+
+| Cluster state | pass / fail | What moved |
+|---|---|---|
+| GPU Operator + DRA driver | 5 / 4 | baseline |
+| plus cert-manager, NFD, kube-prometheus-stack | 5 / 4 | `platform-health` 8 missing namespaces to 5; `ai-service-metrics` moved from "no Prometheus service" to "no `DCGM_FI_DEV_GPU_UTIL` time series" |
+| plus dcgm-exporter ServiceMonitor | 5 / 4 | `ai-service-metrics` moved past the time-series assertion to "custom metrics API not available" |
+| plus prometheus-adapter | **6 / 3** | **`ai-service-metrics` passes** |
+
+That progression is the strongest evidence in this POC that the A-bucket checks carry real signal. A
+check that passed trivially against a mock could not have failed four different ways for four
+different real reasons.
 
 **Caveat on `gpu-operator-health`.** ClusterPolicy reaching `ready` is a weaker statement under Mokka
 than on silicon. Two sub-validations are deliberately neutered: cuda-validation runs with
@@ -131,6 +143,37 @@ error mounting "/var/lib/nvml-mock/imex/proc-devices" to rootfs at "/proc/device
 
 The bucket does not change: a user of the `nvml-mock` chart alone still cannot run this check, so it
 stays G. The size drops to S and the fix is adaptation rather than invention. Tracked as #498.
+
+## 2b. A defect in AICR's own recipe, found pre-silicon
+
+The `ai-service-metrics` progression above surfaced something worth Mark's attention directly.
+
+**The generated `kind` + `gb200` recipe declares a check its own bundle cannot satisfy.** It selects
+`ai-service-metrics` as a conformance check, and it declares both `kube-prometheus-stack` and
+`prometheus-adapter` as components. But nothing in it wires the GPU Operator's dcgm-exporter into
+Prometheus, so no GPU time series ever exists and the check cannot pass from a clean deploy of that
+bundle.
+
+Verified three ways against the generated recipe, because a single negative grep is not evidence:
+
+1. The `gpu-operator` component's `dcgmExporter` overrides contain only `config: {create: false, data: '', name: ''}`. There is no `serviceMonitor` block, and the chart default is disabled. On the live cluster, no `nvidia-dcgm-exporter` ServiceMonitor existed until it was enabled by hand.
+2. The `kube-prometheus-stack` overrides touch only `alertmanager`, `defaultRules`, `grafana`, `prometheus` (resources, retention, storage) and `prometheusOperator`. No `additionalScrapeConfigs`, no widened `serviceMonitorSelector`.
+3. The recipe mentions DCGM exactly twice, both inside the gpu-operator block quoted above. There is no scrape configuration for it anywhere.
+
+Prometheus selects ServiceMonitors labelled `release: kube-prometheus-stack`. With no ServiceMonitor
+created at all, no selector can help.
+
+Setting `dcgmExporter.serviceMonitor.enabled=true` with that label made the metric appear
+(`DCGM_FI_DEV_GPU_UTIL`, carrying `DCGM_FI_DRIVER_VERSION: 580.65.06` and the GB200 model name off the
+mock), and the check advanced. Installing `prometheus-adapter` made it pass.
+
+This is an AICR-side finding, not a Mokka gap, and **it has not been filed**: NVIDIA/aicr is Mark's
+repo. It is raised here for him to confirm or correct, since he may know a deployment path that
+configures the wiring and that the generated recipe simply does not express.
+
+It is also the cleanest single answer to the POC's question. A misconfiguration that would otherwise
+surface during bring-up, when a customer wonders why their GPU dashboards are empty, was found on a
+laptop with no GPU present.
 
 ## 3. Back-test against real failures
 
@@ -216,7 +259,7 @@ Summary issue: **#502**.
 
 | Claim | Supported? | Basis |
 |---|---|---|
-| Pre-silicon **integration preflight** for the A-bucket checks | **Yes, scoped** | 5 checks passed and 4 failed for real, diagnosable reasons on a simulated cluster; `check-nvidia-smi` exercised the full allocation-to-NVML chain |
+| Pre-silicon **integration preflight** for the A-bucket checks | **Yes, scoped** | 6 checks passed and 3 failed for real, diagnosable reasons; coverage improved monotonically as components were added, and two genuine integration defects were found |
 | **Reduces** time to first token | **Directionally, not quantified** | 2 of 4 proxy failures were control-plane class and would surface pre-silicon; no timeline data exists to attach hours to that |
 | **Hit** first token on day one | **No** | simulation cannot prove it; the entire hardware-dependent path is untested by construction |
 | AICR-on-silicon remains the final readiness gate | **Yes** | bucket C is non-empty by construction: NCCL, NVLS, firmware and driver, and TTFT are all unrunnable here |

--- a/tests/aicr-preflight/FINDINGS.md
+++ b/tests/aicr-preflight/FINDINGS.md
@@ -1,0 +1,226 @@
+# Mokka + AICR pre-silicon preflight, POC findings
+
+**Date:** 2026-07-25 · **Ran by:** Carlos Eduardo Arango Gutierrez · **For review by:** Mark Chmarny
+**Cluster:** 1-node Kind (`nvml-mock-op`), Kubernetes v1.36.1, linux/arm64, `nvml-mock` `gb200` profile,
+GPU Operator (ClusterPolicy `ready`), `nvidia-dra-driver-gpu` v25.12.0, AICR at commit `06256cc8`
+**All evidence below is simulation provenance (`sim`). Nothing here has been confirmed on silicon.**
+
+## The question
+
+Does Mokka + AICR materially reduce GB200 bring-up time, or does it merely prove the stack deploys
+against mocked APIs? (Mark Chmarny, 2026-07-24.)
+
+## Answer
+
+It does more than prove deployment against mocked APIs, but by less than the headline coverage number
+suggests, and the strongest single result is a real integration defect found pre-silicon rather than a
+green suite. Of 21 AICR checks, 14 are analytically meaningful under Mokka, but only 9 of those depend
+on the GPU stack at all, and only 9 checks of the 21 actually executed in this run. The honest verdict
+is go-with-scope: preflight is real for operator install, NVML-facing components, resource
+advertisement and control-plane behaviour, and it is nothing at all for the hardware-dependent path
+that determines first token.
+
+## 1. Check coverage
+
+Of **21** AICR checks: **14 meaningful under Mokka (A)**, **0 pass trivially (B)**,
+**4 hardware-dependent and not runnable (C)**, **3 blocked by closable Mokka gaps (G)**.
+
+- **Today: 66.7% of the AICR suite carries real pre-silicon signal** (A / total).
+- **Reachable: 81.0% once the tracked gaps close** ((A + G) / total). Roadmap, not a current claim.
+
+Two qualifications, both of which cut against the headline:
+
+1. **Only 9 of the 14 bucket-A checks depend on the GPU stack.** The other 5
+   (`gpu-operator-version`, `gang-scheduling`, `inference-gateway`, `robust-controller`,
+   `platform-health`) are control-plane checks that any cluster would run. `gang-scheduling` is
+   deliberately CPU-only upstream. They move left, but Mokka is not what unlocks them. **The share
+   Mokka specifically unlocks is 9/21, or 42.9%.**
+2. **Only 9 of 21 checks executed.** 5 passed, 4 failed, 12 were not run because the generated
+   `kind` + `gb200` recipe did not select them. Bucket assignment is analysis over the whole catalog;
+   it is not evidence that the other 12 would behave as classified.
+
+| Bucket | Count | What it means for a customer |
+|---|---:|---|
+| A meaningful | 14 | integration work that can move left, before silicon |
+| B trivial | 0 | see note below |
+| C hardware | 4 | why AICR-on-silicon remains the final gate |
+| G gap | 3 | not covered yet, but closable in Mokka |
+
+**On B being empty.** This is a real result rather than an oversight, and it is worth stating because
+an empty B bucket in a study like this deserves suspicion. AICR's checks are written as integration
+assertions, not value assertions, so none is green purely because the mock answered an API. The
+corresponding limitation, which the bucket scheme does not capture, is that where Mokka's values are
+synthetic a check validates the path and stays silent on the values. `accelerator-metrics` is the
+clearest case: it requires `DCGM_FI_DEV_GPU_UTIL`, `FB_USED`, `GPU_TEMP` and `POWER_USAGE` to be
+present, and Mokka's `FB_USED` is a constant zero. The exporter-to-NVML path is genuinely exercised;
+the telemetry values are not checked by anyone.
+
+Full catalog: [`results/2026-07-25-gb200-kind/coverage.md`](results/2026-07-25-gb200-kind/coverage.md).
+Machine-readable: [`report.json`](results/2026-07-25-gb200-kind/report.json).
+
+### What actually ran
+
+| Check | Phase | Bucket | Outcome | Note |
+|---|---|---|---|---|
+| `operator-health` | deployment | A | pass | real operator reconciled against the mock |
+| `gpu-operator-version` | deployment | A | pass | constraint `>= v25.10.0` satisfied |
+| `check-nvidia-smi` | deployment | A | **pass** | device plugin, CDI, toolkit, `libnvidia-ml.so.1` resolution |
+| `expected-resources` | deployment | A | fail | missing `agentgateway` Deployment (prerequisite absent) |
+| `gpu-operator-health` | conformance | A | pass | ClusterPolicy `ready`, see caveat below |
+| `accelerator-metrics` | conformance | A | pass | real dcgm-exporter against mock NVML |
+| `dra-support` | conformance | G | fail | see gap #498 |
+| `ai-service-metrics` | conformance | A | fail | no Prometheus in `monitoring` (prerequisite absent) |
+| `platform-health` | conformance | A | fail | 8 namespaces absent (prerequisites) |
+
+Three of the four failures are missing prerequisite components rather than simulation limits: this
+harness deployed the GPU Operator and the DRA driver, while the recipe declares 14 components. That is
+harness scoping, and it is recorded as such rather than counted against Mokka.
+
+Evidence that these checks read live state rather than passing trivially: installing the DRA driver
+mid-run moved `platform-health` from 9 missing namespaces to 8.
+
+**Caveat on `gpu-operator-health`.** ClusterPolicy reaching `ready` is a weaker statement under Mokka
+than on silicon. Two sub-validations are deliberately neutered: cuda-validation runs with
+`WITH_WORKLOAD=false` because kernel launch is a no-op under the mock, and the toolkit stage is
+short-circuited by a pre-touched `/run/nvidia/validations/toolkit-ready` marker. This row should not be
+read as validating the driver or the toolkit.
+
+## 2. The strongest result is a defect, not a pass
+
+`check-nvidia-smi` passing is the cleanest demonstration of the value proposition. It schedules a pod
+requesting `nvidia.com/gpu` and runs `nvidia-smi` inside it, which exercises device-plugin allocation,
+CDI injection, container-toolkit wiring, and `dlopen` resolution of `libnvidia-ml.so.1`. That is
+precisely the chain that broke in NVIDIA/k8s-test-infra#455, where three missing `//export` symbols
+made `RTLD_NOW` abort while build, unit tests, and lint all stayed green. It proves the plumbing
+resolves. It does not prove the GPU computes anything.
+
+`dra-support` failing is more informative still. On this cluster the real `nvidia-dra-driver-gpu` chart
+installs and publishes all 8 GB200 devices as DRA ResourceSlices off the mock NVML. The check still
+fails, because it also requires a `nvidia-dra-driver-gpu-controller` Deployment that chart v25.12.0
+templates only when `resources.computeDomains.enabled=true`. Enabling that makes the kubelet plugin's
+`compute-domains` container CrashLoopBackOff:
+
+```
+error getting nvcap for IMEX channel '0': error getting device major:
+error parsing '/proc/devices': unexpected regex match: []
+```
+
+Mokka registers no `nvidia-caps-imex-channels` char-device major and creates no channel device nodes.
+That is a concrete, closable gap (#498), found on a laptop, that would otherwise have surfaced during
+bring-up.
+
+## 3. Back-test against real failures
+
+**Primary back-test: pending real failure data.** No captured DSX-OS GB200 NVL72 bring-up failure set
+exists in any searchable location. DSX-OS configs live on internal GitLab, so the artifacts are not
+reachable from the repositories searched. Tracking issue: #501. Leads: Andre Prado and the DSX Sw
+Bringup org, the DGXC Capacity Bring-up thread, and Aleksei Vasilevskii's outstanding runbook request.
+No failure set was synthesized to fill the gap.
+
+**Secondary, explicitly relabelled proxy.** Against real hardware-encountered failures from **cloud**
+GB200 (`p6e-gb200.36xlarge`, EKS/OKE) recorded in NVIDIA/aicr issues. This is a different platform and
+a different context from an NVL72 rack bring-up, and it needs Mark's agreement before it carries any
+weight.
+
+| # | Real failure | Caught pre-silicon? | By which check | Note |
+|---|---|---|---|---|
+| aicr#859 | bundler emits `manifestFiles` as `-post`, breaking prereq ConfigMaps, GB200/EKS deploy hangs | **caught** | `operator-health`, `expected-resources` | ordering bug, needs no GPU; this run reproduced the shape (prereq absent, check failed) |
+| aicr#1255 | EKS GB200 recipe K8s floor (>= 1.32.4) below the DRA `resource.k8s.io/v1` requirement (1.34+) | **caught** | readiness version constraint, `dra-support` | pure control-plane version skew |
+| aicr#1553 | `tools/cleanup` leaves `nvidia_uvm` wedged on driver-managed nodes | **missed** | none | kernel module state; Mokka runs `driver.enabled=false` and has no kernel module. Bucket C, permanently |
+| aicr#1861 | long GB200 validate phase outlives the AWS token, K8s calls 401 | **missed** | none | cloud IAM credential lifetime; out of simulation scope, not a Mokka gap |
+
+**Caught 2 of 4.** Both misses are explained by category rather than by a fixable gap: one is
+driver and kernel state that is inherently hardware-dependent, one is cloud credential lifetime that
+simulation has no view of. Neither would be closed by any item in the gap backlog.
+
+**Four caveats, all material:**
+
+1. Cloud GB200, not a DSX-OS NVL72 rack bring-up. Different topology, different failure modes.
+2. n=4. Far too small to generalize, and not a random sample.
+3. Two of the four (#859, #1255) are failures of AICR's own bundler and recipe metadata, caught by
+   AICR's own validators. That is partly circular and should be discounted accordingly.
+4. This proxy was run over an explicit objection. A devil's-advocate review recommended against running
+   any proxy back-test, on the grounds that numbers from non-NVL72 hardware invite exactly the
+   conflation the guardrail exists to prevent. The objection is recorded here because Mark may share
+   it; the mitigation is that the primary back-test remains openly pending and this table is never
+   quoted as the bring-up result.
+
+## 4. Bring-up-time read
+
+Not quantified, and this POC cannot honestly quantify it. Estimating hours saved needs a real bring-up
+timeline with per-failure cost attached, which is exactly the missing data in section 3.
+
+What can be said: the failure classes that move left are prerequisite ordering, missing components,
+version and API skew, resource advertisement, and driver-userspace resolution. The classes that do not
+move are CUDA execution, firmware and driver compatibility, NCCL / NVLink / NVLS and fabric, and
+TTFT and throughput.
+
+- Failures moved left: demonstrated for 2 of 4 proxy records, both control-plane class.
+- Rough time saved per bring-up: **not established**.
+- Confidence: **low**, because the bring-up timeline data does not exist yet.
+
+## 5. Gap backlog
+
+Summary issue: **#502**.
+
+| Gap | Issue | Blocks | Coverage unlocked | Size | Status |
+|---|---|---|---|---:|---|
+| No `nvidia-caps-imex-channels` device class, blocks DRA ComputeDomains | [#498](https://github.com/NVIDIA/k8s-test-infra/issues/498) | `dra-support`, `slinky-slurm-imex-channel` | 2 checks, G to A | M | open |
+| No simulated node provisioner | [#499](https://github.com/NVIDIA/k8s-test-infra/issues/499) | `cluster-autoscaling` | 1 check, G to A | M | open |
+| GFD e2e assertion is warning-only and can never fail | [#500](https://github.com/NVIDIA/k8s-test-infra/issues/500) | confidence in the resource-advertisement surface | test quality | S | **closed in this PR** |
+
+- **Closed during this POC:** 1 gap (#500). It did not move a bucket, because it was a defect in our
+  own e2e rather than in Mokka's capability. It is reported as a test-quality fix, not as coverage.
+- **Highest-leverage remaining:** #498. It unlocks 2 checks and is the only gap on the GB200 critical
+  path, since ComputeDomains is how IMEX is expressed in DRA.
+- **Deliberately not worth closing:** MIG. Mokka's MIG coverage is zero (every GpuInstance and
+  ComputeInstance call is a stub), but **no check in the AICR catalog requires MIG**, so closing it
+  would unlock no coverage. Filed nowhere on purpose, recorded here so nobody refiles it as a blocker.
+
+## 6. Limits
+
+- **Fidelity at scale is unproven and is not claimed.** The mock replaces `libnvidia-ml.so.1` on the
+  host and needs a real kubelet, so KWOK nodes cannot run it. This POC ran on **one node**. It says
+  nothing whatsoever about GPU-stack fidelity at KWOK-scale node counts. #499 would compose the two
+  axes for the autoscaling check specifically, and even that would prove only the control loop, not
+  node-level fidelity.
+- **12 of 21 checks did not run.** Their buckets are analysis, not observation.
+- **Single architecture and single profile.** linux/arm64, `gb200`, 1 node, 8 simulated GPUs.
+- **Back-test data status:** pending real DSX-OS NVL72 failure history (#501).
+
+## 7. Claims this supports (and does not)
+
+| Claim | Supported? | Basis |
+|---|---|---|
+| Pre-silicon **integration preflight** for the A-bucket checks | **Yes, scoped** | 5 checks passed and 4 failed for real, diagnosable reasons on a simulated cluster; `check-nvidia-smi` exercised the full allocation-to-NVML chain |
+| **Reduces** time to first token | **Directionally, not quantified** | 2 of 4 proxy failures were control-plane class and would surface pre-silicon; no timeline data exists to attach hours to that |
+| **Hit** first token on day one | **No** | simulation cannot prove it; the entire hardware-dependent path is untested by construction |
+| AICR-on-silicon remains the final readiness gate | **Yes** | bucket C is non-empty by construction: NCCL, NVLS, firmware and driver, and TTFT are all unrunnable here |
+| Deep GPU-stack fidelity at KWOK scale | **No** | not tested; the mock cannot run on KWOK nodes at all |
+| Mokka validates CUDA execution | **No** | 1 CUDA driver-API symbol (`cuInit`); the operator's cuda-validation runs `WITH_WORKLOAD=false` because kernel launch is a no-op |
+
+## 8. Recommendation
+
+**Go with scope**, on a narrower claim than the original pitch.
+
+The defensible product statement is: *Mokka + AICR is a pre-silicon integration preflight covering
+operator install, DRA and resource advertisement, NVML-facing components, and control-plane behaviour.
+AICR validation on real silicon remains the final readiness gate.* Roughly 43% of the AICR suite is
+what Mokka specifically unlocks today, rising toward 57% if #498 and #499 close.
+
+Three things would change the answer materially, in priority order:
+
+1. **Real DSX-OS NVL72 bring-up failure history** (#501). Without it there is no defensible
+   time-saved number, and the bring-up-time claim stays qualitative. This is the single highest-value
+   unblock and it needs a human, not more engineering.
+2. **Close #498.** It is the only gap on the GB200 critical path and it unlocks the DRA check that
+   most directly supports the "GPU Operator + DRA installation moves earlier" claim.
+3. **Run the full 14-component recipe.** 12 of 21 checks did not execute here. A larger cluster would
+   convert analysis into observation, which is what makes the coverage number defensible rather than
+   argued.
+
+## Appendix
+
+- Harness and buckets: [`README.md`](README.md)
+- Catalog with per-check rationale and source evidence: [`catalog.yaml`](catalog.yaml)
+- Raw run: [`results/2026-07-25-gb200-kind/`](results/2026-07-25-gb200-kind/)

--- a/tests/aicr-preflight/FINDINGS.md
+++ b/tests/aicr-preflight/FINDINGS.md
@@ -94,20 +94,43 @@ precisely the chain that broke in NVIDIA/k8s-test-infra#455, where three missing
 made `RTLD_NOW` abort while build, unit tests, and lint all stayed green. It proves the plumbing
 resolves. It does not prove the GPU computes anything.
 
-`dra-support` failing is more informative still. On this cluster the real `nvidia-dra-driver-gpu` chart
-installs and publishes all 8 GB200 devices as DRA ResourceSlices off the mock NVML. The check still
-fails, because it also requires a `nvidia-dra-driver-gpu-controller` Deployment that chart v25.12.0
-templates only when `resources.computeDomains.enabled=true`. Enabling that makes the kubelet plugin's
-`compute-domains` container CrashLoopBackOff:
+`dra-support` failing is more informative still, and it took two passes to characterise correctly.
+
+On this cluster the real `nvidia-dra-driver-gpu` chart installs and publishes all 8 GB200 devices as
+DRA ResourceSlices off the mock NVML. The check still fails, because it also requires a
+`nvidia-dra-driver-gpu-controller` Deployment that the chart templates only when
+`resources.computeDomains.enabled=true`. Enabling that makes the kubelet plugin's `compute-domains`
+container CrashLoopBackOff:
 
 ```
 error getting nvcap for IMEX channel '0': error getting device major:
 error parsing '/proc/devices': unexpected regex match: []
 ```
 
-Mokka registers no `nvidia-caps-imex-channels` char-device major and creates no channel device nodes.
-That is a concrete, closable gap (#498), found on a laptop, that would otherwise have surfaced during
-bring-up.
+**The first conclusion drawn from this was wrong**, and it is worth recording because the correction
+changes the recommendation. The initial reading was that Mokka lacks an `nvidia-caps-imex-channels`
+device class and that closing it meant inventing a way to fake `/proc/devices`, sized M.
+
+In fact the DRA driver already solves this. Its chart exposes an `altProcDevices` value whose
+documented example path is literally `/var/lib/nvml-mock/imex/proc-devices`, mounting an alternate
+file and passing `ALT_PROC_DEVICES_PATH`. Its CI (`hack/ci/mock-nvml/setup-mock-gpu.sh`, step 7b)
+builds the whole surface against `nvml-mock`: the proc-devices file with `235 nvidia-caps-imex-channels`
+appended, a `fabric-imex-mgmt` capability file, and 2048 channel device nodes.
+
+So the real gap is **packaging, not capability**, and it is smaller: `nvml-mock` does not ship that
+surface, and the released NGC chart v25.12.0 that this repo's e2e uses has no `altProcDevices` key.
+Both halves exist; neither is reachable from the `nvml-mock` chart.
+
+Attempting the obvious workaround confirmed why the indirection exists. Building the surface by hand
+and mounting it over `/proc/devices` in the container is rejected by runc:
+
+```
+error mounting "/var/lib/nvml-mock/imex/proc-devices" to rootfs at "/proc/devices":
+... cannot be mounted because it is inside /proc
+```
+
+The bucket does not change: a user of the `nvml-mock` chart alone still cannot run this check, so it
+stays G. The size drops to S and the fix is adaptation rather than invention. Tracked as #498.
 
 ## 3. Back-test against real failures
 
@@ -165,14 +188,15 @@ Summary issue: **#502**.
 
 | Gap | Issue | Blocks | Coverage unlocked | Size | Status |
 |---|---|---|---|---:|---|
-| No `nvidia-caps-imex-channels` device class, blocks DRA ComputeDomains | [#498](https://github.com/NVIDIA/k8s-test-infra/issues/498) | `dra-support`, `slinky-slurm-imex-channel` | 2 checks, G to A | M | open |
+| nvml-mock does not ship the mock IMEX surface the DRA compute-domain plugin needs | [#498](https://github.com/NVIDIA/k8s-test-infra/issues/498) | `dra-support`, `slinky-slurm-imex-channel` | 2 checks, G to A | S | open |
 | No simulated node provisioner | [#499](https://github.com/NVIDIA/k8s-test-infra/issues/499) | `cluster-autoscaling` | 1 check, G to A | M | open |
 | GFD e2e assertion is warning-only and can never fail | [#500](https://github.com/NVIDIA/k8s-test-infra/issues/500) | confidence in the resource-advertisement surface | test quality | S | **closed in this PR** |
 
 - **Closed during this POC:** 1 gap (#500). It did not move a bucket, because it was a defect in our
   own e2e rather than in Mokka's capability. It is reported as a test-quality fix, not as coverage.
-- **Highest-leverage remaining:** #498. It unlocks 2 checks and is the only gap on the GB200 critical
-  path, since ComputeDomains is how IMEX is expressed in DRA.
+- **Highest-leverage remaining:** #498. It unlocks 2 checks, is the only gap on the GB200 critical
+  path since ComputeDomains is how IMEX is expressed in DRA, and is now sized S because the DRA
+  driver already ships the consumption mechanism and the setup shell already exists in its CI.
 - **Deliberately not worth closing:** MIG. Mokka's MIG coverage is zero (every GpuInstance and
   ComputeInstance call is a stub), but **no check in the AICR catalog requires MIG**, so closing it
   would unlock no coverage. Filed nowhere on purpose, recorded here so nobody refiles it as a blocker.

--- a/tests/aicr-preflight/README.md
+++ b/tests/aicr-preflight/README.md
@@ -1,0 +1,146 @@
+# AICR pre-silicon preflight harness
+
+Runs the [AICR](https://github.com/NVIDIA/aicr) `validate` suite against an
+`nvml-mock` (Mokka Sim) cluster and classifies what each check actually proves
+when there is no GPU present.
+
+This exists to answer one question, posed by the AICR maintainer on 2026-07-24:
+
+> Does Mokka + AICR materially reduce GB200 bring-up time, or does it merely
+> prove the stack deploys against mocked APIs?
+
+An honest negative answer is a successful run. Nothing here is tuned toward a
+favourable number.
+
+## What this is not
+
+This is a **pre-silicon integration preflight**, not a readiness gate. AICR
+validation on real silicon remains the final gate. Preflight cannot judge CUDA
+execution, firmware and driver compatibility, NCCL / NVLink / NVLS and the
+network fabric, or workload TTFT and throughput. Those determine time to first
+token. Preflight reduces the time spent on integration failures before you get
+there; it does not prove you will hit first token on day one.
+
+## Buckets
+
+| Bucket | Meaning | Counts as coverage? |
+|---|---|---|
+| **A** | Exercises real integration. Could plausibly fail for a real reason. | Yes. This is the movable-left set. |
+| **B** | Green only because the mock answers the API. Would pass regardless of correctness. | No. Recorded honestly because it bounds the claim. |
+| **C** | Hardware-dependent. Cannot be judged pre-silicon. | No. These are why AICR-on-silicon stays the final gate. |
+| **G** | Would be meaningful pre-silicon, but Mokka lacks the capability. Not hardware-dependent, so closable. | As roadmap only. Requires a tracked issue. |
+
+Two numbers are always reported side by side:
+
+- **A / total**: the share carrying real pre-silicon signal **today**.
+- **(A + G) / total**: the share **reachable** once tracked gaps close. Roadmap,
+  never a current claim.
+
+A third number keeps the first honest. Some bucket-A checks are GPU-independent
+(`gang-scheduling` is explicitly CPU-only upstream, `platform-health` is pure
+control-plane). They move left, but any cluster runs them, so Mokka is not what
+unlocks them. The report splits bucket A into GPU-dependent and GPU-independent
+so the headline cannot be inflated by control-plane checks.
+
+## Design invariants
+
+The harness is built so that an incomplete run degrades to "not run" rather than
+to a favourable number:
+
+1. A check the run never reported is recorded `not-run`. It is never promoted to
+   a pass. (`TestCheckAbsentFromRunIsNotRunNeverPass`)
+2. CTRF `pending` and `other` mean the suite reached no verdict, and map to
+   `not-run` rather than being laundered into a pass.
+3. A bucket-C check reporting green under `sim` provenance is flagged
+   `suspect`, because a hardware-dependent check cannot legitimately pass
+   without hardware.
+4. Every emitted record carries `provenance`, `sim` or `silicon`. They are never
+   conflated.
+5. A bucket-G row without a tracked gap issue fails catalog validation. An
+   untracked gap is not a roadmap.
+6. A check present in the run but absent from the catalog is reported as
+   catalog drift rather than silently dropped.
+
+## Prerequisites
+
+- `docker`, `kind`, `kubectl`, `helm`, and a Go toolchain matching the project.
+- The `aicr` CLI, built from [NVIDIA/aicr](https://github.com/NVIDIA/aicr):
+  `go build -o aicr ./cmd/aicr`.
+- **Real nodes.** The mock replaces `libnvidia-ml.so.1` on the host and needs a
+  real kubelet and container runtime. KWOK nodes cannot host it. This harness
+  therefore says nothing about GPU-stack fidelity at KWOK-scale node counts.
+- Roughly 8 GiB of container memory for the cluster used here. The full 14
+  component recipe stack needs considerably more.
+
+## Running it
+
+### 1. Stand up a Mokka cluster with the GPU stack
+
+The GPU Operator scenario in `tests/e2e/go` already does this, and is the
+supported path:
+
+```bash
+make e2e-gpu-operator E2E_PROFILES=gb200 E2E_KEEP_CLUSTER=true
+```
+
+That builds the mock image, creates the `nvml-mock-op` Kind cluster, installs
+the NVIDIA Container Toolkit, configures containerd for CDI, installs the
+`nvml-mock` chart with the `gb200` profile, and installs the real GPU Operator.
+
+Add the DRA driver so `dra-support` gets a fair run:
+
+```bash
+helm upgrade nvidia-dra-driver-gpu nvidia/nvidia-dra-driver-gpu --install --namespace nvidia-dra-driver --create-namespace --set gpuResourcesEnabledOverride=true --set nvidiaDriverRoot=/var/lib/nvml-mock/driver --set resources.computeDomains.enabled=false --wait
+```
+
+### 2. Generate a recipe and run AICR
+
+```bash
+aicr recipe --service kind --accelerator gb200 --intent inference -o recipe-gb200-kind.yaml
+```
+
+```bash
+aicr validate --recipe recipe-gb200-kind.yaml --phase deployment --phase conformance --namespace aicr-validation --fail-on-error=false --output ctrf/validate.json
+```
+
+`--fail-on-error=false` matters: the point is to record every outcome, not to
+stop at the first failure.
+
+### 3. Classify
+
+```bash
+go run ./tests/aicr-preflight -ctrf ctrf -markdown coverage.md -json report.json -cluster kind-nvml-mock-op -profile gb200
+```
+
+Omitting `-ctrf` is legal and prints the catalog with every outcome recorded
+`not-run`. That is the correct output when no run happened.
+
+## Interpreting the results
+
+A failing check is not automatically a Mokka gap. Separate three causes before
+drawing any conclusion:
+
+1. **Missing prerequisite component.** The recipe declares 14 components; a
+   cluster running only the GPU Operator will fail `platform-health` and
+   `ai-service-metrics` on absent namespaces. That is harness scoping, not a
+   simulation limit.
+2. **Version or contract skew** between AICR and the component it inspects.
+   These are real integration findings and exactly what preflight is for.
+3. **A genuine Mokka capability gap.** Only these are bucket G, and each needs a
+   tracked issue.
+
+Bucket B is scope information, not failure. Do not reclassify B as A to improve
+the headline.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `catalog.yaml` | The analytical judgment: one row per AICR check, with bucket, rationale, and source evidence. Reviewable independently of any run. |
+| `classify.go` | Buckets, outcomes, provenance, the join, and the roll-up. |
+| `ctrf.go` | CTRF report parsing and catalog loading. |
+| `report.go` | JSON and markdown emission. |
+| `main.go` | CLI. |
+
+The catalog carries the judgment; the harness carries the observation. The
+harness never edits a bucket.

--- a/tests/aicr-preflight/catalog.yaml
+++ b/tests/aicr-preflight/catalog.yaml
@@ -140,20 +140,22 @@ checks:
     gpuDependent: true
     gapIssue: "#498"
     rationale: >-
-      Half of this check already works under Mokka and half is blocked, so the
-      precise split matters. WORKS: the real nvidia-dra-driver-gpu chart
-      installs, the kubelet plugin runs, and ResourceSlices publish all 8 GB200
-      devices off the mock NVML (observed 2026-07-25). BLOCKED: the check also
-      requires the nvidia-dra-driver-gpu-controller Deployment, which chart
-      v25.12.0 templates only when resources.computeDomains.enabled=true. Turning
-      that on makes the kubelet plugin's compute-domains container CrashLoopBackOff
-      with "error getting nvcap for IMEX channel '0': error parsing
-      '/proc/devices': unexpected regex match: []", because Mokka registers no
-      nvidia-caps-imex-channels char-device major and creates no
-      /dev/nvidia-caps-imex-channels nodes. Not hardware-dependent, therefore
-      bucket G rather than C: this is device-node and /proc/devices plumbing, not
-      fabric transport.
-    evidence: "validators/conformance/dra_support_check.go:42-54,242-264; observed CrashLoopBackOff on nvidia-dra-driver-gpu 25.12.0 templates/controller.yaml"
+      Half of this check already works under Mokka and half is blocked by
+      PACKAGING, not by a capability limit. WORKS: the real nvidia-dra-driver-gpu
+      chart installs, the kubelet plugin runs, and ResourceSlices publish all 8
+      GB200 devices off the mock NVML (observed 2026-07-25). BLOCKED: the check
+      also requires the nvidia-dra-driver-gpu-controller Deployment, which the
+      chart templates only when resources.computeDomains.enabled=true, and
+      enabling that crashes the kubelet plugin's compute-domains container on
+      "error getting nvcap for IMEX channel '0': error parsing '/proc/devices'".
+      The DRA driver already solves this: its chart exposes altProcDevices, which
+      mounts an alternate proc-devices file and passes ALT_PROC_DEVICES_PATH, and
+      its own CI (hack/ci/mock-nvml/setup-mock-gpu.sh) builds the surface against
+      nvml-mock. Two things are missing: nvml-mock does not ship that surface,
+      and the released NGC chart v25.12.0 has no altProcDevices key. Bucket G
+      because a user of the nvml-mock chart alone cannot run this check today,
+      but the gap is packaging and is small. See issue #498.
+    evidence: "validators/conformance/dra_support_check.go:42-54,242-264; kubernetes-sigs/dra-driver-nvidia-gpu values.yaml altProcDevices + hack/ci/mock-nvml/setup-mock-gpu.sh step 7b"
 
   - name: gang-scheduling
     area: scheduling
@@ -283,11 +285,15 @@ checks:
       fabric carries traffic is hardware-dependent (bucket C, see
       nccl-all-reduce-bw-nvls), but whether channel ALLOCATION hands out distinct
       channels is driver-surface and control-plane behaviour that is simulatable.
-      Same root cause as dra-support: Mokka registers no
-      nvidia-caps-imex-channels char-device major and creates no channel device
-      nodes, which the DRA driver's own compute-domains component confirmed by
-      crashing on /proc/devices. Flagged for Mark's review as the closest call in
-      the catalog, since it sits nearest his hardware-dependent boundary.
+      Same root cause and same issue as dra-support (#498): nvml-mock does not
+      ship the mock IMEX surface (proc-devices entries, fabric-imex-mgmt
+      capability file, channel device nodes) that the DRA driver's compute-domain
+      plugin consumes via ALT_PROC_DEVICES_PATH. The DRA driver's own CI builds
+      that surface against nvml-mock, so this is packaging rather than a
+      capability limit. Flagged for Mark's review as the closest call in the
+      catalog, since it sits nearest his hardware-dependent boundary. The
+      allocation-distinctness behaviour itself is unverified here: static channel
+      device nodes may or may not model per-job allocation faithfully.
     evidence: "validators/conformance/slinky_slurm_imex_channel_check.go:82-84"
 
   - name: gpu-operator-health

--- a/tests/aicr-preflight/catalog.yaml
+++ b/tests/aicr-preflight/catalog.yaml
@@ -1,0 +1,319 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# AICR check-coverage catalog under Mokka (nvml-mock).
+#
+# One row per check in the AICR validate catalog. The bucket is an ANALYTICAL
+# judgment about what the check proves when it runs against a simulated cluster,
+# made from source evidence and reviewable independently of any run. The harness
+# supplies the observed outcome separately and never edits a bucket.
+#
+# Buckets:
+#   A  exercises real integration; could plausibly fail for a real reason.
+#   B  green only because the mock answers the API; would pass regardless of
+#      correctness. Not a win. Recorded honestly because it bounds the claim.
+#   C  hardware-dependent; cannot be judged pre-silicon. These are why
+#      AICR-on-silicon remains the final readiness gate.
+#   G  would be meaningful pre-silicon, but Mokka lacks the capability. Not
+#      hardware-dependent, therefore closable, therefore roadmap. Needs an issue.
+#
+# gpuDependent records whether the check actually touches the GPU stack. A
+# bucket-A row with gpuDependent:false still moves left, but ANY cluster runs it,
+# so Mokka is not what unlocks it. Keeping that split visible is what stops the
+# headline A number from being inflated by pure control-plane checks.
+#
+# Check names and evidence lines are from NVIDIA/aicr at commit 06256cc8.
+# The authoritative source list is recipes/validators/catalog.yaml (21 entries:
+# 4 deployment, 4 performance, 13 conformance).
+
+source: "NVIDIA/aicr recipes/validators/catalog.yaml @06256cc8 (21 checks)"
+
+checks:
+  # ---------------------------------------------------------------- deployment
+  - name: operator-health
+    area: operator-install
+    phase: deployment
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      Installs and reconciles the real NVIDIA GPU Operator against the mock
+      driver surface, then requires its pods to actually reach a healthy state.
+      Fails for real reasons: a broken operand, an unschedulable DaemonSet, a
+      driver-root misconfiguration. This is integration work that genuinely
+      moves left.
+    evidence: "validators/deployment/operator_health.go:32-45"
+
+  - name: expected-resources
+    area: control-plane
+    phase: deployment
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      Verifies every resource declared in the recipe's componentRefs exists and
+      is healthy, and dispatches 34 nested chainsaw component health checks
+      plus verifyGPUReadinessSignals. Real control-plane reconciliation against
+      a real cluster; a missing prerequisite or a stuck operand fails it.
+    evidence: "validators/deployment/expected_resources.go:153-155,215,226-248"
+
+  - name: gpu-operator-version
+    area: operator-install
+    phase: deployment
+    bucket: A
+    gpuDependent: false
+    rationale: >-
+      Reads the deployed operator version and evaluates it against the recipe
+      constraint, so a wrong or unpinned chart version fails it for a real
+      reason. Marked GPU-independent: it inspects a Helm release and would work
+      on any cluster with the operator installed, so Mokka is not what unlocks
+      it.
+    evidence: "validators/deployment/gpu_operator_version.go:29-31"
+
+  - name: check-nvidia-smi
+    area: nvml-surface
+    phase: deployment
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      The strongest bucket-A case in the suite. Schedules a pod requesting
+      nvidia.com/gpu and runs nvidia-smi inside it, which exercises the whole
+      chain: device-plugin allocation, CDI injection, container-toolkit wiring,
+      and dlopen resolution of libnvidia-ml.so.1. This is exactly the class of
+      failure that shipped as NVIDIA/k8s-test-infra#455, where three missing
+      //export symbols made RTLD_NOW abort while build, unit tests, and lint all
+      stayed green. It does NOT prove the GPU computes anything; it proves the
+      plumbing resolves.
+    evidence: "validators/deployment/nvidia_smi.go:38-39; testdata/nvidia-smi-verify-pod.yaml:40,42"
+
+  # --------------------------------------------------------------- performance
+  - name: nccl-all-reduce-bw
+    area: nccl-nvlink-fabric
+    phase: performance
+    bucket: C
+    gpuDependent: true
+    rationale: >-
+      Runs all_reduce_perf across GPU nodes and measures achieved bandwidth.
+      Mokka simulates no collective transport and no fabric, and measured
+      bandwidth is meaningless without real links. Hardware-dependent by
+      construction.
+    evidence: "validators/performance/nccl_all_reduce_bw.go:26-30"
+
+  - name: nccl-all-reduce-bw-net
+    area: nccl-nvlink-fabric
+    phase: performance
+    bucket: C
+    gpuDependent: true
+    rationale: >-
+      Asserts the NET transport (EFA and equivalents) actually carried the
+      traffic. Requires a real network fabric.
+    evidence: "validators/performance/nccl_all_reduce_bw.go:33-36"
+
+  - name: nccl-all-reduce-bw-nvls
+    area: nccl-nvlink-fabric
+    phase: performance
+    bucket: C
+    gpuDependent: true
+    rationale: >-
+      Asserts NVLS/MNNVL initialized and carried traffic, and fails loudly if a
+      broken IMEX domain makes NCCL fall back to NET. This is precisely the
+      GB200 NVL72 failure mode that matters most on real silicon, and precisely
+      what simulation cannot judge.
+    evidence: "validators/performance/nccl_all_reduce_bw.go:39-42; catalog.yaml:258-260"
+
+  - name: inference-perf
+    area: ttft-throughput
+    phase: performance
+    bucket: C
+    gpuDependent: true
+    rationale: >-
+      Runs AIPerf against a live inference endpoint backed by vLLM/Dynamo GPU
+      workers and evaluates throughput and TTFT p99 constraints. Requires real
+      CUDA execution and real model serving. This check is the definition of
+      time to first token, and it is the reason preflight reduces bring-up time
+      rather than proving readiness.
+    evidence: "validators/performance/inference_perf.go:25-28; catalog.yaml:88-146"
+
+  # --------------------------------------------------------------- conformance
+  - name: dra-support
+    area: dra
+    phase: conformance
+    bucket: G
+    gpuDependent: true
+    gapIssue: "#498"
+    rationale: >-
+      Half of this check already works under Mokka and half is blocked, so the
+      precise split matters. WORKS: the real nvidia-dra-driver-gpu chart
+      installs, the kubelet plugin runs, and ResourceSlices publish all 8 GB200
+      devices off the mock NVML (observed 2026-07-25). BLOCKED: the check also
+      requires the nvidia-dra-driver-gpu-controller Deployment, which chart
+      v25.12.0 templates only when resources.computeDomains.enabled=true. Turning
+      that on makes the kubelet plugin's compute-domains container CrashLoopBackOff
+      with "error getting nvcap for IMEX channel '0': error parsing
+      '/proc/devices': unexpected regex match: []", because Mokka registers no
+      nvidia-caps-imex-channels char-device major and creates no
+      /dev/nvidia-caps-imex-channels nodes. Not hardware-dependent, therefore
+      bucket G rather than C: this is device-node and /proc/devices plumbing, not
+      fabric transport.
+    evidence: "validators/conformance/dra_support_check.go:42-54,242-264; observed CrashLoopBackOff on nvidia-dra-driver-gpu 25.12.0 templates/controller.yaml"
+
+  - name: gang-scheduling
+    area: scheduling
+    phase: conformance
+    bucket: A
+    gpuDependent: false
+    rationale: >-
+      Verifies KAI scheduler deployments and CRDs, then co-schedules a PodGroup.
+      Upstream deliberately keeps the workload CPU-only so one-GPU CI clusters
+      can run the full conformance phase, so this exercises real scheduling
+      behaviour but touches no GPU at all. It moves left, but any cluster runs
+      it and Mokka is not what unlocks it.
+    evidence: "validators/conformance/gang_scheduling_check.go:94-99"
+
+  - name: accelerator-metrics
+    area: nvml-surface
+    phase: conformance
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      Scrapes the DCGM exporter and requires DCGM_FI_DEV_GPU_UTIL, FB_USED,
+      GPU_TEMP and POWER_USAGE to be present. Under Mokka the real dcgm-exporter
+      runs against the mock NVML, so a broken exporter-to-NVML path fails this
+      for a real reason. Bounded honestly: the assertion is presence-only, and
+      Mokka's values are synthetic (FB_USED is a constant 0), so this validates
+      the telemetry path, not telemetry correctness.
+    evidence: "validators/conformance/accelerator_metrics_check.go:28-38"
+
+  - name: ai-service-metrics
+    area: control-plane
+    phase: conformance
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      Discovers Prometheus from the recipe and verifies GPU metric time series
+      exist and the custom metrics API is available. Real integration of the
+      monitoring stack with the GPU telemetry source; same value caveat as
+      accelerator-metrics.
+    evidence: "validators/conformance/ai_service_metrics_check.go:37-40"
+
+  - name: inference-gateway
+    area: control-plane
+    phase: conformance
+    bucket: A
+    gpuDependent: false
+    rationale: >-
+      Verifies the agentgateway GatewayClass is accepted, the Gateway is
+      programmed, and the Gateway API plus InferencePool CRDs exist. Pure
+      control-plane status reconciliation with no GPU involvement.
+    evidence: "validators/conformance/inference_gateway_check.go:51-53"
+
+  - name: pod-autoscaling
+    area: scheduling
+    phase: conformance
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      Requires the external metrics API to expose a cluster-wide GPU metric
+      (dcgm_gpu_power_usage) and proves the capability with an HPA scale-up and
+      scale-down. Mokka's power values vary over time, which this repo's e2e
+      already asserts, so the metrics-to-autoscaler loop is genuinely driven.
+    evidence: "validators/conformance/pod_autoscaling_check.go:55-69,208"
+
+  - name: cluster-autoscaling
+    area: scheduling
+    phase: conformance
+    bucket: G
+    gpuDependent: false
+    gapIssue: "#499"
+    rationale: >-
+      Checks Karpenter, EKS node groups, or the GKE cluster autoscaler, and
+      skips gracefully when none is detectable, which is what happens on a kind
+      cluster. Not hardware-dependent: AICR's own CI already exercises the
+      Karpenter path against KWOK-faked nodes. Blocked only because this harness
+      composes no simulated provisioner, which is a closable gap and the exact
+      point where Mokka's vertical depth should compose with KWOK's horizontal
+      breadth.
+    evidence: "validators/conformance/cluster_autoscaling_check.go:61-67; .github/actions/gpu-validate-conformance/action.yml:38-43"
+
+  - name: robust-controller
+    area: control-plane
+    phase: conformance
+    bucket: A
+    gpuDependent: false
+    rationale: >-
+      Proves a complex AI operator with a CRD is installed and reconciles
+      custom resources, with running pods and operational webhooks. Real
+      controller behaviour, no GPU dependency.
+    evidence: "validators/conformance/robust_controller_check.go:69-77"
+
+  - name: secure-accelerator-access
+    area: dra
+    phase: conformance
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      Grants a GPU to one container and requires an unauthorized sibling
+      container, plus a standalone no-allocation probe pod, to see no
+      accelerator at all. Isolation is enforced by CDI and device-plugin
+      allocation, which Mokka drives for real, so a leak fails this for a real
+      reason. Worth watching under Mokka's node-wide NRI ambient injection mode,
+      where a genuine isolation failure would be the correct result.
+    evidence: "validators/conformance/secure_access_check.go:268-275"
+
+  - name: slinky-slurm-health
+    area: scheduling
+    phase: conformance
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      Requires a Slinky-managed Slurm cluster to be reachable, to have idle or
+      mixed workers, and to schedule a minimal job; GPU-backed NodeSets also run
+      a bounded containerized GPU job through Pyxis. The GPU job runs plain
+      alpine rather than a CUDA workload, so it tests allocation and injection
+      rather than computation, which Mokka can drive.
+    evidence: "validators/conformance/slinky_slurm_health_check.go:91-94,162"
+
+  - name: slinky-slurm-imex-channel
+    area: nccl-nvlink-fabric
+    phase: conformance
+    bucket: G
+    gpuDependent: true
+    gapIssue: "#498"
+    rationale: >-
+      Verifies two concurrent Slurm jobs each receive a distinct NVIDIA IMEX
+      channel. Bucketed G rather than C, and the distinction matters: whether the
+      fabric carries traffic is hardware-dependent (bucket C, see
+      nccl-all-reduce-bw-nvls), but whether channel ALLOCATION hands out distinct
+      channels is driver-surface and control-plane behaviour that is simulatable.
+      Same root cause as dra-support: Mokka registers no
+      nvidia-caps-imex-channels char-device major and creates no channel device
+      nodes, which the DRA driver's own compute-domains component confirmed by
+      crashing on /proc/devices. Flagged for Mark's review as the closest call in
+      the catalog, since it sits nearest his hardware-dependent boundary.
+    evidence: "validators/conformance/slinky_slurm_imex_channel_check.go:82-84"
+
+  - name: gpu-operator-health
+    area: operator-install
+    phase: conformance
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      Verifies the GPU Operator deployment, ClusterPolicy state=ready, and the
+      DCGM exporter DaemonSet. ClusterPolicy reaching ready requires the driver,
+      toolkit, CUDA and plugin validators to pass, which is real reconciliation.
+      Bounded honestly: under Mokka two of those sub-validations are weakened,
+      because cuda-validation runs with WITH_WORKLOAD=false (kernel launch is a
+      no-op) and the toolkit stage is short-circuited by a pre-touched
+      /run/nvidia/validations/toolkit-ready marker. So ready under simulation is
+      a weaker statement than ready on silicon, and this row should not be read
+      as validating the driver or toolkit.
+    evidence: "validators/conformance/gpu_operator_health_check.go:28-29; tests/e2e/go/assets/gpu-operator-values.yaml (WITH_WORKLOAD=false)"
+
+  - name: platform-health
+    area: control-plane
+    phase: conformance
+    bucket: A
+    gpuDependent: false
+    rationale: >-
+      Validates namespace existence and expectedResources health for every
+      componentRef in the recipe. Real deployment verification, no GPU
+      dependency.
+    evidence: "validators/conformance/platform_health_check.go:28-30"

--- a/tests/aicr-preflight/classify.go
+++ b/tests/aicr-preflight/classify.go
@@ -1,0 +1,299 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// Command aicr-preflight joins an AICR validate run against the Mokka coverage
+// catalog and emits a provenance-labelled, bucketed result set.
+//
+// The governing invariant is that a check the run did not report can never be
+// recorded as passing. Outcomes are only ever promoted by an observed result,
+// so an incomplete run degrades to "not run" rather than to a favourable
+// number. See README.md for the bucket definitions.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// Bucket classifies what an AICR check actually proves when it runs against a
+// Mokka-simulated cluster rather than against silicon.
+type Bucket string
+
+const (
+	// BucketA exercises real integration logic and could plausibly fail for a
+	// real reason. This is the movable-left set.
+	BucketA Bucket = "A"
+	// BucketB is green only because the mock answers the API. No real signal.
+	// Recording it honestly is what bounds the claim.
+	BucketB Bucket = "B"
+	// BucketC is hardware-dependent and cannot be judged pre-silicon.
+	BucketC Bucket = "C"
+	// BucketG could be meaningful pre-silicon but Mokka lacks the capability.
+	// Not hardware-dependent, therefore closable, therefore roadmap.
+	BucketG Bucket = "G"
+)
+
+// Provenance records whether the evidence came from simulation or from silicon.
+// It is attached to every emitted record so the two can never be conflated.
+type Provenance string
+
+const (
+	ProvenanceSim     Provenance = "sim"
+	ProvenanceSilicon Provenance = "silicon"
+)
+
+// Outcome is what the run observed. The zero value is deliberately OutcomeNotRun
+// so that a missing result can never read as a pass.
+type Outcome string
+
+const (
+	OutcomeNotRun Outcome = "not-run"
+	OutcomePass   Outcome = "pass"
+	OutcomeFail   Outcome = "fail"
+	OutcomeSkip   Outcome = "skip"
+)
+
+// CatalogCheck is one row of the coverage catalog: the analytical judgment about
+// an AICR check, made from evidence and reviewable independently of any run.
+type CatalogCheck struct {
+	Name      string `json:"name" yaml:"name"`
+	Area      string `json:"area,omitempty" yaml:"area,omitempty"`
+	Phase     string `json:"phase,omitempty" yaml:"phase,omitempty"`
+	Bucket    Bucket `json:"bucket" yaml:"bucket"`
+	Rationale string `json:"rationale" yaml:"rationale"`
+	// GPUDependent records whether the check actually depends on the GPU stack.
+	// A bucket-A check that is GPU-independent still moves left, but any cluster
+	// would run it, so Mokka is not what unlocks it. Tracking this separately
+	// stops the headline A number from being inflated by control-plane checks
+	// that have nothing to do with GPU simulation.
+	GPUDependent bool `json:"gpuDependent" yaml:"gpuDependent"`
+	// GapIssue links the tracked issue for a bucket-G row. Required for G so the
+	// roadmap claim is auditable.
+	GapIssue string `json:"gapIssue,omitempty" yaml:"gapIssue,omitempty"`
+	// Evidence cites the source that justifies the bucket, as file:line or URL.
+	Evidence string `json:"evidence,omitempty" yaml:"evidence,omitempty"`
+}
+
+// Catalog is the full set of AICR checks under consideration.
+type Catalog struct {
+	Source string         `json:"source,omitempty" yaml:"source,omitempty"`
+	Checks []CatalogCheck `json:"checks" yaml:"checks"`
+}
+
+// Validate rejects a catalog that cannot be trusted to produce an honest
+// roll-up: unknown buckets, duplicates, unexplained rows, or a bucket-G claim
+// with no tracked issue behind it.
+func (c *Catalog) Validate() error {
+	var errs []error
+	seen := make(map[string]struct{}, len(c.Checks))
+
+	for i, check := range c.Checks {
+		if check.Name == "" {
+			errs = append(errs, fmt.Errorf("checks[%d]: name must not be empty", i))
+			continue
+		}
+		if _, dup := seen[check.Name]; dup {
+			errs = append(errs, fmt.Errorf("checks[%d]: duplicate check name %q", i, check.Name))
+		}
+		seen[check.Name] = struct{}{}
+
+		switch check.Bucket {
+		case BucketA, BucketB, BucketC, BucketG:
+		default:
+			errs = append(errs, fmt.Errorf("checks[%d] (%s): unknown bucket %q, want one of A, B, C, G",
+				i, check.Name, check.Bucket))
+		}
+
+		if check.Rationale == "" {
+			errs = append(errs, fmt.Errorf("checks[%d] (%s): rationale must not be empty, a bucket without a stated mechanism is not reviewable",
+				i, check.Name))
+		}
+
+		if check.Bucket == BucketG && check.GapIssue == "" {
+			errs = append(errs, fmt.Errorf("checks[%d] (%s): bucket G requires a gapIssue, an untracked gap is not a roadmap",
+				i, check.Name))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// RunTest is one observed result from an AICR CTRF report.
+type RunTest struct {
+	Name    string
+	Status  string
+	Suite   string
+	Message string
+}
+
+// RunResults is the set of results parsed from one or more CTRF reports.
+type RunResults struct {
+	Tests []RunTest
+}
+
+// Record is one catalog row joined with what the run actually observed.
+type Record struct {
+	Name         string     `json:"name"`
+	Area         string     `json:"area,omitempty"`
+	Phase        string     `json:"phase,omitempty"`
+	Bucket       Bucket     `json:"bucket"`
+	Outcome      Outcome    `json:"outcome"`
+	Provenance   Provenance `json:"provenance"`
+	Rationale    string     `json:"rationale"`
+	GPUDependent bool       `json:"gpuDependent"`
+	GapIssue     string     `json:"gapIssue,omitempty"`
+	Evidence     string     `json:"evidence,omitempty"`
+	Message      string     `json:"message,omitempty"`
+	// Suspect marks a result that contradicts its bucket badly enough to need a
+	// human look, specifically a hardware-dependent check reporting green from a
+	// simulated run.
+	Suspect bool `json:"suspect,omitempty"`
+}
+
+// outcomeFor maps a CTRF status onto an Outcome. Anything that is not an
+// explicit verdict degrades to OutcomeNotRun; "pending" and "other" mean the
+// suite reached no conclusion and must not be laundered into a pass.
+func outcomeFor(status string) Outcome {
+	switch status {
+	case "passed":
+		return OutcomePass
+	case "failed":
+		return OutcomeFail
+	case "skipped":
+		return OutcomeSkip
+	default:
+		return OutcomeNotRun
+	}
+}
+
+// Classify joins every catalog row with the run, in catalog order. A catalog row
+// with no corresponding run result is recorded OutcomeNotRun; it is never
+// promoted to a pass.
+func Classify(catalog *Catalog, run *RunResults, provenance Provenance) []Record {
+	if catalog == nil {
+		return nil
+	}
+
+	observed := make(map[string]RunTest)
+	if run != nil {
+		for _, test := range run.Tests {
+			observed[test.Name] = test
+		}
+	}
+
+	records := make([]Record, 0, len(catalog.Checks))
+	for _, check := range catalog.Checks {
+		rec := Record{
+			Name:         check.Name,
+			Area:         check.Area,
+			Phase:        check.Phase,
+			Bucket:       check.Bucket,
+			Outcome:      OutcomeNotRun,
+			Provenance:   provenance,
+			Rationale:    check.Rationale,
+			GPUDependent: check.GPUDependent,
+			GapIssue:     check.GapIssue,
+			Evidence:     check.Evidence,
+		}
+
+		if test, ran := observed[check.Name]; ran {
+			rec.Outcome = outcomeFor(test.Status)
+			rec.Message = test.Message
+		}
+
+		// A hardware-dependent check cannot legitimately go green without
+		// hardware. Flag it rather than counting it.
+		rec.Suspect = check.Bucket == BucketC &&
+			rec.Outcome == OutcomePass &&
+			provenance == ProvenanceSim
+
+		records = append(records, rec)
+	}
+
+	return records
+}
+
+// UncataloguedChecks returns run results with no catalog row, sorted. These are
+// catalog drift: the suite grew a check the catalog does not describe.
+func UncataloguedChecks(catalog *Catalog, run *RunResults) []string {
+	if run == nil {
+		return nil
+	}
+
+	known := make(map[string]struct{})
+	if catalog != nil {
+		for _, check := range catalog.Checks {
+			known[check.Name] = struct{}{}
+		}
+	}
+
+	var missing []string
+	seen := make(map[string]struct{})
+	for _, test := range run.Tests {
+		if _, ok := known[test.Name]; ok {
+			continue
+		}
+		if _, dup := seen[test.Name]; dup {
+			continue
+		}
+		seen[test.Name] = struct{}{}
+		missing = append(missing, test.Name)
+	}
+
+	sort.Strings(missing)
+	return missing
+}
+
+// Summary is the roll-up. It deliberately carries both percentages so the
+// reachable number can never be presented as the current one.
+type Summary struct {
+	Total    int             `json:"total"`
+	ByBucket map[Bucket]int  `json:"byBucket"`
+	ByOutcom map[Outcome]int `json:"byOutcome"`
+	// MeaningfulTodayPct is A/total: the share carrying real pre-silicon signal
+	// today. The honest current state.
+	MeaningfulTodayPct float64 `json:"meaningfulTodayPct"`
+	// ReachablePct is (A+G)/total: the share reachable once the tracked gaps
+	// close. Roadmap, never a current claim.
+	ReachablePct float64 `json:"reachablePct"`
+	SuspectCount int     `json:"suspectCount"`
+	// MokkaUnlockedA counts bucket-A checks that actually depend on the GPU
+	// stack. This is the subset Mokka specifically enables; the remainder of A
+	// would run on any cluster.
+	MokkaUnlockedA int `json:"mokkaUnlockedA"`
+	// GPUIndependentA counts bucket-A checks that need no GPU stack at all.
+	GPUIndependentA int `json:"gpuIndependentA"`
+}
+
+// Summarize computes the roll-up over classified records.
+func Summarize(records []Record) Summary {
+	sum := Summary{
+		Total:    len(records),
+		ByBucket: map[Bucket]int{BucketA: 0, BucketB: 0, BucketC: 0, BucketG: 0},
+		ByOutcom: map[Outcome]int{},
+	}
+
+	for _, rec := range records {
+		sum.ByBucket[rec.Bucket]++
+		sum.ByOutcom[rec.Outcome]++
+		if rec.Suspect {
+			sum.SuspectCount++
+		}
+		if rec.Bucket == BucketA {
+			if rec.GPUDependent {
+				sum.MokkaUnlockedA++
+			} else {
+				sum.GPUIndependentA++
+			}
+		}
+	}
+
+	if sum.Total > 0 {
+		total := float64(sum.Total)
+		sum.MeaningfulTodayPct = float64(sum.ByBucket[BucketA]) / total * 100
+		sum.ReachablePct = float64(sum.ByBucket[BucketA]+sum.ByBucket[BucketG]) / total * 100
+	}
+
+	return sum
+}

--- a/tests/aicr-preflight/classify_test.go
+++ b/tests/aicr-preflight/classify_test.go
@@ -1,0 +1,255 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// catalogFixture returns a small catalog covering every bucket, so each test can
+// scope down to the rows it cares about without re-declaring the shape.
+func catalogFixture() *Catalog {
+	return &Catalog{
+		Checks: []CatalogCheck{
+			{Name: "operator-health", Area: "operator-install", Bucket: BucketA, Rationale: "installs the real operator", GPUDependent: true},
+			{Name: "gang-scheduling", Area: "scheduling", Bucket: BucketA, Rationale: "real KAI scheduling", GPUDependent: false},
+			{Name: "accelerator-metrics", Area: "nvml-surface", Bucket: BucketB, Rationale: "presence-only against static mock values"},
+			{Name: "nccl-all-reduce-bw-nvls", Area: "nccl-nvlink-fabric", Bucket: BucketC, Rationale: "needs a real NVLS fabric"},
+			{Name: "secure-accelerator-access", Area: "dra", Bucket: BucketG, Rationale: "blocked: MIG surface absent", GapIssue: "#1001"},
+		},
+	}
+}
+
+// The central honesty invariant: a check the run never reported must never be
+// recorded as passing. If Classify defaulted a missing check to pass (or to the
+// zero value of a type whose zero value is pass), this test fails.
+func TestCheckAbsentFromRunIsNotRunNeverPass(t *testing.T) {
+	t.Parallel()
+
+	// The run only reported operator-health. Every other catalog row is absent.
+	run := &RunResults{Tests: []RunTest{
+		{Name: "operator-health", Status: "passed", Suite: "deployment"},
+	}}
+
+	records := Classify(catalogFixture(), run, ProvenanceSim)
+	byName := indexByName(t, records)
+
+	require.Len(t, records, 5, "every catalog row must produce exactly one record")
+
+	assert.Equal(t, OutcomePass, byName["operator-health"].Outcome,
+		"a check the run reported passed must be recorded as pass")
+
+	for _, absent := range []string{"gang-scheduling", "accelerator-metrics", "nccl-all-reduce-bw-nvls", "secure-accelerator-access"} {
+		assert.Equal(t, OutcomeNotRun, byName[absent].Outcome,
+			"%s was absent from the run and must be recorded not-run", absent)
+		assert.NotEqual(t, OutcomePass, byName[absent].Outcome,
+			"%s must never be recorded as pass without a run", absent)
+	}
+}
+
+// A hardware-dependent (bucket C) check that comes back green from a simulated
+// run is the exact overclaim this POC exists to prevent, so it must be flagged.
+func TestBucketCPassUnderSimIsFlaggedSuspect(t *testing.T) {
+	t.Parallel()
+
+	run := &RunResults{Tests: []RunTest{
+		{Name: "nccl-all-reduce-bw-nvls", Status: "passed", Suite: "performance"},
+		{Name: "operator-health", Status: "passed", Suite: "deployment"},
+	}}
+
+	byName := indexByName(t, Classify(catalogFixture(), run, ProvenanceSim))
+
+	assert.True(t, byName["nccl-all-reduce-bw-nvls"].Suspect,
+		"a green bucket-C check under sim provenance must be flagged suspect")
+	assert.False(t, byName["operator-health"].Suspect,
+		"a green bucket-A check is expected and must not be flagged")
+}
+
+// The same green bucket-C result is legitimate on real hardware, so the flag
+// must key off provenance and not off the bucket alone.
+func TestBucketCPassUnderSiliconIsNotSuspect(t *testing.T) {
+	t.Parallel()
+
+	run := &RunResults{Tests: []RunTest{
+		{Name: "nccl-all-reduce-bw-nvls", Status: "passed", Suite: "performance"},
+	}}
+
+	byName := indexByName(t, Classify(catalogFixture(), run, ProvenanceSilicon))
+
+	assert.False(t, byName["nccl-all-reduce-bw-nvls"].Suspect,
+		"bucket C passing on silicon is the expected case, not a suspect result")
+}
+
+func TestEveryRecordCarriesProvenance(t *testing.T) {
+	t.Parallel()
+
+	records := Classify(catalogFixture(), &RunResults{}, ProvenanceSim)
+	require.NotEmpty(t, records)
+
+	for _, rec := range records {
+		assert.Equal(t, ProvenanceSim, rec.Provenance,
+			"record %q must carry the run's provenance", rec.Name)
+	}
+}
+
+func TestStatusMappingCoversEveryCTRFStatus(t *testing.T) {
+	t.Parallel()
+
+	cat := &Catalog{Checks: []CatalogCheck{
+		{Name: "a", Bucket: BucketA}, {Name: "b", Bucket: BucketA},
+		{Name: "c", Bucket: BucketA}, {Name: "d", Bucket: BucketA},
+		{Name: "e", Bucket: BucketA},
+	}}
+	run := &RunResults{Tests: []RunTest{
+		{Name: "a", Status: "passed"},
+		{Name: "b", Status: "failed"},
+		{Name: "c", Status: "skipped"},
+		{Name: "d", Status: "pending"},
+		{Name: "e", Status: "other"},
+	}}
+
+	byName := indexByName(t, Classify(cat, run, ProvenanceSim))
+
+	assert.Equal(t, OutcomePass, byName["a"].Outcome)
+	assert.Equal(t, OutcomeFail, byName["b"].Outcome)
+	assert.Equal(t, OutcomeSkip, byName["c"].Outcome)
+	// pending and other are both "the suite did not reach a verdict", which is
+	// materially different from a pass and must not be laundered into one.
+	assert.Equal(t, OutcomeNotRun, byName["d"].Outcome)
+	assert.Equal(t, OutcomeNotRun, byName["e"].Outcome)
+}
+
+// A result the catalog does not know about must surface loudly rather than be
+// dropped, otherwise the catalog silently drifts from the suite it describes.
+func TestRunResultAbsentFromCatalogIsReportedAsUncatalogued(t *testing.T) {
+	t.Parallel()
+
+	run := &RunResults{Tests: []RunTest{
+		{Name: "operator-health", Status: "passed", Suite: "deployment"},
+		{Name: "brand-new-check", Status: "passed", Suite: "conformance"},
+	}}
+
+	missing := UncataloguedChecks(catalogFixture(), run)
+
+	assert.Equal(t, []string{"brand-new-check"}, missing,
+		"a check present in the run but absent from the catalog must be reported")
+}
+
+func TestRollUpReportsTodayAndReachableSeparately(t *testing.T) {
+	t.Parallel()
+
+	// 2 A, 1 B, 1 C, 1 G out of 5.
+	sum := Summarize(Classify(catalogFixture(), &RunResults{}, ProvenanceSim))
+
+	assert.Equal(t, 5, sum.Total)
+	assert.Equal(t, 2, sum.ByBucket[BucketA])
+	assert.Equal(t, 1, sum.ByBucket[BucketB])
+	assert.Equal(t, 1, sum.ByBucket[BucketC])
+	assert.Equal(t, 1, sum.ByBucket[BucketG])
+
+	// Today = A/total = 2/5. Reachable = (A+G)/total = 3/5.
+	assert.InDelta(t, 40.0, sum.MeaningfulTodayPct, 0.001,
+		"today's number is A/total and must not include the closable gaps")
+	assert.InDelta(t, 60.0, sum.ReachablePct, 0.001,
+		"the reachable number is (A+G)/total")
+	assert.Greater(t, sum.ReachablePct, sum.MeaningfulTodayPct)
+}
+
+// The headline A number is inflated if control-plane checks that would run on
+// any cluster are counted as something Mokka unlocked, so the split has to be
+// reported separately.
+func TestSummarySplitsMokkaUnlockedAFromGPUIndependentA(t *testing.T) {
+	t.Parallel()
+
+	sum := Summarize(Classify(catalogFixture(), &RunResults{}, ProvenanceSim))
+
+	// The fixture has 2 bucket-A rows: operator-health (GPU-dependent) and
+	// gang-scheduling (GPU-independent, explicitly CPU-only upstream).
+	assert.Equal(t, 1, sum.MokkaUnlockedA,
+		"only the GPU-dependent bucket-A check is unlocked by Mokka specifically")
+	assert.Equal(t, 1, sum.GPUIndependentA,
+		"a GPU-independent bucket-A check must not be credited to Mokka")
+	assert.Equal(t, sum.ByBucket[BucketA], sum.MokkaUnlockedA+sum.GPUIndependentA,
+		"the split must account for every bucket-A row exactly once")
+}
+
+func TestSummarizeOnEmptyCatalogDoesNotDivideByZero(t *testing.T) {
+	t.Parallel()
+
+	sum := Summarize(nil)
+
+	assert.Equal(t, 0, sum.Total)
+	assert.Zero(t, sum.MeaningfulTodayPct)
+	assert.Zero(t, sum.ReachablePct)
+}
+
+func TestCatalogValidationRejectsUnknownBucket(t *testing.T) {
+	t.Parallel()
+
+	cat := &Catalog{Checks: []CatalogCheck{{Name: "x", Bucket: "Z", Rationale: "r"}}}
+
+	err := cat.Validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Z", "the error must name the offending bucket")
+}
+
+func TestCatalogValidationRejectsDuplicateCheckNames(t *testing.T) {
+	t.Parallel()
+
+	cat := &Catalog{Checks: []CatalogCheck{
+		{Name: "dup", Bucket: BucketA, Rationale: "r"},
+		{Name: "dup", Bucket: BucketB, Rationale: "r"},
+	}}
+
+	err := cat.Validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dup")
+}
+
+// Bucket G is the roadmap claim, so it has to point at a tracked issue or the
+// backlog is unauditable.
+func TestCatalogValidationRequiresGapIssueForBucketG(t *testing.T) {
+	t.Parallel()
+
+	cat := &Catalog{Checks: []CatalogCheck{{Name: "g", Bucket: BucketG, Rationale: "r"}}}
+
+	err := cat.Validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gapIssue")
+}
+
+func TestCatalogValidationRequiresRationale(t *testing.T) {
+	t.Parallel()
+
+	cat := &Catalog{Checks: []CatalogCheck{{Name: "x", Bucket: BucketA}}}
+
+	err := cat.Validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rationale")
+}
+
+func TestCatalogValidationAcceptsAWellFormedCatalog(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, catalogFixture().Validate())
+}
+
+func indexByName(t *testing.T, records []Record) map[string]Record {
+	t.Helper()
+
+	byName := make(map[string]Record, len(records))
+	for _, rec := range records {
+		_, dup := byName[rec.Name]
+		require.False(t, dup, "duplicate record for %q", rec.Name)
+		byName[rec.Name] = rec
+	}
+	return byName
+}

--- a/tests/aicr-preflight/ctrf.go
+++ b/tests/aicr-preflight/ctrf.go
@@ -1,0 +1,106 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"sigs.k8s.io/yaml"
+)
+
+// ctrfReport is the subset of the CTRF schema that AICR emits and this harness
+// consumes. Full schema: https://ctrf.io.
+type ctrfReport struct {
+	ReportFormat string `json:"reportFormat"`
+	Results      struct {
+		Tests []struct {
+			Name    string   `json:"name"`
+			Status  string   `json:"status"`
+			Suite   []string `json:"suite"`
+			Message string   `json:"message"`
+		} `json:"tests"`
+	} `json:"results"`
+}
+
+// ParseCTRF reads one CTRF report. A report with no tests is an error: an empty
+// result set must not be mistaken for a clean run.
+func ParseCTRF(data []byte) (*RunResults, error) {
+	var report ctrfReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		return nil, fmt.Errorf("parse CTRF report: %w", err)
+	}
+
+	if len(report.Results.Tests) == 0 {
+		return nil, fmt.Errorf("CTRF report contains no tests, refusing to treat an empty report as a run")
+	}
+
+	run := &RunResults{Tests: make([]RunTest, 0, len(report.Results.Tests))}
+	for _, test := range report.Results.Tests {
+		var suite string
+		if len(test.Suite) > 0 {
+			suite = test.Suite[0]
+		}
+		run.Tests = append(run.Tests, RunTest{
+			Name:    test.Name,
+			Status:  test.Status,
+			Suite:   suite,
+			Message: test.Message,
+		})
+	}
+
+	return run, nil
+}
+
+// LoadCTRFDir merges every *.json CTRF report in dir, so a run split across
+// deployment/performance/conformance phase reports lands as one result set.
+func LoadCTRFDir(dir string) (*RunResults, error) {
+	entries, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil {
+		return nil, fmt.Errorf("scan CTRF directory %s: %w", dir, err)
+	}
+	sort.Strings(entries)
+
+	merged := &RunResults{}
+	for _, path := range entries {
+		data, err := os.ReadFile(path) //nolint:gosec // operator-supplied results path
+		if err != nil {
+			return nil, fmt.Errorf("read CTRF report %s: %w", path, err)
+		}
+		run, err := ParseCTRF(data)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+		merged.Tests = append(merged.Tests, run.Tests...)
+	}
+
+	if len(merged.Tests) == 0 {
+		return nil, fmt.Errorf("no CTRF reports with results found in %s", dir)
+	}
+
+	return merged, nil
+}
+
+// LoadCatalog reads and validates the coverage catalog. An invalid catalog is an
+// error rather than a warning, because every downstream number depends on it.
+func LoadCatalog(path string) (*Catalog, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // operator-supplied catalog path
+	if err != nil {
+		return nil, fmt.Errorf("read catalog %s: %w", path, err)
+	}
+
+	var catalog Catalog
+	if err := yaml.Unmarshal(data, &catalog); err != nil {
+		return nil, fmt.Errorf("parse catalog %s: %w", path, err)
+	}
+
+	if err := catalog.Validate(); err != nil {
+		return nil, fmt.Errorf("catalog %s is invalid: %w", path, err)
+	}
+
+	return &catalog, nil
+}

--- a/tests/aicr-preflight/ctrf_test.go
+++ b/tests/aicr-preflight/ctrf_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Shape taken verbatim from a real AICR CTRF report
+// (NVIDIA/aicr pkg/corroborate/testdata/.../ctrf/deployment.json).
+const deploymentCTRF = `{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-07-25T09:00:00Z",
+  "generatedBy": "aicr validate",
+  "results": {
+    "tool": {"name": "aicr", "version": "v1.0.0"},
+    "summary": {"tests": 2, "passed": 1, "failed": 1, "skipped": 0, "pending": 0, "other": 0},
+    "tests": [
+      {"name": "operator-health", "status": "passed", "duration": 1000, "suite": ["deployment"]},
+      {"name": "check-nvidia-smi", "status": "failed", "duration": 2000, "suite": ["deployment"],
+       "message": "nvidia-smi returned 9"}
+    ]
+  }
+}`
+
+const conformanceCTRF = `{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "results": {
+    "tool": {"name": "aicr"},
+    "summary": {"tests": 1},
+    "tests": [
+      {"name": "dra-support", "status": "skipped", "suite": ["conformance"]}
+    ]
+  }
+}`
+
+func TestParseCTRFExtractsNameStatusSuiteAndMessage(t *testing.T) {
+	t.Parallel()
+
+	run, err := ParseCTRF([]byte(deploymentCTRF))
+	require.NoError(t, err)
+	require.Len(t, run.Tests, 2)
+
+	assert.Equal(t, "operator-health", run.Tests[0].Name)
+	assert.Equal(t, "passed", run.Tests[0].Status)
+	assert.Equal(t, "deployment", run.Tests[0].Suite)
+
+	assert.Equal(t, "check-nvidia-smi", run.Tests[1].Name)
+	assert.Equal(t, "failed", run.Tests[1].Status)
+	assert.Equal(t, "nvidia-smi returned 9", run.Tests[1].Message,
+		"the failure message is the only diagnostic a reader gets, it must survive parsing")
+}
+
+func TestParseCTRFRejectsMalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseCTRF([]byte(`{"results": `))
+
+	require.Error(t, err)
+}
+
+// A report that parses but carries no tests must not silently look like a
+// successful empty run.
+func TestParseCTRFRejectsReportWithNoTests(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseCTRF([]byte(`{"reportFormat":"CTRF","results":{"tests":[]}}`))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no tests")
+}
+
+func TestLoadCTRFDirMergesEveryPhaseReport(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "deployment.json"), []byte(deploymentCTRF), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "conformance.json"), []byte(conformanceCTRF), 0o600))
+	// A non-JSON sibling must be ignored rather than break the load.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("ignore me"), 0o600))
+
+	run, err := LoadCTRFDir(dir)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(run.Tests))
+	for _, test := range run.Tests {
+		names = append(names, test.Name)
+	}
+	assert.ElementsMatch(t, []string{"operator-health", "check-nvidia-smi", "dra-support"}, names,
+		"results from every phase report in the directory must be merged")
+}
+
+func TestLoadCTRFDirFailsWhenDirectoryHasNoReports(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadCTRFDir(t.TempDir())
+
+	require.Error(t, err)
+}
+
+func TestLoadCatalogRoundTripsAndValidates(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "catalog.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+source: test
+checks:
+  - name: operator-health
+    area: operator-install
+    phase: deployment
+    bucket: A
+    rationale: installs the real operator
+    evidence: validators/deployment/operator_health.go:32
+`), 0o600))
+
+	cat, err := LoadCatalog(path)
+	require.NoError(t, err)
+
+	require.Len(t, cat.Checks, 1)
+	assert.Equal(t, "operator-health", cat.Checks[0].Name)
+	assert.Equal(t, BucketA, cat.Checks[0].Bucket)
+	assert.Equal(t, "validators/deployment/operator_health.go:32", cat.Checks[0].Evidence)
+}
+
+// Loading must refuse an invalid catalog rather than hand back something that
+// produces a plausible but unreviewable roll-up.
+func TestLoadCatalogRejectsInvalidCatalog(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "catalog.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+checks:
+  - name: broken
+    bucket: A
+`), 0o600))
+
+	_, err := LoadCatalog(path)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rationale")
+}
+
+// The shipped catalog is a deliverable in its own right, so it must stay valid.
+func TestShippedCatalogIsValid(t *testing.T) {
+	t.Parallel()
+
+	cat, err := LoadCatalog("catalog.yaml")
+	require.NoError(t, err, "the catalog shipped alongside this harness must load and validate")
+
+	assert.NotEmpty(t, cat.Checks)
+	for _, check := range cat.Checks {
+		assert.NotEmpty(t, check.Evidence,
+			"catalog row %q must cite the evidence for its bucket", check.Name)
+	}
+}

--- a/tests/aicr-preflight/main.go
+++ b/tests/aicr-preflight/main.go
@@ -1,0 +1,86 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "aicr-preflight: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout, stderr *os.File) error {
+	fs := flag.NewFlagSet("aicr-preflight", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	catalogPath := fs.String("catalog", "catalog.yaml", "path to the coverage catalog")
+	ctrfDir := fs.String("ctrf", "", "directory of AICR CTRF reports from `aicr validate --output`")
+	jsonOut := fs.String("json", "", "write the machine-readable report here (default stdout)")
+	mdOut := fs.String("markdown", "", "also write a markdown catalog table here")
+	provenance := fs.String("provenance", string(ProvenanceSim), "evidence provenance: sim or silicon")
+	cluster := fs.String("cluster", "", "cluster identifier recorded in the report")
+	profile := fs.String("profile", "", "nvml-mock GPU profile recorded in the report")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	prov := Provenance(*provenance)
+	if prov != ProvenanceSim && prov != ProvenanceSilicon {
+		return fmt.Errorf("invalid -provenance %q, want sim or silicon", *provenance)
+	}
+
+	catalog, err := LoadCatalog(*catalogPath)
+	if err != nil {
+		return err
+	}
+
+	// No CTRF directory means no run happened. That is a legitimate state: the
+	// catalog still reports, with every outcome recorded not-run. It must never
+	// silently look like a clean pass.
+	var results *RunResults
+	if *ctrfDir != "" {
+		results, err = LoadCTRFDir(*ctrfDir)
+		if err != nil {
+			return err
+		}
+	} else {
+		_, _ = fmt.Fprintln(stderr, "aicr-preflight: no -ctrf directory given; every check will be recorded not-run")
+	}
+
+	report := BuildReport(catalog, results, prov, *cluster, *profile, time.Now())
+
+	jsonTarget := stdout
+	if *jsonOut != "" {
+		f, err := os.Create(*jsonOut) //nolint:gosec // operator-supplied output path
+		if err != nil {
+			return fmt.Errorf("create %s: %w", *jsonOut, err)
+		}
+		defer f.Close() //nolint:errcheck // best-effort close on the output file
+		jsonTarget = f
+	}
+	if err := report.WriteJSON(jsonTarget); err != nil {
+		return err
+	}
+
+	if *mdOut != "" {
+		f, err := os.Create(*mdOut) //nolint:gosec // operator-supplied output path
+		if err != nil {
+			return fmt.Errorf("create %s: %w", *mdOut, err)
+		}
+		defer f.Close() //nolint:errcheck // best-effort close on the output file
+		if err := report.WriteMarkdown(f); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/tests/aicr-preflight/report.go
+++ b/tests/aicr-preflight/report.go
@@ -1,0 +1,136 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// Report is the machine-readable output. Every record carries provenance, and
+// the roll-up carries both the current and the reachable number so the second
+// can never be quoted as the first.
+type Report struct {
+	Schema string `json:"schema"`
+	// GeneratedAt is supplied by the caller rather than read from the clock, so
+	// the report is reproducible in tests.
+	GeneratedAt  string     `json:"generatedAt"`
+	Provenance   Provenance `json:"provenance"`
+	CatalogSrc   string     `json:"catalogSource,omitempty"`
+	Cluster      string     `json:"cluster,omitempty"`
+	Profile      string     `json:"profile,omitempty"`
+	Summary      Summary    `json:"summary"`
+	Records      []Record   `json:"records"`
+	Uncatalogued []string   `json:"uncatalogued,omitempty"`
+}
+
+// BuildReport assembles the report from a classified run.
+func BuildReport(catalog *Catalog, run *RunResults, provenance Provenance, cluster, profile string, at time.Time) Report {
+	records := Classify(catalog, run, provenance)
+
+	report := Report{
+		Schema:       "nvidia.com/aicr-preflight/v1alpha1",
+		GeneratedAt:  at.UTC().Format(time.RFC3339),
+		Provenance:   provenance,
+		Cluster:      cluster,
+		Profile:      profile,
+		Summary:      Summarize(records),
+		Records:      records,
+		Uncatalogued: UncataloguedChecks(catalog, run),
+	}
+	if catalog != nil {
+		report.CatalogSrc = catalog.Source
+	}
+
+	return report
+}
+
+// WriteJSON emits the machine-readable report.
+func (r Report) WriteJSON(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(r); err != nil {
+		return fmt.Errorf("encode report: %w", err)
+	}
+	return nil
+}
+
+// WriteMarkdown emits the human-readable catalog table. The roll-up always
+// prints both percentages, and prints the Mokka-unlocked split so the headline
+// cannot be read as more than it is.
+func (r Report) WriteMarkdown(w io.Writer) error {
+	var b strings.Builder
+
+	b.WriteString("# AICR check coverage under Mokka\n\n")
+	fmt.Fprintf(&b, "Generated %s. Provenance: `%s`. Cluster: `%s`. Profile: `%s`.\n\n",
+		r.GeneratedAt, r.Provenance, orNone(r.Cluster), orNone(r.Profile))
+	fmt.Fprintf(&b, "Catalog source: %s\n\n", orNone(r.CatalogSrc))
+
+	b.WriteString("## Roll-up\n\n")
+	fmt.Fprintf(&b, "- Checks total: %d (A: %d, B: %d, C: %d, G: %d)\n",
+		r.Summary.Total, r.Summary.ByBucket[BucketA], r.Summary.ByBucket[BucketB],
+		r.Summary.ByBucket[BucketC], r.Summary.ByBucket[BucketG])
+	fmt.Fprintf(&b, "- Meaningful pre-silicon TODAY: %.1f%% (A / total)\n", r.Summary.MeaningfulTodayPct)
+	fmt.Fprintf(&b, "- Reachable once tracked gaps close: %.1f%% ((A + G) / total). Roadmap, not a current claim.\n",
+		r.Summary.ReachablePct)
+	fmt.Fprintf(&b, "- Of the %d bucket-A checks, %d depend on the GPU stack (unlocked by Mokka) and %d are GPU-independent (any cluster runs them).\n",
+		r.Summary.ByBucket[BucketA], r.Summary.MokkaUnlockedA, r.Summary.GPUIndependentA)
+
+	// Bucket assignment is analysis over the whole catalog; execution is what
+	// this run actually observed. Reporting only the first would imply evidence
+	// the run does not have.
+	executed := r.Summary.ByOutcom[OutcomePass] + r.Summary.ByOutcom[OutcomeFail] + r.Summary.ByOutcom[OutcomeSkip]
+	fmt.Fprintf(&b, "- Executed in this run: %d of %d (%d pass, %d fail, %d skip). **%d were not run** and carry no evidence either way.\n",
+		executed, r.Summary.Total,
+		r.Summary.ByOutcom[OutcomePass], r.Summary.ByOutcom[OutcomeFail],
+		r.Summary.ByOutcom[OutcomeSkip], r.Summary.ByOutcom[OutcomeNotRun])
+
+	if r.Summary.ByBucket[BucketB] == 0 {
+		b.WriteString("- Bucket B is empty. That is a real result, not an oversight: AICR's checks are written as integration assertions rather than value assertions, so none of them is green purely because the mock answered. The corresponding limitation is that where Mokka's values are synthetic, a check validates the path and stays silent on the values.\n")
+	}
+
+	if r.Summary.SuspectCount > 0 {
+		fmt.Fprintf(&b, "- **%d suspect result(s)**: a hardware-dependent check reported green under simulation. Review before quoting.\n",
+			r.Summary.SuspectCount)
+	}
+	if len(r.Uncatalogued) > 0 {
+		fmt.Fprintf(&b, "- **Catalog drift**: the run reported %d check(s) the catalog does not describe: %s\n",
+			len(r.Uncatalogued), strings.Join(r.Uncatalogued, ", "))
+	}
+
+	b.WriteString("\n## Catalog\n\n")
+	b.WriteString("| # | Check | Area | Phase | Bucket | GPU-dep | Outcome | Provenance | Gap issue |\n")
+	b.WriteString("|---|---|---|---|---|---|---|---|---|\n")
+	for i, rec := range r.Records {
+		suspect := ""
+		if rec.Suspect {
+			suspect = " **(suspect)**"
+		}
+		fmt.Fprintf(&b, "| %d | `%s` | %s | %s | %s | %s | %s%s | %s | %s |\n",
+			i+1, rec.Name, orNone(rec.Area), orNone(rec.Phase), rec.Bucket,
+			yesNo(rec.GPUDependent), rec.Outcome, suspect, rec.Provenance, orNone(rec.GapIssue))
+	}
+
+	if _, err := io.WriteString(w, b.String()); err != nil {
+		return fmt.Errorf("write markdown report: %w", err)
+	}
+	return nil
+}
+
+func orNone(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func yesNo(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}

--- a/tests/aicr-preflight/results/2026-07-25-gb200-kind/aicr-validate.log
+++ b/tests/aicr-preflight/results/2026-07-25-gb200-kind/aicr-validate.log
@@ -6,23 +6,23 @@
 [cli] deploying agent: namespace=aicr-validation
 [cli] agent deployed successfully
 [cli] waiting for Job completion: job=aicr-validate timeout=12m0s
-[cli] pod current phase: name=aicr-validate-l5l6c status=Pending
-[cli] pod current phase: name=aicr-validate-l5l6c status=Pending waitingReason=ContainerCreating
-[cli] pod current phase: name=aicr-validate-l5l6c status=Pending waitingReason=ContainerCreating
-[cli] pod current phase: name=aicr-validate-l5l6c status=Running
+[cli] pod current phase: name=aicr-validate-fcsr5 status=Pending
+[cli] pod current phase: name=aicr-validate-fcsr5 status=Pending waitingReason=ContainerCreating
+[cli] pod current phase: name=aicr-validate-fcsr5 status=Pending waitingReason=ContainerCreating
+[cli] pod current phase: name=aicr-validate-fcsr5 status=Running
 [agent] collecting GPU information
+[agent] collecting OS configuration
 [agent] collecting Kubernetes cluster information
 [agent] collecting SystemD service configurations
-E0725 07:06:47.822960   16726 kernel.go:150] "failed to get builtin kernel modules" err="failed to read file /lib/modules/6.12.76-linuxkit/modules.builtin: open /lib/modules/6.12.76-linuxkit/modules.builtin: no such file or directory"
+E0725 09:06:54.626197   37093 kernel.go:150] "failed to get builtin kernel modules" err="failed to read file /lib/modules/6.12.76-linuxkit/modules.builtin: open /lib/modules/6.12.76-linuxkit/modules.builtin: no such file or directory"
 [agent] collecting node topology information
-[agent] collecting OS configuration
-[agent] node topology collection complete: nodes=1 taints=0 labels=95
+[agent] node topology collection complete: nodes=1 taints=0 labels=96
 [agent] configmap operation: namespace=aicr-validation name=aicr-snapshot auth_method=bearer-token format=yaml
 [agent] applying ConfigMap: namespace=aicr-validation name=aicr-snapshot format=yaml
 [cli] job completed successfully
 [cli] snapshot has no GPU data but cluster topology shows GPU-capable nodes — agent likely ran on a non-GPU node: detection_note=relies on nvidia.com/gpu.present/product labels (NFD); clusters without these labels are not detected fix_1=--node-selector nvidia.com/gpu.present=true (after GPU Operator/NFD) fix_2=--node-selector kubernetes.io/hostname=<gpu-node> (before GPU Operator) fix_3=--require-gpu (requests nvidia.com/gpu resource; needs Device Plugin) fix_4=--runtime-class nvidia (nvidia-smi access without consuming a GPU slot)
 [cli] running validation: phases=[deployment conformance]
-[cli] running validation phases: runID=20260725-090650-71cdbfe2fcfd8d50 phases=[deployment conformance]
+[cli] running validation phases: runID=20260725-110657-6c7bc170e27a951d phases=[deployment conformance]
 [cli] readiness pre-flight: constraints=1
 [cli] readiness constraint passed: name=K8s.server.version expected=>= 1.30 actual=v1.36.1
 [cli] running validation phase: phase=deployment catalog=4 selected=4
@@ -34,20 +34,19 @@ E0725 07:06:47.822960   16726 kernel.go:150] "failed to get builtin kernel modul
 [cli] validator completed: name=gpu-operator-version status=passed
 [cli] running validator: name=check-nvidia-smi phase=deployment
 [cli] validator completed: name=check-nvidia-smi status=passed
-[cli] phase completed: phase=deployment status=failed validators=4 passed=3 failed=1 duration=2m47.322568708s
+[cli] phase completed: phase=deployment status=failed validators=4 passed=3 failed=1 duration=2m17.238596917s
 [cli] running validation phase: phase=conformance catalog=13 selected=5
 [cli] running validator: name=dra-support phase=conformance
 [cli] validator completed: name=dra-support status=failed
 [cli] running validator: name=accelerator-metrics phase=conformance
 [cli] validator completed: name=accelerator-metrics status=passed
 [cli] running validator: name=ai-service-metrics phase=conformance
-[cli] dependencyAffinity selector matched zero pods at deploy time; affinity term will be a no-op until matching pods appear: validator=ai-service-metrics namespace=monitoring selector=app.kubernetes.io/name=prometheus reason=zero-match
-[cli] validator completed: name=ai-service-metrics status=failed
+[cli] validator completed: name=ai-service-metrics status=passed
 [cli] running validator: name=gpu-operator-health phase=conformance
 [cli] validator completed: name=gpu-operator-health status=passed
 [cli] running validator: name=platform-health phase=conformance
 [cli] validator completed: name=platform-health status=failed
-[cli] phase completed: phase=conformance status=failed validators=5 passed=2 failed=3 duration=17.111289083s
-[cli] all phases completed: runID=20260725-090650-71cdbfe2fcfd8d50 phases=2
-[cli] phase result: phase=deployment status=failed duration=2m47.322568708s
-[cli] phase result: phase=conformance status=failed duration=17.111289083s
+[cli] phase completed: phase=conformance status=failed validators=5 passed=3 failed=2 duration=17.135913791s
+[cli] all phases completed: runID=20260725-110657-6c7bc170e27a951d phases=2
+[cli] phase result: phase=deployment status=failed duration=2m17.238596917s
+[cli] phase result: phase=conformance status=failed duration=17.135913791s

--- a/tests/aicr-preflight/results/2026-07-25-gb200-kind/aicr-validate.log
+++ b/tests/aicr-preflight/results/2026-07-25-gb200-kind/aicr-validate.log
@@ -1,0 +1,53 @@
+[cli] CLI flag overriding config value: flag=fail-on-error config=true override=false
+[cli] validating against the live cluster — validator Jobs will be deployed to the active kube-context
+[cli] loading recipe: uri=/private/tmp/claude-502/-Users-eduardoa-src-github-nvidia-k8s-test-infra/52d7ee39-5ee8-4336-b3c6-e28103c496f3/scratchpad/recipe-gb200-kind.yaml
+[cli] deploying agent to capture snapshot
+[cli] auto-targeting GPU nodes: selector=nvidia.com/gpu.present=true hint=pass --node-selector to override
+[cli] deploying agent: namespace=aicr-validation
+[cli] agent deployed successfully
+[cli] waiting for Job completion: job=aicr-validate timeout=12m0s
+[cli] pod current phase: name=aicr-validate-l5l6c status=Pending
+[cli] pod current phase: name=aicr-validate-l5l6c status=Pending waitingReason=ContainerCreating
+[cli] pod current phase: name=aicr-validate-l5l6c status=Pending waitingReason=ContainerCreating
+[cli] pod current phase: name=aicr-validate-l5l6c status=Running
+[agent] collecting GPU information
+[agent] collecting Kubernetes cluster information
+[agent] collecting SystemD service configurations
+E0725 07:06:47.822960   16726 kernel.go:150] "failed to get builtin kernel modules" err="failed to read file /lib/modules/6.12.76-linuxkit/modules.builtin: open /lib/modules/6.12.76-linuxkit/modules.builtin: no such file or directory"
+[agent] collecting node topology information
+[agent] collecting OS configuration
+[agent] node topology collection complete: nodes=1 taints=0 labels=95
+[agent] configmap operation: namespace=aicr-validation name=aicr-snapshot auth_method=bearer-token format=yaml
+[agent] applying ConfigMap: namespace=aicr-validation name=aicr-snapshot format=yaml
+[cli] job completed successfully
+[cli] snapshot has no GPU data but cluster topology shows GPU-capable nodes — agent likely ran on a non-GPU node: detection_note=relies on nvidia.com/gpu.present/product labels (NFD); clusters without these labels are not detected fix_1=--node-selector nvidia.com/gpu.present=true (after GPU Operator/NFD) fix_2=--node-selector kubernetes.io/hostname=<gpu-node> (before GPU Operator) fix_3=--require-gpu (requests nvidia.com/gpu resource; needs Device Plugin) fix_4=--runtime-class nvidia (nvidia-smi access without consuming a GPU slot)
+[cli] running validation: phases=[deployment conformance]
+[cli] running validation phases: runID=20260725-090650-71cdbfe2fcfd8d50 phases=[deployment conformance]
+[cli] readiness pre-flight: constraints=1
+[cli] readiness constraint passed: name=K8s.server.version expected=>= 1.30 actual=v1.36.1
+[cli] running validation phase: phase=deployment catalog=4 selected=4
+[cli] running validator: name=operator-health phase=deployment
+[cli] validator completed: name=operator-health status=passed
+[cli] running validator: name=expected-resources phase=deployment
+[cli] validator completed: name=expected-resources status=failed
+[cli] running validator: name=gpu-operator-version phase=deployment
+[cli] validator completed: name=gpu-operator-version status=passed
+[cli] running validator: name=check-nvidia-smi phase=deployment
+[cli] validator completed: name=check-nvidia-smi status=passed
+[cli] phase completed: phase=deployment status=failed validators=4 passed=3 failed=1 duration=2m47.322568708s
+[cli] running validation phase: phase=conformance catalog=13 selected=5
+[cli] running validator: name=dra-support phase=conformance
+[cli] validator completed: name=dra-support status=failed
+[cli] running validator: name=accelerator-metrics phase=conformance
+[cli] validator completed: name=accelerator-metrics status=passed
+[cli] running validator: name=ai-service-metrics phase=conformance
+[cli] dependencyAffinity selector matched zero pods at deploy time; affinity term will be a no-op until matching pods appear: validator=ai-service-metrics namespace=monitoring selector=app.kubernetes.io/name=prometheus reason=zero-match
+[cli] validator completed: name=ai-service-metrics status=failed
+[cli] running validator: name=gpu-operator-health phase=conformance
+[cli] validator completed: name=gpu-operator-health status=passed
+[cli] running validator: name=platform-health phase=conformance
+[cli] validator completed: name=platform-health status=failed
+[cli] phase completed: phase=conformance status=failed validators=5 passed=2 failed=3 duration=17.111289083s
+[cli] all phases completed: runID=20260725-090650-71cdbfe2fcfd8d50 phases=2
+[cli] phase result: phase=deployment status=failed duration=2m47.322568708s
+[cli] phase result: phase=conformance status=failed duration=17.111289083s

--- a/tests/aicr-preflight/results/2026-07-25-gb200-kind/coverage.md
+++ b/tests/aicr-preflight/results/2026-07-25-gb200-kind/coverage.md
@@ -1,6 +1,6 @@
 # AICR check coverage under Mokka
 
-Generated 2026-07-25T07:29:58Z. Provenance: `sim`. Cluster: `kind-nvml-mock-op`. Profile: `gb200`.
+Generated 2026-07-25T08:27:54Z. Provenance: `sim`. Cluster: `kind-nvml-mock-op`. Profile: `gb200`.
 
 Catalog source: NVIDIA/aicr recipes/validators/catalog.yaml @06256cc8 (21 checks)
 

--- a/tests/aicr-preflight/results/2026-07-25-gb200-kind/coverage.md
+++ b/tests/aicr-preflight/results/2026-07-25-gb200-kind/coverage.md
@@ -1,6 +1,6 @@
 # AICR check coverage under Mokka
 
-Generated 2026-07-25T08:27:54Z. Provenance: `sim`. Cluster: `kind-nvml-mock-op`. Profile: `gb200`.
+Generated 2026-07-25T09:10:12Z. Provenance: `sim`. Cluster: `kind-nvml-mock-op`. Profile: `gb200`.
 
 Catalog source: NVIDIA/aicr recipes/validators/catalog.yaml @06256cc8 (21 checks)
 
@@ -10,7 +10,7 @@ Catalog source: NVIDIA/aicr recipes/validators/catalog.yaml @06256cc8 (21 checks
 - Meaningful pre-silicon TODAY: 66.7% (A / total)
 - Reachable once tracked gaps close: 81.0% ((A + G) / total). Roadmap, not a current claim.
 - Of the 14 bucket-A checks, 9 depend on the GPU stack (unlocked by Mokka) and 5 are GPU-independent (any cluster runs them).
-- Executed in this run: 9 of 21 (5 pass, 4 fail, 0 skip). **12 were not run** and carry no evidence either way.
+- Executed in this run: 9 of 21 (6 pass, 3 fail, 0 skip). **12 were not run** and carry no evidence either way.
 - Bucket B is empty. That is a real result, not an oversight: AICR's checks are written as integration assertions rather than value assertions, so none of them is green purely because the mock answered. The corresponding limitation is that where Mokka's values are synthetic, a check validates the path and stays silent on the values.
 
 ## Catalog
@@ -28,7 +28,7 @@ Catalog source: NVIDIA/aicr recipes/validators/catalog.yaml @06256cc8 (21 checks
 | 9 | `dra-support` | dra | conformance | G | yes | fail | sim | #498 |
 | 10 | `gang-scheduling` | scheduling | conformance | A | no | not-run | sim | - |
 | 11 | `accelerator-metrics` | nvml-surface | conformance | A | yes | pass | sim | - |
-| 12 | `ai-service-metrics` | control-plane | conformance | A | yes | fail | sim | - |
+| 12 | `ai-service-metrics` | control-plane | conformance | A | yes | pass | sim | - |
 | 13 | `inference-gateway` | control-plane | conformance | A | no | not-run | sim | - |
 | 14 | `pod-autoscaling` | scheduling | conformance | A | yes | not-run | sim | - |
 | 15 | `cluster-autoscaling` | scheduling | conformance | G | no | not-run | sim | #499 |

--- a/tests/aicr-preflight/results/2026-07-25-gb200-kind/coverage.md
+++ b/tests/aicr-preflight/results/2026-07-25-gb200-kind/coverage.md
@@ -1,0 +1,40 @@
+# AICR check coverage under Mokka
+
+Generated 2026-07-25T07:29:58Z. Provenance: `sim`. Cluster: `kind-nvml-mock-op`. Profile: `gb200`.
+
+Catalog source: NVIDIA/aicr recipes/validators/catalog.yaml @06256cc8 (21 checks)
+
+## Roll-up
+
+- Checks total: 21 (A: 14, B: 0, C: 4, G: 3)
+- Meaningful pre-silicon TODAY: 66.7% (A / total)
+- Reachable once tracked gaps close: 81.0% ((A + G) / total). Roadmap, not a current claim.
+- Of the 14 bucket-A checks, 9 depend on the GPU stack (unlocked by Mokka) and 5 are GPU-independent (any cluster runs them).
+- Executed in this run: 9 of 21 (5 pass, 4 fail, 0 skip). **12 were not run** and carry no evidence either way.
+- Bucket B is empty. That is a real result, not an oversight: AICR's checks are written as integration assertions rather than value assertions, so none of them is green purely because the mock answered. The corresponding limitation is that where Mokka's values are synthetic, a check validates the path and stays silent on the values.
+
+## Catalog
+
+| # | Check | Area | Phase | Bucket | GPU-dep | Outcome | Provenance | Gap issue |
+|---|---|---|---|---|---|---|---|---|
+| 1 | `operator-health` | operator-install | deployment | A | yes | pass | sim | - |
+| 2 | `expected-resources` | control-plane | deployment | A | yes | fail | sim | - |
+| 3 | `gpu-operator-version` | operator-install | deployment | A | no | pass | sim | - |
+| 4 | `check-nvidia-smi` | nvml-surface | deployment | A | yes | pass | sim | - |
+| 5 | `nccl-all-reduce-bw` | nccl-nvlink-fabric | performance | C | yes | not-run | sim | - |
+| 6 | `nccl-all-reduce-bw-net` | nccl-nvlink-fabric | performance | C | yes | not-run | sim | - |
+| 7 | `nccl-all-reduce-bw-nvls` | nccl-nvlink-fabric | performance | C | yes | not-run | sim | - |
+| 8 | `inference-perf` | ttft-throughput | performance | C | yes | not-run | sim | - |
+| 9 | `dra-support` | dra | conformance | G | yes | fail | sim | #498 |
+| 10 | `gang-scheduling` | scheduling | conformance | A | no | not-run | sim | - |
+| 11 | `accelerator-metrics` | nvml-surface | conformance | A | yes | pass | sim | - |
+| 12 | `ai-service-metrics` | control-plane | conformance | A | yes | fail | sim | - |
+| 13 | `inference-gateway` | control-plane | conformance | A | no | not-run | sim | - |
+| 14 | `pod-autoscaling` | scheduling | conformance | A | yes | not-run | sim | - |
+| 15 | `cluster-autoscaling` | scheduling | conformance | G | no | not-run | sim | #499 |
+| 16 | `robust-controller` | control-plane | conformance | A | no | not-run | sim | - |
+| 17 | `secure-accelerator-access` | dra | conformance | A | yes | not-run | sim | - |
+| 18 | `slinky-slurm-health` | scheduling | conformance | A | yes | not-run | sim | - |
+| 19 | `slinky-slurm-imex-channel` | nccl-nvlink-fabric | conformance | G | yes | not-run | sim | #498 |
+| 20 | `gpu-operator-health` | operator-install | conformance | A | yes | pass | sim | - |
+| 21 | `platform-health` | control-plane | conformance | A | no | fail | sim | - |

--- a/tests/aicr-preflight/results/2026-07-25-gb200-kind/ctrf/validate.json
+++ b/tests/aicr-preflight/results/2026-07-25-gb200-kind/ctrf/validate.json
@@ -1,0 +1,250 @@
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-07-25T07:09:37Z",
+  "generatedBy": "aicr",
+  "results": {
+    "tool": {
+      "name": "aicr",
+      "version": "dev"
+    },
+    "summary": {
+      "tests": 9,
+      "passed": 5,
+      "failed": 4,
+      "skipped": 0,
+      "pending": 0,
+      "other": 0,
+      "start": 1784963210652,
+      "stop": 1784963395080
+    },
+    "tests": [
+      {
+        "name": "operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "stdout": [
+          "time=2026-07-25T07:06:51.665Z level=INFO msg=\"starting check\" name=operator-health",
+          "time=2026-07-25T07:06:51.671Z level=INFO msg=\"listing pods\" namespace=gpu-operator label=\"app=gpu-operator\"",
+          "time=2026-07-25T07:06:51.676Z level=INFO msg=\"operator-health: passed\" running=1",
+          "Found 1 gpu-operator pod(s):",
+          "  gpu-operator-57d75775c8-strvb: Running",
+          "Running: 1/1"
+        ]
+      },
+      {
+        "name": "expected-resources",
+        "status": "failed",
+        "duration": 150000,
+        "suite": [
+          "deployment"
+        ],
+        "message": "[NOT_FOUND] Deployment agentgateway-system/agentgateway not found: deployments.apps \"agentgateway\" not found",
+        "stdout": [
+          "time=2026-07-25T07:06:55.683Z level=INFO msg=\"starting check\" name=expected-resources",
+          "  Namespace gpu-operator: Active",
+          "  Namespace nvidia-dra-driver: Active",
+          "  DaemonSet nvidia-dra-driver/nvidia-dra-driver-gpu-kubelet-plugin: healthy (stable ≥1m0s)",
+          "time=2026-07-25T07:07:55.741Z level=INFO msg=\"running health check assertions\" components=14",
+          "time=2026-07-25T07:07:55.787Z level=INFO msg=\"health check passed\" component=gpu-operator",
+          "time=2026-07-25T07:08:25.750Z level=WARN msg=\"health check failed\" component=agentgateway-crds step=validate-gateway-api-crds-established error=\"[NOT_FOUND] CustomResourceDefinition /gatewayclasses.gateway.networking.k8s.io not found: customresourcedefinitions.apiextensions.k8s.io \\\"gatewayclasses.gateway.networking.k8s.io\\\" not found\"",
+          "time=2026-07-25T07:08:25.750Z level=WARN msg=\"health check failed\" component=agentgateway step=validate-deployment-exists error=\"[NOT_FOUND] Deployment agentgateway-system/agentgateway not found: deployments.apps \\\"agentgateway\\\" not found\"",
+          "time=2026-07-25T07:08:25.750Z level=WARN msg=\"health check failed\" component=cert-manager step=validate-crds-established error=\"[NOT_FOUND] CustomResourceDefinition /certificates.cert-manager.io not found: customresourcedefinitions.apiextensions.k8s.io \\\"certificates.cert-manager.io\\\" not found\"",
+          "time=2026-07-25T07:08:25.790Z level=WARN msg=\"health check failed\" component=k8s-ephemeral-storage-metrics step=validate-deployment-exists error=\"[NOT_FOUND] Deployment monitoring/k8s-ephemeral-storage-metrics not found: deployments.apps \\\"k8s-ephemeral-storage-metrics\\\" not found\"",
+          "time=2026-07-25T07:08:55.756Z level=WARN msg=\"health check failed\" component=kube-prometheus-stack step=validate-deployment-exists error=\"[NOT_FOUND] Deployment monitoring/kube-prometheus-operator not found: deployments.apps \\\"kube-prometheus-operator\\\" not found\"",
+          "time=2026-07-25T07:08:55.757Z level=WARN msg=\"health check failed\" component=kai-scheduler step=validate-deployment-exists error=\"[NOT_FOUND] Deployment kai-scheduler/kai-operator not found: deployments.apps \\\"kai-operator\\\" not found\"",
+          "time=2026-07-25T07:08:55.756Z level=WARN msg=\"health check failed\" component=network-operator step=validate-deployment-exists error=\"[NOT_FOUND] Deployment nvidia-network-operator/network-operator not found: deployments.apps \\\"network-operator\\\" not found\"",
+          "time=2026-07-25T07:08:55.765Z level=INFO msg=\"health check passed\" component=nvidia-dra-driver-gpu",
+          "time=2026-07-25T07:08:55.792Z level=WARN msg=\"health check failed\" component=nfd step=validate-master-deployment error=\"[NOT_FOUND] Deployment node-feature-discovery/nfd-node-feature-discovery-master not found: deployments.apps \\\"nfd-node-feature-discovery-master\\\" not found\"",
+          "time=2026-07-25T07:09:25.762Z level=WARN msg=\"health check failed\" component=nvsentinel step=validate-deployment-exists error=\"[NOT_FOUND] Deployment nvsentinel/labeler not found: deployments.apps \\\"labeler\\\" not found\"",
+          "time=2026-07-25T07:09:25.763Z level=WARN msg=\"health check failed\" component=nodewright-operator step=validate-skyhook-crd-established error=\"[NOT_FOUND] CustomResourceDefinition /skyhooks.skyhook.nvidia.com not found: customresourcedefinitions.apiextensions.k8s.io \\\"skyhooks.skyhook.nvidia.com\\\" not found\"",
+          "time=2026-07-25T07:09:25.767Z level=WARN msg=\"health check failed\" component=prometheus-adapter step=validate-deployment-exists error=\"[NOT_FOUND] Deployment monitoring/prometheus-adapter not found: deployments.apps \\\"prometheus-adapter\\\" not found\"",
+          "time=2026-07-25T07:09:25.795Z level=WARN msg=\"health check failed\" component=prometheus-operator-crds step=validate-prometheus-operator-crds-established error=\"[NOT_FOUND] CustomResourceDefinition /alertmanagers.monitoring.coreos.com not found: customresourcedefinitions.apiextensions.k8s.io \\\"alertmanagers.monitoring.coreos.com\\\" not found\"",
+          "time=2026-07-25T07:09:25.795Z level=ERROR msg=FAIL message=\"[NOT_FOUND] Deployment agentgateway-system/agentgateway not found: deployments.apps \\\"agentgateway\\\" not found\"",
+          "  [chainsaw] gpu-operator: health check passed",
+          "  [chainsaw] nvidia-dra-driver-gpu: health check passed",
+          "Failed resources:",
+          "  namespace agentgateway-system: namespaces \"agentgateway-system\" not found",
+          "  namespace cert-manager: namespaces \"cert-manager\" not found",
+          "  namespace monitoring: namespaces \"monitoring\" not found",
+          "  namespace kai-scheduler: namespaces \"kai-scheduler\" not found",
+          "  namespace nvidia-network-operator: namespaces \"nvidia-network-operator\" not found",
+          "  namespace node-feature-discovery: namespaces \"node-feature-discovery\" not found",
+          "  namespace skyhook: namespaces \"skyhook\" not found",
+          "  namespace nvsentinel: namespaces \"nvsentinel\" not found",
+          "  [chainsaw] agentgateway: health check failed:",
+          "[NOT_FOUND] Deployment agentgateway-system/agentgateway not found: deployments.apps \"agentgateway\" not found",
+          "error: [NOT_FOUND] Deployment agentgateway-system/agentgateway not found: deployments.apps \"agentgateway\" not found",
+          "  [chainsaw] agentgateway-crds: health check failed:",
+          "[NOT_FOUND] CustomResourceDefinition /gatewayclasses.gateway.networking.k8s.io not found: customresourcedefinitions.apiextensions.k8s.io \"gatewayclasses.gateway.networking.k8s.io\" not found",
+          "error: [NOT_FOUND] CustomResourceDefinition /gatewayclasses.gateway.networking.k8s.io not found: customresourcedefinitions.apiextensions.k8s.io \"gatewayclasses.gateway.networking.k8s.io\" not found",
+          "  [chainsaw] cert-manager: health check failed:",
+          "[NOT_FOUND] CustomResourceDefinition /certificates.cert-manager.io not found: customresourcedefinitions.apiextensions.k8s.io \"certificates.cert-manager.io\" not found",
+          "error: [NOT_FOUND] CustomResourceDefinition /certificates.cert-manager.io not found: customresourcedefinitions.apiextensions.k8s.io \"certificates.cert-manager.io\" not found",
+          "  [chainsaw] k8s-ephemeral-storage-metrics: health check failed:",
+          "[NOT_FOUND] Deployment monitoring/k8s-ephemeral-storage-metrics not found: deployments.apps \"k8s-ephemeral-storage-metrics\" not found",
+          "error: [NOT_FOUND] Deployment monitoring/k8s-ephemeral-storage-metrics not found: deployments.apps \"k8s-ephemeral-storage-metrics\" not found",
+          "  [chainsaw] kai-scheduler: health check failed:",
+          "[NOT_FOUND] Deployment kai-scheduler/kai-operator not found: deployments.apps \"kai-operator\" not found",
+          "error: [NOT_FOUND] Deployment kai-scheduler/kai-operator not found: deployments.apps \"kai-operator\" not found",
+          "  [chainsaw] kube-prometheus-stack: health check failed:",
+          "[NOT_FOUND] Deployment monitoring/kube-prometheus-operator not found: deployments.apps \"kube-prometheus-operator\" not found",
+          "error: [NOT_FOUND] Deployment monitoring/kube-prometheus-operator not found: deployments.apps \"kube-prometheus-operator\" not found",
+          "  [chainsaw] network-operator: health check failed:",
+          "[NOT_FOUND] Deployment nvidia-network-operator/network-operator not found: deployments.apps \"network-operator\" not found",
+          "error: [NOT_FOUND] Deployment nvidia-network-operator/network-operator not found: deployments.apps \"network-operator\" not found",
+          "  [chainsaw] nfd: health check failed:",
+          "[NOT_FOUND] Deployment node-feature-discovery/nfd-node-feature-discovery-master not found: deployments.apps \"nfd-node-feature-discovery-master\" not found",
+          "error: [NOT_FOUND] Deployment node-feature-discovery/nfd-node-feature-discovery-master not found: deployments.apps \"nfd-node-feature-discovery-master\" not found",
+          "  [chainsaw] nodewright-operator: health check failed:",
+          "[NOT_FOUND] CustomResourceDefinition /skyhooks.skyhook.nvidia.com not found: customresourcedefinitions.apiextensions.k8s.io \"skyhooks.skyhook.nvidia.com\" not found",
+          "error: [NOT_FOUND] CustomResourceDefinition /skyhooks.skyhook.nvidia.com not found: customresourcedefinitions.apiextensions.k8s.io \"skyhooks.skyhook.nvidia.com\" not found",
+          "  [chainsaw] nvsentinel: health check failed:",
+          "[NOT_FOUND] Deployment nvsentinel/labeler not found: deployments.apps \"labeler\" not found",
+          "error: [NOT_FOUND] Deployment nvsentinel/labeler not found: deployments.apps \"labeler\" not found",
+          "  [chainsaw] prometheus-adapter: health check failed:",
+          "[NOT_FOUND] Deployment monitoring/prometheus-adapter not found: deployments.apps \"prometheus-adapter\" not found",
+          "error: [NOT_FOUND] Deployment monitoring/prometheus-adapter not found: deployments.apps \"prometheus-adapter\" not found",
+          "  [chainsaw] prometheus-operator-crds: health check failed:",
+          "[NOT_FOUND] CustomResourceDefinition /alertmanagers.monitoring.coreos.com not found: customresourcedefinitions.apiextensions.k8s.io \"alertmanagers.monitoring.coreos.com\" not found",
+          "error: [NOT_FOUND] CustomResourceDefinition /alertmanagers.monitoring.coreos.com not found: customresourcedefinitions.apiextensions.k8s.io \"alertmanagers.monitoring.coreos.com\" not found"
+        ]
+      },
+      {
+        "name": "gpu-operator-version",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "stdout": [
+          "time=2026-07-25T07:09:29.024Z level=INFO msg=\"starting check\" name=gpu-operator-version",
+          "Detected GPU Operator version: v26.3.3",
+          "Constraint: \u003e= v25.10.0 → true"
+        ]
+      },
+      {
+        "name": "check-nvidia-smi",
+        "status": "passed",
+        "duration": 3000,
+        "suite": [
+          "deployment"
+        ],
+        "stdout": [
+          "time=2026-07-25T07:09:32.917Z level=INFO msg=\"starting check\" name=check-nvidia-smi",
+          "Found 1 GPU node(s):",
+          "  nvml-mock-op-control-plane",
+          "time=2026-07-25T07:09:32.928Z level=INFO msg=\"verifying node\" node=nvml-mock-op-control-plane",
+          "time=2026-07-25T07:09:32.928Z level=INFO msg=\"deploying nvidia-smi verify pod\" node=nvml-mock-op-control-plane podName=nvidia-smi-verify-nvml-mock-op-control-plane image=nvcr.io/nvidia/cuda:13.0.0-base-ubuntu22.04 namespace=aicr-validation",
+          "All 1 GPU node(s) available. Verifying...",
+          "time=2026-07-25T07:09:32.931Z level=INFO msg=\"waiting for pod to reach Succeeded state\" name=nvidia-smi-verify-nvml-mock-op-control-plane",
+          "time=2026-07-25T07:09:33.080Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-nvml-mock-op-control-plane status=Pending waitingReason=ContainerCreating",
+          "time=2026-07-25T07:09:33.446Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-nvml-mock-op-control-plane status=Pending waitingReason=ContainerCreating",
+          "time=2026-07-25T07:09:33.522Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-nvml-mock-op-control-plane status=Running",
+          "time=2026-07-25T07:09:33.946Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-nvml-mock-op-control-plane status=Running",
+          "time=2026-07-25T07:09:35.007Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-nvml-mock-op-control-plane status=Succeeded",
+          "time=2026-07-25T07:09:35.007Z level=INFO msg=\"pod successfully completed\" name=nvidia-smi-verify-nvml-mock-op-control-plane",
+          "  nvml-mock-op-control-plane: OK",
+          "Successfully verified GPU on all 1 nodes"
+        ]
+      },
+      {
+        "name": "dra-support",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found",
+        "stdout": [
+          "time=2026-07-25T07:09:38.912Z level=INFO msg=\"starting check\" name=dra-support",
+          "--- DRA driver namespace ---",
+          "Namespace: nvidia-dra-driver",
+          "Source:    resolved recipe componentRef nvidia-dra-driver-gpu",
+          "--- DRA API resources ---",
+          "Equivalent: kubectl api-resources --api-group=resource.k8s.io",
+          "",
+          "Served version: resource.k8s.io/v1",
+          "deviceclasses              DeviceClass            namespaced=false",
+          "resourceclaims             ResourceClaim          namespaced=true",
+          "resourceclaims/status      ResourceClaim          namespaced=true",
+          "resourceclaimtemplates     ResourceClaimTemplate  namespaced=true",
+          "resourceslices             ResourceSlice          namespaced=false",
+          "",
+          "--- DRA driver pods ---",
+          "Equivalent: kubectl get pods -n nvidia-dra-driver -o wide",
+          "",
+          "nvidia-dra-driver-gpu-kubelet-plugin-rbfns       ready=1/1 phase=Running node=nvml-mock-op-control-plane",
+          "",
+          "time=2026-07-25T07:09:38.926Z level=ERROR msg=FAIL message=\"[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \\\"nvidia-dra-driver-gpu-controller\\\" not found\""
+        ]
+      },
+      {
+        "name": "accelerator-metrics",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "stdout": [
+          "time=2026-07-25T07:09:42.010Z level=INFO msg=\"starting check\" name=accelerator-metrics",
+          "--- DCGM Exporter Metrics (sample) ---",
+          "# HELP DCGM_FI_DEV_SM_CLOCK SM clock frequency (in MHz).",
+          "# TYPE DCGM_FI_DEV_SM_CLOCK gauge",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"0\",UUID=\"GPU-b200b200-0000-0000-0000-000000000000\",pci_bus_id=\"0000:0A:00.0\",device=\"nvidia0\",modelName=\"NVIDIA GB200\",Hostname=\"nvml-mock-op-control-plane\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"1\",UUID=\"GPU-b200b200-0000-0000-0000-000000000001\",pci_bus_id=\"0000:0B:00.0\",device=\"nvidia1\",modelName=\"NVIDIA GB200\",Hostname=\"nvml-mock-op-control-plane\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"2\",UUID=\"GPU-b200b200-0000-0000-0000-000000000002\",pci_bus_id=\"0000:4A:00.0\",device=\"nvidia2\",modelName=\"NVIDIA GB200\",Hostname=\"nvml-mock-op-control-plane\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"3\",UUID=\"GPU-b200b200-0000-0000-0000-000000000003\",pci_bus_id=\"0000:4B:00.0\",device=\"nvidia3\",modelName=\"NVIDIA GB200\",Hostname=\"nvml-mock-op-control-plane\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"4\",UUID=\"GPU-b200b200-0000-0000-0000-000000000004\",pci_bus_id=\"0000:8A:00.0\",device=\"nvidia4\",modelName=\"NVIDIA GB200\",Hostname=\"nvml-mock-op-control-plane\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"5\",UUID=\"GPU-b200b200-0000-0000-0000-000000000005\",pci_bus_id=\"0000:8B:00.0\",device=\"nvidia5\",modelName=\"NVIDIA GB200\",Hostname=\"nvml-mock-op-control-plane\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "... [truncated]",
+          "--- Required DCGM Metrics ---",
+          "  DCGM_FI_DEV_GPU_UTIL           FOUND",
+          "  DCGM_FI_DEV_FB_USED            FOUND",
+          "  DCGM_FI_DEV_GPU_TEMP           FOUND",
+          "  DCGM_FI_DEV_POWER_USAGE        FOUND"
+        ]
+      },
+      {
+        "name": "ai-service-metrics",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\"",
+        "stdout": [
+          "time=2026-07-25T07:09:45.020Z level=INFO msg=\"starting check\" name=ai-service-metrics",
+          "time=2026-07-25T07:09:45.029Z level=ERROR msg=FAIL message=\"[NOT_FOUND] no Prometheus service with port 9090 found in namespace \\\"monitoring\\\"\""
+        ]
+      },
+      {
+        "name": "gpu-operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "stdout": [
+          "time=2026-07-25T07:09:48.171Z level=INFO msg=\"starting check\" name=gpu-operator-health"
+        ]
+      },
+      {
+        "name": "platform-health",
+        "status": "failed",
+        "duration": 1000,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] platform health check failed (8 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvsentinel: not found",
+        "stdout": [
+          "time=2026-07-25T07:09:51.985Z level=INFO msg=\"starting check\" name=platform-health",
+          "time=2026-07-25T07:09:52.000Z level=ERROR msg=FAIL message=\"[NOT_FOUND] platform health check failed (8 issues):\\n  namespace agentgateway-system: not found\\n  namespace cert-manager: not found\\n  namespace monitoring: not found\\n  namespace kai-scheduler: not found\\n  namespace nvidia-network-operator: not found\\n  namespace node-feature-discovery: not found\\n  namespace skyhook: not found\\n  namespace nvsentinel: not found\""
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aicr-preflight/results/2026-07-25-gb200-kind/ctrf/validate.json
+++ b/tests/aicr-preflight/results/2026-07-25-gb200-kind/ctrf/validate.json
@@ -1,7 +1,7 @@
 {
   "reportFormat": "CTRF",
   "specVersion": "0.0.1",
-  "timestamp": "2026-07-25T07:09:37Z",
+  "timestamp": "2026-07-25T09:09:14Z",
   "generatedBy": "aicr",
   "results": {
     "tool": {
@@ -10,13 +10,13 @@
     },
     "summary": {
       "tests": 9,
-      "passed": 5,
-      "failed": 4,
+      "passed": 6,
+      "failed": 3,
       "skipped": 0,
       "pending": 0,
       "other": 0,
-      "start": 1784963210652,
-      "stop": 1784963395080
+      "start": 1784970417469,
+      "stop": 1784970571839
     },
     "tests": [
       {
@@ -27,52 +27,54 @@
           "deployment"
         ],
         "stdout": [
-          "time=2026-07-25T07:06:51.665Z level=INFO msg=\"starting check\" name=operator-health",
-          "time=2026-07-25T07:06:51.671Z level=INFO msg=\"listing pods\" namespace=gpu-operator label=\"app=gpu-operator\"",
-          "time=2026-07-25T07:06:51.676Z level=INFO msg=\"operator-health: passed\" running=1",
+          "time=2026-07-25T09:06:58.458Z level=INFO msg=\"starting check\" name=operator-health",
+          "time=2026-07-25T09:06:58.464Z level=INFO msg=\"listing pods\" namespace=gpu-operator label=\"app=gpu-operator\"",
           "Found 1 gpu-operator pod(s):",
           "  gpu-operator-57d75775c8-strvb: Running",
-          "Running: 1/1"
+          "Running: 1/1",
+          "time=2026-07-25T09:06:58.468Z level=INFO msg=\"operator-health: passed\" running=1"
         ]
       },
       {
         "name": "expected-resources",
         "status": "failed",
-        "duration": 150000,
+        "duration": 120000,
         "suite": [
           "deployment"
         ],
         "message": "[NOT_FOUND] Deployment agentgateway-system/agentgateway not found: deployments.apps \"agentgateway\" not found",
         "stdout": [
-          "time=2026-07-25T07:06:55.683Z level=INFO msg=\"starting check\" name=expected-resources",
+          "time=2026-07-25T09:07:01.496Z level=INFO msg=\"starting check\" name=expected-resources",
+          "  Namespace cert-manager: Active",
           "  Namespace gpu-operator: Active",
+          "  Namespace monitoring: Active",
+          "  Namespace node-feature-discovery: Active",
           "  Namespace nvidia-dra-driver: Active",
           "  DaemonSet nvidia-dra-driver/nvidia-dra-driver-gpu-kubelet-plugin: healthy (stable ≥1m0s)",
-          "time=2026-07-25T07:07:55.741Z level=INFO msg=\"running health check assertions\" components=14",
-          "time=2026-07-25T07:07:55.787Z level=INFO msg=\"health check passed\" component=gpu-operator",
-          "time=2026-07-25T07:08:25.750Z level=WARN msg=\"health check failed\" component=agentgateway-crds step=validate-gateway-api-crds-established error=\"[NOT_FOUND] CustomResourceDefinition /gatewayclasses.gateway.networking.k8s.io not found: customresourcedefinitions.apiextensions.k8s.io \\\"gatewayclasses.gateway.networking.k8s.io\\\" not found\"",
-          "time=2026-07-25T07:08:25.750Z level=WARN msg=\"health check failed\" component=agentgateway step=validate-deployment-exists error=\"[NOT_FOUND] Deployment agentgateway-system/agentgateway not found: deployments.apps \\\"agentgateway\\\" not found\"",
-          "time=2026-07-25T07:08:25.750Z level=WARN msg=\"health check failed\" component=cert-manager step=validate-crds-established error=\"[NOT_FOUND] CustomResourceDefinition /certificates.cert-manager.io not found: customresourcedefinitions.apiextensions.k8s.io \\\"certificates.cert-manager.io\\\" not found\"",
-          "time=2026-07-25T07:08:25.790Z level=WARN msg=\"health check failed\" component=k8s-ephemeral-storage-metrics step=validate-deployment-exists error=\"[NOT_FOUND] Deployment monitoring/k8s-ephemeral-storage-metrics not found: deployments.apps \\\"k8s-ephemeral-storage-metrics\\\" not found\"",
-          "time=2026-07-25T07:08:55.756Z level=WARN msg=\"health check failed\" component=kube-prometheus-stack step=validate-deployment-exists error=\"[NOT_FOUND] Deployment monitoring/kube-prometheus-operator not found: deployments.apps \\\"kube-prometheus-operator\\\" not found\"",
-          "time=2026-07-25T07:08:55.757Z level=WARN msg=\"health check failed\" component=kai-scheduler step=validate-deployment-exists error=\"[NOT_FOUND] Deployment kai-scheduler/kai-operator not found: deployments.apps \\\"kai-operator\\\" not found\"",
-          "time=2026-07-25T07:08:55.756Z level=WARN msg=\"health check failed\" component=network-operator step=validate-deployment-exists error=\"[NOT_FOUND] Deployment nvidia-network-operator/network-operator not found: deployments.apps \\\"network-operator\\\" not found\"",
-          "time=2026-07-25T07:08:55.765Z level=INFO msg=\"health check passed\" component=nvidia-dra-driver-gpu",
-          "time=2026-07-25T07:08:55.792Z level=WARN msg=\"health check failed\" component=nfd step=validate-master-deployment error=\"[NOT_FOUND] Deployment node-feature-discovery/nfd-node-feature-discovery-master not found: deployments.apps \\\"nfd-node-feature-discovery-master\\\" not found\"",
-          "time=2026-07-25T07:09:25.762Z level=WARN msg=\"health check failed\" component=nvsentinel step=validate-deployment-exists error=\"[NOT_FOUND] Deployment nvsentinel/labeler not found: deployments.apps \\\"labeler\\\" not found\"",
-          "time=2026-07-25T07:09:25.763Z level=WARN msg=\"health check failed\" component=nodewright-operator step=validate-skyhook-crd-established error=\"[NOT_FOUND] CustomResourceDefinition /skyhooks.skyhook.nvidia.com not found: customresourcedefinitions.apiextensions.k8s.io \\\"skyhooks.skyhook.nvidia.com\\\" not found\"",
-          "time=2026-07-25T07:09:25.767Z level=WARN msg=\"health check failed\" component=prometheus-adapter step=validate-deployment-exists error=\"[NOT_FOUND] Deployment monitoring/prometheus-adapter not found: deployments.apps \\\"prometheus-adapter\\\" not found\"",
-          "time=2026-07-25T07:09:25.795Z level=WARN msg=\"health check failed\" component=prometheus-operator-crds step=validate-prometheus-operator-crds-established error=\"[NOT_FOUND] CustomResourceDefinition /alertmanagers.monitoring.coreos.com not found: customresourcedefinitions.apiextensions.k8s.io \\\"alertmanagers.monitoring.coreos.com\\\" not found\"",
-          "time=2026-07-25T07:09:25.795Z level=ERROR msg=FAIL message=\"[NOT_FOUND] Deployment agentgateway-system/agentgateway not found: deployments.apps \\\"agentgateway\\\" not found\"",
+          "time=2026-07-25T09:08:01.557Z level=INFO msg=\"running health check assertions\" components=14",
+          "time=2026-07-25T09:08:01.593Z level=INFO msg=\"health check passed\" component=gpu-operator",
+          "time=2026-07-25T09:08:01.596Z level=INFO msg=\"health check passed\" component=cert-manager",
+          "time=2026-07-25T09:08:31.561Z level=WARN msg=\"health check failed\" component=agentgateway step=validate-deployment-exists error=\"[NOT_FOUND] Deployment agentgateway-system/agentgateway not found: deployments.apps \\\"agentgateway\\\" not found\"",
+          "time=2026-07-25T09:08:31.561Z level=WARN msg=\"health check failed\" component=agentgateway-crds step=validate-gateway-api-crds-established error=\"[NOT_FOUND] CustomResourceDefinition /gatewayclasses.gateway.networking.k8s.io not found: customresourcedefinitions.apiextensions.k8s.io \\\"gatewayclasses.gateway.networking.k8s.io\\\" not found\"",
+          "time=2026-07-25T09:08:31.596Z level=WARN msg=\"health check failed\" component=k8s-ephemeral-storage-metrics step=validate-deployment-exists error=\"[NOT_FOUND] Deployment monitoring/k8s-ephemeral-storage-metrics not found: deployments.apps \\\"k8s-ephemeral-storage-metrics\\\" not found\"",
+          "time=2026-07-25T09:08:31.596Z level=WARN msg=\"health check failed\" component=kai-scheduler step=validate-deployment-exists error=\"[NOT_FOUND] Deployment kai-scheduler/kai-operator not found: deployments.apps \\\"kai-operator\\\" not found\"",
+          "time=2026-07-25T09:08:31.608Z level=INFO msg=\"health check passed\" component=nfd",
+          "time=2026-07-25T09:08:31.615Z level=INFO msg=\"health check passed\" component=nvidia-dra-driver-gpu",
+          "time=2026-07-25T09:09:01.567Z level=WARN msg=\"health check failed\" component=kube-prometheus-stack step=validate-deployment-exists error=\"[NOT_FOUND] Deployment monitoring/kube-prometheus-operator not found: deployments.apps \\\"kube-prometheus-operator\\\" not found\"",
+          "time=2026-07-25T09:09:01.567Z level=WARN msg=\"health check failed\" component=network-operator step=validate-deployment-exists error=\"[NOT_FOUND] Deployment nvidia-network-operator/network-operator not found: deployments.apps \\\"network-operator\\\" not found\"",
+          "time=2026-07-25T09:09:01.576Z level=INFO msg=\"health check passed\" component=prometheus-adapter",
+          "time=2026-07-25T09:09:01.598Z level=WARN msg=\"health check failed\" component=nodewright-operator step=validate-skyhook-crd-established error=\"[NOT_FOUND] CustomResourceDefinition /skyhooks.skyhook.nvidia.com not found: customresourcedefinitions.apiextensions.k8s.io \\\"skyhooks.skyhook.nvidia.com\\\" not found\"",
+          "time=2026-07-25T09:09:01.617Z level=WARN msg=\"health check failed\" component=nvsentinel step=validate-deployment-exists error=\"[NOT_FOUND] Deployment nvsentinel/labeler not found: deployments.apps \\\"labeler\\\" not found\"",
+          "  [chainsaw] cert-manager: health check passed",
           "  [chainsaw] gpu-operator: health check passed",
+          "  [chainsaw] nfd: health check passed",
           "  [chainsaw] nvidia-dra-driver-gpu: health check passed",
+          "  [chainsaw] prometheus-adapter: health check passed",
+          "  [chainsaw] prometheus-operator-crds: health check passed",
           "Failed resources:",
           "  namespace agentgateway-system: namespaces \"agentgateway-system\" not found",
-          "  namespace cert-manager: namespaces \"cert-manager\" not found",
-          "  namespace monitoring: namespaces \"monitoring\" not found",
           "  namespace kai-scheduler: namespaces \"kai-scheduler\" not found",
           "  namespace nvidia-network-operator: namespaces \"nvidia-network-operator\" not found",
-          "  namespace node-feature-discovery: namespaces \"node-feature-discovery\" not found",
           "  namespace skyhook: namespaces \"skyhook\" not found",
           "  namespace nvsentinel: namespaces \"nvsentinel\" not found",
           "  [chainsaw] agentgateway: health check failed:",
@@ -81,9 +83,6 @@
           "  [chainsaw] agentgateway-crds: health check failed:",
           "[NOT_FOUND] CustomResourceDefinition /gatewayclasses.gateway.networking.k8s.io not found: customresourcedefinitions.apiextensions.k8s.io \"gatewayclasses.gateway.networking.k8s.io\" not found",
           "error: [NOT_FOUND] CustomResourceDefinition /gatewayclasses.gateway.networking.k8s.io not found: customresourcedefinitions.apiextensions.k8s.io \"gatewayclasses.gateway.networking.k8s.io\" not found",
-          "  [chainsaw] cert-manager: health check failed:",
-          "[NOT_FOUND] CustomResourceDefinition /certificates.cert-manager.io not found: customresourcedefinitions.apiextensions.k8s.io \"certificates.cert-manager.io\" not found",
-          "error: [NOT_FOUND] CustomResourceDefinition /certificates.cert-manager.io not found: customresourcedefinitions.apiextensions.k8s.io \"certificates.cert-manager.io\" not found",
           "  [chainsaw] k8s-ephemeral-storage-metrics: health check failed:",
           "[NOT_FOUND] Deployment monitoring/k8s-ephemeral-storage-metrics not found: deployments.apps \"k8s-ephemeral-storage-metrics\" not found",
           "error: [NOT_FOUND] Deployment monitoring/k8s-ephemeral-storage-metrics not found: deployments.apps \"k8s-ephemeral-storage-metrics\" not found",
@@ -96,21 +95,14 @@
           "  [chainsaw] network-operator: health check failed:",
           "[NOT_FOUND] Deployment nvidia-network-operator/network-operator not found: deployments.apps \"network-operator\" not found",
           "error: [NOT_FOUND] Deployment nvidia-network-operator/network-operator not found: deployments.apps \"network-operator\" not found",
-          "  [chainsaw] nfd: health check failed:",
-          "[NOT_FOUND] Deployment node-feature-discovery/nfd-node-feature-discovery-master not found: deployments.apps \"nfd-node-feature-discovery-master\" not found",
-          "error: [NOT_FOUND] Deployment node-feature-discovery/nfd-node-feature-discovery-master not found: deployments.apps \"nfd-node-feature-discovery-master\" not found",
           "  [chainsaw] nodewright-operator: health check failed:",
           "[NOT_FOUND] CustomResourceDefinition /skyhooks.skyhook.nvidia.com not found: customresourcedefinitions.apiextensions.k8s.io \"skyhooks.skyhook.nvidia.com\" not found",
           "error: [NOT_FOUND] CustomResourceDefinition /skyhooks.skyhook.nvidia.com not found: customresourcedefinitions.apiextensions.k8s.io \"skyhooks.skyhook.nvidia.com\" not found",
           "  [chainsaw] nvsentinel: health check failed:",
           "[NOT_FOUND] Deployment nvsentinel/labeler not found: deployments.apps \"labeler\" not found",
           "error: [NOT_FOUND] Deployment nvsentinel/labeler not found: deployments.apps \"labeler\" not found",
-          "  [chainsaw] prometheus-adapter: health check failed:",
-          "[NOT_FOUND] Deployment monitoring/prometheus-adapter not found: deployments.apps \"prometheus-adapter\" not found",
-          "error: [NOT_FOUND] Deployment monitoring/prometheus-adapter not found: deployments.apps \"prometheus-adapter\" not found",
-          "  [chainsaw] prometheus-operator-crds: health check failed:",
-          "[NOT_FOUND] CustomResourceDefinition /alertmanagers.monitoring.coreos.com not found: customresourcedefinitions.apiextensions.k8s.io \"alertmanagers.monitoring.coreos.com\" not found",
-          "error: [NOT_FOUND] CustomResourceDefinition /alertmanagers.monitoring.coreos.com not found: customresourcedefinitions.apiextensions.k8s.io \"alertmanagers.monitoring.coreos.com\" not found"
+          "time=2026-07-25T09:09:01.658Z level=INFO msg=\"health check passed\" component=prometheus-operator-crds",
+          "time=2026-07-25T09:09:01.658Z level=ERROR msg=FAIL message=\"[NOT_FOUND] Deployment agentgateway-system/agentgateway not found: deployments.apps \\\"agentgateway\\\" not found\""
         ]
       },
       {
@@ -121,7 +113,7 @@
           "deployment"
         ],
         "stdout": [
-          "time=2026-07-25T07:09:29.024Z level=INFO msg=\"starting check\" name=gpu-operator-version",
+          "time=2026-07-25T09:09:05.728Z level=INFO msg=\"starting check\" name=gpu-operator-version",
           "Detected GPU Operator version: v26.3.3",
           "Constraint: \u003e= v25.10.0 → true"
         ]
@@ -129,24 +121,24 @@
       {
         "name": "check-nvidia-smi",
         "status": "passed",
-        "duration": 3000,
+        "duration": 2000,
         "suite": [
           "deployment"
         ],
         "stdout": [
-          "time=2026-07-25T07:09:32.917Z level=INFO msg=\"starting check\" name=check-nvidia-smi",
+          "time=2026-07-25T09:09:09.785Z level=INFO msg=\"starting check\" name=check-nvidia-smi",
           "Found 1 GPU node(s):",
           "  nvml-mock-op-control-plane",
-          "time=2026-07-25T07:09:32.928Z level=INFO msg=\"verifying node\" node=nvml-mock-op-control-plane",
-          "time=2026-07-25T07:09:32.928Z level=INFO msg=\"deploying nvidia-smi verify pod\" node=nvml-mock-op-control-plane podName=nvidia-smi-verify-nvml-mock-op-control-plane image=nvcr.io/nvidia/cuda:13.0.0-base-ubuntu22.04 namespace=aicr-validation",
           "All 1 GPU node(s) available. Verifying...",
-          "time=2026-07-25T07:09:32.931Z level=INFO msg=\"waiting for pod to reach Succeeded state\" name=nvidia-smi-verify-nvml-mock-op-control-plane",
-          "time=2026-07-25T07:09:33.080Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-nvml-mock-op-control-plane status=Pending waitingReason=ContainerCreating",
-          "time=2026-07-25T07:09:33.446Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-nvml-mock-op-control-plane status=Pending waitingReason=ContainerCreating",
-          "time=2026-07-25T07:09:33.522Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-nvml-mock-op-control-plane status=Running",
-          "time=2026-07-25T07:09:33.946Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-nvml-mock-op-control-plane status=Running",
-          "time=2026-07-25T07:09:35.007Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-nvml-mock-op-control-plane status=Succeeded",
-          "time=2026-07-25T07:09:35.007Z level=INFO msg=\"pod successfully completed\" name=nvidia-smi-verify-nvml-mock-op-control-plane",
+          "time=2026-07-25T09:09:09.796Z level=INFO msg=\"verifying node\" node=nvml-mock-op-control-plane",
+          "time=2026-07-25T09:09:09.796Z level=INFO msg=\"deploying nvidia-smi verify pod\" node=nvml-mock-op-control-plane podName=nvidia-smi-verify-nvml-mock-op-control-plane image=nvcr.io/nvidia/cuda:13.0.0-base-ubuntu22.04 namespace=aicr-validation",
+          "time=2026-07-25T09:09:09.799Z level=INFO msg=\"waiting for pod to reach Succeeded state\" name=nvidia-smi-verify-nvml-mock-op-control-plane",
+          "time=2026-07-25T09:09:09.958Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-nvml-mock-op-control-plane status=Pending waitingReason=ContainerCreating",
+          "time=2026-07-25T09:09:10.323Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-nvml-mock-op-control-plane status=Pending waitingReason=ContainerCreating",
+          "time=2026-07-25T09:09:10.388Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-nvml-mock-op-control-plane status=Running",
+          "time=2026-07-25T09:09:10.676Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-nvml-mock-op-control-plane status=Running",
+          "time=2026-07-25T09:09:11.743Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-nvml-mock-op-control-plane status=Succeeded",
+          "time=2026-07-25T09:09:11.743Z level=INFO msg=\"pod successfully completed\" name=nvidia-smi-verify-nvml-mock-op-control-plane",
           "  nvml-mock-op-control-plane: OK",
           "Successfully verified GPU on all 1 nodes"
         ]
@@ -160,7 +152,7 @@
         ],
         "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found",
         "stdout": [
-          "time=2026-07-25T07:09:38.912Z level=INFO msg=\"starting check\" name=dra-support",
+          "time=2026-07-25T09:09:15.660Z level=INFO msg=\"starting check\" name=dra-support",
           "--- DRA driver namespace ---",
           "Namespace: nvidia-dra-driver",
           "Source:    resolved recipe componentRef nvidia-dra-driver-gpu",
@@ -177,9 +169,9 @@
           "--- DRA driver pods ---",
           "Equivalent: kubectl get pods -n nvidia-dra-driver -o wide",
           "",
-          "nvidia-dra-driver-gpu-kubelet-plugin-rbfns       ready=1/1 phase=Running node=nvml-mock-op-control-plane",
+          "nvidia-dra-driver-gpu-kubelet-plugin-4wthw       ready=1/1 phase=Running node=nvml-mock-op-control-plane",
           "",
-          "time=2026-07-25T07:09:38.926Z level=ERROR msg=FAIL message=\"[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \\\"nvidia-dra-driver-gpu-controller\\\" not found\""
+          "time=2026-07-25T09:09:15.669Z level=ERROR msg=FAIL message=\"[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \\\"nvidia-dra-driver-gpu-controller\\\" not found\""
         ]
       },
       {
@@ -190,7 +182,7 @@
           "conformance"
         ],
         "stdout": [
-          "time=2026-07-25T07:09:42.010Z level=INFO msg=\"starting check\" name=accelerator-metrics",
+          "time=2026-07-25T09:09:19.767Z level=INFO msg=\"starting check\" name=accelerator-metrics",
           "--- DCGM Exporter Metrics (sample) ---",
           "# HELP DCGM_FI_DEV_SM_CLOCK SM clock frequency (in MHz).",
           "# TYPE DCGM_FI_DEV_SM_CLOCK gauge",
@@ -210,15 +202,50 @@
       },
       {
         "name": "ai-service-metrics",
-        "status": "failed",
+        "status": "passed",
         "duration": 0,
         "suite": [
           "conformance"
         ],
-        "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\"",
         "stdout": [
-          "time=2026-07-25T07:09:45.020Z level=INFO msg=\"starting check\" name=ai-service-metrics",
-          "time=2026-07-25T07:09:45.029Z level=ERROR msg=FAIL message=\"[NOT_FOUND] no Prometheus service with port 9090 found in namespace \\\"monitoring\\\"\""
+          "time=2026-07-25T09:09:22.845Z level=INFO msg=\"starting check\" name=ai-service-metrics",
+          "--- Prometheus Query: DCGM_FI_DEV_GPU_UTIL ---",
+          "Equivalent: curl -sf 'http://kube-prometheus-stack-prometheus.monitoring.svc:9090/api/v1/query?query=DCGM_FI_DEV_GPU_UTIL'",
+          "",
+          "Status:            success",
+          "Time series count: 8",
+          "--- Prometheus query response (GPU util) ---",
+          "Equivalent: curl -sf 'http://kube-prometheus-stack-prometheus.monitoring.svc:9090/api/v1/query?query=DCGM_FI_DEV_GPU_UTIL'",
+          "",
+          "{\"status\":\"success\",\"data\":{\"resultType\":\"vector\",\"result\":[{\"metric\":{\"DCGM_FI_DRIVER_VERSION\":\"580.65.06\",\"Hostname\":\"nvml-mock-op-control-plane\",\"UUID\":\"GPU-b200b200-0000-0000-0000-000000000000\",\"__name__\":\"DCGM_FI_DEV_GPU_UTIL\",\"container\":\"nvidia-dcgm-exporter\",\"device\":\"nvidia0\",\"endpoint\":\"gpu-metrics\",\"gpu\":\"0\",\"instance\":\"10.244.0.19:9400\",\"job\":\"nvidia-dcgm-exporter\",\"modelName\":\"NVIDIA GB200\",\"namespace\":\"gpu-operator\",\"pci_bus_id\":\"0000:0A:00.0\",\"pod\":\"nvidia-dcgm-exporter-m6lzm\",\"service\":\"nvid... [truncated 3566 chars]",
+          "--- Custom Metrics API ---",
+          "Equivalent: kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1",
+          "",
+          "HTTP Status:    200",
+          "GroupVersion:   custom.metrics.k8s.io/v1beta1",
+          "Resource count: 5355",
+          "",
+          "Resources:",
+          "- jobs.batch/node_sockstat_TCP_inuse (namespaced=true)",
+          "- services/go_goroutines (namespaced=true)",
+          "- services/process_virtual_memory_max_bytes (namespaced=true)",
+          "- jobs.batch/prometheus_tsdb_compaction_chunk_size_bytes_sum (namespaced=true)",
+          "- pods/node_network_receive_nohandler (namespaced=true)",
+          "- services/rest_client_rate_limiter_duration_seconds_bucket (namespaced=true)",
+          "- services/node_nf_conntrack_stat_drop (namespaced=true)",
+          "- namespaces/node_disk_read_bytes (namespaced=false)",
+          "- jobs.batch/node_scrape_collector_success (namespaced=true)",
+          "- namespaces/kube_pod_container_status_restarts (namespaced=false)",
+          "- pods/prometheus_target_scrapes_cache_flush_forced (namespaced=true)",
+          "- namespaces/go_sched_goroutines_runnable_goroutines (namespaced=false)",
+          "- jobs.batch/kubelet_pod_start_duration_seconds_count (namespaced=true)",
+          "- nodes/kubelet_pod_worker_start_duration_seconds_count (namespaced=false)",
+          "- services/apiserver_watch_cache_resource_version (namespaced=true)",
+          "- jobs.batch/prometheus_sd_file_scan_duration_seconds_sum (namespaced=true)",
+          "- pods/prometheus_tsdb_compactions_skipped (namespaced=true)",
+          "- namespaces/node_nfsd_read_ahead_cache_not_found (namespaced=false)",
+          "- namespaces/memory_failures (namespaced=false)",
+          "- services/go_memstats_mcache_inuse_bytes (namespaced=true)"
         ]
       },
       {
@@ -229,20 +256,20 @@
           "conformance"
         ],
         "stdout": [
-          "time=2026-07-25T07:09:48.171Z level=INFO msg=\"starting check\" name=gpu-operator-health"
+          "time=2026-07-25T09:09:26.675Z level=INFO msg=\"starting check\" name=gpu-operator-health"
         ]
       },
       {
         "name": "platform-health",
         "status": "failed",
-        "duration": 1000,
+        "duration": 0,
         "suite": [
           "conformance"
         ],
-        "message": "[NOT_FOUND] platform health check failed (8 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvsentinel: not found",
+        "message": "[NOT_FOUND] platform health check failed (5 issues):\n  namespace agentgateway-system: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace skyhook: not found\n  namespace nvsentinel: not found",
         "stdout": [
-          "time=2026-07-25T07:09:51.985Z level=INFO msg=\"starting check\" name=platform-health",
-          "time=2026-07-25T07:09:52.000Z level=ERROR msg=FAIL message=\"[NOT_FOUND] platform health check failed (8 issues):\\n  namespace agentgateway-system: not found\\n  namespace cert-manager: not found\\n  namespace monitoring: not found\\n  namespace kai-scheduler: not found\\n  namespace nvidia-network-operator: not found\\n  namespace node-feature-discovery: not found\\n  namespace skyhook: not found\\n  namespace nvsentinel: not found\""
+          "time=2026-07-25T09:09:29.779Z level=INFO msg=\"starting check\" name=platform-health",
+          "time=2026-07-25T09:09:29.791Z level=ERROR msg=FAIL message=\"[NOT_FOUND] platform health check failed (5 issues):\\n  namespace agentgateway-system: not found\\n  namespace kai-scheduler: not found\\n  namespace nvidia-network-operator: not found\\n  namespace skyhook: not found\\n  namespace nvsentinel: not found\""
         ]
       }
     ]

--- a/tests/aicr-preflight/results/2026-07-25-gb200-kind/imex-gap-evidence.log
+++ b/tests/aicr-preflight/results/2026-07-25-gb200-kind/imex-gap-evidence.log
@@ -1,0 +1,27 @@
+I0725 07:17:03.032044       1 utils.go:43] 
+Feature gates: map[string]bool{"AllAlpha":false, "AllBeta":false, "ComputeDomainCliques":true, "ContextualLogging":true, "CrashOnNVLinkFabricErrors":true, "DynamicMIG":false, "IMEXDaemonsWithDNSNames":true, "LoggingAlphaOptions":false, "LoggingBetaOptions":true, "MPSSupport":false, "NVMLDeviceHealthCheck":false, "PassthroughSupport":false, "TimeSlicingSettings":false}
+Flags: (*main.Flags)({
+  kubeClientConfig: (flags.KubeClientConfig) {
+    KubeConfig: (string) "",
+    KubeAPIQPS: (float64) 5,
+    KubeAPIBurst: (int) 10
+  },
+  nodeName: (string) (len=26) "nvml-mock-op-control-plane",
+  namespace: (string) (len=17) "nvidia-dra-driver",
+  cdiRoot: (string) (len=12) "/var/run/cdi",
+  containerDriverRoot: (string) (len=12) "/driver-root",
+  hostDriverRoot: (string) (len=25) "/var/lib/nvml-mock/driver",
+  nvidiaCDIHookPath: (string) "",
+  kubeletRegistrarDirectoryPath: (string) (len=33) "/var/lib/kubelet/plugins_registry",
+  kubeletPluginsDirectoryPath: (string) (len=24) "/var/lib/kubelet/plugins",
+  healthcheckPort: (int) 51515,
+  klogVerbosity: (int) 4
+})
+I0725 07:17:03.032465       1 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
+I0725 07:17:03.032477       1 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
+I0725 07:17:03.032479       1 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
+I0725 07:17:03.032480       1 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
+I0725 07:17:03.032484       1 envvar.go:172] "Feature gate default state" feature="InOrderInformers" enabled=true
+I0725 07:17:03.032857       1 util.go:69] Started debug signal handler(s)
+I0725 07:17:03.046012       1 main.go:194] shutdown
+Error: error creating driver: failed to create device library: error getting nvcap for IMEX channel '0': error getting device major: error parsing '/proc/devices': unexpected regex match: []

--- a/tests/aicr-preflight/results/2026-07-25-gb200-kind/recipe-gb200-kind.yaml
+++ b/tests/aicr-preflight/results/2026-07-25-gb200-kind/recipe-gb200-kind.yaml
@@ -1,0 +1,2003 @@
+apiVersion: aicr.run/v1alpha2
+componentRefs:
+  - chart: agentgateway
+    dependencyRefs:
+      - agentgateway-crds
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Agentgateway Health Check
+      #
+      # Validates that agentgateway is running and healthy in the agentgateway-system
+      # namespace. Checks that the agentgateway deployment has at least one available
+      # replica and that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # agentgateway deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: agentgateway
+                      namespace: agentgateway-system
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    manifestFiles:
+      - components/agentgateway/manifests/inference-gateway.yaml
+    name: agentgateway
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway/values.yaml
+    version: v1.3.1
+  - chart: agentgateway-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # agentgateway-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this component installs
+      # has reached the `Established=True` condition (CRD storage is up and
+      # the apiserver will accept CRs of those kinds).
+      #
+      # Scope: this component bundles BOTH the chart's agentgateway.dev/v1alpha1
+      # CRDs and the vendored Gateway API + Inference Extension manifests under
+      # recipes/components/agentgateway-crds/manifests/.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-gateway-api-crds-established
+            # Standard Gateway API CRDs vendored under
+            # manifests/gateway-api-crds.yaml. Verified against the in-tree
+            # manifest content.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gatewayclasses.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gateways.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: grpcroutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: httproutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: referencegrants.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-agentgateway-crds-established
+            # agentgateway.dev/v1alpha1 CRDs installed by the agentgateway-crds
+            # Helm chart.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaybackends.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewayparameters.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaypolicies.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-inference-extension-crds-established
+            # Gateway API Inference Extension CRDs vendored under
+            # manifests/inference-extension-crds.yaml.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencemodelrewrites.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferenceobjectives.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepoolimports.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    manifestFiles:
+      - components/agentgateway-crds/manifests/gateway-api-crds.yaml
+      - components/agentgateway-crds/manifests/inference-extension-crds.yaml
+    name: agentgateway-crds
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway-crds/values.yaml
+    version: v1.3.1
+  - chart: cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Cert Manager Health Check
+      #
+      # Validates that cert-manager is running and healthy in the cert-manager
+      # namespace. The chart deploys three Deployments — the controller
+      # (cert-manager), the CA injector (cert-manager-cainjector), and the
+      # webhook (cert-manager-webhook) — all of which must be available for
+      # the operator to issue / inject / validate certificates. The previous
+      # check only asserted the controller; this check covers all three to
+      # avoid silently passing while the webhook is down (which would block
+      # every Certificate/Issuer CR admission).
+      #
+      # Also asserts the three core CRDs are Established=True so the
+      # apiserver will accept CRs of those kinds (per #1222 / #660).
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: cert-manager-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: certificates.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: issuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterissuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-controller-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cainjector-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-cainjector
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-webhook-deployment
+            try:
+              # The webhook must be ready before any Certificate / Issuer CR
+              # can be admitted. Without this assert, a healthy controller
+              # with a dead webhook would still pass the check while the
+              # cluster silently rejects every cert-manager CR.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-webhook
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: cert-manager
+    namespace: cert-manager
+    source: https://charts.jetstack.io
+    type: Helm
+    valuesFile: components/cert-manager/values.yaml
+    version: v1.20.2
+  - chart: gpu-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # GPU Operator Health Check
+      #
+      # Validates the GPU operator stack:
+      # 1. The gpu-operator Deployment has at least one available replica.
+      # 2. The clusterpolicies.nvidia.com CRD is Established (apiserver will
+      #    accept the singleton ClusterPolicy CR).
+      # 3. The ClusterPolicy singleton named "cluster-policy" has reconciled
+      #    to status.state == "ready" — this is the deepest signal that the
+      #    full GPU stack (driver, toolkit, cuda, plugin DaemonSets, validators)
+      #    is healthy. Migrates the verifyClusterPolicyReady Go check that
+      #    PR #1235 task 7 deferred for assertion-equivalence proof.
+      # 4. No pods in unhealthy phases or stuck container-waiting states.
+      #
+      # The nvidia-operator-validator DaemonSet runs 4 sequential init
+      # containers (driver, toolkit, cuda, plugin) before reaching Running;
+      # the ClusterPolicy state assertion is the canonical post-reconcile
+      # signal that all four passed.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: gpu-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-cluster-policy-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterpolicies.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # gpu-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: gpu-operator
+                      namespace: gpu-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cluster-policy-ready
+            try:
+              # Deepest GPU readiness signal: ClusterPolicy singleton has
+              # reconciled to state=ready. Replaces the deferred
+              # verifyClusterPolicyReady Go check from PR #1235 task 7.
+              - assert:
+                  resource:
+                    apiVersion: nvidia.com/v1
+                    kind: ClusterPolicy
+                    metadata:
+                      name: cluster-policy
+                    status:
+                      state: ready
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: gpu-operator
+    namespace: gpu-operator
+    overrides:
+      daemonsets:
+        tolerations: []
+      dcgm:
+        enabled: false
+      dcgmExporter:
+        config:
+          create: false
+          data: ""
+          name: ""
+      devicePlugin:
+        env: []
+      driver:
+        enabled: false
+        rdma:
+          enabled: false
+      gdrcopy:
+        enabled: false
+      migManager:
+        enabled: false
+      operator:
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+      toolkit:
+        enabled: false
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/gpu-operator/values.yaml
+    version: v26.3.2
+  - chart: k8s-ephemeral-storage-metrics
+    dependencyRefs:
+      - kube-prometheus-stack
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # K8s Ephemeral Storage Metrics Health Check
+      #
+      # Validates that the k8s-ephemeral-storage-metrics Deployment is running and
+      # healthy in the monitoring namespace. Checks that the Deployment has at least
+      # one available replica and that no ephemeral storage metrics pods (selected by label)
+      # are stuck in Pending, Failed, or Unknown phases. Label selectors are used
+      # because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: k8s-ephemeral-storage-metrics-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the k8s-ephemeral-storage-metrics
+              # DaemonSet exists and has at least one ready pod.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: k8s-ephemeral-storage-metrics
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no ephemeral storage metrics pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: k8s-ephemeral-storage-metrics
+    namespace: monitoring
+    source: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
+    type: Helm
+    valuesFile: components/k8s-ephemeral-storage-metrics/values.yaml
+    version: 1.19.2
+  - chart: kai-scheduler
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # KAI Scheduler Health Check
+      #
+      # Validates that the KAI Scheduler is running and healthy in the kai-scheduler
+      # namespace. Checks that the kai-operator deployment has at least one
+      # available replica and that no pods in the namespace are stuck in Pending,
+      # Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kai-scheduler-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # kai-scheduler deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kai-operator
+                      namespace: kai-scheduler
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kai-scheduler
+    namespace: kai-scheduler
+    source: oci://ghcr.io/kai-scheduler/kai-scheduler
+    type: Helm
+    valuesFile: components/kai-scheduler/values.yaml
+    version: v0.14.1
+  - chart: kube-prometheus-stack
+    dependencyRefs:
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Kube Prometheus Stack Health Check
+      #
+      # Validates that the kube-prometheus-stack operator, its managed CRs, and
+      # associated workloads are running and healthy in the monitoring namespace:
+      #
+      # 1. The kube-prometheus-operator Deployment has at least one available replica.
+      # 2. The Prometheus CR (kube-prometheus-prometheus) reports Available=True.
+      #    This explicitly catches operator-level reconcile stalls (e.g., webhook
+      #    rejections) where a target StatefulSet might never be created at all.
+      # 3. The Alertmanager CR (kube-prometheus-alertmanager) reports Available=True.
+      # 4. The Prometheus StatefulSet (prometheus-kube-prometheus-prometheus) has
+      #    reached full rollout: readyReplicas >= replicas, with a replicas > 0
+      #    vacuous-pass guard so a missing StatefulSet does not silently pass.
+      # 5. The Alertmanager StatefulSet (alertmanager-kube-prometheus-alertmanager)
+      #    reaches the same full-rollout threshold.
+      # 6. No stack operator pods (label-scoped to app.kubernetes.io/name:
+      #    kube-prometheus-stack) are stuck in Pending, Failed, Unknown, or a
+      #    known-bad container-waiting reason (CrashLoopBackOff, ImagePullBackOff,
+      #    ErrImagePull, CreateContainerConfigError).
+      #
+      # StatefulSet and CR names are derived from fullnameOverride=kube-prometheus
+      # in recipes/components/kube-prometheus-stack/values.yaml. The prometheus-
+      # operator creates StatefulSets named <workload>-<cr-name>, and the chart
+      # renders CR names as <fullname>-<workload>. Names verified against
+      # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml and
+      # tests/chainsaw/ai-conformance/kind-common/assert-monitoring.yaml
+      # (both live-cluster-validated). Label selectors are used in the pod-health
+      # step because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kube-prometheus-stack-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the kube-prometheus-stack-operator
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kube-prometheus-operator
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-prometheus-cr-available
+            try:
+              # Assert the Prometheus CR has been reconciled by the operator.
+              # The prometheus-operator sets an Available condition on the CR once
+              # it has successfully reconciled the CR into a running StatefulSet.
+              # CR name kube-prometheus-prometheus derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -prometheus suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Prometheus
+                    metadata:
+                      name: kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-alertmanager-cr-available
+            try:
+              # Assert the Alertmanager CR has been reconciled by the operator.
+              # CR name kube-prometheus-alertmanager derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -alertmanager suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Alertmanager
+                    metadata:
+                      name: kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-prometheus-statefulset-ready
+            try:
+              # Assert the Prometheus StatefulSet created by the operator has
+              # reached full rollout. readyReplicas >= replicas ensures all pods
+              # are ready, not just some. The replicas > 0 guard prevents a
+              # vacuous pass when the StatefulSet is missing or has 0 replicas.
+              # StatefulSet name prometheus-kube-prometheus-prometheus is
+              # <workload>-<cr-name> per prometheus-operator convention, verified
+              # from tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: prometheus-kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-alertmanager-statefulset-ready
+            try:
+              # Assert the Alertmanager StatefulSet has reached full rollout.
+              # Same pattern as Prometheus above. StatefulSet name
+              # alertmanager-kube-prometheus-alertmanager is <workload>-<cr-name>
+              # per prometheus-operator convention, verified from
+              # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: alertmanager-kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus stack pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kube-prometheus-stack
+    namespace: monitoring
+    overrides:
+      alertmanager:
+        alertmanagerSpec:
+          resources:
+            limits:
+              cpu: 250m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+      defaultRules:
+        create: false
+      grafana:
+        enabled: false
+      prometheus:
+        prometheusSpec:
+          resources:
+            limits:
+              cpu: 1
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          retention: 7d
+          storageSpec:
+            emptyDir:
+              medium: ""
+              sizeLimit: 5Gi
+      prometheusOperator:
+        alertmanagerConfigNamespaces:
+          - monitoring
+        alertmanagerInstanceNamespaces:
+          - monitoring
+        livenessProbe:
+          failureThreshold: 10
+          timeoutSeconds: 10
+        prometheusInstanceNamespaces:
+          - monitoring
+        readinessProbe:
+          failureThreshold: 6
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        thanosRulerInstanceNamespaces:
+          - monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/kube-prometheus-stack/values.yaml
+    version: 84.4.0
+  - chart: network-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Network Operator Health Check
+      #
+      # Validates that the NVIDIA Network Operator is running and healthy in the
+      # nvidia-network-operator namespace. Checks that the network-operator
+      # deployment has at least one available replica and that no pods in the
+      # namespace are stuck in Pending, Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: network-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # network-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: network-operator
+                      namespace: nvidia-network-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: network-operator
+    namespace: nvidia-network-operator
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/network-operator/values.yaml
+    version: 26.1.1
+  - chart: node-feature-discovery
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Node Feature Discovery Health Check
+      #
+      # Validates the standalone NFD deployment by checking:
+      # 1. NFD Master Deployment has at least one ready replica
+      # 2. NFD Worker DaemonSet has fully rolled out (desiredNumberScheduled > 0
+      #    and numberReady == desiredNumberScheduled, so partial failures don't pass)
+      # 3. NFD GC Deployment has at least one ready replica (gc.enable: true)
+      #
+      # Resource names: AICR deploys the kubernetes-sigs/node-feature-discovery
+      # chart under release name "nfd" (matching the ComponentRef Name in
+      # recipes/registry.yaml). The chart's fullname template prefixes the
+      # release name to the chart name when they don't overlap, yielding
+      # "nfd-node-feature-discovery-*" for the master Deployment, worker
+      # DaemonSet, and gc Deployment. If a deployer ever switches the release
+      # name to "node-feature-discovery", these asserts need updating in
+      # lockstep.
+      # 4. No pods in unhealthy phases (Pending, Failed, Unknown) or stuck in
+      #    Running with a known-unhealthy container waiting reason
+      #    (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+      #    CreateContainerConfigError)
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nfd-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-master-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-master
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-worker-daemonset
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nfd-node-feature-discovery-worker
+                      namespace: node-feature-discovery
+                    status:
+                      # Guard against vacuous pass when 0 nodes match the
+                      # DaemonSet: require at least one scheduled pod.
+                      (desiredNumberScheduled > `0`): true
+                      # Full rollout: every scheduled pod is ready. Combined with
+                      # the guard above, this rejects partial failures. We assert on
+                      # numberReady (always present in DaemonSetStatus) rather than
+                      # numberUnavailable, which is `omitempty` and disappears from
+                      # the status when zero — making `numberUnavailable == 0`
+                      # evaluate `null == 0` (false) on a fully-healthy DaemonSet.
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-gc-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-gc
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nfd
+    namespace: node-feature-discovery
+    source: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+    type: Helm
+    valuesFile: components/nfd/values.yaml
+    version: 0.19.0
+  - chart: nodewright
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Nodewright Operator Health Check
+      #
+      # Validates that the Nodewright Operator is running and healthy in the
+      # skyhook namespace:
+      # 1. skyhooks.skyhook.nvidia.com CRD Established=True (the apiserver
+      #    will accept Skyhook CRs that nodewright-customizations declares).
+      # 2. skyhook-operator-controller-manager Deployment has at least one
+      #    available replica.
+      # 3. No pods stuck in Pending/Failed/Unknown phases or known-bad
+      #    container-waiting states.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nodewright-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-skyhook-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: skyhooks.skyhook.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: skyhook-operator-controller-manager
+                      namespace: skyhook
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nodewright-operator
+    namespace: skyhook
+    overrides:
+      controllerManager:
+        manager:
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+    source: oci://ghcr.io/nvidia/nodewright/charts
+    type: Helm
+    valuesFile: components/nodewright-operator/values.yaml
+    version: v0.17.1
+  - chart: dra-driver-nvidia-gpu
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVIDIA DRA Driver GPU Health Check
+      #
+      # Validates that the NVIDIA DRA (Dynamic Resource Allocation) GPU driver
+      # is running and healthy in the nvidia-dra-driver namespace. The
+      # kubelet-plugin DaemonSet must roll out fully — numberReady ==
+      # desiredNumberScheduled (with desiredNumberScheduled > 0 as a guard).
+      # Previous check gated only on numberReady > 0, passing on partial
+      # failures; see #1222 and recipes/checks/nfd/health-check.yaml for
+      # the same rationale.
+      #
+      # Resource names: the DaemonSet name is release-derived
+      # (<release>-kubelet-plugin). AICR's release name is
+      # `nvidia-dra-driver-gpu` (matches ComponentRef Name in registry.yaml).
+      # If a deployer renames the release, this assert needs updating in
+      # lockstep — see verifyDRAKubeletPluginReady commentary in
+      # validators/deployment/expected_resources.go for why a chart-shape
+      # label would be a more robust selector.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvidia-dra-driver-gpu-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-kubelet-plugin-daemonset-fully-rolled-out
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nvidia-dra-driver-gpu-kubelet-plugin
+                      namespace: nvidia-dra-driver
+                    status:
+                      (desiredNumberScheduled > `0`): true
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvidia-dra-driver-gpu
+    namespace: nvidia-dra-driver
+    overrides:
+      nvidiaDriverRoot: /
+    source: oci://registry.k8s.io/dra-driver-nvidia/charts
+    type: Helm
+    valuesFile: components/nvidia-dra-driver-gpu/values.yaml
+    version: 0.4.1
+  - chart: nvsentinel
+    dependencyRefs:
+      - cert-manager
+      - gpu-operator
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVSentinel Health Check
+      #
+      # Validates that the NVSentinel labeler is running and healthy in
+      # the nvsentinel namespace. Checks that the labeler deployment has at
+      # least one available replica and that no pods in the
+      # namespace are stuck in Pending, Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvsentinel-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # nvsentinel-controller-manager deployment exists and has at least
+              # one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: labeler
+                      namespace: nvsentinel
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvsentinel
+    namespace: nvsentinel
+    overrides:
+      platformConnector:
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+    source: oci://ghcr.io/nvidia
+    type: Helm
+    valuesFile: components/nvsentinel/values.yaml
+    version: v1.9.0
+  - chart: prometheus-adapter
+    dependencyRefs:
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Prometheus Adapter Health Check
+      #
+      # Validates that the Prometheus Adapter is running and healthy in the
+      # monitoring namespace. Checks that the prometheus-adapter deployment has
+      # at least one available replica and that no prometheus adapter pods
+      # (selected by label) are stuck in Pending, Failed, or Unknown phases.
+      # Label selectors are used because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-adapter-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the prometheus-adapter
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: prometheus-adapter
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus adapter pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: prometheus-adapter
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-adapter/values.yaml
+    version: 5.3.0
+  - chart: prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # prometheus-operator-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this chart installs has
+      # reached the `Established=True` condition (CRD storage is up and the
+      # apiserver will accept CRs of those kinds).
+      #
+      # CRDs come from the upstream prometheus-community/prometheus-operator-crds
+      # chart pinned to 28.0.1 in recipes/registry.yaml. The 8 kinds under
+      # monitoring.coreos.com/v1 are enumerated in
+      # recipes/components/prometheus-operator-crds/values.yaml header:
+      # Alertmanager, AlertmanagerConfig, PodMonitor, Probe, Prometheus,
+      # PrometheusRule, ServiceMonitor, ThanosRuler. Plural names match the
+      # long-standing upstream prometheus-operator chart shape.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-operator-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-prometheus-operator-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagerconfigs.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: podmonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: probes.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheuses.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheusrules.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: servicemonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: thanosrulers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    name: prometheus-operator-crds
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-operator-crds/values.yaml
+    version: 28.0.1
+constraints:
+  - name: K8s.server.version
+    value: '>= 1.30'
+criteria:
+  accelerator: gb200
+  intent: inference
+  os: any
+  platform: any
+  service: kind
+deploymentOrder:
+  - agentgateway-crds
+  - cert-manager
+  - agentgateway
+  - nfd
+  - network-operator
+  - nodewright-operator
+  - prometheus-operator-crds
+  - kube-prometheus-stack
+  - gpu-operator
+  - k8s-ephemeral-storage-metrics
+  - kai-scheduler
+  - nvidia-dra-driver-gpu
+  - nvsentinel
+  - prometheus-adapter
+kind: RecipeResult
+metadata:
+  appliedOverlays:
+    - base
+    - monitoring-hpa
+    - gb200-any
+    - kind
+    - kind-inference
+  version: dev
+validation:
+  conformance:
+    checks:
+      - platform-health
+      - gpu-operator-health
+      - dra-support
+      - accelerator-metrics
+      - ai-service-metrics
+  deployment:
+    checks:
+      - operator-health
+      - expected-resources
+      - gpu-operator-version
+      - check-nvidia-smi
+    constraints:
+      - name: Deployment.gpu-operator.version
+        value: '>= v25.10.0'

--- a/tests/aicr-preflight/results/2026-07-25-gb200-kind/report.json
+++ b/tests/aicr-preflight/results/2026-07-25-gb200-kind/report.json
@@ -1,0 +1,267 @@
+{
+  "schema": "nvidia.com/aicr-preflight/v1alpha1",
+  "generatedAt": "2026-07-25T07:29:58Z",
+  "provenance": "sim",
+  "catalogSource": "NVIDIA/aicr recipes/validators/catalog.yaml @06256cc8 (21 checks)",
+  "cluster": "kind-nvml-mock-op",
+  "profile": "gb200",
+  "summary": {
+    "total": 21,
+    "byBucket": {
+      "A": 14,
+      "B": 0,
+      "C": 4,
+      "G": 3
+    },
+    "byOutcome": {
+      "fail": 4,
+      "not-run": 12,
+      "pass": 5
+    },
+    "meaningfulTodayPct": 66.66666666666666,
+    "reachablePct": 80.95238095238095,
+    "suspectCount": 0,
+    "mokkaUnlockedA": 9,
+    "gpuIndependentA": 5
+  },
+  "records": [
+    {
+      "name": "operator-health",
+      "area": "operator-install",
+      "phase": "deployment",
+      "bucket": "A",
+      "outcome": "pass",
+      "provenance": "sim",
+      "rationale": "Installs and reconciles the real NVIDIA GPU Operator against the mock driver surface, then requires its pods to actually reach a healthy state. Fails for real reasons: a broken operand, an unschedulable DaemonSet, a driver-root misconfiguration. This is integration work that genuinely moves left.",
+      "gpuDependent": true,
+      "evidence": "validators/deployment/operator_health.go:32-45"
+    },
+    {
+      "name": "expected-resources",
+      "area": "control-plane",
+      "phase": "deployment",
+      "bucket": "A",
+      "outcome": "fail",
+      "provenance": "sim",
+      "rationale": "Verifies every resource declared in the recipe's componentRefs exists and is healthy, and dispatches 34 nested chainsaw component health checks plus verifyGPUReadinessSignals. Real control-plane reconciliation against a real cluster; a missing prerequisite or a stuck operand fails it.",
+      "gpuDependent": true,
+      "evidence": "validators/deployment/expected_resources.go:153-155,215,226-248",
+      "message": "[NOT_FOUND] Deployment agentgateway-system/agentgateway not found: deployments.apps \"agentgateway\" not found"
+    },
+    {
+      "name": "gpu-operator-version",
+      "area": "operator-install",
+      "phase": "deployment",
+      "bucket": "A",
+      "outcome": "pass",
+      "provenance": "sim",
+      "rationale": "Reads the deployed operator version and evaluates it against the recipe constraint, so a wrong or unpinned chart version fails it for a real reason. Marked GPU-independent: it inspects a Helm release and would work on any cluster with the operator installed, so Mokka is not what unlocks it.",
+      "gpuDependent": false,
+      "evidence": "validators/deployment/gpu_operator_version.go:29-31"
+    },
+    {
+      "name": "check-nvidia-smi",
+      "area": "nvml-surface",
+      "phase": "deployment",
+      "bucket": "A",
+      "outcome": "pass",
+      "provenance": "sim",
+      "rationale": "The strongest bucket-A case in the suite. Schedules a pod requesting nvidia.com/gpu and runs nvidia-smi inside it, which exercises the whole chain: device-plugin allocation, CDI injection, container-toolkit wiring, and dlopen resolution of libnvidia-ml.so.1. This is exactly the class of failure that shipped as NVIDIA/k8s-test-infra#455, where three missing //export symbols made RTLD_NOW abort while build, unit tests, and lint all stayed green. It does NOT prove the GPU computes anything; it proves the plumbing resolves.",
+      "gpuDependent": true,
+      "evidence": "validators/deployment/nvidia_smi.go:38-39; testdata/nvidia-smi-verify-pod.yaml:40,42"
+    },
+    {
+      "name": "nccl-all-reduce-bw",
+      "area": "nccl-nvlink-fabric",
+      "phase": "performance",
+      "bucket": "C",
+      "outcome": "not-run",
+      "provenance": "sim",
+      "rationale": "Runs all_reduce_perf across GPU nodes and measures achieved bandwidth. Mokka simulates no collective transport and no fabric, and measured bandwidth is meaningless without real links. Hardware-dependent by construction.",
+      "gpuDependent": true,
+      "evidence": "validators/performance/nccl_all_reduce_bw.go:26-30"
+    },
+    {
+      "name": "nccl-all-reduce-bw-net",
+      "area": "nccl-nvlink-fabric",
+      "phase": "performance",
+      "bucket": "C",
+      "outcome": "not-run",
+      "provenance": "sim",
+      "rationale": "Asserts the NET transport (EFA and equivalents) actually carried the traffic. Requires a real network fabric.",
+      "gpuDependent": true,
+      "evidence": "validators/performance/nccl_all_reduce_bw.go:33-36"
+    },
+    {
+      "name": "nccl-all-reduce-bw-nvls",
+      "area": "nccl-nvlink-fabric",
+      "phase": "performance",
+      "bucket": "C",
+      "outcome": "not-run",
+      "provenance": "sim",
+      "rationale": "Asserts NVLS/MNNVL initialized and carried traffic, and fails loudly if a broken IMEX domain makes NCCL fall back to NET. This is precisely the GB200 NVL72 failure mode that matters most on real silicon, and precisely what simulation cannot judge.",
+      "gpuDependent": true,
+      "evidence": "validators/performance/nccl_all_reduce_bw.go:39-42; catalog.yaml:258-260"
+    },
+    {
+      "name": "inference-perf",
+      "area": "ttft-throughput",
+      "phase": "performance",
+      "bucket": "C",
+      "outcome": "not-run",
+      "provenance": "sim",
+      "rationale": "Runs AIPerf against a live inference endpoint backed by vLLM/Dynamo GPU workers and evaluates throughput and TTFT p99 constraints. Requires real CUDA execution and real model serving. This check is the definition of time to first token, and it is the reason preflight reduces bring-up time rather than proving readiness.",
+      "gpuDependent": true,
+      "evidence": "validators/performance/inference_perf.go:25-28; catalog.yaml:88-146"
+    },
+    {
+      "name": "dra-support",
+      "area": "dra",
+      "phase": "conformance",
+      "bucket": "G",
+      "outcome": "fail",
+      "provenance": "sim",
+      "rationale": "Half of this check already works under Mokka and half is blocked, so the precise split matters. WORKS: the real nvidia-dra-driver-gpu chart installs, the kubelet plugin runs, and ResourceSlices publish all 8 GB200 devices off the mock NVML (observed 2026-07-25). BLOCKED: the check also requires the nvidia-dra-driver-gpu-controller Deployment, which chart v25.12.0 templates only when resources.computeDomains.enabled=true. Turning that on makes the kubelet plugin's compute-domains container CrashLoopBackOff with \"error getting nvcap for IMEX channel '0': error parsing '/proc/devices': unexpected regex match: []\", because Mokka registers no nvidia-caps-imex-channels char-device major and creates no /dev/nvidia-caps-imex-channels nodes. Not hardware-dependent, therefore bucket G rather than C: this is device-node and /proc/devices plumbing, not fabric transport.",
+      "gpuDependent": true,
+      "gapIssue": "#498",
+      "evidence": "validators/conformance/dra_support_check.go:42-54,242-264; observed CrashLoopBackOff on nvidia-dra-driver-gpu 25.12.0 templates/controller.yaml",
+      "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found"
+    },
+    {
+      "name": "gang-scheduling",
+      "area": "scheduling",
+      "phase": "conformance",
+      "bucket": "A",
+      "outcome": "not-run",
+      "provenance": "sim",
+      "rationale": "Verifies KAI scheduler deployments and CRDs, then co-schedules a PodGroup. Upstream deliberately keeps the workload CPU-only so one-GPU CI clusters can run the full conformance phase, so this exercises real scheduling behaviour but touches no GPU at all. It moves left, but any cluster runs it and Mokka is not what unlocks it.",
+      "gpuDependent": false,
+      "evidence": "validators/conformance/gang_scheduling_check.go:94-99"
+    },
+    {
+      "name": "accelerator-metrics",
+      "area": "nvml-surface",
+      "phase": "conformance",
+      "bucket": "A",
+      "outcome": "pass",
+      "provenance": "sim",
+      "rationale": "Scrapes the DCGM exporter and requires DCGM_FI_DEV_GPU_UTIL, FB_USED, GPU_TEMP and POWER_USAGE to be present. Under Mokka the real dcgm-exporter runs against the mock NVML, so a broken exporter-to-NVML path fails this for a real reason. Bounded honestly: the assertion is presence-only, and Mokka's values are synthetic (FB_USED is a constant 0), so this validates the telemetry path, not telemetry correctness.",
+      "gpuDependent": true,
+      "evidence": "validators/conformance/accelerator_metrics_check.go:28-38"
+    },
+    {
+      "name": "ai-service-metrics",
+      "area": "control-plane",
+      "phase": "conformance",
+      "bucket": "A",
+      "outcome": "fail",
+      "provenance": "sim",
+      "rationale": "Discovers Prometheus from the recipe and verifies GPU metric time series exist and the custom metrics API is available. Real integration of the monitoring stack with the GPU telemetry source; same value caveat as accelerator-metrics.",
+      "gpuDependent": true,
+      "evidence": "validators/conformance/ai_service_metrics_check.go:37-40",
+      "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\""
+    },
+    {
+      "name": "inference-gateway",
+      "area": "control-plane",
+      "phase": "conformance",
+      "bucket": "A",
+      "outcome": "not-run",
+      "provenance": "sim",
+      "rationale": "Verifies the agentgateway GatewayClass is accepted, the Gateway is programmed, and the Gateway API plus InferencePool CRDs exist. Pure control-plane status reconciliation with no GPU involvement.",
+      "gpuDependent": false,
+      "evidence": "validators/conformance/inference_gateway_check.go:51-53"
+    },
+    {
+      "name": "pod-autoscaling",
+      "area": "scheduling",
+      "phase": "conformance",
+      "bucket": "A",
+      "outcome": "not-run",
+      "provenance": "sim",
+      "rationale": "Requires the external metrics API to expose a cluster-wide GPU metric (dcgm_gpu_power_usage) and proves the capability with an HPA scale-up and scale-down. Mokka's power values vary over time, which this repo's e2e already asserts, so the metrics-to-autoscaler loop is genuinely driven.",
+      "gpuDependent": true,
+      "evidence": "validators/conformance/pod_autoscaling_check.go:55-69,208"
+    },
+    {
+      "name": "cluster-autoscaling",
+      "area": "scheduling",
+      "phase": "conformance",
+      "bucket": "G",
+      "outcome": "not-run",
+      "provenance": "sim",
+      "rationale": "Checks Karpenter, EKS node groups, or the GKE cluster autoscaler, and skips gracefully when none is detectable, which is what happens on a kind cluster. Not hardware-dependent: AICR's own CI already exercises the Karpenter path against KWOK-faked nodes. Blocked only because this harness composes no simulated provisioner, which is a closable gap and the exact point where Mokka's vertical depth should compose with KWOK's horizontal breadth.",
+      "gpuDependent": false,
+      "gapIssue": "#499",
+      "evidence": "validators/conformance/cluster_autoscaling_check.go:61-67; .github/actions/gpu-validate-conformance/action.yml:38-43"
+    },
+    {
+      "name": "robust-controller",
+      "area": "control-plane",
+      "phase": "conformance",
+      "bucket": "A",
+      "outcome": "not-run",
+      "provenance": "sim",
+      "rationale": "Proves a complex AI operator with a CRD is installed and reconciles custom resources, with running pods and operational webhooks. Real controller behaviour, no GPU dependency.",
+      "gpuDependent": false,
+      "evidence": "validators/conformance/robust_controller_check.go:69-77"
+    },
+    {
+      "name": "secure-accelerator-access",
+      "area": "dra",
+      "phase": "conformance",
+      "bucket": "A",
+      "outcome": "not-run",
+      "provenance": "sim",
+      "rationale": "Grants a GPU to one container and requires an unauthorized sibling container, plus a standalone no-allocation probe pod, to see no accelerator at all. Isolation is enforced by CDI and device-plugin allocation, which Mokka drives for real, so a leak fails this for a real reason. Worth watching under Mokka's node-wide NRI ambient injection mode, where a genuine isolation failure would be the correct result.",
+      "gpuDependent": true,
+      "evidence": "validators/conformance/secure_access_check.go:268-275"
+    },
+    {
+      "name": "slinky-slurm-health",
+      "area": "scheduling",
+      "phase": "conformance",
+      "bucket": "A",
+      "outcome": "not-run",
+      "provenance": "sim",
+      "rationale": "Requires a Slinky-managed Slurm cluster to be reachable, to have idle or mixed workers, and to schedule a minimal job; GPU-backed NodeSets also run a bounded containerized GPU job through Pyxis. The GPU job runs plain alpine rather than a CUDA workload, so it tests allocation and injection rather than computation, which Mokka can drive.",
+      "gpuDependent": true,
+      "evidence": "validators/conformance/slinky_slurm_health_check.go:91-94,162"
+    },
+    {
+      "name": "slinky-slurm-imex-channel",
+      "area": "nccl-nvlink-fabric",
+      "phase": "conformance",
+      "bucket": "G",
+      "outcome": "not-run",
+      "provenance": "sim",
+      "rationale": "Verifies two concurrent Slurm jobs each receive a distinct NVIDIA IMEX channel. Bucketed G rather than C, and the distinction matters: whether the fabric carries traffic is hardware-dependent (bucket C, see nccl-all-reduce-bw-nvls), but whether channel ALLOCATION hands out distinct channels is driver-surface and control-plane behaviour that is simulatable. Same root cause as dra-support: Mokka registers no nvidia-caps-imex-channels char-device major and creates no channel device nodes, which the DRA driver's own compute-domains component confirmed by crashing on /proc/devices. Flagged for Mark's review as the closest call in the catalog, since it sits nearest his hardware-dependent boundary.",
+      "gpuDependent": true,
+      "gapIssue": "#498",
+      "evidence": "validators/conformance/slinky_slurm_imex_channel_check.go:82-84"
+    },
+    {
+      "name": "gpu-operator-health",
+      "area": "operator-install",
+      "phase": "conformance",
+      "bucket": "A",
+      "outcome": "pass",
+      "provenance": "sim",
+      "rationale": "Verifies the GPU Operator deployment, ClusterPolicy state=ready, and the DCGM exporter DaemonSet. ClusterPolicy reaching ready requires the driver, toolkit, CUDA and plugin validators to pass, which is real reconciliation. Bounded honestly: under Mokka two of those sub-validations are weakened, because cuda-validation runs with WITH_WORKLOAD=false (kernel launch is a no-op) and the toolkit stage is short-circuited by a pre-touched /run/nvidia/validations/toolkit-ready marker. So ready under simulation is a weaker statement than ready on silicon, and this row should not be read as validating the driver or toolkit.",
+      "gpuDependent": true,
+      "evidence": "validators/conformance/gpu_operator_health_check.go:28-29; tests/e2e/go/assets/gpu-operator-values.yaml (WITH_WORKLOAD=false)"
+    },
+    {
+      "name": "platform-health",
+      "area": "control-plane",
+      "phase": "conformance",
+      "bucket": "A",
+      "outcome": "fail",
+      "provenance": "sim",
+      "rationale": "Validates namespace existence and expectedResources health for every componentRef in the recipe. Real deployment verification, no GPU dependency.",
+      "gpuDependent": false,
+      "evidence": "validators/conformance/platform_health_check.go:28-30",
+      "message": "[NOT_FOUND] platform health check failed (8 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvsentinel: not found"
+    }
+  ]
+}

--- a/tests/aicr-preflight/results/2026-07-25-gb200-kind/report.json
+++ b/tests/aicr-preflight/results/2026-07-25-gb200-kind/report.json
@@ -1,6 +1,6 @@
 {
   "schema": "nvidia.com/aicr-preflight/v1alpha1",
-  "generatedAt": "2026-07-25T08:27:54Z",
+  "generatedAt": "2026-07-25T09:10:12Z",
   "provenance": "sim",
   "catalogSource": "NVIDIA/aicr recipes/validators/catalog.yaml @06256cc8 (21 checks)",
   "cluster": "kind-nvml-mock-op",
@@ -14,9 +14,9 @@
       "G": 3
     },
     "byOutcome": {
-      "fail": 4,
+      "fail": 3,
       "not-run": 12,
-      "pass": 5
+      "pass": 6
     },
     "meaningfulTodayPct": 66.66666666666666,
     "reachablePct": 80.95238095238095,
@@ -154,12 +154,11 @@
       "area": "control-plane",
       "phase": "conformance",
       "bucket": "A",
-      "outcome": "fail",
+      "outcome": "pass",
       "provenance": "sim",
       "rationale": "Discovers Prometheus from the recipe and verifies GPU metric time series exist and the custom metrics API is available. Real integration of the monitoring stack with the GPU telemetry source; same value caveat as accelerator-metrics.",
       "gpuDependent": true,
-      "evidence": "validators/conformance/ai_service_metrics_check.go:37-40",
-      "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\""
+      "evidence": "validators/conformance/ai_service_metrics_check.go:37-40"
     },
     {
       "name": "inference-gateway",
@@ -261,7 +260,7 @@
       "rationale": "Validates namespace existence and expectedResources health for every componentRef in the recipe. Real deployment verification, no GPU dependency.",
       "gpuDependent": false,
       "evidence": "validators/conformance/platform_health_check.go:28-30",
-      "message": "[NOT_FOUND] platform health check failed (8 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvsentinel: not found"
+      "message": "[NOT_FOUND] platform health check failed (5 issues):\n  namespace agentgateway-system: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace skyhook: not found\n  namespace nvsentinel: not found"
     }
   ]
 }

--- a/tests/aicr-preflight/results/2026-07-25-gb200-kind/report.json
+++ b/tests/aicr-preflight/results/2026-07-25-gb200-kind/report.json
@@ -1,6 +1,6 @@
 {
   "schema": "nvidia.com/aicr-preflight/v1alpha1",
-  "generatedAt": "2026-07-25T07:29:58Z",
+  "generatedAt": "2026-07-25T08:27:54Z",
   "provenance": "sim",
   "catalogSource": "NVIDIA/aicr recipes/validators/catalog.yaml @06256cc8 (21 checks)",
   "cluster": "kind-nvml-mock-op",
@@ -121,10 +121,10 @@
       "bucket": "G",
       "outcome": "fail",
       "provenance": "sim",
-      "rationale": "Half of this check already works under Mokka and half is blocked, so the precise split matters. WORKS: the real nvidia-dra-driver-gpu chart installs, the kubelet plugin runs, and ResourceSlices publish all 8 GB200 devices off the mock NVML (observed 2026-07-25). BLOCKED: the check also requires the nvidia-dra-driver-gpu-controller Deployment, which chart v25.12.0 templates only when resources.computeDomains.enabled=true. Turning that on makes the kubelet plugin's compute-domains container CrashLoopBackOff with \"error getting nvcap for IMEX channel '0': error parsing '/proc/devices': unexpected regex match: []\", because Mokka registers no nvidia-caps-imex-channels char-device major and creates no /dev/nvidia-caps-imex-channels nodes. Not hardware-dependent, therefore bucket G rather than C: this is device-node and /proc/devices plumbing, not fabric transport.",
+      "rationale": "Half of this check already works under Mokka and half is blocked by PACKAGING, not by a capability limit. WORKS: the real nvidia-dra-driver-gpu chart installs, the kubelet plugin runs, and ResourceSlices publish all 8 GB200 devices off the mock NVML (observed 2026-07-25). BLOCKED: the check also requires the nvidia-dra-driver-gpu-controller Deployment, which the chart templates only when resources.computeDomains.enabled=true, and enabling that crashes the kubelet plugin's compute-domains container on \"error getting nvcap for IMEX channel '0': error parsing '/proc/devices'\". The DRA driver already solves this: its chart exposes altProcDevices, which mounts an alternate proc-devices file and passes ALT_PROC_DEVICES_PATH, and its own CI (hack/ci/mock-nvml/setup-mock-gpu.sh) builds the surface against nvml-mock. Two things are missing: nvml-mock does not ship that surface, and the released NGC chart v25.12.0 has no altProcDevices key. Bucket G because a user of the nvml-mock chart alone cannot run this check today, but the gap is packaging and is small. See issue #498.",
       "gpuDependent": true,
       "gapIssue": "#498",
-      "evidence": "validators/conformance/dra_support_check.go:42-54,242-264; observed CrashLoopBackOff on nvidia-dra-driver-gpu 25.12.0 templates/controller.yaml",
+      "evidence": "validators/conformance/dra_support_check.go:42-54,242-264; kubernetes-sigs/dra-driver-nvidia-gpu values.yaml altProcDevices + hack/ci/mock-nvml/setup-mock-gpu.sh step 7b",
       "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found"
     },
     {
@@ -235,7 +235,7 @@
       "bucket": "G",
       "outcome": "not-run",
       "provenance": "sim",
-      "rationale": "Verifies two concurrent Slurm jobs each receive a distinct NVIDIA IMEX channel. Bucketed G rather than C, and the distinction matters: whether the fabric carries traffic is hardware-dependent (bucket C, see nccl-all-reduce-bw-nvls), but whether channel ALLOCATION hands out distinct channels is driver-surface and control-plane behaviour that is simulatable. Same root cause as dra-support: Mokka registers no nvidia-caps-imex-channels char-device major and creates no channel device nodes, which the DRA driver's own compute-domains component confirmed by crashing on /proc/devices. Flagged for Mark's review as the closest call in the catalog, since it sits nearest his hardware-dependent boundary.",
+      "rationale": "Verifies two concurrent Slurm jobs each receive a distinct NVIDIA IMEX channel. Bucketed G rather than C, and the distinction matters: whether the fabric carries traffic is hardware-dependent (bucket C, see nccl-all-reduce-bw-nvls), but whether channel ALLOCATION hands out distinct channels is driver-surface and control-plane behaviour that is simulatable. Same root cause and same issue as dra-support (#498): nvml-mock does not ship the mock IMEX surface (proc-devices entries, fabric-imex-mgmt capability file, channel device nodes) that the DRA driver's compute-domain plugin consumes via ALT_PROC_DEVICES_PATH. The DRA driver's own CI builds that surface against nvml-mock, so this is packaging rather than a capability limit. Flagged for Mark's review as the closest call in the catalog, since it sits nearest his hardware-dependent boundary. The allocation-distinctness behaviour itself is unverified here: static channel device nodes may or may not model per-job allocation faithfully.",
       "gpuDependent": true,
       "gapIssue": "#498",
       "evidence": "validators/conformance/slinky_slurm_imex_channel_check.go:82-84"

--- a/tests/aicr-preflight/results/2026-07-25-gb200-kind/runc-proc-devices-mount-rejected.log
+++ b/tests/aicr-preflight/results/2026-07-25-gb200-kind/runc-proc-devices-mount-rejected.log
@@ -1,0 +1,1 @@
+back-off 2m40s restarting failed container=compute-domains pod=nvidia-dra-driver-gpu-kubelet-plugin-5cpq7_nvidia-dra-driver(b2b7240c-39c4-452f-b68f-ec1c7e20572f)

--- a/tests/e2e/go/assertions/gfd_labels.go
+++ b/tests/e2e/go/assertions/gfd_labels.go
@@ -1,0 +1,92 @@
+//go:build e2e
+
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package assertions
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/kube"
+)
+
+// GFD label keys asserted against GPU Feature Discovery.
+const (
+	GFDLabelProduct = "nvidia.com/gpu.product"
+	GFDLabelMemory  = "nvidia.com/gpu.memory"
+	GFDLabelCount   = "nvidia.com/gpu.count"
+)
+
+// ExpectedGFDLabels derives the GFD labels a node must carry from the profile,
+// rather than from the node itself. Deriving them independently is what makes
+// the assertion discriminating: if GFD stopped reading the mock NVML, the count
+// would go absent or wrong and the comparison would catch it.
+func ExpectedGFDLabels(product string, memoryMiB, gpuCount int) map[string]string {
+	return map[string]string{
+		GFDLabelProduct: product,
+		GFDLabelMemory:  strconv.Itoa(memoryMiB),
+		GFDLabelCount:   strconv.Itoa(gpuCount),
+	}
+}
+
+// DiffGFDLabels returns one human-readable problem per expected label that is
+// missing or carries the wrong value. An empty result means the node matches.
+// It reports every problem rather than stopping at the first, so one run shows
+// the whole picture.
+func DiffGFDLabels(want, got map[string]string) []string {
+	keys := make([]string, 0, len(want))
+	for key := range want {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var problems []string
+	for _, key := range keys {
+		actual, present := got[key]
+		switch {
+		case !present || actual == "":
+			problems = append(problems, fmt.Sprintf("label %s missing (want %q)", key, want[key]))
+		case actual != want[key]:
+			problems = append(problems, fmt.Sprintf("label %s = %q, want %q", key, actual, want[key]))
+		}
+	}
+
+	return problems
+}
+
+// WaitGFDLabels polls until the node carries every expected GFD label with the
+// expected value, and fails the spec otherwise.
+//
+// This replaces a warning-only check that could never fail: GPU Feature
+// Discovery could have been removed entirely and the scenario would still have
+// gone green. Labels are published asynchronously after the operator settles,
+// hence the poll rather than a single read.
+func WaitGFDLabels(ctx context.Context, k *kube.Client, node string, want map[string]string, timeout, poll time.Duration) {
+	ginkgo.GinkgoHelper()
+	ginkgo.By(fmt.Sprintf("waiting for GFD labels on %s", node))
+
+	var last []string
+	gomega.Eventually(func() ([]string, error) {
+		got := make(map[string]string, len(want))
+		for key := range want {
+			value, ok, err := k.NodeLabel(ctx, node, key)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				got[key] = value
+			}
+		}
+		last = DiffGFDLabels(want, got)
+		return last, nil
+	}).WithContext(ctx).WithTimeout(timeout).WithPolling(poll).
+		Should(gomega.BeEmpty(), "GFD labels on node %s did not match the profile: %v", node, &last)
+}

--- a/tests/e2e/go/assertions/gfd_labels_test.go
+++ b/tests/e2e/go/assertions/gfd_labels_test.go
@@ -1,0 +1,119 @@
+//go:build e2e
+
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package assertions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These cover the pure derivation and comparison used by WaitGFDLabels, so they
+// run without a cluster. The cluster-facing poll is exercised by the
+// gpu-operator e2e scenario.
+
+func TestExpectedGFDLabelsDerivesCountAndProductFromProfile(t *testing.T) {
+	t.Parallel()
+
+	want := ExpectedGFDLabels("NVIDIA-GB200", 196608, 8)
+
+	assert.Equal(t, "NVIDIA-GB200", want[GFDLabelProduct])
+	assert.Equal(t, "196608", want[GFDLabelMemory])
+	assert.Equal(t, "8", want[GFDLabelCount])
+}
+
+// The count label is the one that actually discriminates: if GFD were removed or
+// stopped reading the mock NVML, the count would be absent or wrong. Deriving it
+// from the profile rather than reading it back off the node is what makes the
+// assertion real.
+func TestExpectedGFDLabelsCountTracksProfileNotAConstant(t *testing.T) {
+	t.Parallel()
+
+	four := ExpectedGFDLabels("NVIDIA-A100-SXM4-40GB", 40960, 4)
+	eight := ExpectedGFDLabels("NVIDIA-GB200", 196608, 8)
+
+	assert.Equal(t, "4", four[GFDLabelCount])
+	assert.Equal(t, "8", eight[GFDLabelCount])
+	assert.NotEqual(t, four[GFDLabelCount], eight[GFDLabelCount])
+	assert.NotEqual(t, four[GFDLabelProduct], eight[GFDLabelProduct])
+}
+
+func TestDiffGFDLabelsReportsMissingLabel(t *testing.T) {
+	t.Parallel()
+
+	want := ExpectedGFDLabels("NVIDIA-GB200", 196608, 8)
+	got := map[string]string{
+		GFDLabelProduct: "NVIDIA-GB200",
+		GFDLabelMemory:  "196608",
+		// gpu.count absent: this is what a removed or broken GFD looks like.
+	}
+
+	problems := DiffGFDLabels(want, got)
+
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], GFDLabelCount)
+	assert.Contains(t, problems[0], "missing")
+}
+
+func TestDiffGFDLabelsReportsWrongValue(t *testing.T) {
+	t.Parallel()
+
+	want := ExpectedGFDLabels("NVIDIA-GB200", 196608, 8)
+	got := map[string]string{
+		GFDLabelProduct: "NVIDIA-GB200",
+		GFDLabelMemory:  "196608",
+		GFDLabelCount:   "1", // GFD saw a different device count than the profile declares
+	}
+
+	problems := DiffGFDLabels(want, got)
+
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], GFDLabelCount)
+	assert.Contains(t, problems[0], `"1"`)
+	assert.Contains(t, problems[0], `"8"`)
+}
+
+func TestDiffGFDLabelsReturnsNothingWhenLabelsMatch(t *testing.T) {
+	t.Parallel()
+
+	want := ExpectedGFDLabels("NVIDIA-GB200", 196608, 8)
+	got := map[string]string{
+		GFDLabelProduct: "NVIDIA-GB200",
+		GFDLabelMemory:  "196608",
+		GFDLabelCount:   "8",
+	}
+
+	assert.Empty(t, DiffGFDLabels(want, got))
+}
+
+func TestDiffGFDLabelsReportsEveryProblemNotJustTheFirst(t *testing.T) {
+	t.Parallel()
+
+	want := ExpectedGFDLabels("NVIDIA-GB200", 196608, 8)
+
+	problems := DiffGFDLabels(want, map[string]string{})
+
+	assert.Len(t, problems, 3, "an empty label set must report all three labels, not stop at the first")
+}
+
+// A label that exists but carries no value must count as missing rather than
+// matching against an empty expectation.
+func TestDiffGFDLabelsTreatsEmptyValueAsMissing(t *testing.T) {
+	t.Parallel()
+
+	want := ExpectedGFDLabels("NVIDIA-GB200", 196608, 8)
+	got := map[string]string{
+		GFDLabelProduct: "",
+		GFDLabelMemory:  "196608",
+		GFDLabelCount:   "8",
+	}
+
+	problems := DiffGFDLabels(want, got)
+
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "missing")
+}

--- a/tests/e2e/go/profile/gfd_test.go
+++ b/tests/e2e/go/profile/gfd_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package profile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The expected values are the ones GPU Feature Discovery actually published on a
+// live gb200 Mokka cluster on 2026-07-25:
+//
+//	nvidia.com/gpu.product=NVIDIA-GB200
+//	nvidia.com/gpu.memory=196608
+//	nvidia.com/gpu.count=8
+//
+// Deriving them from the profile and comparing against those observed literals
+// is what makes the e2e GFD assertion discriminating.
+func TestGB200ProfileDerivesObservedGFDLabelValues(t *testing.T) {
+	t.Parallel()
+
+	p, err := Load(profilesDir, "gb200")
+	require.NoError(t, err)
+
+	assert.Equal(t, "NVIDIA-GB200", p.GFDProductName())
+	assert.Equal(t, 196608, p.MemoryMiB())
+	assert.Equal(t, 8, p.ExpectedGPUs())
+}
+
+func TestGFDProductNameReplacesSpacesWithDashes(t *testing.T) {
+	t.Parallel()
+
+	p, err := Load(profilesDir, "a100")
+	require.NoError(t, err)
+
+	// device_defaults.name is "NVIDIA A100-SXM4-40GB"; GFD publishes it dashed.
+	assert.Equal(t, "NVIDIA-A100-SXM4-40GB", p.GFDProductName())
+	assert.NotContains(t, p.GFDProductName(), " ")
+}
+
+// Memory must come from the profile rather than a constant, or the assertion
+// would not notice a profile whose device memory changed.
+func TestMemoryMiBDiffersAcrossProfiles(t *testing.T) {
+	t.Parallel()
+
+	gb200, err := Load(profilesDir, "gb200")
+	require.NoError(t, err)
+	a100, err := Load(profilesDir, "a100")
+	require.NoError(t, err)
+
+	assert.Positive(t, gb200.MemoryMiB())
+	assert.Positive(t, a100.MemoryMiB())
+	assert.Greater(t, gb200.MemoryMiB(), a100.MemoryMiB(),
+		"GB200 carries more device memory than A100; if these match, memory is not being read from the profile")
+}
+
+// Every shipped profile must yield usable GFD expectations, otherwise the
+// gpu-operator scenario would silently assert against a zero value.
+func TestEveryKnownProfileYieldsNonZeroGFDExpectations(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range KnownProfiles {
+		p, err := Load(profilesDir, name)
+		require.NoError(t, err, "load profile %s", name)
+
+		assert.NotEmpty(t, p.GFDProductName(), "profile %s has no product name", name)
+		assert.Positive(t, p.MemoryMiB(), "profile %s reports zero device memory", name)
+		assert.Positive(t, p.ExpectedGPUs(), "profile %s reports zero GPUs", name)
+	}
+}

--- a/tests/e2e/go/profile/profile.go
+++ b/tests/e2e/go/profile/profile.go
@@ -47,6 +47,9 @@ type rawProfile struct {
 		Fabric *struct {
 			State string `json:"state"`
 		} `json:"fabric"`
+		Memory struct {
+			TotalBytes int64 `json:"total_bytes"`
+		} `json:"memory"`
 	} `json:"device_defaults"`
 	Devices []struct {
 		Index int `json:"index"`
@@ -83,7 +86,23 @@ type Profile struct {
 	fabricAuto  bool
 	hasFabric   bool
 	pciRoots    int
+	memoryBytes int64
 }
+
+// bytesPerMiB is the divisor GPU Feature Discovery uses when it publishes
+// nvidia.com/gpu.memory, which is reported in MiB.
+const bytesPerMiB = 1024 * 1024
+
+// GFDProductName is DisplayName in the form GPU Feature Discovery publishes as
+// nvidia.com/gpu.product: spaces become dashes. For example "NVIDIA GB200"
+// becomes "NVIDIA-GB200".
+func (p Profile) GFDProductName() string {
+	return strings.ReplaceAll(p.DisplayName, " ", "-")
+}
+
+// MemoryMiB is per-device memory in MiB, matching what GFD publishes as
+// nvidia.com/gpu.memory.
+func (p Profile) MemoryMiB() int { return int(p.memoryBytes / bytesPerMiB) }
 
 // Load reads profilesDir/<name>.yaml and returns the typed Profile.
 func Load(profilesDir, name string) (Profile, error) {
@@ -111,6 +130,7 @@ func Load(profilesDir, name string) (Profile, error) {
 		hcasPerGPU:  raw.Infiniband.HCAsPerGPU,
 		linksPerGPU: raw.NVLink.LinksPerGPU,
 		hasSwitches: len(raw.NVLink.Switches) > 0,
+		memoryBytes: raw.DeviceDefaults.Memory.TotalBytes,
 	}
 	if raw.DeviceDefaults.Fabric != nil {
 		p.hasFabric = true

--- a/tests/e2e/go/scenario_gpu_operator_test.go
+++ b/tests/e2e/go/scenario_gpu_operator_test.go
@@ -64,9 +64,13 @@ var _ = Describe("nvml-mock GPU Operator", Label("gpu-operator"), Ordered, func(
 			It("installs GPU Operator and publishes GPUs", Label("device-plugin"), func(ctx SpecContext) {
 				installGPUOperator(ctx, h)
 				waitOperatorValidatorRunning(ctx, h)
-				for _, label := range []string{"nvidia.com/gpu.product", "nvidia.com/gpu.memory", "nvidia.com/gpu.count"} {
-					assertions.NodeLabelSoft(ctx, h.Kube, node, label)
-				}
+				// Hard assertion, derived from the profile rather than read back
+				// off the node. The previous warning-only check could never fail,
+				// so GPU Feature Discovery could have been removed entirely and
+				// this scenario would still have gone green.
+				assertions.WaitGFDLabels(ctx, h.Kube, node,
+					assertions.ExpectedGFDLabels(p.GFDProductName(), p.MemoryMiB(), p.ExpectedGPUs()),
+					config.ReadyTimeout(), config.PollInterval())
 				assertions.WaitAllocatableGPU(ctx, h.Kube, node, p.ExpectedGPUs(), config.ReadyTimeout(), config.PollInterval())
 			})
 


### PR DESCRIPTION
## The question this answers

Agreed with @mchmarny on 2026-07-24:

> Does Mokka + AICR **materially reduce GB200 bring-up time**, or does it **merely prove the stack deploys against mocked APIs**?

An honest negative result was an acceptable outcome. Nothing here was tuned toward a favourable answer.

## Answer

It does more than prove deployment against mocked APIs, but by less than the headline number suggests, and the strongest results are **two real integration defects found pre-silicon** rather than a green suite. **Verdict: go with scope**, on a narrower claim than the original pitch.

The single most persuasive evidence is not the coverage percentage. It is that coverage improved monotonically as components were added, and each fix moved a check to its *next* real requirement rather than flipping it green:

| Cluster state | pass / fail | What moved |
|---|---|---|
| GPU Operator + DRA driver | 5 / 4 | baseline |
| + cert-manager, NFD, kube-prometheus-stack | 5 / 4 | `platform-health` 8 missing namespaces to 5; `ai-service-metrics` moves to "no `DCGM_FI_DEV_GPU_UTIL` time series" |
| + dcgm-exporter ServiceMonitor | 5 / 4 | moves to "custom metrics API not available" |
| + prometheus-adapter | **6 / 3** | **`ai-service-metrics` passes** |

A check that passed trivially against a mock could not have failed four different ways for four different real reasons.

## Headline numbers

Real run, 2026-07-25, provenance `sim`. 1-node Kind cluster, Kubernetes v1.36.1, linux/arm64 (correct for GB200, since Grace is ARM), `nvml-mock` `gb200` profile, GPU Operator with ClusterPolicy `ready`, `nvidia-dra-driver-gpu` v25.12.0, AICR at `06256cc8`.

Of **21** AICR checks: **A 14 · B 0 · C 4 · G 3**

| Metric | Value |
|---|---|
| **Meaningful pre-silicon TODAY** | **66.7%** (A / total) |
| **Reachable once tracked gaps close** | **81.0%** ((A + G) / total). Roadmap, not a current claim. |
| **What Mokka specifically unlocks** | **42.9%** (9 / 21) |
| **Actually executed in this run** | **9 of 21** (6 pass, 3 fail). 12 not run. |

Two qualifications that cut against the headline, stated up front because they matter more than the percentage:

1. **Only 9 of the 14 bucket-A checks depend on the GPU stack.** The other 5 are control-plane checks any cluster would run; `gang-scheduling` is deliberately CPU-only upstream. Counting them as coverage Mokka bought would inflate the number, so the harness tracks `gpuDependent` separately.
2. **12 of 21 checks did not execute.** Their buckets are analysis, not observation.

## The most useful result was a failure

`dra-support` failed. The real DRA driver installs and publishes all 8 simulated GB200 devices as ResourceSlices, but the check also wants a `nvidia-dra-driver-gpu-controller` Deployment, which chart v25.12.0 templates only when `resources.computeDomains.enabled=true`. Enabling that crashes the kubelet plugin:

```
error getting nvcap for IMEX channel '0': error getting device major:
error parsing '/proc/devices': unexpected regex match: []
```

**This took two corrections to get right, and the second one matters.**

The first reading was that AICR carried a stale expectation. Checking the chart templates disproved it: the controller is gated on `resources.computeDomains.enabled`.

The second reading was that Mokka lacks an `nvidia-caps-imex-channels` device class and that closing it meant inventing a way to fake `/proc/devices`, sized M. That was also wrong. The DRA driver **already** supports mock NVML: its chart exposes `altProcDevices`, whose documented example path is literally `/var/lib/nvml-mock/imex/proc-devices`, and its CI builds the whole surface against `nvml-mock` in `hack/ci/mock-nvml/setup-mock-gpu.sh`.

So the real gap is **packaging, not capability**, and it is smaller (S, not M): `nvml-mock` does not ship that surface, and the released NGC chart v25.12.0 this repo's e2e uses has no `altProcDevices` key. Both halves exist; neither is reachable from the `nvml-mock` chart. Reproducing the surface by hand and mounting it over `/proc/devices` is rejected by runc, which is exactly why the env-var indirection exists.

Buckets and coverage are unchanged, because a user of the `nvml-mock` chart alone still cannot run the check. Tracked as #498, rewritten.

On the positive side, `check-nvidia-smi` passed, exercising device-plugin allocation, CDI injection, container-toolkit wiring, and `dlopen` resolution of `libnvidia-ml.so.1`. That is exactly the chain that broke in #455, where three missing `//export` symbols made `RTLD_NOW` abort while build, unit tests, and lint all stayed green.

## A defect in AICR's own recipe

@mchmarny this one is for you specifically, and it is not filed anywhere.

The generated `kind` + `gb200` recipe **selects `ai-service-metrics` as a conformance check and declares both `kube-prometheus-stack` and `prometheus-adapter` as components, but never wires the GPU Operator's dcgm-exporter into Prometheus.** No GPU time series is ever produced, so the check cannot pass from a clean deploy of its own bundle.

Verified three ways against the generated recipe, since one negative grep is not evidence:

1. The `gpu-operator` component's `dcgmExporter` overrides contain only `config: {create: false, data: '', name: ''}`. No `serviceMonitor` block, and the chart default is disabled. On the live cluster no `nvidia-dcgm-exporter` ServiceMonitor existed until enabled by hand.
2. The `kube-prometheus-stack` overrides touch only alertmanager, defaultRules, grafana, prometheus (resources, retention, storage) and prometheusOperator. No `additionalScrapeConfigs`, no widened `serviceMonitorSelector`.
3. DCGM is mentioned exactly twice in the recipe, both inside that gpu-operator block. No scrape configuration anywhere.

Prometheus selects ServiceMonitors labelled `release: kube-prometheus-stack`; with none created at all, no selector helps. Setting `dcgmExporter.serviceMonitor.enabled=true` with that label made `DCGM_FI_DEV_GPU_UTIL` appear (carrying `DCGM_FI_DRIVER_VERSION: 580.65.06` and the GB200 model name off the mock), and adding prometheus-adapter made the check pass.

**I have not opened an issue on NVIDIA/aicr.** It is your repo, and you may know a deployment path that configures this which the generated recipe simply does not express. If it is real, say so and I will file it properly.

## Back-test: caught 2 of 4, on a proxy set

**The primary back-test is pending.** No captured DSX-OS GB200 NVL72 bring-up failure set exists in any searchable location, because DSX-OS configs live on internal GitLab. **No failure set was synthesized.** Tracked as #501, which needs a human rather than engineering.

A clearly-relabelled **secondary proxy** ran against real hardware-encountered failures on **cloud** GB200 (`p6e-gb200.36xlarge`) from NVIDIA/aicr issues:

| Failure | Caught? | By what |
|---|---|---|
| aicr#859 prereq ConfigMap ordering, deploy hangs | **caught** | `operator-health`, `expected-resources` |
| aicr#1255 K8s floor below the DRA `resource.k8s.io/v1` requirement | **caught** | readiness version constraint, `dra-support` |
| aicr#1553 `nvidia_uvm` wedged on driver-managed nodes | **missed** | kernel module state, bucket C permanently |
| aicr#1861 validate phase outlives the AWS token | **missed** | cloud IAM lifetime, out of simulation scope |

Both misses are explained by category, not by a fixable gap. **Four caveats apply**: cloud GB200 rather than an NVL72 rack, n=4, two of the four are failures of AICR's own tooling caught by AICR's own validators (partly circular), and a devil's-advocate review recommended against running any proxy at all. That objection is recorded in the findings note because you may share it.

## Scale caveat

The mock replaces `libnvidia-ml.so.1` on the host and needs a real kubelet, so **it cannot run on KWOK nodes**. This POC ran on **one node**. It says nothing about GPU-stack fidelity at KWOK-scale node counts. That combination is a claim to prove, not to assert, and nothing here asserts it.

## Claims supported, and not

| Claim | Supported? | Basis |
|---|---|---|
| Pre-silicon **integration preflight** for the A-bucket checks | **Yes, scoped** | 6 passed and 3 failed for real, diagnosable reasons; coverage improved monotonically as components were added |
| **Reduces** time to first token | **Directionally, not quantified** | no bring-up timeline data exists to attach hours to |
| **Hit** first token on day one | **No** | simulation cannot prove it |
| AICR-on-silicon remains the final readiness gate | **Yes** | bucket C is non-empty by construction |
| Deep GPU-stack fidelity at KWOK scale | **No** | not tested; the mock cannot run on KWOK nodes |
| Mokka validates CUDA execution | **No** | 1 CUDA driver-API symbol; cuda-validation runs `WITH_WORKLOAD=false` |

## Gap backlog

Summary issue: **#502**. Gaps filed: **3**. Closed in this PR: **1**.

| Gap | Issue | Unlocks | Size | Status |
|---|---|---|---|---|
| `nvml-mock` does not ship the mock IMEX surface the DRA compute-domain plugin needs | #498 | 2 checks, G to A | S | open |
| No simulated node provisioner | #499 | 1 check, G to A | M | open |
| GFD e2e assertion warning-only, can never fail | #500 | test quality | S | **closed here** |

#500 is worth a look on its own: `NodeLabelSoft` only printed a warning, so GFD could have been deleted entirely and the GPU Operator scenario would still have gone green. It now asserts hard against values derived from the profile. It did **not** move a bucket, because it was a defect in our e2e rather than in Mokka, and it is reported that way.

**Deliberately not filed: MIG.** Coverage is zero, but no AICR check requires it, so closing it would unlock nothing. Recorded so nobody refiles it as a blocker.

## Diagrams

<details>
<summary>Stack layering: AICR is the workload, Mokka is the substrate</summary>

```mermaid
flowchart TB
  L5["AICR: recipes, validate and conformance suite (runs unmodified)"]
  L4["GPU stack: GPU Operator, DRA driver, device plugin, GFD, DCGM"]
  L3["kubelet + containerd, CDI injection"]
  L2["Mokka Sim: libnvidia-ml.so.1 replacement, device nodes, CDI spec -- SIMULATION BOUNDARY"]
  L1["Real CPU nodes: Kubernetes, real kubelet, real container runtime"]
  L1 --> L2 --> L3 --> L4 --> L5
```

Direction matters: the common misreading is that simulation lives inside AICR. It does not.
</details>

<details>
<summary>Preflight timeline: where integration failures get found</summary>

```mermaid
flowchart LR
  subgraph WITHOUT["WITHOUT preflight"]
    W1["~3 months: engineers idle"] --> W2["silicon arrives"] --> W3["integration failures found HERE"] --> W4["hardware-dependent validation"]
  end
  subgraph WITH["WITH preflight"]
    P1["~3 months: AICR on Mokka, integration failures found and fixed"] --> P2["silicon arrives"] --> P3["hardware-dependent validation only. AICR on silicon = FINAL GATE"]
  end
```

No day-one first-token claim is drawn, because simulation does not prove it.
</details>

Five diagrams live in [`docs/aicr-preflight/diagrams/`](docs/aicr-preflight/diagrams/), each as mermaid plus a hand-authored SVG for email and slides.

## Review ask

@mchmarny, the part I most want your eye on is **[`docs/aicr-preflight/`](docs/aicr-preflight/)**, specifically the AICR description and where I have drawn the final-gate boundary. Those are yours to validate and I would rather be corrected now than in front of a customer.

Two specific calls I would like you to check:

1. **`slinky-slurm-imex-channel` is bucketed G, not C.** My reasoning: whether the *fabric carries traffic* is hardware-dependent and stays C (that is what `nccl-all-reduce-bw-nvls` is for), but whether *channel allocation hands out distinct channels* is driver-surface plumbing and is simulatable. This is the closest call in the catalog and sits nearest your boundary.
2. **Whether the cloud-GB200 proxy back-test should exist at all.** It is labelled and caveated, and the objection to it is recorded, but you may still want it removed.

## How to re-run

```bash
make e2e-gpu-operator E2E_PROFILES=gb200 E2E_KEEP_CLUSTER=true
```

```bash
aicr recipe --service kind --accelerator gb200 --intent inference -o recipe.yaml && aicr validate --recipe recipe.yaml --phase deployment --phase conformance --fail-on-error=false --output ctrf/validate.json
```

```bash
go run ./tests/aicr-preflight -ctrf ctrf -markdown coverage.md -json report.json -provenance sim
```

Full prerequisites in [`tests/aicr-preflight/README.md`](tests/aicr-preflight/README.md). Raw run output is committed under [`results/2026-07-25-gb200-kind/`](tests/aicr-preflight/results/2026-07-25-gb200-kind/).

## Design note

The harness is built so an incomplete run degrades to "not run" rather than to a favourable number: a check the run never reported can never be recorded as passing, CTRF `pending` and `other` map to not-run, a bucket-C check reporting green under `sim` is flagged suspect, and every record carries provenance. Both invariants are mutation-tested. The catalog carries the analytical judgment with source citations; the harness supplies only the observed outcome and never edits a bucket.

## Verification

`go build ./...`, `go test ./...`, `go test -tags=e2e` on the touched packages, and `golangci-lint run ./...` all pass (0 issues). All commits are DCO signed-off and GPG signed.

Not for merge as-is: this is a POC for review, and the back-test section is openly pending.
