### PR TITLE
docs(enhancements): fix dash consistency and grammar in MEP docs

### DIFF
--- a/enhancements/README.md
+++ b/enhancements/README.md
@@ -1,6 +1,6 @@
 # Mokka Enhancement Proposals (MEPs)
 
-A MEP is a design document that captures a substantial change to Mokka -
+A MEP is a design document that captures a substantial change to Mokka —
 new components, major cross-cutting refactors, or breaking API changes.
 
 Small bug fixes and routine features do **not** need a

--- a/enhancements/template.md
+++ b/enhancements/template.md
@@ -95,7 +95,8 @@ This might be a good place to talk about core concepts and how they relate.
 
 <!--
 What are the risks of this proposal, and how do we mitigate? Think broadly.
-For example, consider both operational overhead, resource consumption and how this will impact our users.
+For example, consider operational overhead, resource consumption, and how
+this will impact our users.
 -->
 
 ## Design Details


### PR DESCRIPTION
## What This PR Does

Two cosmetic follow-ups to #519, both raised in review there and deferred so they would not hold up the merge.

- `enhancements/README.md` ended a line on an ASCII hyphen used as a dash, while every other dash across both files is an em dash.
- `enhancements/template.md` had the Risks and Mitigations prompt reading "consider both X, Y and Z" — `both` takes two items and three follow. Dropped `both`, added the serial comma, and wrapped the line at 80 columns so it matches the rest of the file.

## Why

The MEP template is the thing every future proposal gets copied from, so wording and wrapping in it propagate. Cheaper to fix now than in every MEP that inherits it.

## Testing Done

Docs-only, no code paths touched. Verified mechanically against the branch:

- All 13 TOC anchors in `template.md` still resolve against their headings (0 broken).
- Max line length across both files is 79, down from 105.
- No trailing whitespace, no tabs, both files end with a newline.

## Breaking Changes

None.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`go test -v -race ./...`) — no Go changes
- [x] Linter passes (`golangci-lint run`) — no Go changes
- [x] New code has SPDX license headers — n/a, prose only
- [x] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (if user-facing change) — not user-facing
