### PR TITLE
ci(lint): lint e2e- and integration-tagged sources

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,19 @@ linters:
       # files guarded by `//go:build e2e`; they are test-only code in the same
       # package as the _test.go files beside them, and miss staticcheck's
       # carve-out purely on the filename. ST1001 stays enabled everywhere else.
-      - path: ^tests/e2e/go/
+      #
+      # Anchored to files directly under tests/e2e/go/ so it covers the suite
+      # itself and not its subpackages (assertions/, framework/..., ibutil/,
+      # profile/), which are ordinary libraries with no reason to dot-import.
+      - path: ^tests/e2e/go/[^/]+\.go$
         linters:
           - staticcheck
         text: "ST1001:"
+
+issues:
+  # Report every occurrence, not the first three. The default of 3 groups by
+  # message text, so a finding repeated across many files is silently truncated:
+  # this tree looked like it had 4 issues behind the e2e tag when it had 14, and
+  # the discrepancy was invisible until the cap was lifted. Under-reporting a
+  # gate is worse than a long log.
+  max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,15 @@ version: "2"
 
 run:
   timeout: 5m
+  # Lint tag-guarded sources too. Without these, `//go:build e2e` and
+  # `//go:build integration` files are invisible to every lint invocation --
+  # CI, `make lint`, and local runs alike -- which is how 14 findings
+  # accumulated unnoticed in tests/e2e/go/. Declaring the tags here rather than
+  # in the workflow keeps every invocation identical, so a clean tree locally
+  # means a clean tree in CI.
+  build-tags:
+    - e2e
+    - integration
 
 linters:
   settings:
@@ -25,3 +34,15 @@ linters:
         - "-ST1000"
         - "-ST1003"
         - "-QF*"
+  exclusions:
+    rules:
+      # Ginkgo suites conventionally dot-import ginkgo and gomega, and
+      # staticcheck already exempts _test.go files from ST1001 for exactly that
+      # reason. The e2e suite keeps its scenario and suite helpers in plain .go
+      # files guarded by `//go:build e2e`; they are test-only code in the same
+      # package as the _test.go files beside them, and miss staticcheck's
+      # carve-out purely on the filename. ST1001 stays enabled everywhere else.
+      - path: ^tests/e2e/go/
+        linters:
+          - staticcheck
+        text: "ST1001:"

--- a/tests/e2e/go/report_skips_test.go
+++ b/tests/e2e/go/report_skips_test.go
@@ -53,7 +53,7 @@ var _ = ReportAfterSuite("skipped specs summary", func(report Report) {
 	}
 	b.WriteString("=======================================\n")
 
-	fmt.Fprint(GinkgoWriter, b.String())
+	GinkgoWriter.Print(b.String())
 })
 
 // emptySkipReason returns a cause-neutral marker for skipped specs that carry no


### PR DESCRIPTION
## Problem

`golangci-lint` was only ever invoked without build tags, so every file behind `//go:build e2e` or `//go:build integration` was skipped by CI, by `make lint`, and by local runs alike.

One correction to the issue: **it is 14 findings, not 4.** `golangci-lint` defaults to `max-same-issues: 3`, and every `ST1001` shares the text "should not use dot imports", so the list in #510 was truncated at three. Uncapped:

```
$ golangci-lint run --build-tags=e2e --max-same-issues=0 --max-issues-per-linter=0 ./...
14 issues:
* errcheck: 1
* staticcheck: 13
```

13 `ST1001` across 7 files, not 3 across 2: `scenario_failure_injection.go`, `scenario_runtime_control.go`, `scenario_standalone_setup.go`, `suite_build.go`, `suite_cluster.go`, `suite_helm.go`, `suite_paths.go`.

That also explains a detail worth recording. 14 files in `tests/e2e/go` dot-import ginkgo and gomega, but only 7 are ever reported. `staticcheck` deliberately skips dot imports in test files (`!code.IsInTest`) precisely because Ginkgo suites conventionally dot-import. The 7 flagged files are test-only code in that same package; they miss the carve-out purely because their names do not end in `_test.go`. So the exclusion this PR adds is not a new dispensation, it is the one staticcheck already grants, applied to files its filename heuristic cannot see.

## Approach

**Build tags in `run.build-tags` rather than in the workflow args.** The issue proposed adding `--build-tags=e2e` to the `Makefile` lint target. Declaring the tags in `.golangci.yml` instead covers the Makefile target, the CI action, and local/IDE runs from one place, so all three invocations stay identical and a clean tree locally means a clean tree in CI. Putting the flag in only one caller would have left the others blind and inverted that guarantee. No `Makefile` or workflow change is needed as a result.

Verified that no file in the tree is constrained with `!e2e` or `!integration`, so a tagged run is a strict superset of the untagged one — nothing that was linted before stops being linted.

`integration` is included alongside `e2e`. It reports 0 issues today, and it closes the identical blind spot over `pkg/network/mockib/render` and `pkg/system/mockpcisysfs/shim`. Happy to drop it to `e2e` only if reviewers would rather keep this to one concern.

**errcheck fixed, not suppressed.** `fmt.Fprint(GinkgoWriter, ...)` becomes `GinkgoWriter.Print(...)`. Ginkgo's `GinkgoWriterInterface` provides `Print`, so there is no error to check and no discard into `_`.

**ST1001 excluded by path, for staticcheck only, under `tests/e2e/go/`,** with the reasoning in a comment. `ST1001` keeps its teeth everywhere else in the repo, and future scenario files are covered without anyone having to remember a `//nolint` directive.

## Testing done

Both forms return rc=0 against the committed tree:

```
$ GOWORK=off golangci-lint run ./...
0 issues.

$ GOWORK=off golangci-lint run --build-tags=e2e ./...
0 issues.
```

Green alone is weak evidence here, since inert config also passes. Each change was mutation-checked to confirm it is load-bearing:

| Mutation | Expected | Result |
| --- | --- | --- |
| Remove the ST1001 exclusion, keep the tags | RED | rc=1, ST1001 returns |
| Remove the exclusion **and** the tags | GREEN (reproduces the blind spot) | rc=0, 0 issues |
| Revert only the errcheck fix, config intact | RED | rc=1, errcheck returns |

The second row is the one that matters for this issue: it shows plain `golangci-lint run ./...` only sees the e2e files because of `run.build-tags`, and goes blind again without it. Both files were then restored byte-identical (`cmp`) and re-verified green.

Also confirmed `golangci-lint config verify` passes, and that both tag sets still compile (`go vet -tags e2e ./tests/e2e/...`, `go vet -tags integration ./pkg/...`).

## Acceptance criteria from #510

- [x] `golangci-lint run --build-tags=e2e ./...` reports 0 issues.
- [x] CI runs the lint with the tag, so a new e2e file cannot land unlinted — via `run.build-tags`, which the action picks up from `.golangci.yml`.

## Breaking changes

None. Config and one test-only line; no runtime code is touched.

## Note for reviewers

`.github/workflows/golang.yaml` no longer states anywhere that tagged linting is happening — that is the one real cost of the config-side approach over putting the flag in the workflow args. A comment in the workflow pointing at `run.build-tags` would close that gap if reviewers want it.

Closes #510
