### PR TITLE
fix(ci): close the tier-1 gaps found by the AICR pre-silicon preflight POC

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
-# Keep the Docker build context small/fast. The nvml-mock Dockerfile only
-# COPYs go.mod/go.sum, vendor/, and specific pkg/ and cmd/ paths, so none of
-# the entries below are needed inside the build.
+# Keep the Docker build context small/fast. The nvml-mock Dockerfile COPYs
+# go.mod/go.sum, vendor/, and all of pkg/ and cmd/, so none of the entries
+# below are needed inside the build.
 .git
 .worktrees
 .github

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -44,11 +44,22 @@ jobs:
         skip-cache: true
 
     - name: Run go vet
-      # pkg/gpu/mocknvml/bridge is excluded: its 6 unsafe.Pointer findings
-      # need the engine handle type changed from uintptr to unsafe.Pointer,
-      # which is 8 API signatures plus 102 bridge call sites. Tracked
-      # separately; do not widen this exclusion.
-      run: go vet $(go list ./... | grep -v '/mocknvml/bridge')
+      # Every package, no exclusions. This overlaps the govet linter inside
+      # golangci-lint above, but it is not redundant with it -- both reasons
+      # were measured on the pre-#511 tree, not assumed:
+      #   * golangci-lint honours //nolint:govet. The bridge carried 7 such
+      #     comments and golangci-lint reported 0 findings; stripping them
+      #     produced findings immediately. Bare go vet has no suppression
+      #     mechanism at all, so this step is the one that cannot be silenced
+      #     one site at a time.
+      #   * golangci-lint caps repeats of the same finding
+      #     (--max-same-issues, default 3). It surfaced 3 where go vet
+      #     surfaced 8, so it under-reports exactly the kind of spreading
+      #     problem this gate exists to catch.
+      # Consequence: if this goes red, fix the code. There is no middle
+      # ground to retreat to, and an exclusion here is a blind spot rather
+      # than a filter.
+      run: go vet ./...
 
     - name: Check golang modules
       run: |

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -43,6 +43,13 @@ jobs:
         args: -v --timeout 5m
         skip-cache: true
 
