### PR TITLE
fix(nvml-mock-nri): unit tests, full Linux dev_t decoding, stale LD_PRELOAD comment

### DIFF
--- a/cmd/nvml-mock-nri/dev_number_oracle_test.go
+++ b/cmd/nvml-mock-nri/dev_number_oracle_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/nri/nvmlmock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// unix.Major and unix.Minor decode the dev_t of the platform they are compiled
+// for, so they are only the right oracle on Linux. The file carries no
+// //go:build linux tag on purpose: it then still type-checks and lints on a
+// macOS workstation, and skips at run time instead of disappearing.
+func requireLinux(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skipf("unix.Major/unix.Minor decode %s dev_t, not Linux dev_t", runtime.GOOS)
+	}
+}
+
+// major and minor reimplement glibc's encoding rather than calling unix.Major
+// and unix.Minor, because stat.Rdev always describes a Linux device node
+// whatever host the binary was built on. This pins the local implementation to
+// the library on the platform where the library agrees, so the two cannot
+// drift.
+func TestMajorMinorAgreeWithUnixOnLinux(t *testing.T) {
+	requireLinux(t)
+	t.Parallel()
+
+	// Each bit in isolation, so every bit's routing between the major and the
+	// minor field is checked on its own. Bits 44-63 and 20-43 are the ones a
+	// truncating mask drops.
+	for bit := range 64 {
+		dev := uint64(1) << bit
+		require.Equal(t, uint64(unix.Major(dev)), major(dev), "major(1<<%d)", bit)
+		require.Equal(t, uint64(unix.Minor(dev)), minor(dev), "minor(1<<%d)", bit)
+	}
+
+	for _, dev := range []uint64{
+		0x0,
+		0x103,              // /dev/null
+		0x1ff05,            // major 511, minor 5
+		0x123459abcde678f0, // every field populated
+		0xffffffffffffffff, // all bits set
+		0xfffff00000000000, // extended major field only
+		0x00000ffffff00000, // extended minor field only
+		0x00000000000fff00, // legacy major field only
+		0x00000000000000ff, // legacy minor field only
+	} {
+		require.Equal(t, uint64(unix.Major(dev)), major(dev), "major(%#x)", dev)
+		require.Equal(t, uint64(unix.Minor(dev)), minor(dev), "minor(%#x)", dev)
+	}
+}
+
+// The device numbers below are fixed by the Linux mem driver, so they are
+// literals rather than values read back from the same syscall the code uses.
+func TestNriDeviceDecodesRealCharacterDevices(t *testing.T) {
+	requireLinux(t)
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		hostPath  string
+		wantMajor int64
+		wantMinor int64
+	}{
+		{name: "/dev/null", hostPath: "/dev/null", wantMajor: 1, wantMinor: 3},
+		{name: "/dev/zero", hostPath: "/dev/zero", wantMajor: 1, wantMinor: 5},
+		{name: "/dev/full", hostPath: "/dev/full", wantMajor: 1, wantMinor: 7},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			device, err := nriDevice(nvmlmock.Device{HostPath: tt.hostPath, Path: "/dev/nvidia0"})
+			require.NoError(t, err)
+			require.NotNil(t, device)
+
+			// Catches decoding stat.Rdev with the wrong encoding: containerd
+			// creates the device node from these two numbers, so a wrong value
+			// gives the container a node pointing at a different driver.
+			require.Equal(t, tt.wantMajor, device.Major)
+			require.Equal(t, tt.wantMinor, device.Minor)
+			require.Equal(t, "c", device.Type)
+			require.Equal(t, "/dev/nvidia0", device.Path)
+		})
+	}
+}

--- a/cmd/nvml-mock-nri/main.go
+++ b/cmd/nvml-mock-nri/main.go
@@ -177,10 +177,20 @@ func envOr(key, fallback string) string {
 	return fallback
 }
 
