### PR TITLE
feat(nri): harden the NRI plugin against wedge and silent unregistration

### DIFF
--- a/cmd/nvml-mock-nri/health.go
+++ b/cmd/nvml-mock-nri/health.go
@@ -1,0 +1,192 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/containerd/nri/pkg/stub"
+)
+
+// wedgeFactor multiplies the runtime's own request timeout to get the
+// threshold past which an in-flight request counts as wedged. Once a request
+// exceeds the runtime's timeout the runtime has already abandoned it, so the
+// container it belonged to was created without injection whatever happens
+// next. The factor buys one whole extra timeout of tolerance before the
+// kubelet is asked to restart the plugin, so a single slow-but-completing
+// request cannot cause a restart.
+const wedgeFactor = 2
+
+// timeoutSource reports the request timeout the runtime is applying to this
+// plugin. The NRI stub satisfies it: the value is whatever containerd sent in
+// the Configure request, not something the plugin chooses.
+type timeoutSource interface {
+	RequestTimeout() time.Duration
+}
+
+// probe is the outcome of one health question.
+type probe struct {
+	ok     bool
+	reason string
+}
+
+// health tracks the two things that separate a serving plugin from a plugin
+// that is merely running.
+//
+// Registration state answers "is containerd still sending us containers?".
+// The plugin can be alive, holding an open socket, and no longer registered —
+// containerd unregisters a plugin it has given up on. Injection stops silently
+// at that moment, because injection is baked into the OCI spec at container
+// creation time: pods already running keep theirs, and only pods created
+// afterwards come up unmocked.
+//
+// In-flight duration answers "is the handler still answering?". A handler
+// blocked forever leaves the process alive and the connection up, so neither a
+// process check nor a plain TCP listener notices. Tracking how long the oldest
+// unfinished request has been running does, and — unlike a "time since the
+// last request" watchdog — it stays quiet on an idle node, which is the normal
+// steady state for this plugin.
+type health struct {
+	mu         sync.Mutex
+	registered bool
+	inFlight   map[uint64]time.Time
+	next       uint64
+	timeouts   timeoutSource
+
+	now    func() time.Time
+	factor int
+}
+
+func newHealth(now func() time.Time, factor int) *health {
+	return &health{
+		inFlight: make(map[uint64]time.Time),
+		now:      now,
+		factor:   factor,
+	}
+}
+
+// setTimeoutSource attaches the stub once it exists. The stub needs the plugin
+// (and so the health tracker) to be constructed first, so the wiring cannot be
+// done in newHealth.
+func (h *health) setTimeoutSource(t timeoutSource) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.timeouts = t
+}
+
+// setRegistered records whether the runtime currently has this plugin
+// registered. Configure sets it; the stub's OnClose callback clears it.
+func (h *health) setRegistered(v bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.registered = v
+}
+
+// begin marks a request as started and returns the function that marks it
+// finished. The returned function is safe to call once; callers defer it.
+func (h *health) begin() func() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	id := h.next
+	h.next++
+	h.inFlight[id] = h.now()
+
+	return func() {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		delete(h.inFlight, id)
+	}
+}
+
+// wedgeLimit is the in-flight duration past which the handler is considered
+// stuck. Callers hold h.mu.
+func (h *health) wedgeLimit() time.Duration {
+	timeout := stub.DefaultRequestTimeout
+	if h.timeouts != nil {
+		if reported := h.timeouts.RequestTimeout(); reported > 0 {
+			timeout = reported
+		}
+	}
+	return timeout * time.Duration(h.factor)
+}
+
+// wedged reports the age of the oldest unfinished request and whether it has
+// passed the threshold. Callers hold h.mu.
+func (h *health) wedged() (time.Duration, bool) {
+	limit := h.wedgeLimit()
+	now := h.now()
+
+	var oldest time.Duration
+	for _, start := range h.inFlight {
+		if age := now.Sub(start); age > oldest {
+			oldest = age
+		}
+	}
+	return oldest, oldest > limit
+}
+
+// liveness fails only for a wedged handler, because that is the one state the
+// plugin cannot leave on its own. Losing the connection is deliberately not a
+// liveness failure: the stub's Run returns when the connection drops and the
+// process exits on its own, and failing liveness on "not registered yet" would
+// restart the plugin every time containerd is slow to come up.
+func (h *health) liveness() probe {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if age, stuck := h.wedged(); stuck {
+		return probe{false, h.wedgeReason(age)}
+	}
+	return probe{true, "ok"}
+}
+
+// readiness is the detectable half of the fail-open posture. It reports the
+// plugin as serving only while it is registered with the runtime and its
+// handler is answering, so every window in which injection is silently not
+// happening shows up as a NotReady pod.
+func (h *health) readiness() probe {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if !h.registered {
+		return probe{false, "not registered with the container runtime; new containers are not being injected"}
+	}
+	if age, stuck := h.wedged(); stuck {
+		return probe{false, h.wedgeReason(age)}
+	}
+	return probe{true, "ok"}
+}
+
+// wedgeReason renders the failure text. Callers hold h.mu.
+func (h *health) wedgeReason(age time.Duration) string {
+	return fmt.Sprintf("wedged: a container request has been in flight for %s, past the %s threshold",
+		age.Round(time.Millisecond), h.wedgeLimit())
+}
+
+// handler serves the two probe endpoints. Both write the reason in the body so
+// a failure is legible in `kubectl describe pod` and to a curl from a debug
+// pod, rather than being a bare status code.
+func (h *health) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", writeProbe(h.liveness))
+	mux.HandleFunc("GET /readyz", writeProbe(h.readiness))
+	return mux
+}
+
+func writeProbe(check func() probe) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		result := check()
+		status := http.StatusOK
+		if !result.ok {
+			status = http.StatusServiceUnavailable
+		}
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(status)
+		_, _ = fmt.Fprintln(w, result.reason)
+	}
+}