+    - name: Run go vet
+      # pkg/gpu/mocknvml/bridge is excluded: its 6 unsafe.Pointer findings
+      # need the engine handle type changed from uintptr to unsafe.Pointer,
+      # which is 8 API signatures plus 102 bridge call sites. Tracked
+      # separately; do not widen this exclusion.
+      run: go vet $(go list ./... | grep -v '/mocknvml/bridge')
+
     - name: Check golang modules
       run: |
         make check-modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Operator via the Go harness (`gpu-operator` scenario, `dcgm`/`xid` labels):
   it asserts DEV + PROF and time-varying telemetry, plus `DCGM_FI_DEV_XID_ERRORS`
   under failure injection. `spike-dcgm.sh` provides a container-level recipe. (#370)
+- `docs/configuration.md` gains a **Metric Fidelity** section stating, per metric,
+  which reported values are simulated (clock-driven via `dynamic_metrics`), which
+  are static until the config changes, and which are fixed by design — including
+  the exact fractions of `utilization.gpu` behind each `DCGM_FI_PROF_*` activity
+  metric, and why tying them to real work is out of scope for a library that
+  never runs a kernel. It also records that no reported value is workload-aware:
+  a pod holding an `nvidia.com/gpu` claim does not move `memory.used_bytes`,
+  `processes`, or `utilization.gpu`. (#506)
 
 ### Changed
 - ComputeDomain simulation now runs the REAL `nvidia-imex` daemon in NO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scripts) to resolve `GO-2026-5856` (Encrypted Client Hello privacy leak
   in `crypto/tls`), which was failing the `govulncheck` CI check.
 
+### Fixed
+- `nvml-mock-ctl set --gpu <n> memory.total_bytes|free_bytes|used_bytes=...` now
+  takes effect within one override TTL instead of silently doing nothing until
+  the pod restarts. `nvmlDeviceGetMemoryInfo` and `nvmlDeviceGetMemoryInfo_v2`
+  read device memory from the effective (override-merged) config rather than a
+  struct baked at device construction. Values are reported verbatim: overriding
+  `used_bytes` alone does not recompute `free_bytes`. The BAR1 aperture
+  (`bar1_memory`) is still baked at construction. (#506)
+
 ### Deprecated
 - The fake `nvidia-imex` / `nvidia-imex-ctl` binaries, `pkg/imexcoord`,
   and the chart's `imex.enabled` hostPath coordination — superseded by

--- a/deployments/nvml-mock/Dockerfile
+++ b/deployments/nvml-mock/Dockerfile
@@ -17,21 +17,8 @@ FROM golang:${GOLANG_VERSION}-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
 COPY vendor/ vendor/
-COPY pkg/gpu/mocknvml/ pkg/gpu/mocknvml/
-COPY pkg/gpu/mockctl/ pkg/gpu/mockctl/
-COPY pkg/gpu/mockcuda/ pkg/gpu/mockcuda/
-COPY pkg/network/mockib/ pkg/network/mockib/
-COPY pkg/nri/ pkg/nri/
-COPY pkg/system/mockpcisysfs/ pkg/system/mockpcisysfs/
-COPY pkg/imexcoord/ pkg/imexcoord/
-COPY pkg/fmcoord/ pkg/fmcoord/
-COPY cmd/mock-ib/ cmd/mock-ib/
-COPY cmd/nvml-mock-nri/ cmd/nvml-mock-nri/
-COPY cmd/nvml-mock-ctl/ cmd/nvml-mock-ctl/
-COPY cmd/render-pci-sysfs/ cmd/render-pci-sysfs/
-COPY cmd/fake-imex/ cmd/fake-imex/
-COPY cmd/fake-fabricmanager/ cmd/fake-fabricmanager/
-COPY cmd/check-fabric/ cmd/check-fabric/
+COPY pkg/ pkg/
+COPY cmd/ cmd/
 RUN cd pkg/gpu/mocknvml && make clean && make
 RUN cd pkg/gpu/mockcuda && make clean && make
 RUN cd pkg/network/mockib && make clean && make

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -733,11 +733,50 @@ for env vars (`MOCK_IB`, `MOCK_IB_PING_FABRIC`, `MOCK_IB_PEERS`,
 | `driverVersion` | `""` (auto) | NVIDIA driver version to mock. When empty, read from `system.driver_version` of the resolved GPU config (the selected `gpu.profile` file, or `gpu.customConfig` if set), so the profile is the single source of truth (e.g. GB200 → `580.65.06`, B200 → `560.35.03`, GB300 → `570.124.06`, others → `550.163.01`). Set explicitly only to override the profile. |
 | `nodeSelector` | `{}` | Node selector for DaemonSet |
 | `tolerations` | `[{operator: Exists}]` | Pod tolerations (default: tolerate all) |
+| `nodeLabels.pciVendorPresent` | `true` | Write `feature.node.kubernetes.io/pci-10de.present=true` on each node. Hand-written because NFD's PCI source structurally cannot see mock devices. Set to `false` when a real NFD owns `feature.node.kubernetes.io/*`. See [Node Labels](#node-labels) |
 | `integrations.fakeGpuOperator.enabled` | `false` | Create per-profile ConfigMaps for fake-gpu-operator discovery |
 | `integrations.fakeGpuOperator.profileLabels` | `{"run.ai/gpu-profile": "true"}` | Labels on profile ConfigMaps for discovery |
 | `infiniband.mockTier` | `""` (auto) | `MOCK_IB` tier: `off`, `sysfs`, or `full`. Empty auto-derives `full` for IB-enabled profiles and `sysfs` otherwise (keeps the `libibmocksys` redirect active so any real host IB is masked). `off` makes every shim a no-op and skips the daemon. An invalid value fails `helm template` |
 | `infiniband.ping.port` | `18515` | TCP port for fabric relay between nvml-mock pods (`mock-ib` / `ibping` always enabled) |
 | `infiniband.ping.networkPolicy.enabled` | `true` | Restrict inbound access to the fabric port to peer nvml-mock pods. No-op on CNIs that don't enforce NetworkPolicy (e.g. Kind's kindnet) |
+
+### Node Labels
+
+The DaemonSet's `setup.sh` writes two node labels with `kubectl label`, and the
+preStop `cleanup.sh` removes them again:
+
+| Label | Gated by | Default |
+|-------|----------|---------|
+| `nvidia.com/gpu.present=true` | not gated — always written | n/a |
+| `feature.node.kubernetes.io/pci-10de.present=true` | `nodeLabels.pciVendorPresent` | `true` |
+
+The second label is normally produced by Node Feature Discovery, not by hand.
+nvml-mock writes it itself because NFD's PCI source structurally cannot see a
+mock GPU: it reads a host-prefixed sysfs path fixed at link time
+(`/host-sys/bus/pci/devices`, from `HOSTMOUNT_PREFIX`), while nvml-mock's
+rendered PCI tree lives under `/var/lib/nvml-mock/sys` and is reachable only
+through an `LD_PRELOAD` sysfs shim — and `nfd-worker` ships statically linked,
+so `LD_PRELOAD` is inert in it. Either fact alone is enough; both hold. The
+`setup.sh` comment at step 7 carries the full analysis with upstream file
+references (verified against NFD v0.19.0).
+
+Keep the default (`true`) on a mock-only cluster: consumers that gate on the NFD
+PCI label — GPU Operator operands, NFD-based `nodeSelector`s — need it to
+schedule. Disable it when a real NFD (or anything else) owns
+`feature.node.kubernetes.io/*` and the forged label would conflict:
+
+```bash
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
+  --set nodeLabels.pciVendorPresent=false
+```
+
+`setup.sh` and `cleanup.sh` read the same switch, so a disabled label is neither
+written nor deleted — the mock never removes a label it did not create.
+
+A follow-up is planned to retire the `kubectl` call altogether: NFD's *local*
+source reads feature files from
+`/etc/kubernetes/node-feature-discovery/features.d/` via a plain literal path
+(not host-prefixed), which is reachable where the PCI source is not.
 
 ### GPU Profiles
 
@@ -1044,7 +1083,9 @@ The chart deploys:
    - Creates symlinks (`libnvidia-ml.so.1` → `libnvidia-ml.so.{version}`)
    - Creates mock device nodes at `/var/lib/nvml-mock/driver/dev/nvidia{N,ctl,-uvm,-uvm-tools}` (CDI bind-mounts them to `/dev/nvidia*` in consumer containers)
    - Writes GPU config YAML at `/var/lib/nvml-mock/driver/config/config.yaml`
-   - Labels the node `nvidia.com/gpu.present=true`
+   - Labels the node `nvidia.com/gpu.present=true`, and
+     `feature.node.kubernetes.io/pci-10de.present=true` unless
+     `nodeLabels.pciVendorPresent=false` (see [Node Labels](#node-labels))
 2. **ConfigMap** — GPU configuration from the selected profile
 3. **RBAC** — ServiceAccount with permission to patch node labels
 
@@ -1061,7 +1102,7 @@ discovery and monitoring. Some host-level subsystems are not mocked:
 |----------------|-------------------|--------|
 | `/sys/bus/pci/devices/{busID}` sysfs entries | DRA driver | `dra.k8s.io/pcieRoot` attribute absent from ResourceSlices — **blocks topology-aware scheduling demos** (e.g., GPU + SR-IOV VF alignment) |
 | `/sys/bus/pci/devices/{busID}/numa_node` | Device plugin | NUMA-aware topology hints unavailable; scheduling works but NUMA affinity not enforced |
-| `/sys/bus/pci/devices/*/vendor,device,class` | NFD (Node Feature Discovery) | PCI feature labels not auto-detected (nvml-mock sets `nvidia.com/gpu.present` and `pci-10de.present` directly) |
+| `/sys/bus/pci/devices/*/vendor,device,class` **as NFD reads them** (`/host-sys/…`, fixed at link time) | NFD (Node Feature Discovery) | PCI feature labels not auto-detected; nvml-mock writes `nvidia.com/gpu.present` and `pci-10de.present` directly instead. The latter is gated by `nodeLabels.pciVendorPresent` — see [Node Labels](#node-labels) |
 
 ### PCIe Root Complex (DRA driver)
 

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -72,6 +72,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # Gates the hand-written NFD label
+            # feature.node.kubernetes.io/pci-10de.present=true. setup.sh writes
+            # it and cleanup.sh removes it only when this is "on", so the mock
+            # never deletes a label it did not create. NFD's PCI source cannot
+            # derive the label on a mock node — see setup.sh step 7.
+            - name: MOCK_NFD_PCI_LABEL
+              value: {{ ternary "on" "off" .Values.nodeLabels.pciVendorPresent | quote }}
             # Point the mock NVML library at the in-pod ConfigMap mount so any
             # nvidia-smi / NVML caller running INSIDE the daemonset pod
             # (e.g. `kubectl exec ds/nvml-mock -- nvidia-smi`) loads the same

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -37,6 +37,8 @@ should match snapshot with all overrides:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
+                - name: MOCK_NFD_PCI_LABEL
+                  value: "on"
                 - name: MOCK_NVML_CONFIG
                   value: /etc/nvml-mock/config.yaml
                 - name: MOCK_NVML_OVERRIDES
@@ -176,6 +178,8 @@ should match snapshot with b200 profile:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
+                - name: MOCK_NFD_PCI_LABEL
+                  value: "on"
                 - name: MOCK_NVML_CONFIG
                   value: /etc/nvml-mock/config.yaml
                 - name: MOCK_NVML_OVERRIDES
@@ -294,6 +298,8 @@ should match snapshot with default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
+                - name: MOCK_NFD_PCI_LABEL
+                  value: "on"
                 - name: MOCK_NVML_CONFIG
                   value: /etc/nvml-mock/config.yaml
                 - name: MOCK_NVML_OVERRIDES

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -165,6 +165,29 @@ tests:
             name: DRIVER_VERSION
             value: "580.65.06"
 
+  # ── NFD pci-10de label gate (nodeLabels.pciVendorPresent) ───────────
+  # setup.sh and cleanup.sh both branch on MOCK_NFD_PCI_LABEL. They accept
+  # only "on"/"off" and abort the pod on anything else, so the exact string
+  # matters, not merely the presence of the variable.
+  - it: should write the NFD pci-10de label by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MOCK_NFD_PCI_LABEL
+            value: "on"
+
+  - it: should suppress the NFD pci-10de label when nodeLabels.pciVendorPresent=false
+    set:
+      nodeLabels:
+        pciVendorPresent: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MOCK_NFD_PCI_LABEL
+            value: "off"
+
   # ── fabricmanager enablement (derived from the profile) ─────────────
   - it: should start fabricmanager for an auto-state profile (gb200)
     set:

--- a/deployments/nvml-mock/helm/nvml-mock/values.schema.json
+++ b/deployments/nvml-mock/helm/nvml-mock/values.schema.json
@@ -129,6 +129,17 @@
     "nodeSelector": { "type": "object" },
     "tolerations": { "type": "array" },
     "resources": { "type": "object" },
+    "nodeLabels": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Node labels written by setup.sh and removed by the preStop cleanup.sh.",
+      "properties": {
+        "pciVendorPresent": {
+          "type": "boolean",
+          "description": "Write feature.node.kubernetes.io/pci-10de.present=true on the node. Hand-written because NFD's PCI source reads a link-time-fixed /host-sys path and nfd-worker is statically linked, so it can see neither our rendered PCI tree nor our LD_PRELOAD sysfs shim. Set false when a real NFD owns feature.node.kubernetes.io/*. Typed as a boolean here because the DaemonSet renders it with `ternary`, which rejects a string with a template error rather than silently treating \"false\" as true."
+        }
+      }
+    },
     "nri": {
       "type": "object",
       "additionalProperties": true,

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -68,6 +68,25 @@ tolerations:
 
 resources: {}
 
+# Node labels written by setup.sh (`kubectl label`) and removed again by the
+# preStop cleanup.sh. Both scripts read the same switch, so a disabled label is
+# neither written nor deleted — the mock never touches a key it does not own.
+nodeLabels:
+  # feature.node.kubernetes.io/pci-10de.present=true
+  #
+  # Hand-written, because NFD's PCI source cannot see our devices: it reads a
+  # host-prefixed sysfs path fixed at link time (/host-sys/bus/pci/devices) and
+  # nfd-worker is statically linked, so neither our LD_PRELOAD sysfs shim nor
+  # our rendered PCI tree is reachable from it. See setup.sh step 7 for the
+  # full analysis.
+  #
+  # Default true preserves the historical behaviour: consumers that gate on the
+  # NFD PCI label (GPU Operator operands, nfd-based nodeSelectors) schedule on a
+  # mock node out of the box. Set to false when a real NFD — or anything else
+  # that owns feature.node.kubernetes.io/* — runs on the cluster and the forged
+  # label would conflict with it.
+  pciVendorPresent: true
+
 # Node-wide ambient injection via containerd NRI. When enabled, a lightweight
 # node-local plugin appends the nvml-mock overlay mount and environment to each
 # container at runtime without mutating pod specs. Opt-in (default false): it

--- a/deployments/nvml-mock/scripts/cleanup.sh
+++ b/deployments/nvml-mock/scripts/cleanup.sh
@@ -23,6 +23,12 @@ if [ -f "$CDI_FILE" ]; then
 fi
 if command -v kubectl >/dev/null 2>&1; then
   kubectl label node "$NODE_NAME" nvidia.com/gpu.present- || true
-  kubectl label node "$NODE_NAME" feature.node.kubernetes.io/pci-10de.present- || true
+  # Mirror of setup.sh step 7: remove the NFD PCI label only when this pod was
+  # the one that wrote it. Chart value nodeLabels.pciVendorPresent maps to
+  # MOCK_NFD_PCI_LABEL; with the gate off a real NFD owns that key, and an
+  # unconditional delete here would strip a label the mock never created.
+  if [ "$(printf '%s' "${MOCK_NFD_PCI_LABEL:-on}" | tr '[:upper:]' '[:lower:]')" = "on" ]; then
+    kubectl label node "$NODE_NAME" feature.node.kubernetes.io/pci-10de.present- || true
+  fi
 fi
 echo "Mock GPU environment cleaned up on $NODE_NAME"

--- a/deployments/nvml-mock/scripts/cleanup.sh
+++ b/deployments/nvml-mock/scripts/cleanup.sh
@@ -16,8 +16,12 @@ fi
 # NOTE: /run/nvidia/validations/toolkit-ready is deliberately NOT removed here.
 # setup.sh no longer creates it (see setup.sh step 8b); its owner is GPU
 # Operator's nvidia-validator. This hook is nvml-mock's preStop, so removing the
-# marker would delete another component's state on every nvml-mock restart and
-# re-arm the operand gate with nothing scheduled to re-satisfy it.
+# marker would delete another component's state from a hook we own. In the
+# GPU-Operator e2e that was probably benign in practice: dropping the
+# nvidia.com/gpu.present label below recycles the operator-validator alongside
+# us, and it rewrites the marker within seconds (observed live). The rm is dead
+# code either way, and the hazard is real wherever the validator does not
+# happen to restart.
 # Remove CDI spec
 CDI_FILE="/host/var/run/cdi/nvidia.yaml"
 if [ -f "$CDI_FILE" ]; then

--- a/deployments/nvml-mock/scripts/cleanup.sh
+++ b/deployments/nvml-mock/scripts/cleanup.sh
@@ -13,8 +13,11 @@ if [ -L "/host/run/nvidia/driver" ]; then
   rm -f "/host/run/nvidia/driver"
   echo "GPU Operator driver symlink removed"
 fi
-# Remove GPU Operator toolkit-ready marker (counterpart to setup.sh:8b)
-rm -f "/host/run/nvidia/validations/toolkit-ready"
+# NOTE: /run/nvidia/validations/toolkit-ready is deliberately NOT removed here.
+# setup.sh no longer creates it (see setup.sh step 8b); its owner is GPU
+# Operator's nvidia-validator. This hook is nvml-mock's preStop, so removing the
+# marker would delete another component's state on every nvml-mock restart and
+# re-arm the operand gate with nothing scheduled to re-satisfy it.
 # Remove CDI spec
 CDI_FILE="/host/var/run/cdi/nvidia.yaml"
 if [ -f "$CDI_FILE" ]; then

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -372,10 +372,27 @@ ln -sfn /var/lib/nvml-mock/driver /host/run/nvidia/driver
 #     any toolkit check had run, turning an ordering barrier into a no-op and
 #     making a green operand look like a validated one. See #504.
 #
-#     The directory needs no mkdir either: every DaemonSet that mounts it
-#     declares hostPath type DirectoryOrCreate
-#     (0500_daemonset.yaml:142-145, state-device-plugin/0500_daemonset.yaml:146-149)
-#     and the validator itself does os.Mkdir on the status dir (main.go:524).
+#     The directory needs no mkdir either. The DaemonSets that mount the
+#     validations dir directly — device-plugin
+#     (state-device-plugin/0500_daemonset.yaml:146-149), mig-manager
+#     (state-mig-manager/0600_daemonset.yaml:96-99) and the validator
+#     (state-operator-validation/0500_daemonset.yaml:142-145) — all declare
+#     hostPath type DirectoryOrCreate. The other four gated operands mount the
+#     parent /run/nvidia instead: gpu-feature-discovery/0500_daemonset.yaml:129-132,
+#     state-dcgm/0400_dcgm.yml:55-58 and
+#     state-mps-control-daemon/0400_daemonset.yaml:125-128 as type Directory
+#     (which requires the parent to pre-exist), and
+#     state-dcgm-exporter/0800_daemonset.yaml:76-78 with no type at all — step 8
+#     above still creates that parent. The validator also does os.Mkdir on the
+#     status dir itself (main.go:524).
+#
+#     Residual hazard, as a debugging pointer: nvidia-validator has a cleanup-all
+#     flag (main.go:302-309, env CLEANUP_ALL, default false) that os.RemoveAll's
+#     the output dir and recreates it (main.go:513-527), replacing the directory
+#     inode. device-plugin and mig-manager bind-mount the validations dir itself,
+#     so a pod already blocked on the gate would poll an unlinked inode forever.
+#     Nothing in assets/ or controllers/ sets CLEANUP_ALL, so this is unreachable
+#     by default — but if an operand ever hangs here, check this first.
 
 # 9. InfiniBand: render sysfs via mock-ib; optionally run UMAD/fabric daemon.
 #    MOCK_IB selects the mock tier (case-insensitive):

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -316,9 +316,28 @@ fi
 #    Full analysis with file:line citations is in the commit message that added
 #    this comment (#505 poses the question; it does not answer it):
 #      git log -S 'pci-10de' -- deployments/nvml-mock/scripts/setup.sh
+#
+#    MOCK_NFD_PCI_LABEL (chart value `nodeLabels.pciVendorPresent`, default
+#    true/on) gates only the pci-10de line. Turn it off on a cluster where a
+#    real NFD owns feature.node.kubernetes.io/*, so the mock does not forge a
+#    key another controller reconciles. cleanup.sh reads the same variable and
+#    skips the corresponding delete, so the preStop hook removes exactly the
+#    labels this step wrote and never one it did not.
+PCI_LABEL_MODE=$(printf '%s' "${MOCK_NFD_PCI_LABEL:-on}" | tr '[:upper:]' '[:lower:]')
+case "$PCI_LABEL_MODE" in
+  off | on) ;;
+  *)
+    echo "ERROR: MOCK_NFD_PCI_LABEL='$MOCK_NFD_PCI_LABEL' is invalid; expected off or on" >&2
+    exit 1
+    ;;
+esac
 if command -v kubectl >/dev/null 2>&1; then
   kubectl label node "$NODE_NAME" nvidia.com/gpu.present=true --overwrite || true
-  kubectl label node "$NODE_NAME" feature.node.kubernetes.io/pci-10de.present=true --overwrite || true
+  if [ "$PCI_LABEL_MODE" = "on" ]; then
+    kubectl label node "$NODE_NAME" feature.node.kubernetes.io/pci-10de.present=true --overwrite || true
+  else
+    echo "Skipping feature.node.kubernetes.io/pci-10de.present (nodeLabels.pciVendorPresent=false)"
+  fi
 fi
 
 # 8. Create GPU Operator compatibility symlink.

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -368,9 +368,10 @@ ln -sfn /var/lib/nvml-mock/driver /host/run/nvidia/driver
 #
 #     Writing it here was never durable — the validator deletes it on every run
 #     and its preStop hook removes every *-ready file on shutdown
-#     (0500_daemonset.yaml:133-136) — and it let operands clear the gate before
-#     any toolkit check had run, turning an ordering barrier into a no-op and
-#     making a green operand look like a validated one. See #504.
+#     (state-operator-validation/0500_daemonset.yaml:133-136) — and it let
+#     operands clear the gate before any toolkit check had run, turning an
+#     ordering barrier into a no-op and making a green operand look like a
+#     validated one. See #504.
 #
 #     The directory needs no mkdir either. The DaemonSets that mount the
 #     validations dir directly — device-plugin
@@ -388,11 +389,16 @@ ln -sfn /var/lib/nvml-mock/driver /host/run/nvidia/driver
 #
 #     Residual hazard, as a debugging pointer: nvidia-validator has a cleanup-all
 #     flag (main.go:302-309, env CLEANUP_ALL, default false) that os.RemoveAll's
-#     the output dir and recreates it (main.go:513-527), replacing the directory
-#     inode. device-plugin and mig-manager bind-mount the validations dir itself,
-#     so a pod already blocked on the gate would poll an unlinked inode forever.
-#     Nothing in assets/ or controllers/ sets CLEANUP_ALL, so this is unreachable
-#     by default — but if an operand ever hangs here, check this first.
+#     the output dir before recreating it (main.go:513-527), wiping every marker;
+#     because the validator's own /run/nvidia/validations is a bind mount
+#     (state-operator-validation/0500_daemonset.yaml:54-55, 73-74, 96-97,
+#     123-124, 138-139, over the hostPath volume cited above), the RemoveAll then
+#     fails EBUSY on the mount point and the validator exits before recreating
+#     anything (main.go:516-520 returns ahead of the os.Mkdir at :524), so
+#     already-gated pods block on a marker that never returns while the validator
+#     itself sits in CrashLoopBackOff. Nothing in assets/ or controllers/ sets
+#     CLEANUP_ALL, so this is unreachable by default — but if an operand ever
+#     hangs here, check this first.
 
 # 9. InfiniBand: render sysfs via mock-ib; optionally run UMAD/fabric daemon.
 #    MOCK_IB selects the mock tier (case-insensitive):

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -347,13 +347,28 @@ fi
 mkdir -p /host/run/nvidia
 ln -sfn /var/lib/nvml-mock/driver /host/run/nvidia/driver
 
-# 8b. Write the toolkit-ready marker that GPU Operator operand pods poll for.
-#     Operand DaemonSets (device-plugin, gpu-feature-discovery) ship with a
-#     hardcoded `toolkit-validation` init container that loops on:
+# 8b. Pre-create the toolkit-ready marker that GPU Operator operand pods poll for.
+#     Six operand DaemonSets ship an unconditional `toolkit-validation` init
+#     container that loops on:
 #       until [ -f /run/nvidia/validations/toolkit-ready ]; do sleep 5; done
-#     Real nvidia-container-toolkit writes this marker as part of its install.
-#     When nvml-mock substitutes for the toolkit, no other component writes
-#     it — so we do, here, alongside the existing /run/nvidia/driver setup.
+#     (gpu-operator v26.3.0: assets/state-device-plugin/0500_daemonset.yaml:29,31;
+#     gpu-feature-discovery/0500_daemonset.yaml:29,32;
+#     state-dcgm-exporter/0800_daemonset.yaml:28,31; state-dcgm/0400_dcgm.yml:28,31;
+#     state-mps-control-daemon/0400_daemonset.yaml:31,33;
+#     state-mig-manager/0600_daemonset.yaml:28,31.)
+#
+#     The marker's real writer is NOT nvidia-container-toolkit. It is GPU
+#     Operator's own nvidia-validator, running as the operator-validator
+#     DaemonSet's `toolkit-validation` init container with COMPONENT=toolkit
+#     (assets/state-operator-validation/0500_daemonset.yaml:59-69). That
+#     DaemonSet is deployed unconditionally. Toolkit.validate() DELETES the
+#     marker (cmd/nvidia-validator/main.go:1134), runs nvidia-smi, and re-creates
+#     it only on success (main.go:1153); the validator's preStop hook then
+#     removes every *-ready file on shutdown (0500_daemonset.yaml:133-136).
+#
+#     So the write below is not durable and validates nothing. Its only effect is
+#     to let operands clear the gate before that check has run — read a green
+#     operand as "scheduled", never as "toolkit validated". See #504.
 mkdir -p /host/run/nvidia/validations
 touch /host/run/nvidia/validations/toolkit-ready
 

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -276,9 +276,13 @@ fi
 
 # 7. Label node (requires RBAC: get+patch on nodes)
 #
-#    The pci-10de label is written by hand because NFD structurally cannot
-#    derive it on a mock node — not because its class filter excludes us. NFD's
-#    PCI source reads exactly one path, fixed at link time: source/pci/utils.go
+#    Keep the pci-10de line below: nothing else writes that label on a mock
+#    node, so removing it silently drops it.
+#
+#    It is hand-written because NFD's *PCI source* cannot see our fake devices.
+#    (Upstream facts here are as of NFD v0.19.0, the version pinned in go.mod;
+#    the worker actually deployed comes from GPU Operator and may differ.)
+#    That source reads exactly one path, fixed at link time: source/pci/utils.go
 #    resolves hostpath.SysfsDir.Path("bus/pci/devices"), and pkg/utils/hostpath
 #    builds SysfsDir from a private `pathPrefix` var set only via linker -X.
 #    Upstream's container build passes HOSTMOUNT_PREFIX=/host- (Makefile), so the
@@ -288,18 +292,30 @@ fi
 #    Our fake tree lives at /var/lib/nvml-mock/sys/bus/pci/devices and is
 #    reachable only through libpcimocksys.so, which the NRI plugin does inject
 #    into the NFD worker (it is opt-out, and NFD is not in an excluded
-#    namespace). The injection is inert for two independent reasons:
+#    namespace). The injection is inert. Either of the following alone would be
+#    enough; both hold:
 #      a) the shim rewrites only paths starting "/sys/" (see k_prefixes[] in
-#         pkg/system/mockpcisysfs/c/shim.c); "/host-sys/..." never matches; and
+#         pkg/system/mockpcisysfs/c/shim.c), so "/host-sys/..." never matches.
 #      b) nfd-worker is built -extldflags=-static, so the binary has no
 #         PT_INTERP and LD_PRELOAD is ignored outright.
 #
 #    The key itself is correct: GPU Operator configures NFD with
 #    deviceLabelFields:[vendor] and whitelists class 0302, which is exactly the
 #    "pci-<vendor>.present" form below, and our rendered devices carry all five
-#    attributes NFD treats as mandatory. Only visibility is missing. Removing
-#    this line would silently drop the label.
-#    Full analysis with file:line citations: refs #505.
+#    attributes NFD treats as mandatory. Only visibility is missing.
+#
+#    None of this rules out NFD entirely — only its PCI source. NFD's *local*
+#    source reads feature files from
+#    /etc/kubernetes/node-feature-discovery/features.d/ (source/local/local.go,
+#    a plain literal, not host-prefixed like the PCI path above), and the worker
+#    mounts that host directory at the same path. We already mount that exact
+#    directory as the GFD mock's output dir (tests/e2e/gfd-mock.yaml:52), so
+#    writing a feature file there is the supported way to retire this kubectl
+#    call — no node RBAC needed.
+#
+#    Full analysis with file:line citations is in the commit message that added
+#    this comment (#505 poses the question; it does not answer it):
+#      git log -S 'pci-10de' -- deployments/nvml-mock/scripts/setup.sh
 if command -v kubectl >/dev/null 2>&1; then
   kubectl label node "$NODE_NAME" nvidia.com/gpu.present=true --overwrite || true
   kubectl label node "$NODE_NAME" feature.node.kubernetes.io/pci-10de.present=true --overwrite || true

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -275,6 +275,31 @@ if [ -f /etc/nvml-mock/topology/topology.yaml ]; then
 fi
 
 # 7. Label node (requires RBAC: get+patch on nodes)
+#
+#    The pci-10de label is written by hand because NFD structurally cannot
+#    derive it on a mock node — not because its class filter excludes us. NFD's
+#    PCI source reads exactly one path, fixed at link time: source/pci/utils.go
+#    resolves hostpath.SysfsDir.Path("bus/pci/devices"), and pkg/utils/hostpath
+#    builds SysfsDir from a private `pathPrefix` var set only via linker -X.
+#    Upstream's container build passes HOSTMOUNT_PREFIX=/host- (Makefile), so the
+#    shipped worker reads /host-sys/bus/pci/devices — the real host /sys,
+#    hostPath-mounted read-only by the worker DaemonSet.
+#
+#    Our fake tree lives at /var/lib/nvml-mock/sys/bus/pci/devices and is
+#    reachable only through libpcimocksys.so, which the NRI plugin does inject
+#    into the NFD worker (it is opt-out, and NFD is not in an excluded
+#    namespace). The injection is inert for two independent reasons:
+#      a) the shim rewrites only paths starting "/sys/" (see k_prefixes[] in
+#         pkg/system/mockpcisysfs/c/shim.c); "/host-sys/..." never matches; and
+#      b) nfd-worker is built -extldflags=-static, so the binary has no
+#         PT_INTERP and LD_PRELOAD is ignored outright.
+#
+#    The key itself is correct: GPU Operator configures NFD with
+#    deviceLabelFields:[vendor] and whitelists class 0302, which is exactly the
+#    "pci-<vendor>.present" form below, and our rendered devices carry all five
+#    attributes NFD treats as mandatory. Only visibility is missing. Removing
+#    this line would silently drop the label.
+#    Full analysis with file:line citations: refs #505.
 if command -v kubectl >/dev/null 2>&1; then
   kubectl label node "$NODE_NAME" nvidia.com/gpu.present=true --overwrite || true
   kubectl label node "$NODE_NAME" feature.node.kubernetes.io/pci-10de.present=true --overwrite || true

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -347,9 +347,9 @@ fi
 mkdir -p /host/run/nvidia
 ln -sfn /var/lib/nvml-mock/driver /host/run/nvidia/driver
 
-# 8b. Pre-create the toolkit-ready marker that GPU Operator operand pods poll for.
-#     Six operand DaemonSets ship an unconditional `toolkit-validation` init
-#     container that loops on:
+# 8b. Deliberately NOT written here: /run/nvidia/validations/toolkit-ready.
+#     Six GPU Operator operand DaemonSets ship an unconditional
+#     `toolkit-validation` init container that loops on:
 #       until [ -f /run/nvidia/validations/toolkit-ready ]; do sleep 5; done
 #     (gpu-operator v26.3.0: assets/state-device-plugin/0500_daemonset.yaml:29,31;
 #     gpu-feature-discovery/0500_daemonset.yaml:29,32;
@@ -357,20 +357,25 @@ ln -sfn /var/lib/nvml-mock/driver /host/run/nvidia/driver
 #     state-mps-control-daemon/0400_daemonset.yaml:31,33;
 #     state-mig-manager/0600_daemonset.yaml:28,31.)
 #
-#     The marker's real writer is NOT nvidia-container-toolkit. It is GPU
-#     Operator's own nvidia-validator, running as the operator-validator
-#     DaemonSet's `toolkit-validation` init container with COMPONENT=toolkit
-#     (assets/state-operator-validation/0500_daemonset.yaml:59-69). That
+#     That gate is real, but nvml-mock is not its satisfier and must not
+#     pre-empt it. The marker's writer is GPU Operator's own nvidia-validator,
+#     running as the operator-validator DaemonSet's `toolkit-validation` init
+#     container with COMPONENT=toolkit
+#     (assets/state-operator-validation/0500_daemonset.yaml:59-69); that
 #     DaemonSet is deployed unconditionally. Toolkit.validate() DELETES the
-#     marker (cmd/nvidia-validator/main.go:1134), runs nvidia-smi, and re-creates
-#     it only on success (main.go:1153); the validator's preStop hook then
-#     removes every *-ready file on shutdown (0500_daemonset.yaml:133-136).
+#     marker (cmd/nvidia-validator/main.go:1134), runs nvidia-smi against our
+#     mock driver, and re-creates it only on success (main.go:1153).
 #
-#     So the write below is not durable and validates nothing. Its only effect is
-#     to let operands clear the gate before that check has run — read a green
-#     operand as "scheduled", never as "toolkit validated". See #504.
-mkdir -p /host/run/nvidia/validations
-touch /host/run/nvidia/validations/toolkit-ready
+#     Writing it here was never durable — the validator deletes it on every run
+#     and its preStop hook removes every *-ready file on shutdown
+#     (0500_daemonset.yaml:133-136) — and it let operands clear the gate before
+#     any toolkit check had run, turning an ordering barrier into a no-op and
+#     making a green operand look like a validated one. See #504.
+#
+#     The directory needs no mkdir either: every DaemonSet that mounts it
+#     declares hostPath type DirectoryOrCreate
+#     (0500_daemonset.yaml:142-145, state-device-plugin/0500_daemonset.yaml:146-149)
+#     and the validator itself does os.Mkdir on the status dir (main.go:524).
 
 # 9. InfiniBand: render sysfs via mock-ib; optionally run UMAD/fabric daemon.
 #    MOCK_IB selects the mock tier (case-insensitive):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -405,6 +405,81 @@ When deploying via Helm, additional values control integration with external pro
 
 See [fake-gpu-operator integration](integrations/fake-gpu-operator.md) for setup details.
 
+## Metric Fidelity
+
+Every value the mock reports comes from configuration, from a clock-driven
+simulator, or from a fixed derivation — never from real GPU work, because the
+mock never executes a kernel. This section states which is which, so a dashboard
+built against nvml-mock is read with the right expectations.
+
+### Simulated — changes between calls
+
+Opt in per metric via `dynamic_metrics`; with that block absent, all of these are
+static. The driver is **elapsed time, not workload**: the numbers move on a
+completely idle node, and they do not move any faster under load.
+
+| Metric | Config | Behaviour |
+|--------|--------|-----------|
+| `temperature.gpu` | `dynamic_metrics.temperature` | `base_c`, plus a sine ramp over `ramp_period_sec` bounded by `ramp_c`, plus uniform noise in ±`variance_c`; clamped to the thermal shutdown threshold when known |
+| `power.draw` | `dynamic_metrics.power` | `base_mw` ± `variance_mw`, clamped to `min_limit_mw` / `max_limit_mw` when those are set |
+| `utilization.gpu`, `utilization.memory` | `dynamic_metrics.utilization` | random within the configured band, shaped by `pattern` (`idle` / `busy` / `burst` / `steady`) |
+| NVLink throughput counters | — | accrue deterministically from a process-independent epoch (`MOCK_NVML_EPOCH`, else `/proc/stat` btime), so they grow monotonically across separate `nvidia-smi` runs |
+
+### Static — held until the config changes
+
+Everything else resolved through the effective config: device memory
+(`memory.total_bytes` / `free_bytes` / `used_bytes` / `reserved_bytes`), ECC mode
+and counters, clocks, fan speed, performance state, power limits, `processes`,
+and failure injection. Each holds its configured value until the profile changes
+or `nvml-mock-ctl` writes a runtime override, which takes effect within one
+override TTL — see [nvml-mock-ctl](nvml-mock-ctl.md).
+
+### Deliberately fixed
+
+**Profiling metrics (`DCGM_FI_PROF_*`).** DCGM reads these on Hopper+ through the
+NVML GPM API. The mock derives every activity metric as a fixed fraction of
+`utilization.gpu`:
+
+| GPM metric | Fraction of `utilization.gpu` |
+|------------|-------------------------------|
+| SM utilization, graphics utilization | 1.00 |
+| SM occupancy | 0.75 |
+| Any-tensor activity | 0.50 |
+| HMMA (FP16 tensor) | 0.40 |
+| FP16 | 0.35 |
+| FP32 | 0.25 |
+| Integer | 0.10 |
+| FP64, DMMA, IMMA | 0.05 |
+| DFMA | 0.02 |
+
+DRAM bandwidth activity mirrors `utilization.memory`, and PCIe / NVLink
+throughput come from the counter snapshots. The fractions approximate the shape
+of a tensor-dominated Hopper training step; they are **intentionally not** tied to
+execution. SM occupancy and tensor-core activity are properties of kernels the
+mock does not run, so deriving them from anything other than the configured
+utilization would be fabrication rather than simulation. They stay fixed by
+design and are not a gap to be closed.
+
+**Identity and topology.** Device `name`, `architecture`, `brand`,
+`compute_capability`, `uuid`, PCI `bus_id`, and the BAR1 aperture
+(`bar1_memory`) are baked onto the device at construction and need a pod restart
+to change.
+
+### Not workload-aware — known gap
+
+No reported value responds to Kubernetes scheduling. A pod holding an
+`nvidia.com/gpu` claim does not move `memory.used_bytes`, does not appear in
+`processes`, and does not raise `utilization.gpu`; the values change only when
+something writes the config.
+
+Nothing in the deployment observes allocation today. The nvml-mock DaemonSet
+stages the driver tree and then sleeps, and the optional NRI plugin subscribes
+only to container **creation** and mounts the overlay read-only. Making memory
+and processes allocation-aware is tracked in
+[#506](https://github.com/NVIDIA/k8s-test-infra/issues/506).
+
+To move these numbers today, drive them explicitly with `nvml-mock-ctl set`.
+
 ## Validation
 
 The configuration is validated on load:

--- a/docs/nvml-mock-ctl.md
+++ b/docs/nvml-mock-ctl.md
@@ -38,7 +38,16 @@ fails the command instead of silently doing nothing.
 
 The config override drives every *config-derived getter*: failure injection, ECC
 mode/counters, temperature, power, utilization, clocks, fan, performance state,
-and the like. These change within one TTL.
+device memory (`memory.total_bytes` / `free_bytes` / `used_bytes` /
+`reserved_bytes` / `memory_bus_width`), and the like. These change within one TTL.
+
+Memory values are reported **verbatim** from the effective config — setting
+`memory.used_bytes` alone does not recompute `memory.free_bytes`. Set both in one
+command to keep the reported triple coherent:
+
+```bash
+nvml-mock-ctl set --gpu 0 memory.used_bytes=1073741824 memory.free_bytes=41264611328
+```
 
 A handful of **identity / topology** fields are baked onto the device at
 construction time and are **not** hot-reloadable in v1 — changing them requires a
@@ -50,8 +59,8 @@ pod restart or a Helm change:
 - `compute_capability`
 - `uuid`
 - PCI `bus_id`
-- device memory totals — `memory` / `bar1_memory` (baked at construction, so e.g.
-  `set --gpu 0 memory.total_bytes=...` won't take effect until a pod restart)
+- the BAR1 aperture — `bar1_memory` (baked at construction, so e.g.
+  `set --gpu 0 bar1_memory.total_bytes=...` won't take effect until a pod restart)
 
 If you need to change any of those, edit the profile / Helm values and restart
 the DaemonSet (or the affected pod).

--- a/docs/nvml-mock-ctl.md
+++ b/docs/nvml-mock-ctl.md
@@ -65,6 +65,11 @@ pod restart or a Helm change:
 If you need to change any of those, edit the profile / Helm values and restart
 the DaemonSet (or the affected pod).
 
+For which reported values are simulated, which are static, and which are fixed
+by design — including why `DCGM_FI_PROF_*` does not track real work, and why no
+value responds to a pod holding an `nvidia.com/gpu` claim — see
+[Metric Fidelity](configuration.md#metric-fidelity).
+
 ## Where it runs
 
 `nvml-mock-ctl` ships inside the nvml-mock DaemonSet image and runs via

--- a/pkg/gpu/mocknvml/bridge/affinity.go
+++ b/pkg/gpu/mocknvml/bridge/affinity.go
@@ -58,7 +58,7 @@ func nvmlDeviceGetCpuAffinity(device C.nvmlDevice_t, cpuSetSize C.uint, cpuSet *
 	if ret, ok := bridgeVersionCheck("nvmlDeviceGetCpuAffinity"); !ok {
 		return ret
 	}
-	dev := engine.GetEngine().LookupConfigurableDevice(uintptr(unsafe.Pointer(device.handle)))
+	dev := engine.GetEngine().LookupConfigurableDevice(unsafe.Pointer(device.handle))
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
@@ -74,7 +74,7 @@ func nvmlDeviceGetCpuAffinityWithinScope(device C.nvmlDevice_t, cpuSetSize C.uin
 	if ret, ok := bridgeVersionCheck("nvmlDeviceGetCpuAffinityWithinScope"); !ok {
 		return ret
 	}
-	dev := engine.GetEngine().LookupConfigurableDevice(uintptr(unsafe.Pointer(device.handle)))
+	dev := engine.GetEngine().LookupConfigurableDevice(unsafe.Pointer(device.handle))
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
@@ -90,7 +90,7 @@ func nvmlDeviceGetMemoryAffinity(device C.nvmlDevice_t, nodeSetSize C.uint, node
 	if ret, ok := bridgeVersionCheck("nvmlDeviceGetMemoryAffinity"); !ok {
 		return ret
 	}
-	dev := engine.GetEngine().LookupConfigurableDevice(uintptr(unsafe.Pointer(device.handle)))
+	dev := engine.GetEngine().LookupConfigurableDevice(unsafe.Pointer(device.handle))
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
@@ -109,7 +109,7 @@ func nvmlDeviceGetNumaNodeId(device C.nvmlDevice_t, node *C.uint) C.nvmlReturn_t
 	if node == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	dev := engine.GetEngine().LookupConfigurableDevice(uintptr(unsafe.Pointer(device.handle)))
+	dev := engine.GetEngine().LookupConfigurableDevice(unsafe.Pointer(device.handle))
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}

--- a/pkg/gpu/mocknvml/bridge/device.go
+++ b/pkg/gpu/mocknvml/bridge/device.go
@@ -148,10 +148,10 @@ func nvmlDeviceGetHandleByIndex_v2(index C.uint, nvmlDevice *C.nvmlDevice_t) C.n
 	debugLog("[NVML] nvmlDeviceGetHandleByIndex(%d)\n", index)
 	handle, ret := engine.GetEngine().DeviceGetHandleByIndex(int(index))
 	if ret == nvml.SUCCESS {
-		// nvmlDevice_t is a struct with a handle field pointing to opaque nvmlDevice_st
-		//nolint:govet // Converting uintptr to unsafe.Pointer is intentional - handle was allocated
-		// as C memory by HandleTable.Register() and we need to pass it back to the C caller
-		nvmlDevice.handle = (*C.struct_nvmlDevice_st)(unsafe.Pointer(handle))
+		// nvmlDevice_t is a struct with a handle field pointing to opaque
+		// nvmlDevice_st. The engine hands back the C block it allocated, so
+		// this is a pointer-to-pointer conversion, not an integer round-trip.
+		nvmlDevice.handle = (*C.struct_nvmlDevice_st)(handle)
 		debugLog("[NVML]   -> handle=0x%x ret=%d\n", uintptr(handle), ret)
 	}
 	return toReturn(ret)
@@ -175,9 +175,7 @@ func nvmlDeviceGetHandleByUUID(uuid *C.char, nvmlDevice *C.nvmlDevice_t) C.nvmlR
 	goUUID := C.GoString(uuid)
 	handle, ret := engine.GetEngine().DeviceGetHandleByUUID(goUUID)
 	if ret == nvml.SUCCESS {
-		//nolint:govet // Converting uintptr to unsafe.Pointer is intentional - handle was allocated
-		// as C memory by HandleTable.Register() and we need to pass it back to the C caller
-		nvmlDevice.handle = (*C.struct_nvmlDevice_st)(unsafe.Pointer(handle))
+		nvmlDevice.handle = (*C.struct_nvmlDevice_st)(handle)
 	}
 	return toReturn(ret)
 }
@@ -190,9 +188,7 @@ func nvmlDeviceGetHandleByPciBusId_v2(pciBusId *C.char, nvmlDevice *C.nvmlDevice
 	goPciBusId := C.GoString(pciBusId)
 	handle, ret := engine.GetEngine().DeviceGetHandleByPciBusId(goPciBusId)
 	if ret == nvml.SUCCESS {
-		//nolint:govet // Converting uintptr to unsafe.Pointer is intentional - handle was allocated
-		// as C memory by HandleTable.Register() and we need to pass it back to the C caller
-		nvmlDevice.handle = (*C.struct_nvmlDevice_st)(unsafe.Pointer(handle))
+		nvmlDevice.handle = (*C.struct_nvmlDevice_st)(handle)
 	}
 	return toReturn(ret)
 }
@@ -208,7 +204,7 @@ func nvmlDeviceGetHandleByPciBusId_v1(pciBusId *C.char, nvmlDevice *C.nvmlDevice
 
 //export nvmlDeviceGetName
 func nvmlDeviceGetName(nvmlDevice C.nvmlDevice_t, name *C.char, length C.uint) C.nvmlReturn_t {
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupDevice(handle)
 	devName, ret := dev.GetName()
 	if ret != nvml.SUCCESS {
@@ -219,7 +215,7 @@ func nvmlDeviceGetName(nvmlDevice C.nvmlDevice_t, name *C.char, length C.uint) C
 
 //export nvmlDeviceGetUUID
 func nvmlDeviceGetUUID(nvmlDevice C.nvmlDevice_t, uuid *C.char, length C.uint) C.nvmlReturn_t {
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupDevice(handle)
 	devUUID, ret := dev.GetUUID()
 	if ret != nvml.SUCCESS {
@@ -233,7 +229,7 @@ func nvmlDeviceGetIndex(nvmlDevice C.nvmlDevice_t, index *C.uint) C.nvmlReturn_t
 	if index == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupDevice(handle)
 	idx, ret := dev.GetIndex()
 	if ret != nvml.SUCCESS {
@@ -248,7 +244,7 @@ func nvmlDeviceGetBrand(nvmlDevice C.nvmlDevice_t, _type *C.nvmlBrandType_t) C.n
 	if _type == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupDevice(handle)
 	brand, ret := dev.GetBrand()
 	if ret != nvml.SUCCESS {
@@ -260,7 +256,7 @@ func nvmlDeviceGetBrand(nvmlDevice C.nvmlDevice_t, _type *C.nvmlBrandType_t) C.n
 
 //export nvmlDeviceGetSerial
 func nvmlDeviceGetSerial(nvmlDevice C.nvmlDevice_t, serial *C.char, length C.uint) C.nvmlReturn_t {
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupDevice(handle)
 	devSerial, ret := dev.GetSerial()
 	if ret != nvml.SUCCESS {
@@ -274,7 +270,7 @@ func nvmlDeviceGetMinorNumber(nvmlDevice C.nvmlDevice_t, minorNumber *C.uint) C.
 	if minorNumber == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupDevice(handle)
 	minor, ret := dev.GetMinorNumber()
 	if ret != nvml.SUCCESS {
@@ -293,7 +289,7 @@ func nvmlDeviceGetPciInfo_v3(nvmlDevice C.nvmlDevice_t, pci *C.nvmlPciInfo_t) C.
 	if pci == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupDevice(handle)
 	info, ret := dev.GetPciInfo()
 	if ret != nvml.SUCCESS {
@@ -339,7 +335,7 @@ func nvmlDeviceGetPciInfoExt(nvmlDevice C.nvmlDevice_t, pci *C.nvmlPciInfoExt_t)
 	if pci == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -374,7 +370,7 @@ func nvmlDeviceGetMemoryInfo(nvmlDevice C.nvmlDevice_t, memory *C.nvmlMemory_t) 
 	if memory == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupDevice(handle)
 	mem, ret := dev.GetMemoryInfo()
 	if ret != nvml.SUCCESS {
@@ -398,8 +394,8 @@ func nvmlDeviceGetTopologyCommonAncestor(device1 C.nvmlDevice_t, device2 C.nvmlD
 	if pathInfo == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle1 := uintptr(unsafe.Pointer(device1.handle))
-	handle2 := uintptr(unsafe.Pointer(device2.handle))
+	handle1 := unsafe.Pointer(device1.handle)
+	handle2 := unsafe.Pointer(device2.handle)
 	dev1 := engine.GetEngine().LookupConfigurableDevice(handle1)
 	if dev1 == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -432,7 +428,7 @@ func nvmlDeviceGetNvLinkState(device C.nvmlDevice_t, link C.uint, isActive *C.nv
 	if isActive == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -453,7 +449,7 @@ func nvmlDeviceGetNvLinkErrorCounter(device C.nvmlDevice_t, link C.uint, counter
 	if counterValue == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -474,7 +470,7 @@ func nvmlDeviceGetNvLinkRemotePciInfo_v2(device C.nvmlDevice_t, link C.uint, pci
 	if pci == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -512,7 +508,7 @@ func nvmlDeviceGetTemperatureThreshold(device C.nvmlDevice_t, thresholdType C.nv
 	if temp == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -533,7 +529,7 @@ func nvmlDeviceGetThermalSettings(device C.nvmlDevice_t, sensorIndex C.uint, pTh
 	if pThermalSettings == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -567,7 +563,7 @@ func nvmlDeviceGetEnforcedPowerLimit(device C.nvmlDevice_t, limit *C.uint) C.nvm
 	if limit == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -588,7 +584,7 @@ func nvmlDeviceGetPowerManagementMode(device C.nvmlDevice_t, mode *C.nvmlEnableS
 	if mode == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -613,7 +609,7 @@ func nvmlDeviceGetMaxMigDeviceCount(device C.nvmlDevice_t, count *C.uint) C.nvml
 	if count == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -634,7 +630,7 @@ func nvmlDeviceGetMigDeviceHandleByIndex(device C.nvmlDevice_t, index C.uint, mi
 	if migDevice == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -658,7 +654,7 @@ func nvmlGpmQueryDeviceSupport(device C.nvmlDevice_t, gpmSupport *C.nvmlGpmSuppo
 	if !validGpmSupportVersion(uint32(gpmSupport.version)) {
 		return C.NVML_ERROR_ARGUMENT_VERSION_MISMATCH
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -683,7 +679,7 @@ func nvmlDeviceGetMemoryInfo_v2(nvmlDevice C.nvmlDevice_t, memory *C.nvmlMemory_
 	if memory == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupDevice(handle)
 	mem, ret := dev.GetMemoryInfo_v2()
 	if ret != nvml.SUCCESS {
@@ -705,7 +701,7 @@ func nvmlDeviceGetArchitecture(nvmlDevice C.nvmlDevice_t, arch *C.nvmlDeviceArch
 	if arch == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupDevice(handle)
 	architecture, ret := dev.GetArchitecture()
 	if ret != nvml.SUCCESS {
@@ -720,7 +716,7 @@ func nvmlDeviceGetCudaComputeCapability(nvmlDevice C.nvmlDevice_t, major *C.int,
 	if major == nil || minor == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupDevice(handle)
 	maj, min, ret := dev.GetCudaComputeCapability()
 	if ret != nvml.SUCCESS {
@@ -736,7 +732,7 @@ func nvmlDeviceGetMigMode(nvmlDevice C.nvmlDevice_t, currentMode *C.uint, pendin
 	if currentMode == nil || pendingMode == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupDevice(handle)
 	current, pending, ret := dev.GetMigMode()
 	if ret != nvml.SUCCESS {
@@ -759,7 +755,7 @@ func nvmlDeviceGetComputeRunningProcesses_v3(nvmlDevice C.nvmlDevice_t, infoCoun
 	if infoCount == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -800,7 +796,7 @@ func nvmlDeviceGetProcessUtilization(nvmlDevice C.nvmlDevice_t, utilization *C.n
 	if processSamplesCount == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -851,7 +847,7 @@ func nvmlDeviceGetPerformanceState(nvmlDevice C.nvmlDevice_t, pState *C.nvmlPsta
 	if pState == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -869,7 +865,7 @@ func nvmlDeviceGetCurrentClocksEventReasons(nvmlDevice C.nvmlDevice_t, clocksEve
 	if clocksEventReasons == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -891,7 +887,7 @@ func nvmlDeviceGetPersistenceMode(nvmlDevice C.nvmlDevice_t, mode *C.nvmlEnableS
 	if mode == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -906,7 +902,7 @@ func nvmlDeviceGetPersistenceMode(nvmlDevice C.nvmlDevice_t, mode *C.nvmlEnableS
 
 //export nvmlDeviceSetPersistenceMode
 func nvmlDeviceSetPersistenceMode(nvmlDevice C.nvmlDevice_t, mode C.nvmlEnableState_t) C.nvmlReturn_t {
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -939,7 +935,7 @@ func deviceGetRemappedRows(nvmlDevice C.nvmlDevice_t, corrRows *C.uint, uncRows 
 	if corrRows == nil || uncRows == nil || isPending == nil || failureOccurred == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -967,7 +963,7 @@ func deviceGetRemappedRowsV2(nvmlDevice C.nvmlDevice_t, info *C.nvmlRemappedRows
 	if info == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1001,7 +997,7 @@ func nvmlDeviceGetGspFirmwareMode(nvmlDevice C.nvmlDevice_t, isEnabled *C.uint, 
 	if isEnabled == nil || defaultMode == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1028,7 +1024,7 @@ func nvmlDeviceGetDisplayActive(nvmlDevice C.nvmlDevice_t, isActive *C.nvmlEnabl
 	if isActive == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(nvmlDevice.handle))
+	handle := unsafe.Pointer(nvmlDevice.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1053,7 +1049,7 @@ func nvmlDeviceGetPowerUsage(device C.nvmlDevice_t, power *C.uint) C.nvmlReturn_
 	if power == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1074,7 +1070,7 @@ func nvmlDeviceGetPowerManagementLimit(device C.nvmlDevice_t, limit *C.uint) C.n
 	if limit == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1095,7 +1091,7 @@ func nvmlDeviceGetPowerManagementDefaultLimit(device C.nvmlDevice_t, defaultLimi
 	if defaultLimit == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1116,7 +1112,7 @@ func nvmlDeviceGetPowerManagementLimitConstraints(device C.nvmlDevice_t, minLimi
 	if minLimit == nil || maxLimit == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1138,7 +1134,7 @@ func nvmlDeviceGetPowerState(device C.nvmlDevice_t, pState *C.nvmlPstates_t) C.n
 	if pState == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1163,7 +1159,7 @@ func nvmlDeviceGetTemperature(device C.nvmlDevice_t, sensorType C.nvmlTemperatur
 	if temp == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1190,7 +1186,7 @@ func nvmlDeviceGetTemperatureV(device C.nvmlDevice_t, temperature *C.nvmlTempera
 	if temperature == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1215,7 +1211,7 @@ func nvmlDeviceGetMarginTemperature(device C.nvmlDevice_t, marginTempInfo *C.nvm
 	if marginTempInfo == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1236,7 +1232,7 @@ func nvmlDeviceGetClockInfo(device C.nvmlDevice_t, clockType C.nvmlClockType_t, 
 	if clock == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1257,7 +1253,7 @@ func nvmlDeviceGetMaxClockInfo(device C.nvmlDevice_t, clockType C.nvmlClockType_
 	if clock == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1278,7 +1274,7 @@ func nvmlDeviceGetApplicationsClock(device C.nvmlDevice_t, clockType C.nvmlClock
 	if clockMHz == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1299,7 +1295,7 @@ func nvmlDeviceGetDefaultApplicationsClock(device C.nvmlDevice_t, clockType C.nv
 	if clockMHz == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1320,7 +1316,7 @@ func nvmlDeviceGetCurrentClocksThrottleReasons(device C.nvmlDevice_t, clocksThro
 	if clocksThrottleReasons == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1345,7 +1341,7 @@ func nvmlDeviceGetUtilizationRates(device C.nvmlDevice_t, utilization *C.nvmlUti
 	if utilization == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1367,7 +1363,7 @@ func nvmlDeviceGetComputeMode(device C.nvmlDevice_t, mode *C.nvmlComputeMode_t) 
 	if mode == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1388,7 +1384,7 @@ func nvmlDeviceGetEccMode(device C.nvmlDevice_t, current *C.nvmlEnableState_t, p
 	if current == nil || pending == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1410,7 +1406,7 @@ func nvmlDeviceGetDisplayMode(device C.nvmlDevice_t, mode *C.nvmlEnableState_t) 
 	if mode == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1431,7 +1427,7 @@ func nvmlDeviceGetAccountingMode(device C.nvmlDevice_t, mode *C.nvmlEnableState_
 	if mode == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1452,7 +1448,7 @@ func nvmlDeviceGetGpuOperationMode(device C.nvmlDevice_t, current *C.nvmlGpuOper
 	if current == nil || pending == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1474,7 +1470,7 @@ func nvmlDeviceGetMultiGpuBoard(device C.nvmlDevice_t, multiGpuBool *C.uint) C.n
 	if multiGpuBool == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1499,7 +1495,7 @@ func nvmlDeviceGetFanSpeed(device C.nvmlDevice_t, speed *C.uint) C.nvmlReturn_t 
 	if speed == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1520,7 +1516,7 @@ func nvmlDeviceGetFanSpeed_v2(device C.nvmlDevice_t, fan C.uint, speed *C.uint) 
 	if speed == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1541,7 +1537,7 @@ func nvmlDeviceGetNumFans(device C.nvmlDevice_t, numFans *C.uint) C.nvmlReturn_t
 	if numFans == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1562,7 +1558,7 @@ func nvmlDeviceGetBAR1MemoryInfo(device C.nvmlDevice_t, bar1Memory *C.nvmlBAR1Me
 	if bar1Memory == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1582,7 +1578,7 @@ func nvmlDeviceGetVbiosVersion(device C.nvmlDevice_t, version *C.char, length C.
 	if ret, ok := bridgeVersionCheck("nvmlDeviceGetVbiosVersion"); !ok {
 		return ret
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1599,7 +1595,7 @@ func nvmlDeviceGetBoardPartNumber(device C.nvmlDevice_t, partNumber *C.char, len
 	if ret, ok := bridgeVersionCheck("nvmlDeviceGetBoardPartNumber"); !ok {
 		return ret
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1616,7 +1612,7 @@ func nvmlDeviceGetInforomImageVersion(device C.nvmlDevice_t, version *C.char, le
 	if ret, ok := bridgeVersionCheck("nvmlDeviceGetInforomImageVersion"); !ok {
 		return ret
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1633,7 +1629,7 @@ func nvmlDeviceGetInforomVersion(device C.nvmlDevice_t, object C.nvmlInforomObje
 	if ret, ok := bridgeVersionCheck("nvmlDeviceGetInforomVersion"); !ok {
 		return ret
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1657,7 +1653,7 @@ func nvmlDeviceGetCurrPcieLinkGeneration(device C.nvmlDevice_t, currLinkGen *C.u
 	if currLinkGen == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1678,7 +1674,7 @@ func nvmlDeviceGetCurrPcieLinkWidth(device C.nvmlDevice_t, currLinkWidth *C.uint
 	if currLinkWidth == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1699,7 +1695,7 @@ func nvmlDeviceGetMaxPcieLinkGeneration(device C.nvmlDevice_t, maxLinkGen *C.uin
 	if maxLinkGen == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1720,7 +1716,7 @@ func nvmlDeviceGetMaxPcieLinkWidth(device C.nvmlDevice_t, maxLinkWidth *C.uint) 
 	if maxLinkWidth == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1741,7 +1737,7 @@ func nvmlDeviceGetPcieReplayCounter(device C.nvmlDevice_t, value *C.uint) C.nvml
 	if value == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1762,7 +1758,7 @@ func nvmlDeviceGetPcieThroughput(device C.nvmlDevice_t, counter C.nvmlPcieUtilCo
 	if value == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1783,7 +1779,7 @@ func nvmlDeviceGetTotalEccErrors(device C.nvmlDevice_t, errorType C.nvmlMemoryEr
 	if eccCounts == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1804,7 +1800,7 @@ func nvmlDeviceGetRetiredPages(device C.nvmlDevice_t, cause C.nvmlPageRetirement
 	if pageCount == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1841,7 +1837,7 @@ func nvmlDeviceGetRetiredPagesPendingStatus(device C.nvmlDevice_t, isPending *C.
 	if isPending == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1862,7 +1858,7 @@ func nvmlDeviceGetBoardId(device C.nvmlDevice_t, boardId *C.uint) C.nvmlReturn_t
 	if boardId == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1887,7 +1883,7 @@ func nvmlDeviceGetEncoderUtilization(device C.nvmlDevice_t, utilization *C.uint,
 	if utilization == nil || samplingPeriodUs == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1909,7 +1905,7 @@ func nvmlDeviceGetDecoderUtilization(device C.nvmlDevice_t, utilization *C.uint,
 	if utilization == nil || samplingPeriodUs == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1931,7 +1927,7 @@ func nvmlDeviceGetGraphicsRunningProcesses_v3(device C.nvmlDevice_t, infoCount *
 	if infoCount == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1971,7 +1967,7 @@ func nvmlDeviceGetNvLinkVersion(device C.nvmlDevice_t, link C.uint, version *C.u
 	if version == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -1992,7 +1988,7 @@ func nvmlDeviceGetNvLinkCapability(device C.nvmlDevice_t, link C.uint, capabilit
 	if capResult == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -2013,7 +2009,7 @@ func nvmlDeviceGetMemoryErrorCounter(device C.nvmlDevice_t, errorType C.nvmlMemo
 	if count == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -2038,7 +2034,7 @@ func nvmlDeviceGetMemoryBusWidth(device C.nvmlDevice_t, busWidth *C.uint) C.nvml
 	if busWidth == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -2059,7 +2055,7 @@ func nvmlDeviceGetDefaultEccMode(device C.nvmlDevice_t, defaultMode *C.nvmlEnabl
 	if defaultMode == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -2080,7 +2076,7 @@ func nvmlDeviceGetSupportedClocksThrottleReasons(device C.nvmlDevice_t, supporte
 	if supportedClocksThrottleReasons == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -2101,7 +2097,7 @@ func nvmlDeviceGetAutoBoostedClocksEnabled(device C.nvmlDevice_t, isEnabled *C.n
 	if isEnabled == nil || defaultIsEnabled == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -2123,7 +2119,7 @@ func nvmlDeviceGetGspFirmwareVersion(device C.nvmlDevice_t, version *C.char) C.n
 	if version == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -2143,7 +2139,7 @@ func nvmlDeviceGetTotalEnergyConsumption(device C.nvmlDevice_t, energy *C.ulongl
 	if energy == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -2164,7 +2160,7 @@ func nvmlDeviceGetDetailedEccErrors(device C.nvmlDevice_t, errorType C.nvmlMemor
 	if eccCounts == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev := engine.GetEngine().LookupConfigurableDevice(handle)
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT

--- a/pkg/gpu/mocknvml/bridge/events.go
+++ b/pkg/gpu/mocknvml/bridge/events.go
@@ -52,7 +52,6 @@ func nvmlEventSetCreate(set *C.nvmlEventSet_t) C.nvmlReturn_t {
 //export nvmlEventSetFree
 func nvmlEventSetFree(set C.nvmlEventSet_t) C.nvmlReturn_t {
 	if set != nil {
-		//nolint:govet // CGo struct pointer to unsafe.Pointer for C.free
 		C.free(unsafe.Pointer(set))
 	}
 	return C.NVML_SUCCESS
@@ -89,11 +88,10 @@ func pollPendingXid(data *C.nvmlEventData_t) bool {
 	if !ok {
 		return false
 	}
-	//nolint:govet // Converting uintptr (handle table key, originally
-	// allocated as C memory) to *C.struct_nvmlDevice_st is intentional
-	// and matches the conversion used in device.go's handle lookup
-	// helpers.
-	data.device.handle = (*C.struct_nvmlDevice_st)(unsafe.Pointer(handle))
+	// The engine returns the C block it allocated for this device, so this
+	// is the same pointer-to-pointer conversion device.go's handle lookup
+	// helpers do.
+	data.device.handle = (*C.struct_nvmlDevice_st)(handle)
 	data.eventType = C.NVML_EVENT_TYPE_XID_CRITICAL_ERROR
 	data.eventData = C.ulonglong(xid)
 	data.gpuInstanceId = 0

--- a/pkg/gpu/mocknvml/bridge/fabric.go
+++ b/pkg/gpu/mocknvml/bridge/fabric.go
@@ -53,7 +53,7 @@ func nvmlDeviceGetGpuFabricInfo(device C.nvmlDevice_t, gpuFabricInfo *C.nvmlGpuF
 	if gpuFabricInfo == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev, ok := engine.GetEngine().LookupDevice(handle).(*engine.ConfigurableDevice)
 	if !ok {
 		return C.NVML_ERROR_INVALID_ARGUMENT
@@ -76,7 +76,7 @@ func nvmlDeviceGetGpuFabricInfoV(device C.nvmlDevice_t, gpuFabricInfo *C.nvmlGpu
 	if gpuFabricInfo == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	dev, ok := engine.GetEngine().LookupDevice(handle).(*engine.ConfigurableDevice)
 	if !ok {
 		return C.NVML_ERROR_INVALID_ARGUMENT

--- a/pkg/gpu/mocknvml/bridge/fieldvalues.go
+++ b/pkg/gpu/mocknvml/bridge/fieldvalues.go
@@ -73,7 +73,7 @@ func nvmlDeviceGetFieldValues(device C.nvmlDevice_t, valuesCount C.int, values *
 	if values == nil || valuesCount <= 0 {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	dev := engine.GetEngine().LookupConfigurableDevice(uintptr(unsafe.Pointer(device.handle)))
+	dev := engine.GetEngine().LookupConfigurableDevice(unsafe.Pointer(device.handle))
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}

--- a/pkg/gpu/mocknvml/bridge/gpm.go
+++ b/pkg/gpu/mocknvml/bridge/gpm.go
@@ -105,7 +105,7 @@ func nvmlGpmSampleGet(device C.nvmlDevice_t, gpmSample C.nvmlGpmSample_t) C.nvml
 	if C.gpmSampleIsNull(gpmSample) != 0 {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	dev := engine.GetEngine().LookupConfigurableDevice(uintptr(unsafe.Pointer(device.handle)))
+	dev := engine.GetEngine().LookupConfigurableDevice(unsafe.Pointer(device.handle))
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}

--- a/pkg/gpu/mocknvml/bridge/nvlink.go
+++ b/pkg/gpu/mocknvml/bridge/nvlink.go
@@ -42,7 +42,7 @@ func nvmlDeviceGetNvLinkRemoteDeviceType(device C.nvmlDevice_t, link C.uint, pNv
 	if pNvLinkDeviceType == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	dev := engine.GetEngine().LookupConfigurableDevice(uintptr(unsafe.Pointer(device.handle)))
+	dev := engine.GetEngine().LookupConfigurableDevice(unsafe.Pointer(device.handle))
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
@@ -62,11 +62,11 @@ func nvmlDeviceGetP2PStatus(device1 C.nvmlDevice_t, device2 C.nvmlDevice_t, p2pI
 	if p2pStatus == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	dev1 := engine.GetEngine().LookupConfigurableDevice(uintptr(unsafe.Pointer(device1.handle)))
+	dev1 := engine.GetEngine().LookupConfigurableDevice(unsafe.Pointer(device1.handle))
 	if dev1 == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	dev2 := engine.GetEngine().LookupDevice(uintptr(unsafe.Pointer(device2.handle)))
+	dev2 := engine.GetEngine().LookupDevice(unsafe.Pointer(device2.handle))
 	if dev2 == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
@@ -86,7 +86,7 @@ func nvmlDeviceGetNvLinkUtilizationCounter(device C.nvmlDevice_t, link C.uint, c
 	if rxcounter == nil || txcounter == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	dev := engine.GetEngine().LookupConfigurableDevice(uintptr(unsafe.Pointer(device.handle)))
+	dev := engine.GetEngine().LookupConfigurableDevice(unsafe.Pointer(device.handle))
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
@@ -104,7 +104,7 @@ func nvmlDeviceFreezeNvLinkUtilizationCounter(device C.nvmlDevice_t, link C.uint
 	if ret, ok := bridgeVersionCheck("nvmlDeviceFreezeNvLinkUtilizationCounter"); !ok {
 		return ret
 	}
-	dev := engine.GetEngine().LookupConfigurableDevice(uintptr(unsafe.Pointer(device.handle)))
+	dev := engine.GetEngine().LookupConfigurableDevice(unsafe.Pointer(device.handle))
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
@@ -116,7 +116,7 @@ func nvmlDeviceResetNvLinkUtilizationCounter(device C.nvmlDevice_t, link C.uint,
 	if ret, ok := bridgeVersionCheck("nvmlDeviceResetNvLinkUtilizationCounter"); !ok {
 		return ret
 	}
-	dev := engine.GetEngine().LookupConfigurableDevice(uintptr(unsafe.Pointer(device.handle)))
+	dev := engine.GetEngine().LookupConfigurableDevice(unsafe.Pointer(device.handle))
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
@@ -128,7 +128,7 @@ func nvmlDeviceResetNvLinkErrorCounters(device C.nvmlDevice_t, link C.uint) C.nv
 	if ret, ok := bridgeVersionCheck("nvmlDeviceResetNvLinkErrorCounters"); !ok {
 		return ret
 	}
-	dev := engine.GetEngine().LookupConfigurableDevice(uintptr(unsafe.Pointer(device.handle)))
+	dev := engine.GetEngine().LookupConfigurableDevice(unsafe.Pointer(device.handle))
 	if dev == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}

--- a/pkg/gpu/mocknvml/bridge/topology.go
+++ b/pkg/gpu/mocknvml/bridge/topology.go
@@ -41,7 +41,7 @@ func nvmlDeviceGetTopologyNearestGpus(device C.nvmlDevice_t, level C.nvmlGpuTopo
 	if count == nil {
 		return C.NVML_ERROR_INVALID_ARGUMENT
 	}
-	handle := uintptr(unsafe.Pointer(device.handle))
+	handle := unsafe.Pointer(device.handle)
 	peers, ret := engine.GetEngine().TopologyNearestGpus(handle, nvml.GpuTopologyLevel(level))
 	if ret != nvml.SUCCESS {
 		return toReturn(ret)
@@ -60,8 +60,7 @@ func nvmlDeviceGetTopologyNearestGpus(device C.nvmlDevice_t, level C.nvmlGpuTopo
 
 	out := unsafe.Slice(deviceArray, len(peers))
 	for i, h := range peers {
-		//nolint:govet // uintptr->unsafe.Pointer: handle is C memory from HandleTable.Register
-		out[i].handle = (*C.struct_nvmlDevice_st)(unsafe.Pointer(h))
+		out[i].handle = (*C.struct_nvmlDevice_st)(h)
 	}
 	*count = C.uint(len(peers))
 	return C.NVML_SUCCESS
@@ -92,8 +91,7 @@ func nvmlSystemGetTopologyGpuSet(cpuNumber C.uint, count *C.uint, deviceArray *C
 
 	out := unsafe.Slice(deviceArray, len(gpus))
 	for i, h := range gpus {
-		//nolint:govet // uintptr->unsafe.Pointer: handle is C memory from HandleTable.Register
-		out[i].handle = (*C.struct_nvmlDevice_st)(unsafe.Pointer(h))
+		out[i].handle = (*C.struct_nvmlDevice_st)(h)
 	}
 	*count = C.uint(len(gpus))
 	return C.NVML_SUCCESS

--- a/pkg/gpu/mocknvml/engine/config_override_refresh_test.go
+++ b/pkg/gpu/mocknvml/engine/config_override_refresh_test.go
@@ -133,3 +133,102 @@ func TestRefresh_HotReloadsDynamicTemperature(t *testing.T) {
 		t.Fatalf("after reset temperature = %d (ret=%v), want 50", got, ret)
 	}
 }
+
+// Memory literals taken from the shipped a100 profile
+// (deployments/nvml-mock/helm/nvml-mock/profiles/a100.yaml) so the fixture
+// matches what a real deployment reports.
+const (
+	a100TotalBytes    uint64 = 42949672960 // 40 GiB HBM2e
+	a100ReservedBytes uint64 = 611319808   // ~583 MiB
+	a100FreeBytes     uint64 = 42338353152 // total - reserved at idle
+	// What `nvml-mock-ctl set --gpu 0 memory.used_bytes=1073741824
+	// memory.free_bytes=41264611328` writes: 1 GiB in use, free reduced to match.
+	overrideUsedBytes uint64 = 1073741824
+	overrideFreeBytes uint64 = 41264611328
+)
+
+func a100MemoryBase() *DeviceConfig {
+	return &DeviceConfig{Memory: &MemoryConfig{
+		TotalBytes:    a100TotalBytes,
+		ReservedBytes: a100ReservedBytes,
+		FreeBytes:     a100FreeBytes,
+		UsedBytes:     0,
+	}}
+}
+
+const usedBytesOverrideDoc = "devices:\n  \"0\":\n    memory:\n      used_bytes: 1073741824\n      free_bytes: 41264611328\n"
+
+// TestRefresh_HotReloadsMemoryUsedBytes verifies that a runtime config override
+// of memory.used_bytes is observed by GetMemoryInfo without restarting the
+// process — the mechanism behind `nvml-mock-ctl set --gpu 0 memory.used_bytes`.
+// Regression guard for #506: the getter used to return a struct baked once at
+// construction, so the override silently did nothing until a pod restart.
+func TestRefresh_HotReloadsMemoryUsedBytes(t *testing.T) {
+	dev, path, clock := newTestDevice(t, a100MemoryBase())
+
+	mem, ret := dev.GetMemoryInfo()
+	require.Equal(t, nvml.SUCCESS, ret, "baseline GetMemoryInfo")
+	require.Equal(t, uint64(0), mem.Used, "baseline used bytes")
+	require.Equal(t, a100TotalBytes, mem.Total, "baseline total bytes")
+	require.Equal(t, a100FreeBytes, mem.Free, "baseline free bytes")
+
+	writeConfigOverride(t, path, usedBytesOverrideDoc, clock)
+
+	mem, ret = dev.GetMemoryInfo()
+	require.Equal(t, nvml.SUCCESS, ret, "GetMemoryInfo after override")
+	require.Equal(t, overrideUsedBytes, mem.Used, "used bytes must follow the runtime override")
+	require.Equal(t, overrideFreeBytes, mem.Free, "free bytes must follow the runtime override")
+	require.Equal(t, a100TotalBytes, mem.Total, "total bytes must survive a partial memory override")
+
+	// Clearing the override reverts to the profile values; a getter that cached
+	// the first effective config would keep reporting 1 GiB used.
+	require.NoError(t, os.Remove(path))
+	*clock = clock.Add(2 * time.Second)
+
+	mem, ret = dev.GetMemoryInfo()
+	require.Equal(t, nvml.SUCCESS, ret, "GetMemoryInfo after override removed")
+	require.Equal(t, uint64(0), mem.Used, "used bytes must revert when the override is removed")
+	require.Equal(t, a100FreeBytes, mem.Free, "free bytes must revert when the override is removed")
+	require.Equal(t, a100TotalBytes, mem.Total, "total bytes must revert when the override is removed")
+}
+
+// TestRefresh_HotReloadsMemoryUsedBytes_v2 is the GetMemoryInfo_v2 counterpart.
+// v2 already sourced Reserved from the effective config but took Total/Free/Used
+// from the same construction-time struct as v1, so it carried the same defect on
+// those three fields; Reserved is asserted here to prove the pre-existing
+// effective-config read still works.
+func TestRefresh_HotReloadsMemoryUsedBytes_v2(t *testing.T) {
+	dev, path, clock := newTestDevice(t, a100MemoryBase())
+
+	mem, ret := dev.GetMemoryInfo_v2()
+	require.Equal(t, nvml.SUCCESS, ret, "baseline GetMemoryInfo_v2")
+	require.Equal(t, uint64(0), mem.Used, "baseline used bytes")
+	require.Equal(t, a100ReservedBytes, mem.Reserved, "baseline reserved bytes")
+
+	writeConfigOverride(t, path, usedBytesOverrideDoc, clock)
+
+	mem, ret = dev.GetMemoryInfo_v2()
+	require.Equal(t, nvml.SUCCESS, ret, "GetMemoryInfo_v2 after override")
+	require.Equal(t, overrideUsedBytes, mem.Used, "used bytes must follow the runtime override")
+	require.Equal(t, overrideFreeBytes, mem.Free, "free bytes must follow the runtime override")
+	require.Equal(t, a100TotalBytes, mem.Total, "total bytes must survive a partial memory override")
+	require.Equal(t, a100ReservedBytes, mem.Reserved, "reserved bytes must survive a partial memory override")
+}
+
+// TestRefresh_MemoryWithoutConfigKeepsBaseDeviceValues pins the legacy path: a
+// device built without a memory block in its YAML must keep reporting the base
+// mock device's memory rather than a zeroed struct, even while an unrelated
+// override is live.
+func TestRefresh_MemoryWithoutConfigKeepsBaseDeviceValues(t *testing.T) {
+	dev, path, clock := newTestDevice(t, &DeviceConfig{})
+
+	baseline, ret := dev.GetMemoryInfo()
+	require.Equal(t, nvml.SUCCESS, ret, "baseline GetMemoryInfo")
+	require.NotZero(t, baseline.Total, "base mock device should report a non-zero total")
+
+	writeConfigOverride(t, path, "devices:\n  \"0\":\n    thermal:\n      temperature_gpu_c: 77\n", clock)
+
+	mem, ret := dev.GetMemoryInfo()
+	require.Equal(t, nvml.SUCCESS, ret, "GetMemoryInfo after unrelated override")
+	require.Equal(t, baseline, mem, "memory must be unchanged when the config carries no memory block")
+}

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -387,13 +387,33 @@ func (d *ConfigurableDevice) GetBAR1MemoryInfo() (nvml.BAR1Memory, nvml.Return) 
 	return d.bar1Memory, nvml.SUCCESS
 }
 
+// memoryInfo resolves device memory from the effective config so a runtime
+// config override of memory.{total,free,used}_bytes is observed without a
+// restart, matching how the process and thermal getters already read d.cfg().
+// The values are reported verbatim: overriding used_bytes alone does not
+// recompute free_bytes, because free_bytes is an explicit profile field and
+// silently deriving it would make that field dead. Falls back to the
+// construction-time struct when the device was built without a memory block
+// (legacy/default mode), where d.MemoryInfo carries the base mock's values.
+func (d *ConfigurableDevice) memoryInfo() nvml.Memory {
+	if c := d.cfg(); c.Memory != nil {
+		return nvml.Memory{
+			Total: c.Memory.TotalBytes,
+			Free:  c.Memory.FreeBytes,
+			Used:  c.Memory.UsedBytes,
+		}
+	}
+	return d.MemoryInfo
+}
+
 // GetMemoryInfo returns GPU memory information
 func (d *ConfigurableDevice) GetMemoryInfo() (nvml.Memory, nvml.Return) {
 	if ret := d.tickFailure(); ret != nvml.SUCCESS {
 		return nvml.Memory{}, ret
 	}
-	debugLog("[NVML] nvmlDeviceGetMemoryInfo -> total=%d\n", d.MemoryInfo.Total)
-	return d.MemoryInfo, nvml.SUCCESS
+	mem := d.memoryInfo()
+	debugLog("[NVML] nvmlDeviceGetMemoryInfo -> total=%d used=%d\n", mem.Total, mem.Used)
+	return mem, nvml.SUCCESS
 }
 
 // GetMemoryInfo_v2 returns GPU memory information (v2 API)
@@ -401,18 +421,19 @@ func (d *ConfigurableDevice) GetMemoryInfo_v2() (nvml.Memory_v2, nvml.Return) {
 	if ret := d.tickFailure(); ret != nvml.SUCCESS {
 		return nvml.Memory_v2{}, ret
 	}
+	base := d.memoryInfo()
 	mem := nvml.Memory_v2{
 		Version:  nvmlStructVersion(unsafe.Sizeof(nvml.Memory_v2{}), 2),
-		Total:    d.MemoryInfo.Total,
+		Total:    base.Total,
 		Reserved: 0,
-		Free:     d.MemoryInfo.Free,
-		Used:     d.MemoryInfo.Used,
+		Free:     base.Free,
+		Used:     base.Used,
 	}
 	// If we have config with reserved bytes, use it
 	if c := d.cfg(); c.Memory != nil {
 		mem.Reserved = c.Memory.ReservedBytes
 	}
-	debugLog("[NVML] nvmlDeviceGetMemoryInfo_v2 -> total=%d reserved=%d\n", mem.Total, mem.Reserved)
+	debugLog("[NVML] nvmlDeviceGetMemoryInfo_v2 -> total=%d reserved=%d used=%d\n", mem.Total, mem.Reserved, mem.Used)
 	return mem, nvml.SUCCESS
 }
 

--- a/pkg/gpu/mocknvml/engine/engine.go
+++ b/pkg/gpu/mocknvml/engine/engine.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"unsafe"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock/dgxa100"
@@ -281,17 +282,19 @@ func (e *Engine) DeviceGetCount() (int, nvml.Return) {
 }
 
 // DeviceGetHandleByIndex returns a handle for the device at the given index.
-func (e *Engine) DeviceGetHandleByIndex(index int) (uintptr, nvml.Return) {
+// The handle is a pointer to a C-allocated block owned by the HandleTable; see
+// HandleTable's documentation for why this is unsafe.Pointer and not uintptr.
+func (e *Engine) DeviceGetHandleByIndex(index int) (unsafe.Pointer, nvml.Return) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	if e.initCount == 0 {
-		return 0, nvml.ERROR_UNINITIALIZED
+		return nil, nvml.ERROR_UNINITIALIZED
 	}
 
 	device, ret := e.server.DeviceGetHandleByIndex(index)
 	if ret != nvml.SUCCESS {
-		return 0, ret
+		return nil, ret
 	}
 
 	// Register in handle table
@@ -300,17 +303,17 @@ func (e *Engine) DeviceGetHandleByIndex(index int) (uintptr, nvml.Return) {
 }
 
 // DeviceGetHandleByUUID returns a handle for the device with the given UUID.
-func (e *Engine) DeviceGetHandleByUUID(uuid string) (uintptr, nvml.Return) {
+func (e *Engine) DeviceGetHandleByUUID(uuid string) (unsafe.Pointer, nvml.Return) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	if e.initCount == 0 {
-		return 0, nvml.ERROR_UNINITIALIZED
+		return nil, nvml.ERROR_UNINITIALIZED
 	}
 
 	device, ret := e.server.DeviceGetHandleByUUID(uuid)
 	if ret != nvml.SUCCESS {
-		return 0, ret
+		return nil, ret
 	}
 
 	handle := e.handles.Register(device)
@@ -318,17 +321,17 @@ func (e *Engine) DeviceGetHandleByUUID(uuid string) (uintptr, nvml.Return) {
 }
 
 // DeviceGetHandleByPciBusId returns a handle for the device with the given PCI Bus ID.
-func (e *Engine) DeviceGetHandleByPciBusId(pciBusId string) (uintptr, nvml.Return) {
+func (e *Engine) DeviceGetHandleByPciBusId(pciBusId string) (unsafe.Pointer, nvml.Return) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	if e.initCount == 0 {
-		return 0, nvml.ERROR_UNINITIALIZED
+		return nil, nvml.ERROR_UNINITIALIZED
 	}
 
 	device, ret := e.server.DeviceGetHandleByPciBusId(pciBusId)
 	if ret != nvml.SUCCESS {
-		return 0, ret
+		return nil, ret
 	}
 
 	handle := e.handles.Register(device)
@@ -337,7 +340,7 @@ func (e *Engine) DeviceGetHandleByPciBusId(pciBusId string) (uintptr, nvml.Retur
 
 // LookupDevice returns the device object for a given handle.
 // Returns InvalidDeviceInstance if the engine is not initialized or the handle is invalid.
-func (e *Engine) LookupDevice(handle uintptr) nvml.Device {
+func (e *Engine) LookupDevice(handle unsafe.Pointer) nvml.Device {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
@@ -349,7 +352,7 @@ func (e *Engine) LookupDevice(handle uintptr) nvml.Device {
 
 // LookupConfigurableDevice returns the ConfigurableDevice for a given handle.
 // This is useful when we need access to ConfigurableDevice-specific methods.
-func (e *Engine) LookupConfigurableDevice(handle uintptr) *ConfigurableDevice {
+func (e *Engine) LookupConfigurableDevice(handle unsafe.Pointer) *ConfigurableDevice {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
@@ -374,7 +377,7 @@ func (e *Engine) LookupConfigurableDevice(handle uintptr) *ConfigurableDevice {
 // requested level. The bridge marshals these into the caller's device
 // array. Handles are registered on demand so the C caller gets valid
 // references.
-func (e *Engine) TopologyNearestGpus(handle uintptr, level nvml.GpuTopologyLevel) ([]uintptr, nvml.Return) {
+func (e *Engine) TopologyNearestGpus(handle unsafe.Pointer, level nvml.GpuTopologyLevel) ([]unsafe.Pointer, nvml.Return) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -390,7 +393,7 @@ func (e *Engine) TopologyNearestGpus(handle uintptr, level nvml.GpuTopologyLevel
 		return nil, nvml.SUCCESS
 	}
 
-	var out []uintptr
+	var out []unsafe.Pointer
 	for j := 0; j < cd.fabric.NumDevices(); j++ {
 		if j == cd.index {
 			continue
@@ -403,7 +406,7 @@ func (e *Engine) TopologyNearestGpus(handle uintptr, level nvml.GpuTopologyLevel
 			continue
 		}
 		h := e.handles.HandleFor(peer)
-		if h == 0 {
+		if h == nil {
 			h = e.handles.Register(peer)
 		}
 		out = append(out, h)
@@ -417,7 +420,7 @@ func (e *Engine) TopologyNearestGpus(handle uintptr, level nvml.GpuTopologyLevel
 // group GPUs by their affined CPU. When no pcie_topology is configured the
 // affinity sets are empty and the result is an empty set (SUCCESS), matching
 // a node whose CPU affinity is unknown rather than an error.
-func (e *Engine) TopologyGpuSet(cpuNumber int) ([]uintptr, nvml.Return) {
+func (e *Engine) TopologyGpuSet(cpuNumber int) ([]unsafe.Pointer, nvml.Return) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -425,7 +428,7 @@ func (e *Engine) TopologyGpuSet(cpuNumber int) ([]uintptr, nvml.Return) {
 		return nil, nvml.ERROR_UNINITIALIZED
 	}
 
-	var out []uintptr
+	var out []unsafe.Pointer
 	for j := 0; j < len(e.server.configurableDevices); j++ {
 		dev := e.server.configurableDevices[j]
 		if dev == nil || dev.fabric == nil {
@@ -442,7 +445,7 @@ func (e *Engine) TopologyGpuSet(cpuNumber int) ([]uintptr, nvml.Return) {
 			continue
 		}
 		h := e.handles.HandleFor(dev)
-		if h == 0 {
+		if h == nil {
 			h = e.handles.Register(dev)
 		}
 		out = append(out, h)
@@ -510,19 +513,19 @@ func (e *Engine) GetConfig() *Config {
 // from any device that has tripped failure injection with a `xid:` block
 // configured. It returns the device handle (auto-registering one if the
 // caller hasn't resolved a handle for that device yet), the Xid code,
-// and true on success. When no event is pending it returns (0, 0,
+// and true on success. When no event is pending it returns (nil, 0,
 // false) and the bridge layer reports NVML_ERROR_TIMEOUT to the
 // nvmlEventSetWait caller.
 //
 // Each tripped Xid is delivered at most once for the lifetime of the
 // engine, matching real NVML semantics where a single Xid critical
 // error fires exactly once per occurrence.
-func (e *Engine) PendingXidEvent() (uintptr, uint64, bool) {
+func (e *Engine) PendingXidEvent() (unsafe.Pointer, uint64, bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	if e.initCount == 0 || e.server == nil {
-		return 0, 0, false
+		return nil, 0, false
 	}
 
 	for _, dev := range e.server.configurableDevices {
@@ -542,12 +545,12 @@ func (e *Engine) PendingXidEvent() (uintptr, uint64, bool) {
 		// the workload has discovered the GPU); if not, register on the
 		// fly so the C-side struct still references valid memory.
 		handle := e.handles.HandleFor(dev)
-		if handle == 0 {
+		if handle == nil {
 			handle = e.handles.Register(dev)
 		}
 		return handle, xid, true
 	}
-	return 0, 0, false
+	return nil, 0, false
 }
 
 // SetVisibleDevicesForTesting sets the visible device mapping on an initialized

--- a/pkg/gpu/mocknvml/engine/engine_test.go
+++ b/pkg/gpu/mocknvml/engine/engine_test.go
@@ -184,14 +184,15 @@ func TestEngine_LookupDevice(t *testing.T) {
 	dev := e.LookupDevice(handle)
 	require.NotNil(t, dev, "LookupDevice returned nil for valid handle")
 
-	// Invalid handle - returns InvalidDeviceInstance (null-object pattern)
-	invalidDev := e.LookupDevice(999)
+	// Handle the engine never issued - returns InvalidDeviceInstance
+	// (null-object pattern)
+	invalidDev := e.LookupDevice(unregisteredHandle())
 	require.Equal(t, InvalidDeviceInstance, invalidDev, "Expected InvalidDeviceInstance for invalid handle")
 }
 
 func TestEngine_LookupDeviceBeforeInit(t *testing.T) {
 	e := NewEngine(nil)
-	dev := e.LookupDevice(1)
+	dev := e.LookupDevice(unregisteredHandle())
 	require.NotNil(t, dev, "LookupDevice on uninitialized engine returned nil, expected InvalidDeviceInstance")
 	require.Equal(t, InvalidDeviceInstance, dev, "Expected InvalidDeviceInstance")
 	_, ret := dev.GetName()
@@ -200,7 +201,7 @@ func TestEngine_LookupDeviceBeforeInit(t *testing.T) {
 
 func TestEngine_LookupConfigurableDevice_UninitializedReturnsNil(t *testing.T) {
 	e := NewEngine(nil)
-	dev := e.LookupConfigurableDevice(0x1234)
+	dev := e.LookupConfigurableDevice(unregisteredHandle())
 	require.Nil(t, dev, "LookupConfigurableDevice on uninitialized engine should return nil")
 }
 

--- a/pkg/gpu/mocknvml/engine/handles.go
+++ b/pkg/gpu/mocknvml/engine/handles.go
@@ -55,21 +55,22 @@ import (
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 )
 
-// handleEntry pairs a registered device with the C pointer its handle was
-// allocated from. Keeping the pointer alongside the device means the
-// validation and free paths never convert a uintptr back to unsafe.Pointer,
-// which is what go vet's unsafeptr check flags. The map key stays a uintptr
-// so the engine's public API is unchanged.
-type handleEntry struct {
-	dev nvml.Device
-	ptr unsafe.Pointer
-}
-
-// HandleTable manages the mapping between C handles (uintptr) and Go device
-// objects. This is necessary because CGo doesn't allow passing Go pointers
-// with nested Go pointers to C code.
+// HandleTable manages the mapping between C handles and Go device objects.
+// This is necessary because CGo doesn't allow passing Go pointers with nested
+// Go pointers to C code.
 //
-// Handles are C-allocated memory blocks that nvidia-smi can safely dereference.
+// Handles are C-allocated memory blocks (see allocHandle above) that
+// nvidia-smi can safely dereference. They are typed unsafe.Pointer rather
+// than uintptr on purpose: a handle IS a pointer, it is dereferenced by
+// isValidHandle and by the C caller, and uintptr is documented as an integer
+// that does not hold a reference. Keeping the pointer type end to end means
+// no code path ever has to convert an integer back into a pointer, which is
+// both the honest model and what lets `go vet`'s unsafeptr check pass without
+// suppression.
+//
+// The memory these handles point at is libc heap, not Go heap, so the Go
+// garbage collector never scans, moves or frees it; the C block outlives any
+// Go reference and is released only by Clear().
 //
 // LIFECYCLE:
 //   - Handles are allocated via Register() when devices are first accessed
@@ -81,25 +82,25 @@ type handleEntry struct {
 //   - All methods are thread-safe via RWMutex
 //   - Lookup() validates handle magic number to detect use-after-free
 type HandleTable struct {
-	devices map[uintptr]handleEntry
-	reverse map[nvml.Device]uintptr
+	devices map[unsafe.Pointer]nvml.Device
+	reverse map[nvml.Device]unsafe.Pointer
 	mu      sync.RWMutex
 }
 
 // NewHandleTable creates a new HandleTable.
 func NewHandleTable() *HandleTable {
 	return &HandleTable{
-		devices: make(map[uintptr]handleEntry),
-		reverse: make(map[nvml.Device]uintptr),
+		devices: make(map[unsafe.Pointer]nvml.Device),
+		reverse: make(map[nvml.Device]unsafe.Pointer),
 	}
 }
 
 // Register adds a device to the handle table and returns its handle.
 // If the device is already registered, returns the existing handle.
 // The handle is a pointer to C-allocated memory.
-func (ht *HandleTable) Register(dev nvml.Device) uintptr {
+func (ht *HandleTable) Register(dev nvml.Device) unsafe.Pointer {
 	if dev == nil {
-		return 0
+		return nil
 	}
 
 	ht.mu.Lock()
@@ -112,20 +113,19 @@ func (ht *HandleTable) Register(dev nvml.Device) uintptr {
 
 	// Check bounds to prevent device index overflow
 	if len(ht.devices) >= MaxDevices {
-		return 0
+		return nil
 	}
 
-	// Allocate a C handle block with device index
+	// Allocate a C handle block with device index. cgo maps C's void* to
+	// unsafe.Pointer, so the handle is already correctly typed here.
 	deviceIndex := uint32(len(ht.devices))
-	cHandle := C.allocHandle(C.uint(deviceIndex))
-	if cHandle == nil {
+	handle := C.allocHandle(C.uint(deviceIndex))
+	if handle == nil {
 		// Memory allocation failed
-		return 0
+		return nil
 	}
-	ptr := unsafe.Pointer(cHandle)
-	handle := uintptr(ptr)
 
-	ht.devices[handle] = handleEntry{dev: dev, ptr: ptr}
+	ht.devices[handle] = dev
 	ht.reverse[dev] = handle
 	return handle
 }
@@ -134,15 +134,18 @@ func (ht *HandleTable) Register(dev nvml.Device) uintptr {
 // Returns InvalidDeviceInstance if the handle is invalid (null-object pattern).
 // This eliminates nil checks in the bridge layer - callers can safely call
 // methods on the returned device; invalid devices return ERROR_INVALID_ARGUMENT.
-func (ht *HandleTable) Lookup(handle uintptr) nvml.Device {
-	if handle == 0 {
+func (ht *HandleTable) Lookup(handle unsafe.Pointer) nvml.Device {
+	if handle == nil {
 		return InvalidDeviceInstance
 	}
 
 	// First check if handle exists in our map - this avoids calling C code
-	// with arbitrary invalid pointers which can trigger Go's checkptr panic
+	// with arbitrary invalid pointers which can trigger Go's checkptr panic.
+	// The bridge passes through whatever pointer the C caller supplied, so
+	// this map check is the trust boundary: an address we never handed out
+	// is rejected before anything dereferences it.
 	ht.mu.RLock()
-	entry, ok := ht.devices[handle]
+	dev, ok := ht.devices[handle]
 	ht.mu.RUnlock()
 
 	if !ok {
@@ -150,22 +153,22 @@ func (ht *HandleTable) Lookup(handle uintptr) nvml.Device {
 	}
 
 	// Validate the handle's magic number to detect use-after-free or corruption
-	if C.isValidHandle(entry.ptr) == 0 {
+	if C.isValidHandle(handle) == 0 {
 		return InvalidDeviceInstance
 	}
 
-	return entry.dev
+	return dev
 }
 
-// HandleFor returns the registered handle for the given device, or 0 when
+// HandleFor returns the registered handle for the given device, or nil when
 // the device has not yet been registered. Used by event-set wiring that
 // needs to translate a tripped device back to a handle the caller
 // already holds (e.g. the Xid critical-error event delivery path). Real
 // NVML accepts events for devices the caller has resolved a handle for;
-// returning 0 here lets the caller treat that case as "no event yet".
-func (ht *HandleTable) HandleFor(dev nvml.Device) uintptr {
+// returning nil here lets the caller treat that case as "no event yet".
+func (ht *HandleTable) HandleFor(dev nvml.Device) unsafe.Pointer {
 	if dev == nil {
-		return 0
+		return nil
 	}
 	ht.mu.RLock()
 	defer ht.mu.RUnlock()
@@ -178,12 +181,12 @@ func (ht *HandleTable) Clear() {
 	defer ht.mu.Unlock()
 
 	// Free all allocated C handle blocks
-	for _, entry := range ht.devices {
-		C.freeHandle(entry.ptr)
+	for handle := range ht.devices {
+		C.freeHandle(handle)
 	}
 
-	ht.devices = make(map[uintptr]handleEntry)
-	ht.reverse = make(map[nvml.Device]uintptr)
+	ht.devices = make(map[unsafe.Pointer]nvml.Device)
+	ht.reverse = make(map[nvml.Device]unsafe.Pointer)
 }
 
 // Count returns the number of registered handles.

--- a/pkg/gpu/mocknvml/engine/handles.go
+++ b/pkg/gpu/mocknvml/engine/handles.go
@@ -55,6 +55,16 @@ import (
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 )
 
+// handleEntry pairs a registered device with the C pointer its handle was
+// allocated from. Keeping the pointer alongside the device means the
+// validation and free paths never convert a uintptr back to unsafe.Pointer,
+// which is what go vet's unsafeptr check flags. The map key stays a uintptr
+// so the engine's public API is unchanged.
+type handleEntry struct {
+	dev nvml.Device
+	ptr unsafe.Pointer
+}
+
 // HandleTable manages the mapping between C handles (uintptr) and Go device
 // objects. This is necessary because CGo doesn't allow passing Go pointers
 // with nested Go pointers to C code.
@@ -71,7 +81,7 @@ import (
 //   - All methods are thread-safe via RWMutex
 //   - Lookup() validates handle magic number to detect use-after-free
 type HandleTable struct {
-	devices map[uintptr]nvml.Device
+	devices map[uintptr]handleEntry
 	reverse map[nvml.Device]uintptr
 	mu      sync.RWMutex
 }
@@ -79,7 +89,7 @@ type HandleTable struct {
 // NewHandleTable creates a new HandleTable.
 func NewHandleTable() *HandleTable {
 	return &HandleTable{
-		devices: make(map[uintptr]nvml.Device),
+		devices: make(map[uintptr]handleEntry),
 		reverse: make(map[nvml.Device]uintptr),
 	}
 }
@@ -112,9 +122,10 @@ func (ht *HandleTable) Register(dev nvml.Device) uintptr {
 		// Memory allocation failed
 		return 0
 	}
-	handle := uintptr(unsafe.Pointer(cHandle))
+	ptr := unsafe.Pointer(cHandle)
+	handle := uintptr(ptr)
 
-	ht.devices[handle] = dev
+	ht.devices[handle] = handleEntry{dev: dev, ptr: ptr}
 	ht.reverse[dev] = handle
 	return handle
 }
@@ -131,7 +142,7 @@ func (ht *HandleTable) Lookup(handle uintptr) nvml.Device {
 	// First check if handle exists in our map - this avoids calling C code
 	// with arbitrary invalid pointers which can trigger Go's checkptr panic
 	ht.mu.RLock()
-	dev, ok := ht.devices[handle]
+	entry, ok := ht.devices[handle]
 	ht.mu.RUnlock()
 
 	if !ok {
@@ -139,13 +150,11 @@ func (ht *HandleTable) Lookup(handle uintptr) nvml.Device {
 	}
 
 	// Validate the handle's magic number to detect use-after-free or corruption
-	//nolint:govet // Converting uintptr to unsafe.Pointer is intentional -
-	// handle was allocated as C memory and we need to validate it
-	if C.isValidHandle(unsafe.Pointer(handle)) == 0 {
+	if C.isValidHandle(entry.ptr) == 0 {
 		return InvalidDeviceInstance
 	}
 
-	return dev
+	return entry.dev
 }
 
 // HandleFor returns the registered handle for the given device, or 0 when
@@ -169,13 +178,11 @@ func (ht *HandleTable) Clear() {
 	defer ht.mu.Unlock()
 
 	// Free all allocated C handle blocks
-	for handle := range ht.devices {
-		//nolint:govet // Converting uintptr back to unsafe.Pointer is intentional here -
-		// the handle was originally allocated as C memory and stored as uintptr for map key use
-		C.freeHandle(unsafe.Pointer(handle))
+	for _, entry := range ht.devices {
+		C.freeHandle(entry.ptr)
 	}
 
-	ht.devices = make(map[uintptr]nvml.Device)
+	ht.devices = make(map[uintptr]handleEntry)
 	ht.reverse = make(map[nvml.Device]uintptr)
 }
 

--- a/pkg/gpu/mocknvml/engine/handles_test.go
+++ b/pkg/gpu/mocknvml/engine/handles_test.go
@@ -14,6 +14,7 @@
 package engine
 
 import (
+	"encoding/binary"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -83,6 +84,41 @@ func TestHandleTable_Lookup(t *testing.T) {
 	// Lookup nil handle - returns InvalidDeviceInstance
 	zero := ht.Lookup(nil)
 	require.Equal(t, InvalidDeviceInstance, zero, "Expected InvalidDeviceInstance for nil handle")
+}
+
+// TestHandleTable_LookupRejectsForgedHandle pins where the handle table's
+// trust boundary sits: membership in the table authorises a handle, NOT the
+// magic number in the block it points at.
+//
+// This matters because the bridge forwards whatever pointer the C caller
+// supplied -- every nvmlDeviceGetX(nvmlDevice_t device, ...) export reads
+// device.handle straight out of the caller's struct and passes it to
+// LookupDevice. So an address that merely looks like a HandleBlock has to be
+// refused.
+//
+// The block below carries the exact magic value isValidHandle checks for.
+// With the map-membership check in place, Lookup returns before C is ever
+// reached. Remove that check, or reorder it after the C validation on the
+// theory that the magic number is sufficient, and this forged handle passes
+// isValidHandle; Lookup then returns the map's zero value -- a nil
+// nvml.Device -- instead of InvalidDeviceInstance, and every bridge caller
+// nil-derefs where it should have returned ERROR_INVALID_ARGUMENT.
+func TestHandleTable_LookupRejectsForgedHandle(t *testing.T) {
+	ht := NewHandleTable()
+	defer ht.Clear()
+
+	// A real registration, so the table is populated and the forged lookup
+	// has to actually miss rather than hit an empty map.
+	require.NotNil(t, ht.Register(dgxa100.NewDevice(0)), "setup: Register must succeed")
+
+	// Mimic the C HandleBlock prefix: a 4-byte magic field at offset 0
+	// holding "NVML" (0x4E564D4C), in native byte order.
+	forged := make([]byte, 64)
+	binary.NativeEndian.PutUint32(forged[:4], 0x4E564D4C)
+
+	got := ht.Lookup(unsafe.Pointer(&forged[0]))
+	require.Equal(t, InvalidDeviceInstance, got,
+		"a pointer the table never issued must be rejected even when it carries a valid magic number")
 }
 
 func TestHandleTable_Clear(t *testing.T) {

--- a/pkg/gpu/mocknvml/engine/handles_test.go
+++ b/pkg/gpu/mocknvml/engine/handles_test.go
@@ -17,11 +17,26 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"unsafe"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock/dgxa100"
 	"github.com/stretchr/testify/require"
 )
+
+// unregisteredHandle returns a valid, non-nil pointer that no HandleTable has
+// ever issued.
+//
+// Negative-path tests used to fabricate handles from integer literals
+// (Lookup(999)). Now that a handle is an unsafe.Pointer, that form is only
+// expressible as unsafe.Pointer(uintptr(999)) -- itself exactly the "possible
+// misuse of unsafe.Pointer" this package was cleaned of, and a real hazard
+// under -race's checkptr instrumentation. Backing the handle with a genuine Go
+// allocation keeps the pointer legal while still landing on the branch under
+// test: an address absent from the table.
+func unregisteredHandle() unsafe.Pointer {
+	return unsafe.Pointer(new([64]byte))
+}
 
 func TestHandleTable_NewHandleTable(t *testing.T) {
 	ht := NewHandleTable()
@@ -60,13 +75,14 @@ func TestHandleTable_Lookup(t *testing.T) {
 	retrieved := ht.Lookup(handle)
 	require.Equal(t, dev, retrieved, "Lookup returned different device")
 
-	// Lookup invalid handle - returns InvalidDeviceInstance (null-object pattern)
-	invalid := ht.Lookup(999)
+	// Lookup a handle this table never issued - returns InvalidDeviceInstance
+	// (null-object pattern)
+	invalid := ht.Lookup(unregisteredHandle())
 	require.Equal(t, InvalidDeviceInstance, invalid, "Expected InvalidDeviceInstance for invalid handle")
 
-	// Lookup zero handle - returns InvalidDeviceInstance
-	zero := ht.Lookup(0)
-	require.Equal(t, InvalidDeviceInstance, zero, "Expected InvalidDeviceInstance for zero handle")
+	// Lookup nil handle - returns InvalidDeviceInstance
+	zero := ht.Lookup(nil)
+	require.Equal(t, InvalidDeviceInstance, zero, "Expected InvalidDeviceInstance for nil handle")
 }
 
 func TestHandleTable_Clear(t *testing.T) {
@@ -92,7 +108,7 @@ func TestHandleTable_MultipleDevices(t *testing.T) {
 	ht := NewHandleTable()
 	// Use MaxDevices to respect the handle table limit
 	devices := make([]nvml.Device, MaxDevices)
-	handles := make([]uintptr, MaxDevices)
+	handles := make([]unsafe.Pointer, MaxDevices)
 
 	// Register multiple devices
 	for i := 0; i < MaxDevices; i++ {
@@ -103,9 +119,9 @@ func TestHandleTable_MultipleDevices(t *testing.T) {
 	require.Equal(t, MaxDevices, ht.Count(), "Expected count %d", MaxDevices)
 
 	// Verify all handles are unique
-	seen := make(map[uintptr]bool)
+	seen := make(map[unsafe.Pointer]bool)
 	for _, h := range handles {
-		require.False(t, seen[h], "Duplicate handle detected: %d", h)
+		require.False(t, seen[h], "Duplicate handle detected: %p", h)
 		seen[h] = true
 	}
 
@@ -130,7 +146,7 @@ func TestHandleTable_ConcurrentAccess(t *testing.T) {
 			defer wg.Done()
 			dev := dgxa100.NewDevice(id)
 			handle := ht.Register(dev)
-			if handle != 0 {
+			if handle != nil {
 				atomic.AddInt32(&successCount, 1)
 			}
 		}(i)
@@ -150,7 +166,7 @@ func TestHandleTable_ConcurrentRegisterAndLookup(t *testing.T) {
 	numGoroutines := 50
 
 	// Pre-register devices up to MaxDevices limit
-	handles := make([]uintptr, MaxDevices)
+	handles := make([]unsafe.Pointer, MaxDevices)
 	devices := make([]nvml.Device, MaxDevices)
 	for i := 0; i < MaxDevices; i++ {
 		devices[i] = dgxa100.NewDevice(i)
@@ -188,6 +204,7 @@ func TestHandleTable_ConcurrentClear(t *testing.T) {
 	}
 
 	// Concurrent clear and operations
+	late := dgxa100.NewDevice(100)
 	wg.Add(3)
 	go func() {
 		defer wg.Done()
@@ -195,14 +212,30 @@ func TestHandleTable_ConcurrentClear(t *testing.T) {
 	}()
 	go func() {
 		defer wg.Done()
-		dev := dgxa100.NewDevice(100)
-		ht.Register(dev)
+		ht.Register(late)
 	}()
 	go func() {
 		defer wg.Done()
-		ht.Lookup(1)
+		ht.Lookup(unregisteredHandle())
 	}()
 	wg.Wait()
 
-	// Should not crash - that's the main test
+	// Clear() and Register() serialise on the mutex, so exactly two orderings
+	// are reachable: Register first (table already at MaxDevices, so it is
+	// refused) then Clear wipes everything -> 0 entries; or Clear first then
+	// Register admits `late` -> 1 entry. Any other count means a pre-Clear
+	// entry survived, i.e. the two operations interleaved instead of
+	// serialising.
+	count := ht.Count()
+	require.LessOrEqual(t, count, 1,
+		"Clear() must not interleave with Register(): at most the one late device may survive, got %d", count)
+
+	// Whichever ordering won, devices and reverse must still agree with each
+	// other -- Clear() resets both maps, so a surviving entry has to round-trip
+	// device -> handle -> device.
+	if count == 1 {
+		h := ht.HandleFor(late)
+		require.NotNil(t, h, "surviving device must still resolve to a handle")
+		require.Equal(t, late, ht.Lookup(h), "surviving handle must resolve back to its device")
+	}
 }


### PR DESCRIPTION
## Problem

The Mokka + AICR pre-silicon preflight POC (#502) surfaced a cluster of gaps where
CI was not looking, or where a green result did not mean what a reader would take
it to mean. This closes four of them and moves two forward.

## What changed

> **Rebased onto #516.** This branch originally carried its own fix for #510 (lint
> blind to `//go:build e2e` files). #516 landed the same fix on `main` first and did it
> better — it caught that `--max-same-issues` defaults to 3, so the tree looked like it
> had 4 findings behind the e2e tag when it had 14, and it scoped the `ST1001` carve-out
> by path instead of whitelisting dot-imports repo-wide. Our commit was dropped rather
> than merged; #510 is already closed by #516.

**The image build could silently lose a package (#508).** The Dockerfile enumerated 8
nested `pkg/` paths covering only 6 of 9 top-level directories. A new package reachable
from a built binary went missing, and `go build -mod=vendor` reported it as inconsistent
vendoring — naming the wrong cause. Now copies `pkg/` and `cmd/` wholesale.

**`go vet` had never run in CI, and the suppressions were not what they looked like
(#511).** Vet reported 8 `unsafe.Pointer` findings. All six in the CGo bridge were
adjudicated individually and all six are sound, for two reasons `unsafeptr` structurally
cannot see: `HandleTable.Register` allocates via `calloc`, so the target is libc heap the
GC never scans, moves or frees; and `Lookup` checks map membership before anything
dereferences the address. Rather than suppress them, the handle is now typed
`unsafe.Pointer` end to end — which is what it always was, since `isValidHandle`
dereferences it and C callers receive it as `nvmlDevice_t`. That *deletes* the
conversions instead of silencing the diagnostic. Vet now runs over all 37 packages with
no exclusions.

**The toolkit-ready marker made a gate hollow (#504).** `setup.sh` pre-created
`/run/nvidia/validations/toolkit-ready`, letting six operand DaemonSets clear their
toolkit-validation gate before any toolkit check had run. The marker is GPU Operator's
own `nvidia-validator` to write — it deletes it (`main.go:1134`) and re-creates it only
on success (`main.go:1153`) — so ours was neither durable nor meaningful. Removed, along
with `cleanup.sh`'s matching `rm`, which was deleting another component's state from our
preStop hook.

**The NFD `pci-10de` label is now explained and optional (#505).** NFD's PCI source
structurally cannot see our devices, for two independently sufficient reasons: it reads
`/host-sys/...`, a link-time constant, while our shim rewrites only paths starting
`/sys/`; and `nfd-worker` is statically linked, so `LD_PRELOAD` is inert. The label stays,
but is now gated behind `nodeLabels.pciVendorPresent` (default `true`, preserving current
behaviour) and documented in the chart README.

**Device memory now follows the effective config (#506).** `GetMemoryInfo` and
`GetMemoryInfo_v2` returned Total/Free/Used from a struct baked at construction and never
consulted `d.cfg()`, so `nvml-mock-ctl set --gpu 0 memory.used_bytes=N` validated, wrote
the override, merged it — and NVML kept reporting the profile value until pod restart.

## Testing

```
go build ./...                              rc=0
go test -count=1 ./...                      rc=0, 0 FAIL, 0 cached
go vet ./...                                rc=0  — all 37 packages, no exclusions
golangci-lint run ./...                     0 issues
golangci-lint run --build-tags=e2e ./...    0 issues
make helm-unittest                          131 passed, 15 snapshots
shellcheck setup.sh / cleanup.sh            3 / 1 — unchanged baselines
```

Beyond the suite:

- **#504 was validated live**, not from source reading: `make e2e-gpu-operator` reported
  `6 Passed | 0 Failed | 0 Pending | 40 Skipped`. With the pre-touch gone,
  `/run/nvidia/validations` did not exist while nvml-mock was already Running, the
  device-plugin's toolkit-validation init container genuinely blocked (17:11:46 → 17:11:51),
  and cleared only after the operator-validator wrote the marker at 17:11:47. A hollow pass
  became a real one.
- **#508 was mutation-proven**: a throwaway package imported from `cmd/mock-ib` fails the
  image build before the change and succeeds after, Dockerfile the only difference.
- **#511's new test is mutation-proven**: deleting the `if !ok` guard lets a forged Go
  pointer carrying the real magic value pass `isValidHandle`, so `Lookup` returns the map's
  nil zero value instead of `InvalidDeviceInstance` — which every bridge caller would
  nil-deref. `TestHandleTable_ConcurrentClear` also gained a real postcondition; it
  previously asserted nothing.
- **#505's gate was probed at runtime** with a PATH-shimmed `kubectl`: unset and `on` write
  the label, `off` skips it, and a typo fails with a clear error and zero kubectl calls.
  `cleanup.sh` is symmetric, so the mock never deletes a label it did not write.
- **#506 was a genuine RED→GREEN**: `GetMemoryInfo().Used` after an override setting
  `memory.used_bytes=1073741824` returned `0x0`; it now returns `0x40000000`. Test and
  implementation are in separate commits.

## Breaking changes

`unsafe.Pointer` replaces `uintptr` on 11 exported engine signatures (#511). No behaviour
change for C callers — the value was always a pointer. Two runtime behaviour changes:
operands now genuinely wait on GPU Operator's validator rather than a pre-satisfied marker
(#504), and memory getters now follow runtime overrides (#506).

## Deliberately not closed

**#505** still needs its follow-up issue filed — its branch-3 path requires recording the
specific sysfs gap, and the `features.d` route (NFD's local source reads a plain literal
path, unlike the PCI source's `hostpath.SysfsDir`) is documented but not implemented or
validated on a cluster.

**#506** keeps items 1–3 open. What lands here is the bug *underneath* item 1: the getter
never read the effective config at all, so no mechanism could have moved the number.
Allocation-driven memory needs a node agent reading the kubelet PodResources API — nothing
in the deployment observes allocation today — plus a third merge tier to resolve a state
collision, since `nvml-mock-ctl reset` would otherwise wipe live allocation state. Items 1
and 2 are really one task, because real NVML derives `used_bytes` from per-process memory.

## Merge note

Please do not trim the squash message. The shipped comment in `setup.sh` points readers at
the NFD analysis via `git log -S 'pci-10de'`, which only reaches the reasoning if the squash
body retains the originating commit. GitHub's default squash body preserves it.

Closes #508
Closes #511
Closes #504
Refs #505
Refs #506
Refs #502
Refs #516