+// major and minor decode a Linux dev_t the way glibc encodes it
+// (MMMM Mmmm mmmM MMmm): the major occupies bits 8-19 and 44-63, the minor
+// bits 0-7 and 20-43.
+//
+// These deliberately do not call unix.Major and unix.Minor. Those resolve per
+// GOOS: on darwin they decode Darwin's dev_t, where the major is bits 24-31.
+// stat.Rdev here always describes a device node on a Linux node, whatever host
+// the binary was built on, so the decoding must not follow the build platform.
+// dev_number_oracle_test.go pins these against unix.Major and unix.Minor so
+// they cannot drift from glibc.
 func major(dev uint64) uint64 {
-	return (dev >> 8) & 0xfff
+	return ((dev & 0x00000000000fff00) >> 8) | ((dev & 0xfffff00000000000) >> 32)
 }
 
 func minor(dev uint64) uint64 {
-	return (dev & 0xff) | ((dev >> 12) & 0xfff00)
+	return (dev & 0x00000000000000ff) | ((dev & 0x00000ffffff00000) >> 12)
 }

--- a/cmd/nvml-mock-nri/main_test.go
+++ b/cmd/nvml-mock-nri/main_test.go
@@ -1,0 +1,377 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/nri/nvmlmock"
+	"github.com/containerd/nri/pkg/api"
+	"github.com/stretchr/testify/require"
+)
+
+// Device numbers are Linux dev_t values harvested from a node's /dev/nvidia*
+// nodes. glibc encodes them as MMMM Mmmm mmmM MMmm: the major occupies bits
+// 8-19 and 44-63, the minor bits 0-7 and 20-43. Cases below are derived from
+// that encoding, not from the implementation.
+//
+// The two "wide" cases are the ones that matter. NVIDIA's real majors (195,
+// 510, 511) and minors are all small, so they sit entirely in the legacy low
+// bits and decode correctly even under a truncating formula. A test built only
+// from real device numbers passes on broken code and proves nothing.
+func TestMajorMinorDecodeLinuxDeviceNumbers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		dev       uint64
+		wantMajor uint64
+		wantMinor uint64
+	}{
+		{
+			name: "zero",
+			dev:  0x0, wantMajor: 0, wantMinor: 0,
+		},
+		{
+			// /dev/null. Legacy 16-bit MMmm layout, entirely in the low bits.
+			name: "legacy low bits only",
+			dev:  0x103, wantMajor: 1, wantMinor: 3,
+		},
+		{
+			// A real nvidia device number: major 511, minor 5. Included as an
+			// anchor, and as the reason this bug survived review -- it decodes
+			// correctly even when the high bits are dropped.
+			name: "nvidia caps device",
+			dev:  0x1ff05, wantMajor: 511, wantMinor: 5,
+		},
+		{
+			// Major bit 44, the lowest bit of the extended major field. A
+			// formula masking the major to 12 bits returns 0 here.
+			name: "major above the legacy 12 bits",
+			dev:  0x100000000000, wantMajor: 4096, wantMinor: 0,
+		},
+		{
+			// Major bit 63, the highest bit of the extended major field.
+			name: "major at the top of the extended field",
+			dev:  0x8000000000000000, wantMajor: 2147483648, wantMinor: 0,
+		},
+		{
+			// Minor bit 32. The extended minor field is bits 20-43; a formula
+			// masking it to bits 20-31 returns 0 here.
+			name: "minor above the legacy 20 bits",
+			dev:  0x100000000, wantMajor: 0, wantMinor: 1048576,
+		},
+		{
+			// Minor bit 43, the highest bit of the extended minor field.
+			name: "minor at the top of the extended field",
+			dev:  0x80000000000, wantMajor: 0, wantMinor: 2147483648,
+		},
+		{
+			// Every field populated at once, so a swapped or overlapping mask
+			// cannot pass by coincidence. Encodes major 0x12345678 and minor
+			// 0x9abcdef0 per the glibc layout.
+			name: "all fields populated",
+			dev:  0x123459abcde678f0, wantMajor: 0x12345678, wantMinor: 0x9abcdef0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.wantMajor, major(tt.dev), "major(%#x)", tt.dev)
+			require.Equal(t, tt.wantMinor, minor(tt.dev), "minor(%#x)", tt.dev)
+		})
+	}
+}
+
+// nriDevice stats a real path, so these exercise the syscall rather than a
+// mock. The error paths are the interesting ones: both mean the plugin is about
+// to hand containerd a device it cannot open.
+func TestNriDeviceRejectsNonDevicePaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nonexistent path returns the wrapped stat error", func(t *testing.T) {
+		t.Parallel()
+		missing := filepath.Join(t.TempDir(), "nvidia0")
+
+		device, err := nriDevice(nvmlmock.Device{HostPath: missing, Path: "/dev/nvidia0"})
+
+		// Catches a swallowed stat error: without the check, a vanished device
+		// node yields a LinuxDevice with major/minor decoded from a zeroed
+		// Stat_t, so containerd is told /dev/nvidia0 is device 0:0.
+		require.Error(t, err)
+		require.Nil(t, device)
+		require.ErrorContains(t, err, "stat device "+missing)
+	})
+
+	t.Run("regular file is rejected as not a character device", func(t *testing.T) {
+		t.Parallel()
+		regular := filepath.Join(t.TempDir(), "nvidia0")
+		require.NoError(t, os.WriteFile(regular, []byte("not a device"), 0o644))
+
+		device, err := nriDevice(nvmlmock.Device{HostPath: regular, Path: "/dev/nvidia0"})
+
+		// Catches a missing S_IFCHR check. A regular file stats fine, so
+		// without it the plugin emits type "c" for a path that is not a
+		// character device and container creation fails inside the runtime.
+		require.Error(t, err)
+		require.Nil(t, device)
+		require.ErrorContains(t, err, regular+" is not a character device")
+	})
+
+	t.Run("directory is rejected as not a character device", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		device, err := nriDevice(nvmlmock.Device{HostPath: dir, Path: "/dev/nvidia0"})
+
+		require.Error(t, err)
+		require.Nil(t, device)
+		require.ErrorContains(t, err, dir+" is not a character device")
+	})
+}
+
+// The device number assertions live in dev_number_oracle_test.go: /dev/null's
+// major and minor are only 1 and 3 under the Linux dev_t encoding. Everything
+// asserted here is platform independent.
+func TestNriDeviceMapsCharacterDeviceMetadata(t *testing.T) {
+	t.Parallel()
+
+	device, err := nriDevice(nvmlmock.Device{HostPath: "/dev/null", Path: "/dev/nvidia0"})
+	require.NoError(t, err)
+	require.NotNil(t, device)
+
+	// Path must be the container path, not the host path. Catches a swap that
+	// would mount the host's staging path into the container namespace.
+	require.Equal(t, "/dev/nvidia0", device.Path)
+	require.Equal(t, "c", device.Type)
+
+	// FileMode must carry only the permission bits. Catches passing the raw
+	// st_mode, whose S_IFCHR bits would land in the mode field.
+	require.NotNil(t, device.FileMode)
+	require.Equal(t, uint32(0o666), device.FileMode.GetValue()&uint32(os.ModePerm))
+	require.Zero(t, device.FileMode.GetValue()&^uint32(os.ModePerm))
+}
+
+func TestFromNRI(t *testing.T) {
+	t.Parallel()
+
+	t.Run("copies pod and container fields", func(t *testing.T) {
+		t.Parallel()
+		pod := &api.PodSandbox{
+			Namespace:   "gpu-tests",
+			Annotations: map[string]string{"nvml-mock.nvidia.com/inject": "true"},
+		}
+		container := &api.Container{
+			Env: []string{"PATH=/usr/bin", "MOCK_IB=off"},
+			Mounts: []*api.Mount{{
+				Source:      "/var/lib/nvml-mock",
+				Destination: "/opt/nvml-mock",
+				Type:        "bind",
+				Options:     []string{"rbind", "ro"},
+			}},
+		}
+
+		result := fromNRI(pod, container)
+
+		require.Equal(t, "gpu-tests", result.Namespace)
+		require.Equal(t, map[string]string{"nvml-mock.nvidia.com/inject": "true"}, result.PodAnnotations)
+		require.Equal(t, []string{"PATH=/usr/bin", "MOCK_IB=off"}, result.Env)
+		require.Equal(t, []nvmlmock.Mount{{
+			Source:      "/var/lib/nvml-mock",
+			Destination: "/opt/nvml-mock",
+			Type:        "bind",
+			Options:     []string{"rbind", "ro"},
+		}}, result.Mounts)
+	})
+
+	t.Run("does not alias the runtime's slices", func(t *testing.T) {
+		t.Parallel()
+		container := &api.Container{
+			Env:    []string{"PATH=/usr/bin"},
+			Mounts: []*api.Mount{{Source: "/src", Options: []string{"rbind"}}},
+		}
+
+		result := fromNRI(nil, container)
+		result.Env[0] = "PATH=/clobbered"
+		result.Mounts[0].Options[0] = "rw"
+
+		// Catches dropping the defensive copies. NRI owns these slices; writing
+		// through them corrupts the runtime's own view of the container.
+		require.Equal(t, []string{"PATH=/usr/bin"}, container.Env)
+		require.Equal(t, []string{"rbind"}, container.Mounts[0].Options)
+	})
+
+	t.Run("tolerates nil pod and nil container", func(t *testing.T) {
+		t.Parallel()
+		// Catches a nil dereference. NRI may deliver either as nil, and a panic
+		// in CreateContainer takes the plugin down and stops all injection.
+		require.NotPanics(t, func() {
+			result := fromNRI(nil, nil)
+			require.Empty(t, result.Namespace)
+			require.Empty(t, result.Env)
+			require.Empty(t, result.Mounts)
+		})
+
+		podOnly := fromNRI(&api.PodSandbox{Namespace: "default"}, nil)
+		require.Equal(t, "default", podOnly.Namespace)
+		require.Empty(t, podOnly.Env)
+	})
+}
+
+func TestToNRI(t *testing.T) {
+	t.Parallel()
+
+	t.Run("maps mounts and env", func(t *testing.T) {
+		t.Parallel()
+		adjustment := nvmlmock.Adjustment{
+			Mounts: []nvmlmock.Mount{{
+				Source:      "/var/lib/nvml-mock",
+				Destination: "/opt/nvml-mock",
+				Type:        "bind",
+				Options:     []string{"rbind", "ro"},
+			}},
+			Env: []string{"MOCK_NVML_CONFIG=/opt/nvml-mock/driver/config/config.yaml"},
+		}
+
+		result, err := toNRI(adjustment)
+		require.NoError(t, err)
+
+		require.Len(t, result.Mounts, 1)
+		require.Equal(t, "/var/lib/nvml-mock", result.Mounts[0].Source)
+		require.Equal(t, "/opt/nvml-mock", result.Mounts[0].Destination)
+		require.Equal(t, "bind", result.Mounts[0].Type)
+		require.Equal(t, []string{"rbind", "ro"}, result.Mounts[0].Options)
+
+		require.Len(t, result.Env, 1)
+		require.Equal(t, "MOCK_NVML_CONFIG", result.Env[0].Key)
+		require.Equal(t, "/opt/nvml-mock/driver/config/config.yaml", result.Env[0].Value)
+	})
+
+	t.Run("splits env on the first separator only", func(t *testing.T) {
+		t.Parallel()
+		result, err := toNRI(nvmlmock.Adjustment{
+			Env: []string{"LD_PRELOAD=/a/lib.so:/b/lib.so", "PATH=/usr/bin=weird"},
+		})
+		require.NoError(t, err)
+
+		// Catches splitting on every separator, which would truncate any value
+		// containing "=" -- LD_PRELOAD chains and PATH entries are the risk.
+		require.Len(t, result.Env, 2)
+		require.Equal(t, "LD_PRELOAD", result.Env[0].Key)
+		require.Equal(t, "/a/lib.so:/b/lib.so", result.Env[0].Value)
+		require.Equal(t, "PATH", result.Env[1].Key)
+		require.Equal(t, "/usr/bin=weird", result.Env[1].Value)
+	})
+
+	t.Run("drops env entries with no separator", func(t *testing.T) {
+		t.Parallel()
+		result, err := toNRI(nvmlmock.Adjustment{
+			Env: []string{"MALFORMED", "PATH=/usr/bin"},
+		})
+		require.NoError(t, err)
+
+		// Catches emitting a KeyValue with an empty key, which claims NRI
+		// ownership of a variable that does not exist and can collide with
+		// another plugin's adjustment.
+		require.Len(t, result.Env, 1)
+		require.Equal(t, "PATH", result.Env[0].Key)
+	})
+
+	t.Run("fails open per device and keeps the usable ones", func(t *testing.T) {
+		t.Parallel()
+		missing := filepath.Join(t.TempDir(), "nvidia1")
+		result, err := toNRI(nvmlmock.Adjustment{
+			Devices: []nvmlmock.Device{
+				{HostPath: missing, Path: "/dev/nvidia1"},
+				{HostPath: "/dev/null", Path: "/dev/nvidia0"},
+			},
+		})
+
+		// Catches turning a per-device stat failure into a whole-container
+		// error. One unstaged device node must not block container creation.
+		require.NoError(t, err)
+		require.NotNil(t, result.Linux)
+		require.Len(t, result.Linux.Devices, 1)
+		require.Equal(t, "/dev/nvidia0", result.Linux.Devices[0].Path)
+	})
+
+	t.Run("leaves Linux unset when no device is usable", func(t *testing.T) {
+		t.Parallel()
+		result, err := toNRI(nvmlmock.Adjustment{
+			Devices: []nvmlmock.Device{
+				{HostPath: filepath.Join(t.TempDir(), "nvidia0"), Path: "/dev/nvidia0"},
+			},
+		})
+		require.NoError(t, err)
+		require.Empty(t, result.Env)
+		require.Empty(t, result.Mounts)
+		require.Nil(t, result.Linux)
+	})
+}
+
+func TestSplitCSV(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  []string
+	}{
+		{name: "empty string yields nothing", value: "", want: nil},
+		{name: "single item", value: "kube-system", want: []string{"kube-system"}},
+		{
+			name:  "several items",
+			value: "kube-system,nvidia-system",
+			want:  []string{"kube-system", "nvidia-system"},
+		},
+		{
+			// Catches dropping the TrimSpace: a namespace of " nvidia-system"
+			// never matches, so the plugin injects into a namespace an operator
+			// asked it to skip.
+			name:  "trims surrounding whitespace",
+			value: " kube-system , nvidia-system ",
+			want:  []string{"kube-system", "nvidia-system"},
+		},
+		{
+			// Catches dropping the empty check: an empty entry becomes an empty
+			// namespace or an empty LD_PRELOAD path, which breaks the chain.
+			name:  "skips empty fields",
+			value: ",kube-system,,nvidia-system,",
+			want:  []string{"kube-system", "nvidia-system"},
+		},
+		{name: "only separators yields nothing", value: ",,,", want: nil},
+		{name: "only whitespace yields nothing", value: "  ,  ", want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, splitCSV(tt.value))
+		})
+	}
+}
+
+// envOr uses os.Getenv, so these cannot run with t.Parallel alongside t.Setenv.
+func TestEnvOr(t *testing.T) {
+	t.Run("returns the environment value when set", func(t *testing.T) {
+		t.Setenv("NVML_MOCK_TEST_KEY", "/from/env")
+		require.Equal(t, "/from/env", envOr("NVML_MOCK_TEST_KEY", "/fallback"))
+	})
+
+	t.Run("returns the fallback when unset", func(t *testing.T) {
+		require.Equal(t, "/fallback", envOr("NVML_MOCK_TEST_UNSET_KEY", "/fallback"))
+	})
+
+	t.Run("treats an empty value as unset", func(t *testing.T) {
+		t.Setenv("NVML_MOCK_TEST_KEY", "")
+
+		// Catches switching to os.LookupEnv. An empty value must fall back:
+		// Kubernetes materialises an unset optional env var as "", and an empty
+		// overlay path would make the plugin bind-mount the container root.
+		require.Equal(t, "/fallback", envOr("NVML_MOCK_TEST_KEY", "/fallback"))
+	})
+}

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -152,11 +152,15 @@ spec:
                   fieldPath: status.podIP
             - name: MOCK_IB_PING_SERVICE_HOST
               value: "{{ include "nvml-mock.fullname" . }}-ibping.{{ .Release.Namespace }}.svc.cluster.local"