--- a/cmd/nvml-mock-nri/health_test.go
+++ b/cmd/nvml-mock-nri/health_test.go
@@ -1,0 +1,299 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The states this file pins down, and why each matters. A probe that only
+// proves the process is alive reports healthy in states 2, 4 and 5 — the
+// process keeps running in every one of them.
+//
+//	state 1  process dead                       -> the kubelet already handles it
+//	state 2  alive, never registered            -> must be NOT READY
+//	state 3  alive, registered, serving         -> READY
+//	state 4  alive, registered, handler wedged  -> NOT READY and NOT LIVE
+//	state 5  alive, unregistered by containerd  -> must be NOT READY
+//
+// The clock is injected so wedge detection is asserted against exact
+// durations rather than by sleeping.
+
+// fakeTimeouts stands in for the NRI stub as the source of the runtime's
+// request timeout. The real value arrives from containerd in the Configure
+// request, so it is not a constant the plugin controls.
+type fakeTimeouts struct{ requestTimeout time.Duration }
+
+func (f fakeTimeouts) RequestTimeout() time.Duration { return f.requestTimeout }
+
+// testClock is a manually advanced clock.
+type testClock struct{ t time.Time }
+
+func (c *testClock) now() time.Time          { return c.t }
+func (c *testClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+// newTestHealth builds a health tracker whose wedge threshold is a known
+// 2 x 4s = 8s, so every duration assertion below is a literal.
+func newTestHealth(t *testing.T) (*health, *testClock) {
+	t.Helper()
+	clock := &testClock{t: time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)}
+	h := newHealth(clock.now, wedgeFactor)
+	h.setTimeoutSource(fakeTimeouts{requestTimeout: 4 * time.Second})
+	return h, clock
+}
+
+// State 2. Catches the probe-shaped no-op: a readiness surface that reports
+// ready the moment the HTTP listener binds, before containerd has registered
+// the plugin. Pods created in that window are silently not injected.
+func TestNotReadyBeforeRegistration(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestHealth(t)
+
+	require.False(t, h.readiness().ok, "must not be ready before Configure")
+	require.True(t, h.liveness().ok, "must stay live while waiting to register")
+}
+
+// State 3.
+func TestReadyOnceRegistered(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestHealth(t)
+	h.setRegistered(true)
+
+	require.True(t, h.readiness().ok)
+	require.True(t, h.liveness().ok)
+}
+
+// State 5. containerd dropped the connection and the plugin is no longer
+// receiving CreateContainer calls. Injection has silently stopped: every pod
+// created from now on runs unmocked. Readiness must surface it.
+func TestNotReadyAfterRuntimeDisconnects(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestHealth(t)
+	h.setRegistered(true)
+	require.True(t, h.readiness().ok, "precondition: registered")
+
+	h.setRegistered(false) // what the stub's OnClose callback does
+
+	require.False(t, h.readiness().ok, "must not be ready once the runtime disconnects")
+}
+
+// A request that is in flight but has not yet exceeded the runtime's own
+// timeout is ordinary traffic. Catches a wedge detector tuned so tight that
+// every normal container creation restarts the plugin.
+func TestInFlightRequestUnderTimeoutStaysHealthy(t *testing.T) {
+	t.Parallel()
+
+	h, clock := newTestHealth(t)
+	h.setRegistered(true)
+
+	done := h.begin()
+	clock.advance(7 * time.Second) // threshold is 8s
+
+	require.True(t, h.liveness().ok, "a request under the wedge threshold is not a wedge")
+	require.True(t, h.readiness().ok)
+
+	done()
+	require.True(t, h.liveness().ok)
+}
+
+// State 4 — the failure the issue is about. The process is alive, the ttRPC
+// connection is up, and the handler is not coming back. containerd has already
+// abandoned this request. Only a liveness failure recovers the node.
+func TestWedgedRequestFailsLivenessAndReadiness(t *testing.T) {
+	t.Parallel()
+
+	h, clock := newTestHealth(t)
+	h.setRegistered(true)
+
+	h.begin() // deliberately never completed
+	clock.advance(9 * time.Second)
+
+	require.False(t, h.liveness().ok, "an in-flight request past the wedge threshold must fail liveness")
+	require.False(t, h.readiness().ok, "a wedged plugin is not serving")
+}
+
+// Catches a latch bug: a wedge flag that is set but never cleared leaves the
+// plugin permanently unhealthy after one slow request, restarting it forever.
+func TestWedgeClearsWhenTheRequestCompletes(t *testing.T) {
+	t.Parallel()
+
+	h, clock := newTestHealth(t)
+	h.setRegistered(true)
+
+	done := h.begin()
+	clock.advance(9 * time.Second)
+	require.False(t, h.liveness().ok, "precondition: wedged")
+
+	done()
+
+	require.True(t, h.liveness().ok, "liveness must recover once the slow request finishes")
+	require.True(t, h.readiness().ok)
+}
+
+// The discriminating test against the obvious wrong design. A "time since the
+// last request" watchdog reports wedged on any node that simply is not
+// creating containers, which is the normal steady state. Idle is not wedged.
+func TestIdleAfterRegistrationIsNotWedged(t *testing.T) {
+	t.Parallel()
+
+	h, clock := newTestHealth(t)
+	h.setRegistered(true)
+
+	done := h.begin()
+	done()
+	clock.advance(72 * time.Hour)
+
+	require.True(t, h.liveness().ok, "an idle plugin is healthy; only in-flight work can wedge")
+	require.True(t, h.readiness().ok)
+}
+
+// Concurrent requests: the oldest one decides. Catches a detector that only
+// tracks the most recent request and so loses the stuck one behind later
+// traffic.
+func TestOldestInFlightRequestDecides(t *testing.T) {
+	t.Parallel()
+
+	h, clock := newTestHealth(t)
+	h.setRegistered(true)
+
+	h.begin() // stuck, never completes
+	clock.advance(9 * time.Second)
+	done := h.begin() // a later, healthy request
+	done()
+
+	require.False(t, h.liveness().ok, "a newer completed request must not mask the stuck one")
+}
+
+// The threshold is derived from what containerd reported, not hardcoded. A
+// runtime configured with a longer plugin_request_timeout must not have its
+// plugin restarted out from under it.
+func TestWedgeThresholdFollowsTheRuntimeRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	h, clock := newTestHealth(t)
+	h.setRegistered(true)
+	h.setTimeoutSource(fakeTimeouts{requestTimeout: time.Minute})
+
+	h.begin()
+	clock.advance(90 * time.Second) // past the 8s default, under 2 x 60s
+
+	require.True(t, h.liveness().ok, "threshold must follow the runtime's request timeout")
+
+	clock.advance(45 * time.Second) // now past 2 x 60s
+
+	require.False(t, h.liveness().ok)
+}
+
+// Before Configure lands there is no runtime-reported timeout, so the stub
+// default applies. Catches a zero threshold, which would make every in-flight
+// request look wedged.
+func TestWedgeThresholdFallsBackBeforeConfigure(t *testing.T) {
+	t.Parallel()
+
+	clock := &testClock{t: time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)}
+	h := newHealth(clock.now, wedgeFactor)
+
+	h.begin()
+	clock.advance(time.Millisecond)
+	require.True(t, h.liveness().ok, "a just-started request must not read as wedged")
+
+	clock.advance(24 * time.Hour)
+	require.False(t, h.liveness().ok, "a request stuck for a day is wedged under any timeout")
+}
+
+func TestHealthEndpointStatusCodes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		path       string
+		setup      func(*health, *testClock)
+		wantStatus int
+	}{
+		{
+			name:       "readyz before registration",
+			path:       "/readyz",
+			setup:      func(*health, *testClock) {},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:       "readyz once registered",
+			path:       "/readyz",
+			setup:      func(h *health, _ *testClock) { h.setRegistered(true) },
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "healthz before registration",
+			path:       "/healthz",
+			setup:      func(*health, *testClock) {},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "readyz after the runtime disconnects",
+			path: "/readyz",
+			setup: func(h *health, _ *testClock) {
+				h.setRegistered(true)
+				h.setRegistered(false)
+			},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name: "healthz while wedged",
+			path: "/healthz",
+			setup: func(h *health, c *testClock) {
+				h.setRegistered(true)
+				h.begin()
+				c.advance(9 * time.Second)
+			},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name: "readyz while wedged",
+			path: "/readyz",
+			setup: func(h *health, c *testClock) {
+				h.setRegistered(true)
+				h.begin()
+				c.advance(9 * time.Second)
+			},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, clock := newTestHealth(t)
+			tt.setup(h, clock)
+
+			rec := httptest.NewRecorder()
+			h.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tt.path, nil))
+
+			require.Equal(t, tt.wantStatus, rec.Code)
+			require.NotEmpty(t, rec.Body.String(), "probe body should say why, for kubectl describe")
+		})
+	}
+}
+
+// An unknown path must not report 200. Catches a catch-all handler that would
+// make any probe path — including a typo in the chart — look healthy forever.
+func TestUnknownHealthPathIsNotOK(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newTestHealth(t)
+	h.setRegistered(true)
+
+	rec := httptest.NewRecorder()
+	h.handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthzz", nil))
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/cmd/nvml-mock-nri/main.go
+++ b/cmd/nvml-mock-nri/main.go
@@ -7,13 +7,17 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
+	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/NVIDIA/k8s-test-infra/pkg/nri/nvmlmock"
 	"github.com/containerd/nri/pkg/api"
@@ -22,12 +26,14 @@ import (
 
 type plugin struct {
 	config nvmlmock.Config
+	health *health
 }
 
 func main() {
 	cfg := nvmlmock.DefaultConfig()
 
 	socketPath := flag.String("socket-path", envOr("NRI_SOCKET_PATH", "/var/run/nri/nri.sock"), "NRI socket path")
+	healthAddr := flag.String("health-addr", envOr("NVML_MOCK_HEALTH_ADDR", ":8080"), "address for the /healthz and /readyz probe endpoints; empty disables them")
 	pluginName := flag.String("plugin-name", envOr("NRI_PLUGIN_NAME", "nvml-mock"), "NRI plugin name")
 	pluginIndex := flag.String("plugin-index", envOr("NRI_PLUGIN_INDEX", "10"), "NRI plugin index")
 	flag.StringVar(&cfg.HostOverlayPath, "overlay-host-path", envOr("NVML_MOCK_OVERLAY_HOST_PATH", cfg.HostOverlayPath), "host path for the nvml-mock overlay")
@@ -45,19 +51,37 @@ func main() {
 	cfg.ExcludedNamespaces = splitCSV(*excludedNamespaces)
 	cfg.Shims = splitCSV(*shims)
 
-	p := &plugin{config: cfg}
+	p := &plugin{config: cfg, health: newHealth(time.Now, wedgeFactor)}
 	s, err := stub.New(
 		p,
 		stub.WithSocketPath(*socketPath),
 		stub.WithPluginName(*pluginName),
 		stub.WithPluginIdx(*pluginIndex),
+		// The runtime dropping the connection is the fail-open failure mode:
+		// the process stays up but stops being asked to inject anything, and
+		// containers created from here on come up unmocked. Clearing the
+		// registered flag is what makes that window visible as a NotReady pod.
+		stub.WithOnClose(func() {
+			log.Printf("nvml-mock-nri: runtime closed the connection; no longer registered")
+			p.health.setRegistered(false)
+		}),
 	)
 	if err != nil {
 		log.Fatalf("nvml-mock-nri: create stub: %v", err)
 	}
+	p.health.setTimeoutSource(s)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
+
+	// Serve the probes before Run, so the un-registered startup window is
+	// reported as a 503 rather than a refused connection, and so a plugin that
+	// never manages to register is visibly NotReady instead of silently idle.
+	if stopHealth, err := serveHealth(*healthAddr, p.health); err != nil {
+		log.Fatalf("nvml-mock-nri: serve health endpoints: %v", err)
+	} else {
+		defer stopHealth()
+	}
 
 	log.Printf("nvml-mock-nri: registering plugin %s/%s on %s", *pluginIndex, *pluginName, *socketPath)
 	if err := s.Run(ctx); err != nil && ctx.Err() == nil {
@@ -65,8 +89,41 @@ func main() {
 	}
 }
 
+// serveHealth starts the probe listener and returns a shutdown function. The
+// listener is bound synchronously so a port clash fails startup loudly instead
+// of leaving the plugin running with no probe surface — which would read as
+// healthy forever.
+func serveHealth(addr string, h *health) (func(), error) {
+	if addr == "" {
+		log.Printf("nvml-mock-nri: health endpoints disabled")
+		return func() {}, nil
+	}
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("listen on %s: %w", addr, err)
+	}
+
+	srv := &http.Server{
+		Handler:           h.handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		if err := srv.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("nvml-mock-nri: health server: %v", err)
+		}
+	}()
+	log.Printf("nvml-mock-nri: serving /healthz and /readyz on %s", listener.Addr())
+
+	return func() { _ = srv.Close() }, nil
+}
+
 func (p *plugin) Configure(_ context.Context, _, runtime, version string) (stub.EventMask, error) {
 	log.Printf("nvml-mock-nri: configured by runtime %s NRI %s", runtime, version)
+
+	// The runtime calls Configure as the last step of registration, so this is
+	// the point at which the plugin actually starts receiving containers.
+	p.health.setRegistered(true)
 
 	var events stub.EventMask
 	events.Set(api.Event_CREATE_CONTAINER)
@@ -74,6 +131,11 @@ func (p *plugin) Configure(_ context.Context, _, runtime, version string) (stub.
 }
 
 func (p *plugin) CreateContainer(_ context.Context, pod *api.PodSandbox, container *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
+	// Bracket the handler so a call that never returns is visible to the
+	// probes. A wedged handler keeps both the process and the connection
+	// alive, so nothing else notices it.
+	defer p.health.begin()()
+
 	adjustment, ok, err := nvmlmock.Adjust(p.config, fromNRI(pod, container))
 	if err != nil {
 		return nil, nil, err

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -711,6 +711,133 @@ See [`pkg/network/mockib/README.md`](../../../../pkg/network/mockib/README.md#mo
 for env vars (`MOCK_IB`, `MOCK_IB_PING_FABRIC`, `MOCK_IB_PEERS`,
 `MOCK_IB_DEBUG_SMP`, …) and architecture details.
 
+## NRI plugin failure modes
+
+Applies only when `nri.enabled=true`.
+
+The NRI plugin injects the mock GPU stack at container-creation time, which is
+what lets ordinary pods see mock GPUs without a pod-spec change. It also means
+the injection is written into the container's OCI spec once, at creation. A pod
+that is already running keeps everything it was given, whatever happens to the
+plugin afterwards. **Only pods created after a failure are affected**, and they
+are affected silently.
+
+That is the property that makes this worth hardening: a test suite that creates
+its pods early and asserts against them later keeps passing on a node where
+injection stopped hours ago.
+
+### The two modes
+
+| | Fail-closed | Fail-open |
+|---|---|---|
+| What the runtime does | Refuses to create the container | Creates the container without the plugin's adjustment |
+| What you see | Pods stuck in `ContainerCreating` / `CreateContainerError` | Pods start normally |
+| What the workload gets | Nothing — it never runs | A container with **no mock GPU stack** |
+| Risk | Test runs stop | Test runs continue and report results that no longer mean what they claim |
+
+Fail-closed is loud and self-announcing. On a dedicated test cluster it is
+arguably the preferable posture: a broken mock stops the run instead of
+corrupting it.
+
+Fail-open is the dangerous one, and it is the mode this chart is built to
+survive. It cannot be prevented from the plugin side — the decision belongs to
+containerd, not to the plugin — so the chart's posture is: **assume fail-open
+can happen, and make it impossible for it to happen quietly.**
+
+### Posture this chart targets
+
+**Detectable fail-open.** Both probes exist to convert a silent window into a
+visible one, not to prevent it:
+
+- **Readiness (`/readyz`)** reports serving only while the plugin is registered
+  with the runtime *and* its handler is answering. Any window in which the node
+  is not injecting shows up as a NotReady pod and a short DaemonSet count.
+  Readiness restarts nothing; it is purely the detection surface.
+- **Liveness (`/healthz`)** fails only when a container-creation request has
+  been in flight past the wedge threshold, and restarts the container into a
+  fresh registration.
+
+Neither probe reduces to "is the process alive", because the process stays
+alive in every mode that matters:
+
+| State | Process | Connection | `/readyz` | `/healthz` |
+|---|---|---|---|---|
+| Registered and serving | up | up | 200 | 200 |
+| Started, not yet registered | up | — | 503 | 200 |
+| Unregistered by the runtime | up | dropped | 503 | 200 |
+| Handler wedged | up | **up** | 503 | **503 → restart** |
+
+A wedged handler is the case that defeats every simpler check: `pgrep
+nvml-mock-nri` finds the process, and a plain TCP check finds the socket bound,
+in exactly the state where nothing is being injected.
+
+Losing the connection is deliberately *not* a liveness failure. The NRI stub's
+`Run` returns when the connection drops and the plugin exits on its own, so the
+kubelet already restarts it; failing liveness on "not registered" as well would
+only add restart loops whenever containerd is slow to come up.
+
+### containerd `plugin_request_timeout`
+
+The wedge threshold is not a constant in the chart. The plugin derives it from
+the request timeout containerd itself reports at registration, and trips at
+**twice** that value. Past one whole timeout the runtime has already abandoned
+the request, so the container it belonged to was created without injection
+whatever happens next; the second is tolerance, so a single slow-but-completing
+request cannot restart the plugin.
+
+NRI's defaults, from `containerd/nri/pkg/api`:
+
+| Setting | Default |
+|---|---|
+| `plugin_request_timeout` | `2s` (wedge threshold `4s`) |
+| `plugin_registration_timeout` | `5s` |
+
+Both are set on the runtime, not in this chart:
+
+```toml
+[plugins."io.containerd.nri.v1.nri"]
+  disable = false
+  socket_path = "/var/run/nri/nri.sock"
+  # Raise only if the plugin legitimately needs longer than 2s to answer.
+  plugin_request_timeout = "2s"
+```
+
+Guidance:
+
+- **Leave it at the default unless you have evidence.** The plugin's
+  `CreateContainer` path does a `stat` of the topology document, a directory
+  read of the device directory, and one `stat` per device node — all against
+  the hostPath-mounted overlay, and nothing else. On a healthy node that is
+  well under 2s. A raised timeout does not make injection more reliable; it
+  widens the window in which each container creation blocks on a plugin that
+  may already be wedged.
+- **Those filesystem calls are the realistic wedge.** They are the only
+  blocking operations in the handler, so an overlay backed by a hung mount is
+  how this plugin stops answering while staying alive and connected.
+- **Raising it widens the wedge threshold automatically.** No chart change is
+  needed, and none should be made — `nri.livenessProbe` tuning and
+  `plugin_request_timeout` are not independent knobs.
+- **Do not raise it to paper over a wedge.** A plugin that needs more than 2s
+  is the failure this hardening detects, not a tuning problem.
+
+### Checking a node by hand
+
+```bash
+# Which nodes are actually injecting right now
+kubectl get pods -n nvml-mock -l app.kubernetes.io/name=nvml-mock-nri -o wide
+
+# Why a given node is not
+kubectl describe pod -n nvml-mock <nvml-mock-nri-pod>
+```
+
+Both probe endpoints answer with the reason in the body, so a readiness failure
+in `kubectl describe` reads as `not registered with the container runtime; new
+containers are not being injected` rather than a bare status code.
+
+The port is not reachable from the node: this DaemonSet does not set
+`hostNetwork`, so `nri.healthPort` is bound only inside the pod's own network
+namespace, on the pod IP where the kubelet reaches it.
+
 ## Configuration
 
 ### Values
@@ -744,6 +871,17 @@ for env vars (`MOCK_IB`, `MOCK_IB_PING_FABRIC`, `MOCK_IB_PEERS`,
 | `infiniband.mockTier` | `""` (auto) | `MOCK_IB` tier: `off`, `sysfs`, or `full`. Empty auto-derives `full` for IB-enabled profiles and `sysfs` otherwise (keeps the `libibmocksys` redirect active so any real host IB is masked). `off` makes every shim a no-op and skips the daemon. An invalid value fails `helm template` |
 | `infiniband.ping.port` | `18515` | TCP port for fabric relay between nvml-mock pods (`mock-ib` / `ibping` always enabled) |
 | `infiniband.ping.networkPolicy.enabled` | `true` | Restrict inbound access to the fabric port to peer nvml-mock pods. No-op on CNIs that don't enforce NetworkPolicy (e.g. Kind's kindnet) |
+| `nri.enabled` | `false` | Deploy the `nvml-mock-nri` containerd NRI plugin DaemonSet. Injects cluster-wide at container-creation time, so it is opt-in. Requires containerd NRI enabled on every node |
+| `nri.socketPath` | `/var/run/nri/nri.sock` | NRI socket on the host. Its directory is hostPath-mounted into the plugin |
+| `nri.pluginName` / `nri.pluginIndex` | `nvml-mock` / `"10"` | NRI registration identity. The index orders this plugin against others |
+| `nri.overlay.hostPath` / `nri.overlay.mountPath` | `/var/lib/nvml-mock` / `/opt/nvml-mock` | Host overlay staged by the main DaemonSet, and the path it is injected at inside workloads |
+| `nri.optOutAnnotation` | `nvml-mock.nvidia.com/inject` | Pod annotation; value `false` disables injection for that pod |
+| `nri.deviceAnnotation` | `nvml-mock.nvidia.com/devices` | Pod annotation; value `true` adds mock `/dev/nvidia*` device nodes. Pod-authored, so treat it as part of the demo trust boundary |
+| `nri.excludedNamespaces` | `[]` | Extra namespaces to skip. The release namespace and `kube-system` are always excluded |
+| `nri.healthPort` | `8080` | Port serving `/healthz` and `/readyz`. Bound only in the pod's network namespace — this DaemonSet does not use `hostNetwork`, so nothing is exposed on the node |
+| `nri.readinessProbe` | `/readyz`, `periodSeconds: 10`, `failureThreshold: 2` | Detects that the node has stopped injecting. Set to `null` to drop. See [NRI plugin failure modes](#nri-plugin-failure-modes) |
+| `nri.livenessProbe` | `/healthz`, `periodSeconds: 10`, `failureThreshold: 3` | Restarts a wedged plugin. Threshold follows containerd's `plugin_request_timeout`; do not tune the two independently. Set to `null` to drop |
+| `nri.resources` | `{}` | Resource requests/limits for the plugin container |
 
 ### Node Labels
 

--- a/deployments/nvml-mock/helm/nvml-mock/templates/nri-daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/nri-daemonset.yaml
@@ -55,11 +55,24 @@ spec:
             # workload so its mock GPUs report this node's clique / cluster
             # UUID. Harmless when topology is disabled (no document to stage).
             - --node-name=$(NODE_NAME)
+            - --health-addr=:{{ .Values.nri.healthPort }}
           env:
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          ports:
+            - name: health
+              containerPort: {{ .Values.nri.healthPort }}
+              protocol: TCP
+          {{- with .Values.nri.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nri.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             runAsUser: 0

--- a/deployments/nvml-mock/helm/nvml-mock/tests/nri_daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/nri_daemonset_test.yaml
@@ -130,3 +130,92 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --excluded-namespaces=NAMESPACE,kube-system,monitoring,gpu-system
+
+  # A probe that cannot reach the plugin is worse than no probe: the pod never
+  # goes Ready and the DaemonSet stalls. These pin the three values that have
+  # to agree -- the flag the plugin binds, the declared containerPort, and the
+  # port the probes name.
+  - it: should serve probes on a port the plugin actually binds
+    set:
+      nri:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --health-addr=:8080
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: health
+            containerPort: 8080
+            protocol: TCP
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /readyz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: health
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: health
+
+  # Readiness must interrogate /readyz, not /healthz. /healthz stays 200 while
+  # the plugin is unregistered -- pointing readiness at it would report a
+  # plugin that is injecting nothing as Ready, which is the exact silent
+  # failure these probes exist to surface.
+  - it: should not point readiness at the liveness endpoint
+    set:
+      nri:
+        enabled: true
+    asserts:
+      - notEqual:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /healthz
+
+  - it: should move both the bind address and the container port together
+    set:
+      nri:
+        enabled: true
+        healthPort: 9310
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --health-addr=:9310
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: health
+            containerPort: 9310
+            protocol: TCP
+
+  - it: should allow dropping either probe
+    set:
+      nri:
+        enabled: true
+        livenessProbe: null
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].livenessProbe
+      - isNotNull:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: should apply custom probe tuning
+    set:
+      nri:
+        enabled: true
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: health
+          periodSeconds: 3
+          failureThreshold: 5
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 5

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -130,6 +130,40 @@ nri:
   deviceAnnotation: nvml-mock.nvidia.com/devices
   excludedNamespaces: []
   resources: {}
+  # Port serving the plugin's /healthz and /readyz endpoints. The NRI DaemonSet
+  # does not use host networking, so this port lives only inside the pod's own
+  # network namespace: it is reachable by the kubelet on the pod IP and is not
+  # bound on the node.
+  healthPort: 8080
+  # Probes for the two ways this plugin fails while its process stays alive.
+  # See the "NRI plugin failure modes" section of the chart README before
+  # retuning either: both thresholds are stated relative to containerd's
+  # plugin_request_timeout.
+  #
+  # readinessProbe reports whether the plugin is registered with the runtime
+  # and answering. It does not restart anything; it makes the window in which
+  # injection has silently stopped visible as a NotReady pod.
+  #
+  # livenessProbe restarts the container when a container-creation request has
+  # been in flight past the wedge threshold. That is the one state the plugin
+  # cannot leave on its own — losing the connection already exits the process.
+  #
+  # Set either to null to drop that probe (an empty map merges with the
+  # default rather than replacing it).
+  readinessProbe:
+    httpGet:
+      path: /readyz
+      port: health
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 2
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: health
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
 
 # DaemonSet rolling update strategy.
 updateStrategy:

--- a/tests/e2e/go/scenario_nri_test.go
+++ b/tests/e2e/go/scenario_nri_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -22,6 +23,7 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/harness"
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/helm"
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/kube"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/runner"
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/profile"
 )
 
@@ -31,6 +33,7 @@ const (
 	nriAgentDaemonSet = "gpu-agent"
 	nriAgentSelector  = "app=gpu-agent"
 	nriNRIDaemonSet   = "nvml-mock-nri"
+	nriPluginSelector = "app.kubernetes.io/name=nvml-mock-nri"
 
 	// nriDomainName / nriDomainUUID identify the single ComputeDomain the
 	// generated topology overlay declares. The UUID is arbitrary but must match
@@ -104,7 +107,174 @@ var _ = Describe("nvml-mock node-wide NRI injection", Label("nri"), Ordered, fun
 			})
 		})
 	}
+
+	// Failure-mode hardening (#434). Everything above asserts that injection
+	// works. This asserts what happens when it stops working mid-run.
+	//
+	// The specs above cannot catch that on their own, and not by oversight:
+	// injection is baked into the OCI spec at container-creation time, so pods
+	// created while the plugin was healthy keep their injection no matter what
+	// happens to the plugin afterwards. A suite that creates its pods early and
+	// asserts later passes cleanly against a node that lost injection halfway
+	// through. Only pods created *after* the failure come up unmocked.
+	//
+	// SIGSTOP is the honest reproduction of a wedged plugin: the process stays
+	// alive, the ttRPC connection stays open, and the handler never answers.
+	// `pgrep nvml-mock-nri` and any check that only proves the socket is bound
+	// both report healthy throughout.
+	Context("when the plugin wedges mid-run", Label("nri-failure"), Ordered, func() {
+		var (
+			victim     cluster.Node
+			pluginPod  kube.PodRef
+			restartsAt int
+		)
+
+		BeforeAll(func(ctx SpecContext) {
+			Expect(selectedProfiles).NotTo(BeEmpty())
+			p := loadProfile(selectedProfiles[0])
+			installNRIChart(ctx, h, p, topoValues, p.HasFabric())
+			assertions.WaitDaemonSetReady(ctx, h.Kube, nvmlMockNamespace, "nvml-mock", config.ReadyTimeout(), config.PollInterval())
+			assertions.WaitDaemonSetReady(ctx, h.Kube, nvmlMockNamespace, nriNRIDaemonSet, config.ReadyTimeout(), config.PollInterval())
+			deployNRIAgent(ctx, h)
+
+			victim = workers[0]
+			pluginPod = nriPluginPodOnNode(ctx, h, victim.Name)
+			var err error
+			restartsAt, err = nriRestartCount(ctx, h, pluginPod)
+			Expect(err).NotTo(HaveOccurred(), "read baseline restart count")
+
+			By("SIGSTOP the nvml-mock-nri process on " + victim.Name)
+			wedgeNRIPlugin(ctx, victim.Name)
+		})
+
+		// The readiness probe is the detectable half of the fail-open posture:
+		// without it the DaemonSet keeps reporting its full desired count while
+		// the node silently injects nothing.
+		It("reports the wedged node as NotReady", Label("nri-failure-detect"), func(ctx SpecContext) {
+			Eventually(func() (bool, error) {
+				return h.Kube.DaemonSetReady(ctx, nvmlMockNamespace, nriNRIDaemonSet)
+			}).WithContext(ctx).WithTimeout(config.ReadyTimeout()).WithPolling(time.Second).
+				Should(BeFalse(), "daemonset %s/%s stayed Ready while the plugin on %s was wedged",
+					nvmlMockNamespace, nriNRIDaemonSet, victim.Name)
+		})
+
+		// The liveness probe is the recovery half. A wedged plugin cannot exit
+		// on its own -- unlike a dropped connection, which makes stub.Run
+		// return and the process exit -- so only a probe-driven restart clears
+		// it. Asserting the kubelet's own reason pins that the restart came
+		// from the liveness probe and not from something incidental.
+		It("restarts the wedged plugin", Label("nri-failure-recover"), func(ctx SpecContext) {
+			Eventually(func() (int, error) {
+				return nriRestartCount(ctx, h, pluginPod)
+			}).WithContext(ctx).WithTimeout(config.ReadyTimeout()).WithPolling(config.PollInterval()).
+				Should(BeNumerically(">", restartsAt),
+					"plugin container on %s never restarted; a wedged plugin cannot recover on its own", victim.Name)
+
+			described, err := h.Kube.DescribePod(ctx, pluginPod.Namespace, pluginPod.Pod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(described).To(ContainSubstring("Liveness probe failed"),
+				"restart was not attributed to the liveness probe:\n%s", described)
+		})
+
+		// The acceptance criterion: a pod created after the failure must be
+		// correctly injected once the plugin recovers. This is the assertion
+		// the positive specs above structurally cannot make.
+		It("injects into a workload created after the wedge", Label("nri-failure-inject"), func(ctx SpecContext) {
+			assertions.WaitDaemonSetReady(ctx, h.Kube, nvmlMockNamespace, nriNRIDaemonSet, config.ReadyTimeout(), config.PollInterval())
+
+			By("recreating gpu-agent so its containers are created after the wedge")
+			deployNRIAgent(ctx, h)
+
+			p := loadProfile(selectedProfiles[0])
+			pod := nriAgentPodOnNode(ctx, h, victim.Name)
+			res, err := h.Kube.Exec(ctx, pod, "nvidia-smi", "-L")
+			Expect(err).NotTo(HaveOccurred(), "nvidia-smi -L in the post-wedge gpu-agent pod: %s", res.Combined())
+			Expect(countGPULines(res.Combined())).To(Equal(p.ExpectedGPUs()),
+				"a pod created after the wedge must still see %d injected GPUs\n%s",
+				p.ExpectedGPUs(), strings.TrimSpace(res.Combined()))
+		})
+	})
 })
+
+// nriPluginPodOnNode returns the nvml-mock-nri pod scheduled on node.
+func nriPluginPodOnNode(ctx context.Context, h *harness.Harness, node string) kube.PodRef {
+	GinkgoHelper()
+	var name string
+	Eventually(func() (string, error) {
+		pods, err := h.Kube.RunningPodNames(ctx, nvmlMockNamespace, nriPluginSelector)
+		if err != nil {
+			return "", err
+		}
+		for _, pod := range pods {
+			podNode, err := h.Kube.PodNode(ctx, nvmlMockNamespace, pod)
+			if err != nil {
+				return "", err
+			}
+			if podNode == node {
+				name = pod
+				return name, nil
+			}
+		}
+		return "", nil
+	}).WithContext(ctx).WithTimeout(config.ReadyTimeout()).WithPolling(config.PollInterval()).
+		ShouldNot(BeEmpty(), "no running nvml-mock-nri pod on node %s", node)
+	return kube.PodRef{Namespace: nvmlMockNamespace, Pod: name}
+}
+
+func nriRestartCount(ctx context.Context, h *harness.Harness, pod kube.PodRef) (int, error) {
+	out, err := h.Kube.KubectlCombined(ctx, "get", "pod", "-n", pod.Namespace, pod.Pod,
+		"-o", "jsonpath={.status.containerStatuses[0].restartCount}")
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(strings.TrimSpace(out))
+}
+
+// wedgeNRIPlugin freezes the plugin process with SIGSTOP, reproducing a handler
+// that never answers while the process and its runtime connection stay up.
+//
+// The signal is sent from the Kind node's PID namespace, not from inside the
+// container, and that is load-bearing: the plugin is PID 1 of its container's
+// PID namespace, and the kernel discards signals with a default action that are
+// sent to a namespace init from within that same namespace. `kubectl exec ...
+// kill -STOP 1` is silently a no-op. From the node -- an ancestor namespace --
+// the signal is delivered.
+func wedgeNRIPlugin(ctx context.Context, node string) {
+	GinkgoHelper()
+	pid := nriPluginHostPID(ctx, node)
+	_, err := runner.Run(ctx, "docker", "exec", node, "kill", "-STOP", pid)
+	Expect(err).NotTo(HaveOccurred(), "SIGSTOP nvml-mock-nri (pid %s) on %s", pid, node)
+
+	// Confirm the process really is stopped rather than trusting kill's exit
+	// code: a wedge that did not take would make every assertion below vacuous.
+	Eventually(func() (string, error) {
+		res, err := runner.RunQuiet(ctx, "docker", "exec", node, "cat", "/proc/"+pid+"/stat")
+		if err != nil {
+			return "", err
+		}
+		fields := strings.Fields(res.Stdout)
+		if len(fields) < 3 {
+			return "", fmt.Errorf("unexpected /proc/%s/stat: %q", pid, res.Stdout)
+		}
+		return fields[2], nil // state: T = stopped
+	}).WithContext(ctx).WithTimeout(30*time.Second).WithPolling(time.Second).
+		Should(Equal("T"), "nvml-mock-nri (pid %s) on %s did not enter the stopped state", pid, node)
+}
+
+// nriPluginHostPID finds the plugin process in the Kind node's PID namespace.
+// It reads /proc/<pid>/exe rather than shelling out to pgrep: procps is not
+// guaranteed in the node image, and matching on a command line would also match
+// the matching process itself.
+func nriPluginHostPID(ctx context.Context, node string) string {
+	GinkgoHelper()
+	const script = `for p in /proc/[0-9]*; do case "$(readlink "$p/exe" 2>/dev/null)" in */nvml-mock-nri) echo "${p##*/}";; esac; done`
+	res, err := runner.Run(ctx, "docker", "exec", node, "sh", "-c", script)
+	Expect(err).NotTo(HaveOccurred(), "locate nvml-mock-nri on %s: %s", node, res.Combined())
+
+	pids := strings.Fields(res.Stdout)
+	Expect(pids).NotTo(BeEmpty(), "no nvml-mock-nri process found on %s", node)
+	return pids[0]
+}
 
 // installNRIChart (re)installs the nvml-mock release with the NRI plugin
 // enabled. Fabric-attached profiles additionally get the generated


### PR DESCRIPTION
## Problem

The NRI plugin had no health surface at all — `main()` built a stub and called `Run(ctx)` — and the NRI DaemonSet carried no probes of any kind. Nothing distinguished a plugin that was injecting containers from one that had silently stopped.

That distinction matters more here than it looks. Injection is baked into the OCI spec at container-creation time, so pods already running keep their injection no matter what happens to the plugin afterwards. Only pods created *after* a failure come up unmocked. A test suite that creates its pods early and asserts against them later keeps passing on a node where injection stopped halfway through — and reports results that no longer mean what they claim.

A probe that only proves the process is alive does not help, because the process stays alive in both failure modes:

| State | Process | Connection | Injecting? |
|---|---|---|---|
| Registered and serving | up | up | yes |
| Started, not yet registered | up | — | **no** |
| Unregistered by the runtime | up | dropped | **no** |
| Handler wedged | up | **up** | **no** |

`pgrep nvml-mock-nri` and a plain TCP check both report healthy in the bottom three rows.

## Approach

**`/readyz`** reports serving only while the plugin is registered with the runtime *and* its handler is answering. `Configure()` sets the registered flag; `stub.WithOnClose` clears it. Readiness restarts nothing — it converts the silent window into a NotReady pod and a short DaemonSet count.

**`/healthz`** fails only for a wedged handler, and restarts the container into a fresh registration. A wedge is detected as *an in-flight `CreateContainer` older than twice the request timeout the runtime itself reported at registration* (NRI default 2s → 4s threshold). Past one whole timeout the runtime has already abandoned that request; the second is tolerance so a single slow-but-completing request cannot cause a restart.

Wedge detection deliberately measures **in-flight duration**, not time since the last request. This plugin is idle whenever no containers are being created, which is its normal steady state, and a last-seen watchdog would report that as a failure.

Losing the connection is deliberately *not* a liveness failure: the stub's `Run` returns when the connection drops and the process exits on its own, so the kubelet already restarts it. Failing liveness on "not registered" as well would only add restart loops whenever containerd is slow to come up.

### Why the listener binds `:8080` and not loopback

A kubelet `httpGet` probe connects to the **pod IP**, not to the container's loopback, so a `127.0.0.1`-only bind would be permanently unreachable. This DaemonSet sets no `hostNetwork`, so binding in the pod's own network namespace exposes nothing on the node — the port is not present there at all. Verified in the e2e run: the kubelet reached `http://10.244.5.2:8080/healthz`.

## Posture

Documented explicitly in the chart README. Fail-closed is arguably preferable on a dedicated test cluster, since it stops a run rather than corrupting it — but that choice belongs to containerd, not to the plugin. So the chart assumes fail-open is possible and makes it impossible for it to happen quietly. The wedge threshold is documented as *derived from* `plugin_request_timeout` rather than as an independent knob, because tuning the two separately is how the liveness probe would start firing on healthy plugins.

## Testing

```
go test -race -count=1 ./...   rc=0   24 packages, 0 failures
golangci-lint run ./...        rc=0   0 issues
helm unittest                  rc=0   138/138
e2e-nri (a100, local kind)     Test Suite Passed
```

The new e2e specs wedge the plugin mid-run with SIGSTOP — which leaves the process alive and the ttRPC connection open while the handler stops answering — then assert the DaemonSet reports NotReady, that the kubelet restarts the container and attributes it to the liveness probe, and that a workload created *after* the wedge is still injected once the plugin re-registers.

The signal is sent from the Kind node's PID namespace rather than through `kubectl exec`: the plugin is PID 1 of its container's namespace, and the kernel discards default-action signals sent to a namespace init from inside that namespace, so `kubectl exec ... kill -STOP 1` is silently a no-op. The wedge is confirmed against `/proc/<pid>/stat` before any assertion runs, so a wedge that did not take fails loudly instead of making the specs vacuous.

**Mutation-checked as a real e2e run**, not as a claim. With the probes reverted:

```
[FAILED] Timed out after 120.001s.
daemonset mokka/nvml-mock-nri stayed Ready while the plugin on
nvml-mock-nri-worker was wedged
Expected <bool>: true to be false
```

Baseline on the same commit passed, with the kubelet event `Container nvml-mock-nri failed liveness probe, will be restarted`.

The unit tests were mutation-checked too — four mutants, each killing 2–5 named tests, including one that pins the "idle is not wedged" behaviour against the obvious wrong design.

Two limits worth stating: the wedge detector's 503 branch is unit-covered only, because SIGSTOP freezes the whole process so the e2e exercises probe timeout rather than that branch; and the local e2e covered the `a100` profile only, so the full matrix runs here.

## Breaking changes

None. Probes are additive and both blocks are overridable from values (set either to `null` to drop it). `nri.enabled` still defaults to `false`.

Closes #434
