### PR TITLE
fix(nvml-mock): let NFD derive the pci-10de label instead of hand-writing it

### DIFF
--- a/.github/workflows/nvml-mock-e2e-go.yaml
+++ b/.github/workflows/nvml-mock-e2e-go.yaml
@@ -356,3 +356,57 @@ jobs:
           else
             echo "no diagnostics written"
           fi
+
+  e2e-nfd:
+    needs: build-image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gpu-profile: ${{ fromJson(inputs.gpu_profiles) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
+
+      - name: Pull pre-built nvml-mock image from ttl.sh (pinned by digest)
+        run: |
+          # Content-addressed pull: even if the sha-derived tag is overwritten on
+          # the anonymous ttl.sh registry, the digest fetches exactly what
+          # build-image pushed. Re-tag to E2E_IMAGE for the harness kind-load and
+          # Helm repo:tag split.
+          pinned="ttl.sh/nvml-mock-${{ github.sha }}@${{ needs.build-image.outputs.digest }}"
+          docker pull "$pinned"
+          docker tag "$pinned" "${{ env.E2E_IMAGE }}"
+
+      - name: Install Kind
+        run: |
+          curl -fsSLo ./kind "https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION }}/kind-linux-amd64"
+          echo "${{ env.KIND_AMD64_SHA256 }}  ./kind" | sha256sum --check
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          kind version
+
+      - name: Run NFD label-provenance E2E (${{ matrix.gpu-profile }})
+        env:
+          E2E_PROFILES: ${{ matrix.gpu-profile }}
+        run: make e2e-nfd
+
+      - name: Print diagnostics on failure
+        if: failure()
+        run: |
+          echo "=== e2e-nfd diagnostics (${{ matrix.gpu-profile }}) ==="
+          if [ -d "$E2E_ARTIFACTS" ]; then
+            find "$E2E_ARTIFACTS" -type f | while read -r f; do
+              echo "----- $f -----"; cat "$f"; echo;
+            done
+          else
+            echo "no diagnostics written"
+          fi

--- a/.github/workflows/nvml-mock-e2e-go.yaml
+++ b/.github/workflows/nvml-mock-e2e-go.yaml
@@ -363,7 +363,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gpu-profile: ${{ fromJson(inputs.gpu_profiles) }}
+        # Deliberately NOT fanned out over inputs.gpu_profiles like the sibling
+        # jobs. The label under test (feature.node.kubernetes.io/pci-10de.present)
+        # is vendor-only — byte-identical for every profile, since every mock GPU
+        # is PCI vendor 0x10de — and the scenario itself hardcodes a100, so extra
+        # legs would spend a kind cluster each to re-run the identical assertion
+        # while reporting a profile name they never exercised.
+        gpu-profile: [a100]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 SHELL := /usr/bin/env bash
 .SHELLFLAGS := -o pipefail -ec
 
-.PHONY: build fmt verify release lint vendor check-vendor helm-unittest e2e e2e-dra e2e-gpu-operator e2e-multi-node e2e-nri
+.PHONY: build fmt verify release lint vendor check-vendor helm-unittest e2e e2e-dra e2e-gpu-operator e2e-multi-node e2e-nri e2e-nfd
 
 GO_CMD ?= go
 GO_FMT ?= gofmt
@@ -146,7 +146,7 @@ cluster-delete:
 # ---------------------------------------------------------------------------
 GINKGO ?= $(GO_CMD) run github.com/onsi/ginkgo/v2/ginkgo
 E2E_TIMEOUT ?= 90m
-E2E_DEFAULT_LABEL_FILTER ?= !validator && !dra && !gpu-operator && !multi-node && !nri
+E2E_DEFAULT_LABEL_FILTER ?= !validator && !dra && !gpu-operator && !multi-node && !nri && !nfd
 E2E_GINKGO_FLAGS ?= --label-filter='$(E2E_DEFAULT_LABEL_FILTER)'
 
 e2e:
@@ -163,3 +163,6 @@ e2e-multi-node:
 
 e2e-nri:
 	$(MAKE) e2e E2E_GINKGO_FLAGS='--label-filter=nri'
+
+e2e-nfd:
+	$(MAKE) e2e E2E_GINKGO_FLAGS='--label-filter=nfd'

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ cluster-delete:
 #   make e2e-gpu-operator          # GPU Operator scenario
 #   make e2e-multi-node            # heterogeneous A100/T4 multi-node scenario
 #   make e2e-nri                   # node-wide NRI ambient-injection scenario
+#   make e2e-nfd                   # NFD label-provenance scenario
 # CI builds the image once per job and sets E2E_SKIP_BUILD=true + E2E_IMAGE.
 #
 # NOTE: this targets ./tests/e2e/go (the Ginkgo suite package) only, NOT

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ After install, deploy a consumer to test:
 ## E2E Testing
 
 The nvml-mock Go E2E workflow gates standalone, DRA, GPU Operator, multi-node,
-and node-wide NRI coverage. Run manually via `workflow_dispatch` or
-automatically on PRs.
+node-wide NRI, and NFD label-provenance coverage. Run manually via
+`workflow_dispatch` or automatically on PRs.
 
 | Test Suite | What It Validates | Profiles |
 |------------|-------------------|----------|
@@ -56,6 +56,7 @@ automatically on PRs.
 | **GPU Operator** | GPU Operator install, validator pod startup, GFD labels, and allocatable GPUs | Workflow-selected profiles |
 | **Multi-Node Fleet** | Heterogeneous A100/T4 workers, mock files, InfiniBand behavior, device plugin resources, and GPU workload scheduling | Fixed multi-node topology |
 | **Node-Wide NRI Injection** | Ambient mock GPU injection into ordinary pods without GPU requests or hostPath mounts | Workflow-selected profiles |
+| **NFD Label Provenance** | That NFD creates `feature.node.kubernetes.io/pci-10de.present` from the feature file nvml-mock writes, and that nvml-mock does not write the label itself | Pinned to `a100` — the label is vendor-only and byte-identical across profiles |
 
 Manual dispatch accepts a JSON array of GPU profiles; local runs default to
 `gb200`.

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -11,6 +11,10 @@ Deploys a DaemonSet that creates on every node:
 - Mock device nodes at `/var/lib/nvml-mock/driver/dev/nvidia{N,ctl,-uvm,-uvm-tools}` (consumers see them at `/dev/nvidia*` via CDI bind-mount)
 - GPU configuration at `/var/lib/nvml-mock/driver/config/config.yaml`
 - Node label `nvidia.com/gpu.present=true`
+- An NFD feature file at
+  `/etc/kubernetes/node-feature-discovery/features.d/nvml-mock.features`, which
+  NFD turns into the node label
+  `feature.node.kubernetes.io/pci-10de.present=true` (see [Node Labels](#node-labels))
 - A fake InfiniBand sysfs tree at `/var/lib/nvml-mock/ib/sys/class/infiniband/...`
   paired with `libibmocksys.so` (`LD_PRELOAD`) so real `ibstat`, `ibstatus`,
   `iblinkinfo`, ... read mock HCAs
@@ -745,7 +749,8 @@ for env vars (`MOCK_IB`, `MOCK_IB_PING_FABRIC`, `MOCK_IB_PEERS`,
 
 The DaemonSet's `setup.sh` writes one node label directly with `kubectl label`,
 and drops a feature file that NFD turns into a second. The preStop `cleanup.sh`
-reverses both:
+removes the first label and deletes the feature file; NFD retires the second
+label itself on its next cycle:
 
 | Label | Written by | Gated by | Default |
 |-------|-----------|----------|---------|

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -733,7 +733,8 @@ for env vars (`MOCK_IB`, `MOCK_IB_PING_FABRIC`, `MOCK_IB_PEERS`,
 | `driverVersion` | `""` (auto) | NVIDIA driver version to mock. When empty, read from `system.driver_version` of the resolved GPU config (the selected `gpu.profile` file, or `gpu.customConfig` if set), so the profile is the single source of truth (e.g. GB200 → `580.65.06`, B200 → `560.35.03`, GB300 → `570.124.06`, others → `550.163.01`). Set explicitly only to override the profile. |
 | `nodeSelector` | `{}` | Node selector for DaemonSet |
 | `tolerations` | `[{operator: Exists}]` | Pod tolerations (default: tolerate all) |
-| `nodeLabels.pciVendorPresent` | `true` | Write `feature.node.kubernetes.io/pci-10de.present=true` on each node. Hand-written because NFD's PCI source structurally cannot see mock devices. Set to `false` when a real NFD owns `feature.node.kubernetes.io/*`. See [Node Labels](#node-labels) |
+| `nodeLabels.pciVendorPresent` | `true` | Write the NFD feature file that makes `feature.node.kubernetes.io/pci-10de.present=true` appear. The label is created by NFD, not by nvml-mock. Set to `false` when something else already supplies that key. See [Node Labels](#node-labels) |
+| `nodeLabels.featuresDir` | `/etc/kubernetes/node-feature-discovery/features.d` | Host directory NFD's local source reads feature files from. Override only if NFD runs with a non-default `featureFilesDir` |
 | `integrations.fakeGpuOperator.enabled` | `false` | Create per-profile ConfigMaps for fake-gpu-operator discovery |
 | `integrations.fakeGpuOperator.profileLabels` | `{"run.ai/gpu-profile": "true"}` | Labels on profile ConfigMaps for discovery |
 | `infiniband.mockTier` | `""` (auto) | `MOCK_IB` tier: `off`, `sysfs`, or `full`. Empty auto-derives `full` for IB-enabled profiles and `sysfs` otherwise (keeps the `libibmocksys` redirect active so any real host IB is masked). `off` makes every shim a no-op and skips the daemon. An invalid value fails `helm template` |
@@ -742,17 +743,24 @@ for env vars (`MOCK_IB`, `MOCK_IB_PING_FABRIC`, `MOCK_IB_PEERS`,
 
 ### Node Labels
 
-The DaemonSet's `setup.sh` writes two node labels with `kubectl label`, and the
-preStop `cleanup.sh` removes them again:
+The DaemonSet's `setup.sh` writes one node label directly with `kubectl label`,
+and drops a feature file that NFD turns into a second. The preStop `cleanup.sh`
+reverses both:
 
-| Label | Gated by | Default |
-|-------|----------|---------|
-| `nvidia.com/gpu.present=true` | not gated — always written | n/a |
-| `feature.node.kubernetes.io/pci-10de.present=true` | `nodeLabels.pciVendorPresent` | `true` |
+| Label | Written by | Gated by | Default |
+|-------|-----------|----------|---------|
+| `nvidia.com/gpu.present=true` | nvml-mock (`kubectl label`) | not gated — always written | n/a |
+| `feature.node.kubernetes.io/pci-10de.present=true` | **NFD**, from a feature file nvml-mock writes | `nodeLabels.pciVendorPresent` | `true` |
 
-The second label is normally produced by Node Feature Discovery, not by hand.
-nvml-mock writes it itself because NFD's PCI source structurally cannot see a
-mock GPU: it reads a host-prefixed sysfs path fixed at link time
+The second label is produced by Node Feature Discovery. nvml-mock only supplies
+the input: it writes `pci-10de.present=true` into
+`nodeLabels.featuresDir`, which NFD's local source reads and turns into the
+namespaced label. With no NFD on the cluster the file is inert and the label
+does not exist — which is the honest state, and is what the e2e in
+`tests/e2e/go/scenario_nfd_test.go` asserts.
+
+NFD's *PCI* source still cannot see mock GPUs as deployed: it reads a
+host-prefixed sysfs path fixed at link time
 (`/host-sys/bus/pci/devices`, from `HOSTMOUNT_PREFIX`), while nvml-mock's
 rendered PCI tree lives under `/var/lib/nvml-mock/sys` and is reachable only
 through an `LD_PRELOAD` sysfs shim — and `nfd-worker` ships statically linked,
@@ -760,23 +768,34 @@ so `LD_PRELOAD` is inert in it. Either fact alone is enough; both hold. The
 `setup.sh` comment at step 7 carries the full analysis with upstream file
 references (verified against NFD v0.19.0).
 
-Keep the default (`true`) on a mock-only cluster: consumers that gate on the NFD
-PCI label — GPU Operator operands, NFD-based `nodeSelector`s — need it to
-schedule. Disable it when a real NFD (or anything else) owns
-`feature.node.kubernetes.io/*` and the forged label would conflict:
+That is a limit of how NFD is deployed, not of the rendered tree. Pointed at
+`/var/lib/nvml-mock/sys`, NFD v0.19.0 enumerates every mock GPU and — with the
+`sources.pci.deviceLabelFields: [vendor]` that GPU Operator configures — derives
+exactly `pci-10de.present` on its own. The rendered devices already carry all
+five attributes its PCI source treats as mandatory. Only visibility is missing,
+and nothing nvml-mock can do supplies it without editing a third party's
+DaemonSet, which is why the local source is the route the chart uses.
+
+Keep the default (`true`) on a mock-only cluster running NFD: consumers that
+gate on the NFD PCI label — GPU Operator operands, NFD-based `nodeSelector`s —
+need it to schedule. Disable it when something else already supplies
+`feature.node.kubernetes.io/pci-10de.present` and a second writer would
+conflict:
 
 ```bash
 helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set nodeLabels.pciVendorPresent=false
 ```
 
-`setup.sh` and `cleanup.sh` read the same switch, so a disabled label is neither
-written nor deleted — the mock never removes a label it did not create.
+`setup.sh` and `cleanup.sh` read the same switch, so a disabled feature file is
+neither written nor deleted — the mock never removes an input it did not
+supply. Because the label itself belongs to NFD, disabling the switch does not
+delete an existing label directly; NFD retires it on its next discovery cycle
+once the feature file is gone.
 
-A follow-up is planned to retire the `kubectl` call altogether: NFD's *local*
-source reads feature files from
-`/etc/kubernetes/node-feature-discovery/features.d/` via a plain literal path
-(not host-prefixed), which is reachable where the PCI source is not.
+Writing a feature file rather than the label is also why the DaemonSet needs no
+`patch` on `nodes` for this key — `nvidia.com/gpu.present` is the only label it
+sets through the API.
 
 ### GPU Profiles
 
@@ -1083,9 +1102,9 @@ The chart deploys:
    - Creates symlinks (`libnvidia-ml.so.1` → `libnvidia-ml.so.{version}`)
    - Creates mock device nodes at `/var/lib/nvml-mock/driver/dev/nvidia{N,ctl,-uvm,-uvm-tools}` (CDI bind-mounts them to `/dev/nvidia*` in consumer containers)
    - Writes GPU config YAML at `/var/lib/nvml-mock/driver/config/config.yaml`
-   - Labels the node `nvidia.com/gpu.present=true`, and
-     `feature.node.kubernetes.io/pci-10de.present=true` unless
-     `nodeLabels.pciVendorPresent=false` (see [Node Labels](#node-labels))
+   - Labels the node `nvidia.com/gpu.present=true`, and writes the NFD feature
+     file that makes `feature.node.kubernetes.io/pci-10de.present=true` appear
+     (unless `nodeLabels.pciVendorPresent=false`) — see [Node Labels](#node-labels)
 2. **ConfigMap** — GPU configuration from the selected profile
 3. **RBAC** — ServiceAccount with permission to patch node labels
 
@@ -1102,7 +1121,7 @@ discovery and monitoring. Some host-level subsystems are not mocked:
 |----------------|-------------------|--------|
 | `/sys/bus/pci/devices/{busID}` sysfs entries | DRA driver | `dra.k8s.io/pcieRoot` attribute absent from ResourceSlices — **blocks topology-aware scheduling demos** (e.g., GPU + SR-IOV VF alignment) |
 | `/sys/bus/pci/devices/{busID}/numa_node` | Device plugin | NUMA-aware topology hints unavailable; scheduling works but NUMA affinity not enforced |
-| `/sys/bus/pci/devices/*/vendor,device,class` **as NFD reads them** (`/host-sys/…`, fixed at link time) | NFD (Node Feature Discovery) | PCI feature labels not auto-detected; nvml-mock writes `nvidia.com/gpu.present` and `pci-10de.present` directly instead. The latter is gated by `nodeLabels.pciVendorPresent` — see [Node Labels](#node-labels) |
+| `/sys/bus/pci/devices/*/vendor,device,class` **as NFD reads them** (`/host-sys/…`, fixed at link time) | NFD (Node Feature Discovery) | PCI feature labels not auto-detected. `nvidia.com/gpu.present` is written directly by nvml-mock; `pci-10de.present` is created by NFD from a feature file nvml-mock drops in `nodeLabels.featuresDir` — see [Node Labels](#node-labels) |
 
 ### PCIe Root Complex (DRA driver)
 

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -760,9 +760,9 @@ does not exist — which is the honest state, and is what the e2e in
 `tests/e2e/go/scenario_nfd_test.go` asserts.
 
 NFD's *PCI* source still cannot see mock GPUs as deployed: it reads a
-host-prefixed sysfs path fixed at link time
-(`/host-sys/bus/pci/devices`, from `HOSTMOUNT_PREFIX`), while nvml-mock's
-rendered PCI tree lives under `/var/lib/nvml-mock/sys` and is reachable only
+host-prefixed sysfs path fixed at link time (`/host-sys/bus/pci/devices`, from
+`HOSTMOUNT_PREFIX`), while nvml-mock's rendered PCI tree lives under
+`/var/lib/nvml-mock/sys` and is reachable at the canonical `/sys` path only
 through an `LD_PRELOAD` sysfs shim — and `nfd-worker` ships statically linked,
 so `LD_PRELOAD` is inert in it. Either fact alone is enough; both hold. The
 `setup.sh` comment at step 7 carries the full analysis with upstream file
@@ -787,11 +787,12 @@ helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set nodeLabels.pciVendorPresent=false
 ```
 
-`setup.sh` and `cleanup.sh` read the same switch, so a disabled feature file is
-neither written nor deleted — the mock never removes an input it did not
-supply. Because the label itself belongs to NFD, disabling the switch does not
-delete an existing label directly; NFD retires it on its next discovery cycle
-once the feature file is gone.
+`setup.sh` converges either way: with the switch on it writes the feature file,
+with it off it removes any file an earlier run left behind. `cleanup.sh` reads
+the same switch and unwinds only the write `setup.sh` makes, so with the switch
+off it has nothing to undo. Because the label itself belongs to NFD, disabling
+the switch does not delete an existing label directly; NFD retires it on its
+next discovery cycle once the feature file is gone.
 
 Writing a feature file rather than the label is also why the DaemonSet needs no
 `patch` on `nodes` for this key — `nvidia.com/gpu.present` is the only label it

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -184,6 +184,8 @@ spec:
               mountPath: /host/var/run/cdi
             - name: host-run-nvidia
               mountPath: /host/run/nvidia
+            - name: host-nfd-features
+              mountPath: /host/etc/kubernetes/node-feature-discovery/features.d
             {{- if .Values.topology.enabled }}
             - name: gpu-topology
               mountPath: /etc/nvml-mock/topology
@@ -211,6 +213,10 @@ spec:
         - name: host-run-nvidia
           hostPath:
             path: /run/nvidia
+            type: DirectoryOrCreate
+        - name: host-nfd-features
+          hostPath:
+            path: {{ .Values.nodeLabels.featuresDir | quote }}
             type: DirectoryOrCreate
         {{- if .Values.topology.enabled }}
         - name: gpu-topology

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -72,11 +72,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            # Gates the hand-written NFD label
+            # Gates the NFD feature file that yields
             # feature.node.kubernetes.io/pci-10de.present=true. setup.sh writes
-            # it and cleanup.sh removes it only when this is "on", so the mock
-            # never deletes a label it did not create. NFD's PCI source cannot
-            # derive the label on a mock node — see setup.sh step 7.
+            # the file and cleanup.sh removes it only when this is "on", so the
+            # mock never deletes an input it did not supply. NFD, not the mock,
+            # creates the label. NFD's PCI source cannot derive it as deployed —
+            # nfd-worker reads a link-time-fixed /host-sys path, so the rendered
+            # tree is not on a path it reads; see setup.sh step 7.
             - name: MOCK_NFD_PCI_LABEL
               value: {{ ternary "on" "off" .Values.nodeLabels.pciVendorPresent | quote }}
             # Point the mock NVML library at the in-pod ConfigMap mount so any

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -105,6 +105,8 @@ should match snapshot with all overrides:
                   name: host-cdi
                 - mountPath: /host/run/nvidia
                   name: host-run-nvidia
+                - mountPath: /host/etc/kubernetes/node-feature-discovery/features.d
+                  name: host-nfd-features
                 - mountPath: /var/lib/nvml-mock/fabric-state
                   name: host-fabric-state
           nodeSelector:
@@ -131,6 +133,10 @@ should match snapshot with all overrides:
                 path: /run/nvidia
                 type: DirectoryOrCreate
               name: host-run-nvidia
+            - hostPath:
+                path: /etc/kubernetes/node-feature-discovery/features.d
+                type: DirectoryOrCreate
+              name: host-nfd-features
             - hostPath:
                 path: /var/lib/nvml-mock/fabric-state
                 type: DirectoryOrCreate
@@ -235,6 +241,8 @@ should match snapshot with b200 profile:
                   name: host-cdi
                 - mountPath: /host/run/nvidia
                   name: host-run-nvidia
+                - mountPath: /host/etc/kubernetes/node-feature-discovery/features.d
+                  name: host-nfd-features
           serviceAccountName: RELEASE-NAME-nvml-mock
           terminationGracePeriodSeconds: 2
           tolerations:
@@ -255,6 +263,10 @@ should match snapshot with b200 profile:
                 path: /run/nvidia
                 type: DirectoryOrCreate
               name: host-run-nvidia
+            - hostPath:
+                path: /etc/kubernetes/node-feature-discovery/features.d
+                type: DirectoryOrCreate
+              name: host-nfd-features
       updateStrategy:
         rollingUpdate:
           maxUnavailable: 25%
@@ -359,6 +371,8 @@ should match snapshot with default values:
                   name: host-cdi
                 - mountPath: /host/run/nvidia
                   name: host-run-nvidia
+                - mountPath: /host/etc/kubernetes/node-feature-discovery/features.d
+                  name: host-nfd-features
                 - mountPath: /var/lib/nvml-mock/fabric-state
                   name: host-fabric-state
           serviceAccountName: RELEASE-NAME-nvml-mock
@@ -381,6 +395,10 @@ should match snapshot with default values:
                 path: /run/nvidia
                 type: DirectoryOrCreate
               name: host-run-nvidia
+            - hostPath:
+                path: /etc/kubernetes/node-feature-discovery/features.d
+                type: DirectoryOrCreate
+              name: host-nfd-features
             - hostPath:
                 path: /var/lib/nvml-mock/fabric-state
                 type: DirectoryOrCreate

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -188,6 +188,38 @@ tests:
             name: MOCK_NFD_PCI_LABEL
             value: "off"
 
+  # ── NFD features.d mount (nodeLabels.featuresDir) ────────────────────
+  # setup.sh writes the pci-10de feature file here instead of calling
+  # kubectl label. Without this mount the write silently lands inside the
+  # container and NFD never sees it, so the mount IS the contract.
+  - it: should mount the NFD features.d host directory
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: host-nfd-features
+            mountPath: /host/etc/kubernetes/node-feature-discovery/features.d
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: host-nfd-features
+            hostPath:
+              path: /etc/kubernetes/node-feature-discovery/features.d
+              type: DirectoryOrCreate
+
+  - it: should honour a custom nodeLabels.featuresDir
+    set:
+      nodeLabels:
+        featuresDir: /custom/features.d
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: host-nfd-features
+            hostPath:
+              path: /custom/features.d
+              type: DirectoryOrCreate
+
   # ── fabricmanager enablement (derived from the profile) ─────────────
   - it: should start fabricmanager for an auto-state profile (gb200)
     set:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -165,11 +165,12 @@ tests:
             name: DRIVER_VERSION
             value: "580.65.06"
 
-  # ── NFD pci-10de label gate (nodeLabels.pciVendorPresent) ───────────
+  # ── NFD pci-10de feature-file gate (nodeLabels.pciVendorPresent) ─────
   # setup.sh and cleanup.sh both branch on MOCK_NFD_PCI_LABEL. They accept
   # only "on"/"off" and abort the pod on anything else, so the exact string
-  # matters, not merely the presence of the variable.
-  - it: should write the NFD pci-10de label by default
+  # matters, not merely the presence of the variable. The value gates the
+  # feature FILE; NFD is what turns that file into the label.
+  - it: should enable the NFD pci-10de feature file by default
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -177,7 +178,7 @@ tests:
             name: MOCK_NFD_PCI_LABEL
             value: "on"
 
-  - it: should suppress the NFD pci-10de label when nodeLabels.pciVendorPresent=false
+  - it: should suppress the NFD pci-10de feature file when nodeLabels.pciVendorPresent=false
     set:
       nodeLabels:
         pciVendorPresent: false

--- a/deployments/nvml-mock/helm/nvml-mock/values.schema.json
+++ b/deployments/nvml-mock/helm/nvml-mock/values.schema.json
@@ -141,7 +141,7 @@
         "featuresDir": {
           "type": "string",
           "minLength": 1,
-          "description": "Host directory NFD's local source reads feature files from. Must be the featureFilesDir the deployed NFD actually reads. Typed as a non-empty string because an empty or null value renders an invalid hostPath that the API server rejects only at apply time."
+          "description": "Host directory NFD's local source reads feature files from. Must be the featureFilesDir the deployed NFD actually reads. Typed as a non-empty string so that an empty string or a non-string value is rejected at `helm template` time instead of rendering an invalid hostPath the API server rejects only at apply time."
         }
       }
     },

--- a/deployments/nvml-mock/helm/nvml-mock/values.schema.json
+++ b/deployments/nvml-mock/helm/nvml-mock/values.schema.json
@@ -132,11 +132,16 @@
     "nodeLabels": {
       "type": "object",
       "additionalProperties": true,
-      "description": "Node labels written by setup.sh and removed by the preStop cleanup.sh.",
+      "description": "Node labels nvml-mock causes to exist, reversed by the preStop cleanup.sh.",
       "properties": {
         "pciVendorPresent": {
           "type": "boolean",
-          "description": "Write feature.node.kubernetes.io/pci-10de.present=true on the node. Hand-written because NFD's PCI source reads a link-time-fixed /host-sys path and nfd-worker is statically linked, so it can see neither our rendered PCI tree nor our LD_PRELOAD sysfs shim. Set false when a real NFD owns feature.node.kubernetes.io/*. Typed as a boolean here because the DaemonSet renders it with `ternary`, which rejects a string with a template error rather than silently treating \"false\" as true."
+          "description": "Cause feature.node.kubernetes.io/pci-10de.present=true to exist on the node by writing an NFD feature file; NFD creates the label. Set false when something else already supplies that key. NFD's PCI source cannot derive it as deployed — nfd-worker reads a link-time-fixed /host-sys path, so the rendered PCI tree is not on a path it reads — but the tree itself is complete: given visibility, NFD derives this exact label. Typed as a boolean here because the DaemonSet renders it with `ternary`, which rejects a string with a template error rather than silently treating \"false\" as true."
+        },
+        "featuresDir": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Host directory NFD's local source reads feature files from. Must be the featureFilesDir the deployed NFD actually reads. Typed as a non-empty string because an empty or null value renders an invalid hostPath that the API server rejects only at apply time."
         }
       }
     },

--- a/deployments/nvml-mock/helm/nvml-mock/values.schema.json
+++ b/deployments/nvml-mock/helm/nvml-mock/values.schema.json
@@ -141,7 +141,7 @@
         "featuresDir": {
           "type": "string",
           "minLength": 1,
-          "description": "Host directory NFD's local source reads feature files from. Must be the featureFilesDir the deployed NFD actually reads. Typed as a non-empty string so that an empty string or a non-string value is rejected at `helm template` time instead of rendering an invalid hostPath the API server rejects only at apply time."
+          "description": "Host directory NFD's local source reads feature files from. Must be the featureFilesDir the deployed NFD actually reads. Typed as a non-empty string so that an empty string, or a boolean/number/array, is rejected at `helm template` time. An explicit `null` deletes the key and is not caught (there is no `required`), rendering a blank hostPath the API server rejects only at apply time."
         }
       }
     },

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -87,6 +87,14 @@ nodeLabels:
   # label would conflict with it.
   pciVendorPresent: true
 
+  # Host directory NFD's *local* source reads feature files from
+  # (source/local/local.go featureFilesDir, a plain literal — unlike the PCI
+  # source's /host-sys path it is not host-prefixed). setup.sh drops the
+  # pci-10de feature file here and NFD turns it into the label, so the mock
+  # never writes to the node API. Override only if NFD is deployed with a
+  # non-default features.d location.
+  featuresDir: /etc/kubernetes/node-feature-discovery/features.d
+
 # Node-wide ambient injection via containerd NRI. When enabled, a lightweight
 # node-local plugin appends the nvml-mock overlay mount and environment to each
 # container at runtime without mutating pod specs. Opt-in (default false): it

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -71,9 +71,11 @@ resources: {}
 # Node labels nvml-mock causes to exist, reversed again by the preStop
 # cleanup.sh. setup.sh writes nvidia.com/gpu.present directly with `kubectl
 # label`; feature.node.kubernetes.io/pci-10de.present is created by NFD from a
-# feature file setup.sh drops in featuresDir below. Both scripts read the same
-# switch, so a disabled feature file is neither written nor deleted — the mock
-# never touches an input it does not own.
+# feature file setup.sh drops in featuresDir below. setup.sh converges either
+# way: with the switch on it writes that file, with it off it removes any file
+# an earlier run left behind. cleanup.sh unwinds only setup.sh's own write, so
+# with the switch off it has nothing to undo. The label belongs to NFD, which
+# retires it on its next discovery cycle once the file is gone.
 nodeLabels:
   # feature.node.kubernetes.io/pci-10de.present=true
   #
@@ -89,9 +91,11 @@ nodeLabels:
   # tree itself is complete — pointed at it, NFD enumerates every mock GPU and
   # derives exactly this label. See setup.sh step 7 for the full analysis.
   #
-  # Default true preserves the historical behaviour: consumers that gate on the
-  # NFD PCI label (GPU Operator operands, nfd-based nodeSelectors) schedule on a
-  # mock node out of the box. Set to false when something else already supplies
+  # Keep the default (true) on a mock-only cluster running NFD: consumers that
+  # gate on the NFD PCI label (GPU Operator operands, nfd-based nodeSelectors)
+  # need it to schedule. The default supplies the input, not the label — with no
+  # NFD on the cluster nothing derives the label and those consumers do not
+  # schedule. Set to false when something else already supplies
   # feature.node.kubernetes.io/pci-10de.present and a second writer would
   # conflict with it.
   pciVendorPresent: true

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -68,30 +68,40 @@ tolerations:
 
 resources: {}
 
-# Node labels written by setup.sh (`kubectl label`) and removed again by the
-# preStop cleanup.sh. Both scripts read the same switch, so a disabled label is
-# neither written nor deleted — the mock never touches a key it does not own.
+# Node labels nvml-mock causes to exist, reversed again by the preStop
+# cleanup.sh. setup.sh writes nvidia.com/gpu.present directly with `kubectl
+# label`; feature.node.kubernetes.io/pci-10de.present is created by NFD from a
+# feature file setup.sh drops in featuresDir below. Both scripts read the same
+# switch, so a disabled feature file is neither written nor deleted — the mock
+# never touches an input it does not own.
 nodeLabels:
   # feature.node.kubernetes.io/pci-10de.present=true
   #
-  # Hand-written, because NFD's PCI source cannot see our devices: it reads a
-  # host-prefixed sysfs path fixed at link time (/host-sys/bus/pci/devices) and
-  # nfd-worker is statically linked, so neither our LD_PRELOAD sysfs shim nor
-  # our rendered PCI tree is reachable from it. See setup.sh step 7 for the
-  # full analysis.
+  # NFD creates this label; nvml-mock only writes the feature file it derives
+  # it from. That keeps the key to exactly one writer, so "NFD works" stays
+  # distinguishable from "we set it ourselves" (#505), and it needs no node
+  # RBAC. With no NFD on the cluster the file is inert and the label does not
+  # exist.
+  #
+  # NFD's PCI source cannot derive it as deployed: nfd-worker reads a
+  # host-prefixed sysfs path fixed at link time (/host-sys/bus/pci/devices), so
+  # our rendered tree at /var/lib/nvml-mock/sys is not on a path it reads. The
+  # tree itself is complete — pointed at it, NFD enumerates every mock GPU and
+  # derives exactly this label. See setup.sh step 7 for the full analysis.
   #
   # Default true preserves the historical behaviour: consumers that gate on the
   # NFD PCI label (GPU Operator operands, nfd-based nodeSelectors) schedule on a
-  # mock node out of the box. Set to false when a real NFD — or anything else
-  # that owns feature.node.kubernetes.io/* — runs on the cluster and the forged
-  # label would conflict with it.
+  # mock node out of the box. Set to false when something else already supplies
+  # feature.node.kubernetes.io/pci-10de.present and a second writer would
+  # conflict with it.
   pciVendorPresent: true
 
   # Host directory NFD's *local* source reads feature files from
   # (source/local/local.go featureFilesDir, a plain literal — unlike the PCI
   # source's /host-sys path it is not host-prefixed). setup.sh drops the
   # pci-10de feature file here and NFD turns it into the label, so the mock
-  # never writes to the node API. Override only if NFD is deployed with a
+  # never writes that key to the node API (nvidia.com/gpu.present is the only
+  # label it still sets directly). Override only if NFD is deployed with a
   # non-default features.d location.
   featuresDir: /etc/kubernetes/node-feature-discovery/features.d
 

--- a/deployments/nvml-mock/scripts/cleanup.sh
+++ b/deployments/nvml-mock/scripts/cleanup.sh
@@ -32,9 +32,10 @@ if command -v kubectl >/dev/null 2>&1; then
   kubectl label node "$NODE_NAME" nvidia.com/gpu.present- || true
 fi
 
-# Mirror of setup.sh step 7: remove the feature file we wrote. NFD drops the
-# label on its next scan. Gated on the same variable so a pod that never
-# wrote the file never deletes it.
+# Mirror of setup.sh step 7: unwind only the write that step made. NFD drops
+# the label on its next scan once the file is gone. Gated on the same variable,
+# so with the gate off this does nothing — setup.sh never wrote the file on
+# this pod and already removed any copy an earlier run left behind.
 if [ "$(printf '%s' "${MOCK_NFD_PCI_LABEL:-on}" | tr '[:upper:]' '[:lower:]')" = "on" ]; then
   rm -f /host/etc/kubernetes/node-feature-discovery/features.d/nvml-mock.features
 fi

--- a/deployments/nvml-mock/scripts/cleanup.sh
+++ b/deployments/nvml-mock/scripts/cleanup.sh
@@ -30,12 +30,12 @@ if [ -f "$CDI_FILE" ]; then
 fi
 if command -v kubectl >/dev/null 2>&1; then
   kubectl label node "$NODE_NAME" nvidia.com/gpu.present- || true
-  # Mirror of setup.sh step 7: remove the NFD PCI label only when this pod was
-  # the one that wrote it. Chart value nodeLabels.pciVendorPresent maps to
-  # MOCK_NFD_PCI_LABEL; with the gate off a real NFD owns that key, and an
-  # unconditional delete here would strip a label the mock never created.
-  if [ "$(printf '%s' "${MOCK_NFD_PCI_LABEL:-on}" | tr '[:upper:]' '[:lower:]')" = "on" ]; then
-    kubectl label node "$NODE_NAME" feature.node.kubernetes.io/pci-10de.present- || true
-  fi
+fi
+
+# Mirror of setup.sh step 7: remove the feature file we wrote. NFD drops the
+# label on its next scan. Gated on the same variable so a pod that never
+# wrote the file never deletes it.
+if [ "$(printf '%s' "${MOCK_NFD_PCI_LABEL:-on}" | tr '[:upper:]' '[:lower:]')" = "on" ]; then
+  rm -f /host/etc/kubernetes/node-feature-discovery/features.d/nvml-mock.features
 fi
 echo "Mock GPU environment cleaned up on $NODE_NAME"

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -339,9 +339,9 @@ fi
 NFD_FEATURES_DIR=/host/etc/kubernetes/node-feature-discovery/features.d
 NFD_FEATURE_FILE="$NFD_FEATURES_DIR/nvml-mock.features"
 if [ "$PCI_LABEL_MODE" = "on" ]; then
-  # Tolerant on purpose — the one write in this script that is not fatal. It
-  # replaced a `kubectl label` call here that carried `|| true` (cleanup.sh
-  # carried the matching one for the removal), and under
+  # Tolerant on purpose — the one host-filesystem write in this script that is
+  # not fatal. It replaced a `kubectl label` call here that carried `|| true`
+  # (cleanup.sh carried the matching one for the removal), and under
   # `set -e` (line 9) a bare failure here would abort the entrypoint before
   # step 8's /host/run/nvidia/driver symlink, crash-looping the whole mock for
   # an optional, gated feature. When the write fails no label appears, which is

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -312,8 +312,11 @@ fi
 #
 #    MOCK_NFD_PCI_LABEL (chart value `nodeLabels.pciVendorPresent`, default
 #    true/on) gates only the feature file. Turn it off on a cluster where
-#    something else already supplies the key. cleanup.sh reads the same
-#    variable and removes exactly the file this step wrote.
+#    something else already supplies the key. This step converges either way:
+#    with the gate on it writes the file, with the gate off it removes any
+#    file an earlier run left behind. cleanup.sh reads the same variable and
+#    unwinds only the write this step makes — with the gate off it has nothing
+#    to remove, because the removal already happened here.
 PCI_LABEL_MODE=$(printf '%s' "${MOCK_NFD_PCI_LABEL:-on}" | tr '[:upper:]' '[:lower:]')
 case "$PCI_LABEL_MODE" in
   off | on) ;;
@@ -336,9 +339,21 @@ fi
 NFD_FEATURES_DIR=/host/etc/kubernetes/node-feature-discovery/features.d
 NFD_FEATURE_FILE="$NFD_FEATURES_DIR/nvml-mock.features"
 if [ "$PCI_LABEL_MODE" = "on" ]; then
-  mkdir -p "$NFD_FEATURES_DIR"
-  echo "pci-10de.present=true" > "$NFD_FEATURE_FILE"
-  echo "Wrote $NFD_FEATURE_FILE (NFD derives feature.node.kubernetes.io/pci-10de.present)"
+  # Tolerant on purpose — the one write in this script that is not fatal. It
+  # replaced two `kubectl label` calls that both carried `|| true`, and under
+  # `set -e` (line 9) a bare failure here would abort the entrypoint before
+  # step 8's /host/run/nvidia/driver symlink, crash-looping the whole mock for
+  # an optional, gated feature. When the write fails no label appears, which is
+  # the honest state (#505), and nothing downstream is corrupted — unlike the
+  # IB and PCI renders in steps 9 and 10, which are deliberately fatal because
+  # a partial tree silently misleads its consumers. A failing `if` CONDITION
+  # does not trip `set -e`, so this form warns and continues rather than
+  # swallowing the error the way `|| true` would.
+  if mkdir -p "$NFD_FEATURES_DIR" && echo "pci-10de.present=true" > "$NFD_FEATURE_FILE"; then
+    echo "Wrote $NFD_FEATURE_FILE (NFD derives feature.node.kubernetes.io/pci-10de.present)"
+  else
+    echo "WARNING: could not write $NFD_FEATURE_FILE — feature.node.kubernetes.io/pci-10de.present will not be created; the mock is otherwise unaffected" >&2
+  fi
 else
   rm -f "$NFD_FEATURE_FILE"
   echo "Skipping NFD pci-10de feature file (nodeLabels.pciVendorPresent=false)"

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -339,8 +339,10 @@ fi
 NFD_FEATURES_DIR=/host/etc/kubernetes/node-feature-discovery/features.d
 NFD_FEATURE_FILE="$NFD_FEATURES_DIR/nvml-mock.features"
 if [ "$PCI_LABEL_MODE" = "on" ]; then
-  # Tolerant on purpose — the one host-filesystem write in this script that is
-  # not fatal. It replaced a `kubectl label` call here that carried `|| true`
+  # Tolerant on purpose — a failure here must not be fatal, as with the `mknod`
+  # calls in step 3, the `cp` calls in step 4b and the `kubectl label` above.
+  # Those three discard the failure with `|| true`; this one reports it on
+  # stderr. It replaced a `kubectl label` call here that carried `|| true`
   # (cleanup.sh carried the matching one for the removal), and under
   # `set -e` (line 9) a bare failure here would abort the entrypoint before
   # step 8's /host/run/nvidia/driver symlink, crash-looping the whole mock for

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -284,7 +284,7 @@ fi
 #    one writer and "NFD works" stays distinguishable from "we set it
 #    ourselves" (#505).
 #
-#    Why not NFD's PCI source? It structurally cannot see our devices.
+#    Why not NFD's PCI source? As deployed it cannot see our devices.
 #    (Upstream facts as of NFD v0.19.0, the version pinned in go.mod; the
 #    worker actually deployed comes from GPU Operator and may differ.)
 #    source/pci/utils.go resolves hostpath.SysfsDir.Path("bus/pci/devices"),
@@ -340,7 +340,8 @@ NFD_FEATURES_DIR=/host/etc/kubernetes/node-feature-discovery/features.d
 NFD_FEATURE_FILE="$NFD_FEATURES_DIR/nvml-mock.features"
 if [ "$PCI_LABEL_MODE" = "on" ]; then
   # Tolerant on purpose — the one write in this script that is not fatal. It
-  # replaced two `kubectl label` calls that both carried `|| true`, and under
+  # replaced a `kubectl label` call here that carried `|| true` (cleanup.sh
+  # carried the matching one for the removal), and under
   # `set -e` (line 9) a bare failure here would abort the entrypoint before
   # step 8's /host/run/nvidia/driver symlink, crash-looping the whole mock for
   # an optional, gated feature. When the write fails no label appears, which is
@@ -355,8 +356,14 @@ if [ "$PCI_LABEL_MODE" = "on" ]; then
     echo "WARNING: could not write $NFD_FEATURE_FILE — feature.node.kubernetes.io/pci-10de.present will not be created; the mock is otherwise unaffected" >&2
   fi
 else
-  rm -f "$NFD_FEATURE_FILE"
-  echo "Skipping NFD pci-10de feature file (nodeLabels.pciVendorPresent=false)"
+  # Mirror of the tolerant write above: the removal is the same optional,
+  # gated feature on its other arm, so an EROFS or unwritable directory must
+  # not abort the entrypoint before step 8 either.
+  if rm -f "$NFD_FEATURE_FILE"; then
+    echo "Skipping NFD pci-10de feature file (nodeLabels.pciVendorPresent=false)"
+  else
+    echo "WARNING: could not remove $NFD_FEATURE_FILE — a stale feature file may keep feature.node.kubernetes.io/pci-10de.present alive; the mock is otherwise unaffected" >&2
+  fi
 fi
 
 # 8. Create GPU Operator compatibility symlink.

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -274,55 +274,46 @@ if [ -f /etc/nvml-mock/topology/topology.yaml ]; then
   echo "Staged ComputeDomain topology overlay at $HOST/topology/topology.yaml"
 fi
 
-# 7. Label node (requires RBAC: get+patch on nodes)
+# 7. Label node (requires RBAC: get+patch on nodes, for gpu.present only)
 #
-#    Keep the pci-10de line below: nothing else writes that label on a mock
-#    node, so removing it silently drops it.
+#    nvidia.com/gpu.present is written directly: it is an NVIDIA-namespaced key
+#    no NFD source derives.
 #
-#    It is hand-written because NFD's *PCI source* cannot see our fake devices.
-#    (Upstream facts here are as of NFD v0.19.0, the version pinned in go.mod;
-#    the worker actually deployed comes from GPU Operator and may differ.)
-#    That source reads exactly one path, fixed at link time: source/pci/utils.go
-#    resolves hostpath.SysfsDir.Path("bus/pci/devices"), and pkg/utils/hostpath
-#    builds SysfsDir from a private `pathPrefix` var set only via linker -X.
-#    Upstream's container build passes HOSTMOUNT_PREFIX=/host- (Makefile), so the
-#    shipped worker reads /host-sys/bus/pci/devices — the real host /sys,
-#    hostPath-mounted read-only by the worker DaemonSet.
+#    feature.node.kubernetes.io/pci-10de.present is NOT written directly. We
+#    drop a feature file and let NFD create the label, so that key has exactly
+#    one writer and "NFD works" stays distinguishable from "we set it
+#    ourselves" (#505).
 #
-#    Our fake tree lives at /var/lib/nvml-mock/sys/bus/pci/devices and is
-#    reachable only through libpcimocksys.so, which the NRI plugin does inject
-#    into the NFD worker (it is opt-out, and NFD is not in an excluded
-#    namespace). The injection is inert. Either of the following alone would be
-#    enough; both hold:
-#      a) the shim rewrites only paths starting "/sys/" (see k_prefixes[] in
+#    Why not NFD's PCI source? It structurally cannot see our devices.
+#    (Upstream facts as of NFD v0.19.0, the version pinned in go.mod; the
+#    worker actually deployed comes from GPU Operator and may differ.)
+#    source/pci/utils.go resolves hostpath.SysfsDir.Path("bus/pci/devices"),
+#    and pkg/utils/hostpath builds SysfsDir from a private `pathPrefix` set
+#    only via linker -X. Upstream's container build passes
+#    HOSTMOUNT_PREFIX=/host- (Makefile), so the shipped worker reads
+#    /host-sys/bus/pci/devices — the real host /sys, hostPath-mounted by the
+#    worker DaemonSet. Our tree is at /var/lib/nvml-mock/sys and is reachable
+#    only through libpcimocksys.so, whose injection into the worker is inert
+#    twice over:
+#      a) the shim rewrites only paths starting "/sys/" (k_prefixes[] in
 #         pkg/system/mockpcisysfs/c/shim.c), so "/host-sys/..." never matches.
-#      b) nfd-worker is built -extldflags=-static, so the binary has no
-#         PT_INTERP and LD_PRELOAD is ignored outright.
-#
-#    The key itself is correct: GPU Operator configures NFD with
+#      b) nfd-worker is built -extldflags=-static, so it has no PT_INTERP and
+#         ignores LD_PRELOAD outright.
+#    The key itself is right: GPU Operator configures NFD with
 #    deviceLabelFields:[vendor] and whitelists class 0302, which is exactly the
-#    "pci-<vendor>.present" form below, and our rendered devices carry all five
+#    "pci-<vendor>.present" form, and our rendered devices carry all five
 #    attributes NFD treats as mandatory. Only visibility is missing.
 #
-#    None of this rules out NFD entirely — only its PCI source. NFD's *local*
-#    source reads feature files from
-#    /etc/kubernetes/node-feature-discovery/features.d/ (source/local/local.go,
-#    a plain literal, not host-prefixed like the PCI path above), and the worker
-#    mounts that host directory at the same path. We already mount that exact
-#    directory as the GFD mock's output dir (tests/e2e/gfd-mock.yaml:52), so
-#    writing a feature file there is the supported way to retire this kubectl
-#    call — no node RBAC needed.
-#
-#    Full analysis with file:line citations is in the commit message that added
-#    this comment (#505 poses the question; it does not answer it):
-#      git log -S 'pci-10de' -- deployments/nvml-mock/scripts/setup.sh
+#    NFD's *local* source has no such limit: source/local/local.go reads
+#    featureFilesDir, a plain literal (not host-prefixed), and the worker
+#    mounts that host directory at the same path. Each line parses as
+#    key[=value]. That is the supported route, and it needs no node RBAC. The
+#    GFD mock already writes to that same directory (tests/e2e/gfd-mock.yaml:52).
 #
 #    MOCK_NFD_PCI_LABEL (chart value `nodeLabels.pciVendorPresent`, default
-#    true/on) gates only the pci-10de line. Turn it off on a cluster where a
-#    real NFD owns feature.node.kubernetes.io/*, so the mock does not forge a
-#    key another controller reconciles. cleanup.sh reads the same variable and
-#    skips the corresponding delete, so the preStop hook removes exactly the
-#    labels this step wrote and never one it did not.
+#    true/on) gates only the feature file. Turn it off on a cluster where
+#    something else already supplies the key. cleanup.sh reads the same
+#    variable and removes exactly the file this step wrote.
 PCI_LABEL_MODE=$(printf '%s' "${MOCK_NFD_PCI_LABEL:-on}" | tr '[:upper:]' '[:lower:]')
 case "$PCI_LABEL_MODE" in
   off | on) ;;
@@ -333,11 +324,24 @@ case "$PCI_LABEL_MODE" in
 esac
 if command -v kubectl >/dev/null 2>&1; then
   kubectl label node "$NODE_NAME" nvidia.com/gpu.present=true --overwrite || true
-  if [ "$PCI_LABEL_MODE" = "on" ]; then
-    kubectl label node "$NODE_NAME" feature.node.kubernetes.io/pci-10de.present=true --overwrite || true
-  else
-    echo "Skipping feature.node.kubernetes.io/pci-10de.present (nodeLabels.pciVendorPresent=false)"
-  fi
+fi
+
+# NFD local source: drop a feature file instead of writing the label
+# ourselves. source/local/local.go reads every file in featureFilesDir and
+# parses each line as key[=value], so this one line becomes
+# feature.node.kubernetes.io/pci-10de.present=true — created by NFD, not by
+# us. Requires no node RBAC, unlike the kubectl label call it replaces.
+# With no NFD on the cluster the file is inert and the label simply does not
+# exist, which is the honest state (#505).
+NFD_FEATURES_DIR=/host/etc/kubernetes/node-feature-discovery/features.d
+NFD_FEATURE_FILE="$NFD_FEATURES_DIR/nvml-mock.features"
+if [ "$PCI_LABEL_MODE" = "on" ]; then
+  mkdir -p "$NFD_FEATURES_DIR"
+  echo "pci-10de.present=true" > "$NFD_FEATURE_FILE"
+  echo "Wrote $NFD_FEATURE_FILE (NFD derives feature.node.kubernetes.io/pci-10de.present)"
+else
+  rm -f "$NFD_FEATURE_FILE"
+  echo "Skipping NFD pci-10de feature file (nodeLabels.pciVendorPresent=false)"
 fi
 
 # 8. Create GPU Operator compatibility symlink.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -268,6 +268,7 @@ Use-case labels:
 - `multi-node`
 - `nri`
 - `nri-inject`
+- `nfd`
 - `compute-domain`
 - `failure-injection`
 - `validator`
@@ -282,6 +283,7 @@ make e2e E2E_PROFILES=a100 E2E_GINKGO_FLAGS='--label-filter="dra"'
 make e2e E2E_PROFILES=a100 E2E_GINKGO_FLAGS='--label-filter="gpu-operator"'
 make e2e E2E_PROFILES=a100,t4 E2E_GINKGO_FLAGS='--label-filter="multi-node"'
 make e2e E2E_GINKGO_FLAGS='--label-filter="nri"'
+make e2e E2E_PROFILES=a100 E2E_GINKGO_FLAGS='--label-filter="nfd"'
 make e2e E2E_RUN_NGC=true E2E_GINKGO_FLAGS='--label-filter="validator"'
 ```
 

--- a/tests/e2e/VERSION-MATRIX.md
+++ b/tests/e2e/VERSION-MATRIX.md
@@ -9,6 +9,7 @@ Tested component versions for the mock GPU E2E test suite.
 | NVIDIA Device Plugin | v0.18.2 | `nvcr.io/nvidia/k8s-device-plugin:v0.18.2` | Tested in CI |
 | DRA Driver (GPU) | v0.10.x | `nvidia/nvidia-dra-driver-gpu` (Helm) | Tested in CI |
 | GPU Feature Discovery | v0.17.0 | `nvcr.io/nvidia/gpu-feature-discovery:v0.17.0` | Tested in CI |
+| Node Feature Discovery | v0.19.0 | `nfd/node-feature-discovery` (Helm) | Pinned + tested in CI |
 | CUDA vectorAdd sample | cuda12.5.0 | `nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0` | Tested in CI |
 | GPU Operator | v24.9.2 | `nvidia/gpu-operator` (Helm) | Pinned + tested in CI |
 | DCGM | 3.3.9 | `nvcr.io/nvidia/cloud-native/dcgm:3.3.9-1-ubuntu22.04` | Spike script (`spike-dcgm.sh`) |

--- a/tests/e2e/VERSION-MATRIX.md
+++ b/tests/e2e/VERSION-MATRIX.md
@@ -21,6 +21,7 @@ Tested component versions for the mock GPU E2E test suite.
 - **Device Plugin** (standalone DaemonSet): discovers mock GPUs via NVML, registers `nvidia.com/gpu` resource
 - **DRA Driver** (Helm chart): discovers mock GPUs via NVML, publishes ResourceSlices
 - **GPU Feature Discovery** (standalone DaemonSet): reads GPU attributes via NVML, labels nodes
+- **Node Feature Discovery** (Helm chart): derives the PCI vendor label from the feature file nvml-mock writes, not nvml-mock itself
 - **CUDA Validator** (Job): runs vectorAdd against mock libcuda.so
 
 ### Values Overlay Only (GPU Operator)

--- a/tests/e2e/go/assertions/resources.go
+++ b/tests/e2e/go/assertions/resources.go
@@ -138,6 +138,30 @@ func NodeLabelAbsent(ctx context.Context, k *kube.Client, node, key string) {
 		"node %s unexpectedly carries %s=%s — nvml-mock must not write this label", node, key, v)
 }
 
+// NodeAnnotationListContains asserts a node annotation holds a comma-separated
+// list with item as one of its ELEMENTS. This is the ownership half of the
+// provenance guard: NFD records every label it owns in
+// nfd.node.kubernetes.io/feature-labels, and a label written by anything else
+// (a `kubectl label` in setup.sh, say) never appears there — so presence of the
+// label plus membership here is the direct discriminator, independent of any
+// ordering argument.
+//
+// Membership, never strings.Contains on the raw value: a substring match would
+// also accept a neighbouring entry that merely contains item (`xpci-10de.presentx`).
+func NodeAnnotationListContains(ctx context.Context, k *kube.Client, node, key, item string) {
+	ginkgo.GinkgoHelper()
+	ginkgo.By(fmt.Sprintf("node %s annotation %s lists %s", node, key, item))
+	v, ok, err := k.NodeAnnotation(ctx, node, key)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(ok).To(gomega.BeTrue(), "node %s missing annotation %s", node, key)
+	items := strings.Split(v, ",")
+	for i := range items {
+		items[i] = strings.TrimSpace(items[i])
+	}
+	gomega.Expect(items).To(gomega.ContainElement(item),
+		"node %s annotation %s=%q does not list %s", node, key, v, item)
+}
+
 // DRAEmptyDeviceEdits classifies a stuck gpu-test-pod: if the pod events show
 // the "empty device edits" string the failure is the dev-node layout
 // regression (preserved from the bash diagnosis). Returns true if seen.

--- a/tests/e2e/go/assertions/resources.go
+++ b/tests/e2e/go/assertions/resources.go
@@ -125,6 +125,19 @@ func NodeLabelSoft(ctx context.Context, k *kube.Client, node, key string) {
 	}
 }
 
+// NodeLabelAbsent asserts a node label is not set at all. This is the guard
+// that proves provenance: with NFD absent, nothing in nvml-mock may create
+// feature.node.kubernetes.io/pci-10de.present. Reinstating a direct
+// `kubectl label` for that key turns this red.
+func NodeLabelAbsent(ctx context.Context, k *kube.Client, node, key string) {
+	ginkgo.GinkgoHelper()
+	ginkgo.By(fmt.Sprintf("node %s has no label %s", node, key))
+	v, ok, err := k.NodeLabel(ctx, node, key)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(ok).To(gomega.BeFalse(),
+		"node %s unexpectedly carries %s=%s — nvml-mock must not write this label", node, key, v)
+}
+
 // DRAEmptyDeviceEdits classifies a stuck gpu-test-pod: if the pod events show
 // the "empty device edits" string the failure is the dev-node layout
 // regression (preserved from the bash diagnosis). Returns true if seen.

--- a/tests/e2e/go/framework/helm/helm.go
+++ b/tests/e2e/go/framework/helm/helm.go
@@ -28,6 +28,7 @@ func New(context string) *Client { return &Client{Context: context} }
 type Release struct {
 	Name            string
 	Chart           string
+	Version         string
 	Namespace       string
 	CreateNamespace bool
 	HideOutput      bool
@@ -84,6 +85,9 @@ func (c *Client) run(ctx context.Context, verb string, rel Release, extra ...str
 	}
 	if rel.CreateNamespace {
 		args = append(args, "--create-namespace")
+	}
+	if rel.Version != "" {
+		args = append(args, "--version", rel.Version)
 	}
 	if rel.ReuseValues {
 		args = append(args, "--reuse-values")

--- a/tests/e2e/go/framework/helm/helm_test.go
+++ b/tests/e2e/go/framework/helm/helm_test.go
@@ -30,6 +30,58 @@ func TestBaseTargetsKubeContext(t *testing.T) {
 	}
 }
 
+func TestRunPinsChartVersionOnlyWhenSet(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		version     string
+		wantVersion bool
+	}{
+		{name: "pinned chart", version: "0.19.0", wantVersion: true},
+		{name: "unpinned chart", version: "", wantVersion: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			oldRunCommand := runCommand
+			t.Cleanup(func() { runCommand = oldRunCommand })
+
+			var args []string
+			runCommand = func(_ context.Context, _ string, a ...string) (runner.Result, error) {
+				args = a
+				return runner.Result{}, nil
+			}
+
+			err := New("kind-nvml-mock-e2e").Install(context.Background(), Release{
+				Name:    "nfd",
+				Chart:   "nfd/node-feature-discovery",
+				Version: tc.version,
+			})
+			if err != nil {
+				t.Fatalf("expected helm install to succeed, got %v", err)
+			}
+
+			flag := -1
+			for i, arg := range args {
+				if arg == "--version" {
+					flag = i
+					break
+				}
+			}
+
+			if !tc.wantVersion {
+				if flag != -1 {
+					t.Fatalf("expected no --version for a release without a pinned version, got %#v", args)
+				}
+				return
+			}
+			if flag == -1 {
+				t.Fatalf("expected --version in the helm argv, got %#v", args)
+			}
+			if flag+1 >= len(args) || args[flag+1] != tc.version {
+				t.Fatalf("expected --version to be followed by %q, got %#v", tc.version, args)
+			}
+		})
+	}
+}
+
 func TestRunHidesReleaseOutputWhenRequested(t *testing.T) {
 	oldRunCommand := runCommand
 	oldRunQuietCommand := runQuietCommand

--- a/tests/e2e/go/framework/kube/kube.go
+++ b/tests/e2e/go/framework/kube/kube.go
@@ -75,8 +75,9 @@ func (c *Client) getJSON(ctx context.Context, out any, args ...string) error {
 // ---------------------------------------------------------------------------
 
 type objectMeta struct {
-	Name   string            `json:"name"`
-	Labels map[string]string `json:"labels"`
+	Name        string            `json:"name"`
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
 }
 
 type nodeCondition struct {
@@ -165,6 +166,16 @@ func (c *Client) NodeLabel(ctx context.Context, node, key string) (string, bool,
 		return "", false, err
 	}
 	v, ok := n.Metadata.Labels[key]
+	return v, ok, nil
+}
+
+// NodeAnnotation returns a node annotation value and whether it was set.
+func (c *Client) NodeAnnotation(ctx context.Context, node, key string) (string, bool, error) {
+	var n nodeObj
+	if err := c.getJSON(ctx, &n, "node", node); err != nil {
+		return "", false, err
+	}
+	v, ok := n.Metadata.Annotations[key]
 	return v, ok, nil
 }
 

--- a/tests/e2e/go/scenario_nfd_test.go
+++ b/tests/e2e/go/scenario_nfd_test.go
@@ -1,0 +1,153 @@
+//go:build e2e
+
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/assertions"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/config"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/harness"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/helm"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/kube"
+)
+
+const (
+	nfdNamespace = "node-feature-discovery"
+	nfdRelease   = "nfd"
+	nfdChart     = "nfd/node-feature-discovery"
+	nfdRepoURL   = "https://kubernetes-sigs.github.io/node-feature-discovery/charts"
+	// Pinned to the version in go.mod. Every upstream behaviour this test
+	// relies on (local-source featureFilesDir, label namespacing) was read
+	// from this tag.
+	nfdVersion = "0.19.0"
+
+	// The label under test. NFD's local source turns a features.d line
+	// "pci-10de.present=true" into exactly this key.
+	pciVendorLabel = "feature.node.kubernetes.io/pci-10de.present"
+
+	// Container path of the feature file setup.sh writes (chart mount from
+	// Task 2; the hostPath behind it is nodeLabels.featuresDir).
+	nfdFeatureFile = "/host/etc/kubernetes/node-feature-discovery/features.d/nvml-mock.features"
+
+	nfdLabelTimeout = 3 * time.Minute
+	nfdLabelPoll    = 5 * time.Second
+)
+
+// Proves provenance of the NFD PCI vendor label by ordering, not inspection:
+// with NFD absent the label must not exist (nothing in nvml-mock may write
+// it), and once NFD is installed it must appear. See issue #505.
+//
+// Ordered because the absent-check is only meaningful before NFD is installed;
+// ContinueOnFailure because the three specs report independent facts (no label,
+// the feature file, the label after NFD) and a plain Ordered container stops at
+// the first failure, hiding the other two.
+var _ = Describe("nvml-mock NFD label provenance", Label("nfd"), Ordered, ContinueOnFailure, func() {
+	var (
+		h    *harness.Harness
+		pod  kube.PodRef
+		node string
+	)
+
+	BeforeAll(func(ctx SpecContext) {
+		h = setupCluster(ctx, "nvml-mock-nfd", demoKindConfig([]string{"a100"}), "nfd")
+		installDemoChart(ctx, h, "a100", 8)
+
+		// Derive the node from where an nvml-mock pod actually runs — never
+		// h.Kube.FirstNodeName, which returns Items[0]: on the demo kind
+		// config that is the CONTROL PLANE, and the NFD chart schedules no
+		// worker there (no control-plane toleration). Targeting it would make
+		// the absent-check pass for the wrong reason and the present-check
+		// fail forever. Measured in the Task 1 experiment.
+		// Using the mock pod's node also guarantees the feature file and the
+		// label assertion refer to the same machine.
+		pod, node = nvmlMockPodOnWorker(ctx, h)
+		Expect(node).NotTo(ContainSubstring("control-plane"),
+			"nvml-mock pod landed on the control plane; NFD runs no worker there")
+	})
+
+	It("does not create the PCI vendor label without NFD", Label("nfd-provenance"), func(ctx SpecContext) {
+		assertions.NodeLabelAbsent(ctx, h.Kube, node, pciVendorLabel)
+	})
+
+	It("writes the feature file NFD's local source reads", Label("nfd-provenance"), func(ctx SpecContext) {
+		res, err := h.Kube.ExecSh(ctx, pod, "cat "+nfdFeatureFile)
+		Expect(err).NotTo(HaveOccurred(), "reading %s: %s", nfdFeatureFile, res.Combined())
+		Expect(strings.TrimSpace(res.Stdout)).To(Equal("pci-10de.present=true"),
+			"feature file contents drive the label NFD creates")
+	})
+
+	It("gets the label from NFD once NFD is installed", Label("nfd-provenance"), func(ctx SpecContext) {
+		Expect(h.Helm.RepoAdd(ctx, "nfd", nfdRepoURL)).To(Succeed(), "add NFD Helm repo")
+		Expect(h.Helm.UpgradeInstall(ctx, helm.Release{
+			Name:            nfdRelease,
+			Chart:           nfdChart,
+			Version:         nfdVersion,
+			Namespace:       nfdNamespace,
+			CreateNamespace: true,
+			Wait:            true,
+			Timeout:         config.HelmTimeout(),
+		})).To(Succeed(), "install NFD")
+
+		assertions.WaitNodeLabelsPresent(ctx, h.Kube, node,
+			[]string{pciVendorLabel}, nfdLabelTimeout, nfdLabelPoll)
+		assertions.NodeLabelEquals(ctx, h.Kube, node, pciVendorLabel, "true")
+	})
+})
+
+// nvmlMockPodOnWorker returns a running nvml-mock pod scheduled on a Kind
+// WORKER node, plus that node's name.
+//
+// The pod is selected by node role, never by list position. The chart's default
+// toleration is `operator: Exists`, so the mock DaemonSet also lands on the
+// control plane; the API returns pods in name order and DaemonSet pod names
+// carry a random suffix, so a positional pick (FirstPodName -> Items[0]) hits
+// the control-plane pod about one run in four — and the NFD chart schedules no
+// worker there, which would make this whole scenario fail for a reason that has
+// nothing to do with the label. Names are sorted so repeated runs on the same
+// cluster agree on which worker they target.
+func nvmlMockPodOnWorker(ctx context.Context, h *harness.Harness) (kube.PodRef, string) {
+	GinkgoHelper()
+	workers, err := h.Cluster.Workers(ctx)
+	Expect(err).NotTo(HaveOccurred(), "list Kind worker nodes")
+	Expect(workers).NotTo(BeEmpty(), "NFD label provenance needs at least one Kind worker node")
+	isWorker := make(map[string]bool, len(workers))
+	for _, w := range workers {
+		isWorker[w.Name] = true
+	}
+
+	var (
+		ref  kube.PodRef
+		node string
+	)
+	Eventually(func() (string, error) {
+		names, err := h.Kube.RunningPodNames(ctx, nvmlMockNamespace, nvmlMockSelector)
+		if err != nil {
+			return "", err
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			n, err := h.Kube.PodNode(ctx, nvmlMockNamespace, name)
+			if err != nil {
+				return "", err
+			}
+			if isWorker[n] {
+				ref = kube.PodRef{Namespace: nvmlMockNamespace, Pod: name}
+				node = n
+				return n, nil
+			}
+		}
+		return "", nil
+	}).WithContext(ctx).WithTimeout(config.ReadyTimeout()).WithPolling(config.PollInterval()).
+		ShouldNot(BeEmpty(), "no running nvml-mock pod on a Kind worker node")
+	return ref, node
+}

--- a/tests/e2e/go/scenario_nfd_test.go
+++ b/tests/e2e/go/scenario_nfd_test.go
@@ -44,8 +44,9 @@ const (
 	nfdOwnedLabelsAnnotation = "nfd.node.kubernetes.io/feature-labels"
 	pciVendorFeature         = "pci-10de.present"
 
-	// Written unconditionally by setup.sh one line BEFORE the pci-10de label,
-	// and used here only as a synchronisation barrier. See spec 1.
+	// Written unconditionally by setup.sh in step 7, before anything
+	// pci-10de-related, and used here only as a synchronisation barrier.
+	// See spec 1.
 	gpuPresentLabel = "nvidia.com/gpu.present"
 
 	// Container path of the feature file setup.sh writes (chart mount from
@@ -100,10 +101,10 @@ var _ = Describe("nvml-mock NFD label provenance", Label("nfd"), Ordered, Contin
 		// DaemonSet declares no readinessProbe, demoRelease sets
 		// maxUnavailable=100% so `helm --wait` returns on merely-scheduled
 		// pods, and pod selection waits only for phase Running. setup.sh writes
-		// nvidia.com/gpu.present unconditionally on the line immediately BEFORE
-		// the pci-10de label, so observing it proves setup.sh reached the
-		// labelling block — and that a still-absent pci-10de label is a real
-		// absence, not a race we won.
+		// nvidia.com/gpu.present unconditionally in step 7, still ahead of the
+		// pci-10de feature-file block that follows it, so observing it proves
+		// setup.sh reached the labelling block — and that a still-absent
+		// pci-10de label is a real absence, not a race we won.
 		assertions.WaitNodeLabelsPresent(ctx, h.Kube, node,
 			[]string{gpuPresentLabel}, nfdLabelTimeout, nfdLabelPoll)
 

--- a/tests/e2e/go/scenario_nfd_test.go
+++ b/tests/e2e/go/scenario_nfd_test.go
@@ -35,6 +35,19 @@ const (
 	// "pci-10de.present=true" into exactly this key.
 	pciVendorLabel = "feature.node.kubernetes.io/pci-10de.present"
 
+	// NFD records every label it owns in this annotation, as a comma-separated
+	// list of label names WITHOUT the feature.node.kubernetes.io/ prefix (its
+	// default namespace). A label written by anything else — setup.sh's
+	// `kubectl label`, say — never appears here, which makes this the direct
+	// ownership discriminator rather than an inference from ordering. Measured
+	// in the Task 1 experiment.
+	nfdOwnedLabelsAnnotation = "nfd.node.kubernetes.io/feature-labels"
+	pciVendorFeature         = "pci-10de.present"
+
+	// Written unconditionally by setup.sh one line BEFORE the pci-10de label,
+	// and used here only as a synchronisation barrier. See spec 1.
+	gpuPresentLabel = "nvidia.com/gpu.present"
+
 	// Container path of the feature file setup.sh writes (chart mount from
 	// Task 2; the hostPath behind it is nodeLabels.featuresDir).
 	nfdFeatureFile = "/host/etc/kubernetes/node-feature-discovery/features.d/nvml-mock.features"
@@ -43,9 +56,13 @@ const (
 	nfdLabelPoll    = 5 * time.Second
 )
 
-// Proves provenance of the NFD PCI vendor label by ordering, not inspection:
-// with NFD absent the label must not exist (nothing in nvml-mock may write
-// it), and once NFD is installed it must appear. See issue #505.
+// Proves provenance of the NFD PCI vendor label two independent ways: by
+// ordering (with NFD absent the label must not exist, because nothing in
+// nvml-mock may write it, and it must appear once NFD is installed) and by
+// ownership (NFD lists the label in its own feature-labels annotation, which a
+// hand-written label never reaches). Either one alone can be fooled — the
+// ordering half by a race, the ownership half by an NFD version that stops
+// annotating — so both are asserted. See issue #505.
 //
 // Ordered because the absent-check is only meaningful before NFD is installed;
 // ContinueOnFailure because the three specs report independent facts (no label,
@@ -69,13 +86,27 @@ var _ = Describe("nvml-mock NFD label provenance", Label("nfd"), Ordered, Contin
 		// the absent-check pass for the wrong reason and the present-check
 		// fail forever. Measured in the Task 1 experiment.
 		// Using the mock pod's node also guarantees the feature file and the
-		// label assertion refer to the same machine.
+		// label assertion refer to the same machine. The worker-role invariant
+		// is enforced inside that helper, by Kind's own node classification.
 		pod, node = nvmlMockPodOnWorker(ctx, h)
-		Expect(node).NotTo(ContainSubstring("control-plane"),
-			"nvml-mock pod landed on the control plane; NFD runs no worker there")
 	})
 
 	It("does not create the PCI vendor label without NFD", Label("nfd-provenance"), func(ctx SpecContext) {
+		// SYNCHRONISATION BARRIER — not a feature assertion. Do not "tidy" it
+		// away: without it this negative check is unordered against setup.sh
+		// and can pass vacuously, which would make the whole guard useless.
+		//
+		// Nothing else orders us after setup.sh's labelling step: the nvml-mock
+		// DaemonSet declares no readinessProbe, demoRelease sets
+		// maxUnavailable=100% so `helm --wait` returns on merely-scheduled
+		// pods, and pod selection waits only for phase Running. setup.sh writes
+		// nvidia.com/gpu.present unconditionally on the line immediately BEFORE
+		// the pci-10de label, so observing it proves setup.sh reached the
+		// labelling block — and that a still-absent pci-10de label is a real
+		// absence, not a race we won.
+		assertions.WaitNodeLabelsPresent(ctx, h.Kube, node,
+			[]string{gpuPresentLabel}, nfdLabelTimeout, nfdLabelPoll)
+
 		assertions.NodeLabelAbsent(ctx, h.Kube, node, pciVendorLabel)
 	})
 
@@ -101,6 +132,13 @@ var _ = Describe("nvml-mock NFD label provenance", Label("nfd"), Ordered, Contin
 		assertions.WaitNodeLabelsPresent(ctx, h.Kube, node,
 			[]string{pciVendorLabel}, nfdLabelTimeout, nfdLabelPoll)
 		assertions.NodeLabelEquals(ctx, h.Kube, node, pciVendorLabel, "true")
+
+		// Presence alone cannot tell "NFD derived it" from "setup.sh wrote it",
+		// so assert ownership directly: NFD patches the label and this
+		// annotation in the same node update, so once the label is observed the
+		// annotation is too — no second wait needed.
+		assertions.NodeAnnotationListContains(ctx, h.Kube, node,
+			nfdOwnedLabelsAnnotation, pciVendorFeature)
 	})
 })
 


### PR DESCRIPTION
## Problem

`deployments/nvml-mock/scripts/setup.sh` wrote `feature.node.kubernetes.io/pci-10de.present=true`
onto each node with `kubectl label`. Node Feature Discovery never derived that value under
nvml-mock, so anything downstream treating it as evidence of NFD working was trusting a value we
wrote ourselves. #505 asked for one of two outcomes: the hand-written label gone with an e2e
proving NFD derives it, or a recorded, specific reason it cannot.

The repo also asserted that NFD's PCI source *structurally* could not see mock devices. That
turned out to be wrong, and it was wrong in the interesting direction.

## What the experiment found

Run on a 3-node kind cluster (nvml-mock a100, 8 GPUs, stock NFD chart 0.19.0):

- Pointed at the rendered tree, NFD's PCI source enumerates all 8 mock GPUs
  (`{"class":"0302","device":"20b0","vendor":"10de",…}`) and, with the
  `deviceLabelFields: [vendor]` that GPU Operator configures, derives exactly
  `pci-10de.present`. The rendered tree was never the problem — it already carries all five
  attributes NFD treats as mandatory.
- The real constraint is narrower: `nfd-worker` resolves `/host-sys/bus/pci/devices` from a
  prefix fixed at link time and is statically linked, so neither our tree nor the `LD_PRELOAD`
  shim reaches it. That wording is now corrected throughout the chart.
- NFD's **local** source has no such limit, and it is the route this PR ships.

## Approach

- `setup.sh` writes `pci-10de.present=true` into
  `/etc/kubernetes/node-feature-discovery/features.d/nvml-mock.features`; NFD creates the label.
  Node `get`/`patch` RBAC is no longer needed for this key (`nvidia.com/gpu.present` still uses
  it). Both the write and the gate-off removal are deliberately tolerant of I/O failure — an
  optional, gated feature must not crash-loop the mock.
- The chart mounts that host directory. New value `nodeLabels.featuresDir`, schema-typed.
  `nodeLabels.pciVendorPresent` keeps its meaning and now gates the file.
- New `e2e-nfd` suite asserts **provenance**, not presence: with NFD absent the label must not
  exist; once NFD is installed it must appear *and* be listed in
  `nfd.node.kubernetes.io/feature-labels`. That annotation is written only by NFD, so a
  `kubectl label` can never satisfy it — the suite goes red if anyone reinstates a direct write.
- Docs, chart comments and the values schema corrected to match.

## Testing done

- `make e2e-nfd` — 3 Passed | 0 Failed at the branch tip. Red before the change (all three
  specs), green after. The ownership spec spends ~50s waiting one NFD discovery cycle; under the
  old code the label appeared the instant the mock pod started.
- `make e2e-gpu-operator` — 6 Passed | 0 Failed, no regression.
- `make helm-unittest` 133 passed / 15 snapshots; `helm lint` clean.
- `go build`, `go vet -tags e2e`, `golangci-lint run ./...` — all clean.
- Tolerance of both feature-file arms demonstrated under `dash` + `set -e` with a control: the
  pre-fix form aborts on an injected failure, the shipped form warns on stderr and continues.
- Guards mutation-checked: removing the chart mount turns the two new helm tests red; removing
  the `!nfd` label filter leaks the new specs into the default e2e job.

## Behaviour change

**On a cluster with no NFD, `feature.node.kubernetes.io/pci-10de.present` no longer exists.**
That is the point of the change — the label is now evidence that NFD ran, rather than something
the mock asserts. Consumers that gate on it need NFD present (GPU Operator bundles it).
`nvidia.com/gpu.present` is unchanged and still written directly.

A node carrying a stale hand-written label from an older nvml-mock keeps it only if the pod is
terminated ungracefully; a rolling upgrade runs the old image's `cleanup.sh`, which removes it.

## Not in scope

`tests/e2e/VERSION-MATRIX.md` claims the GPU Operator is "Pinned + tested in CI", but
`scenario_gpu_operator_test.go` installs the chart with no `Version:`. Pre-existing; a follow-up
issue. This PR adds the `helm.Release.Version` field that would make it a one-line fix.

Closes #505