-            # LD_PRELOAD installs the InfiniBand sysfs redirector in every
-            # process spawned in this container (e.g. `kubectl exec ibstat`).
-            # The shim only rewrites paths under /sys/class/infiniband*,
-            # /sys/class/infiniband_mad/, /sys/class/infiniband_verbs/ and
-            # /dev/infiniband — every other path passes through unchanged.
+            # LD_PRELOAD installs four shims in every process spawned in this
+            # container (e.g. `kubectl exec ibstat`). libibmockumad and
+            # libibmockverbs forward UMAD and verbs traffic to the mock-ib
+            # daemon when MOCK_IB=full. libibmocksys rewrites paths under
+            # /sys/class/infiniband, /sys/class/infiniband_mad,
+            # /sys/class/infiniband_verbs, /sys/class/infiniband_cm and
+            # /dev/infiniband into $MOCK_IB_ROOT. libpcimocksys rewrites
+            # /sys/bus/pci and /sys/devices/pci into $MOCK_PCI_ROOT. A path
+            # outside those prefixes passes through unchanged.
             # libibmockumad must precede libibmocksys so UMAD ioctls are
             # intercepted before sysfs path rewriting.
             - name: LD_PRELOAD


### PR DESCRIPTION
## Problem

`cmd/nvml-mock-nri` is the binary behind the v0.3.0 flagship claim — mock GPU delivery moved to the container runtime layer — and it had zero unit coverage. Seven helpers were untested: `fromNRI`, `toNRI`, `nriDevice`, `splitCSV`, `envOr`, `major`, `minor`.

Writing the tests turned up a real bug, and a bigger one than #439 describes. The issue names `major` as broken. **`minor` is broken too.** Both hand-rolled helpers truncate:

```go
func major(dev uint64) uint64 { return (dev >> 8) & 0xfff }                    // drops bits 44-63
func minor(dev uint64) uint64 { return (dev & 0xff) | ((dev >> 12) & 0xfff00) } // drops bits 32-43
```

glibc encodes `dev_t` as `MMMM Mmmm mmmM MMmm`, so the major lives in bits 8-19 *and* 44-63, the minor in bits 0-7 *and* 20-43. `minor`'s post-shift mask is `0xfff00` where it needs `0xffffff00`.

This is invisible in production, which is why it survived review. Every NVIDIA major (195, 510, 511) and minor is small enough to sit entirely in the legacy low bits.

## Approach

Fixed both helpers to the full glibc masks, and backfilled table-driven tests for all seven.

**The helpers stay rather than calling `unix.Major`/`unix.Minor` directly**, which is the one place this diverges from the issue text. `unix.Major` and `unix.Minor` resolve per `GOOS`: on darwin they decode Darwin's `dev_t`, where the major is bits 24-31. Verified — `unix.Major(0x103)` returns `1` on Linux and `0` on darwin. This package compiles on darwin today, so a direct swap would make the decoding follow the *build* platform, while `stat.Rdev` here always describes a device node on a *Linux* node.

A `//go:build linux` tag would also work, but it drops the package from `go test ./...` on macOS. Since #439 is the DAG root for #434, #436, #437 and #438, keeping the tests runnable on a developer workstation matters.

Instead, `dev_number_oracle_test.go` pins the helpers against `unix.Major`/`unix.Minor` across all 64 bit positions on Linux, and skips elsewhere rather than asserting the wrong encoding. The library is the oracle; it just isn't the implementation. Happy to switch to the build-tag version if reviewers prefer it — it's a small change.

Also corrects the `LD_PRELOAD` comment in the daemonset template. It was wrong in two ways, not one: `libpcimocksys` rewrites `/sys/bus/pci` and `/sys/devices/pci`, so "every other path passes through unchanged" was false; and the InfiniBand list omitted `/sys/class/infiniband_cm`, which `libibmocksys` does rewrite. The ordering rationale below it (umad before sys) is untouched.

## Testing

Test cases are derived from the glibc encoding, not from the implementation. A test built from realistic device numbers **passes on the broken code** — `/dev/null`, `/dev/zero`, `/dev/full` and major 511 all decode correctly even while truncating — so the discriminating cases are synthetic:

| dev | major | minor | old code |
|---|---|---|---|
| `0x100000000000` | 4096 | 0 | major `0` |
| `0x100000000` | 0 | 1048576 | minor `0` |
| `0x123459abcde678f0` | `0x12345678` | `0x9abcdef0` | major `0x678` |

`nriDevice` runs against real character devices rather than a mocked syscall, plus the two error paths that matter: a nonexistent path and a regular file. Both mean the plugin is about to hand containerd a device it cannot open.

Gates, all against the final commit:

```
go test -race ./...                            exit 0 (whole repo)
golangci-lint run ./...                        exit 0, 0 issues
helm unittest deployments/.../nvml-mock        133/133, snapshots 15/15
docker golang:1.26-bookworm go test            41/41 cases, incl. the 2 that skip on darwin
```

**Mutation check**: reverting `major`/`minor` to the old formula turns the suite RED on both darwin and Linux; restoring it returns byte-identical and green. Worth noting the real-character-device test stayed *green* under the mutant, which is the point above.

9 test functions, 41 cases, 71 assertions. Each names the bug it catches.

## Breaking changes

None. The device-number fix only changes behaviour for majors above 4095 or minors above 1048575, which no current NVIDIA device uses. The chart change is a comment.

Closes #439
