### PR TITLE
feat(nvml-mock): render the mock IMEX surface for the DRA compute-domain plugin

### DIFF
--- a/cmd/render-imex-procdevices/main.go
+++ b/cmd/render-imex-procdevices/main.go
@@ -1,0 +1,73 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// render-imex-procdevices writes a substitute /proc/devices carrying NVIDIA
+// caps character-device entries, for consumption by the NVIDIA DRA driver's
+// compute-domain kubelet plugin via ALT_PROC_DEVICES_PATH.
+//
+// On a Mokka node there is no NVIDIA kernel module, so /proc/devices has no
+// nvidia-caps-imex-channels entry and the plugin aborts at startup. The DRA
+// driver's chart exposes an altProcDevices value for exactly this case; this
+// command produces the file it points at.
+//
+// Usage:
+//
+//	render-imex-procdevices \
+//	    --source /proc/devices \
+//	    --output /var/lib/nvml-mock/imex/proc-devices \
+//	    --imex-major 235 --caps-major 236
+//
+// Rendering is idempotent, so the DaemonSet may re-run it on restart.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/system/mockimex/render"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "render-imex-procdevices: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	fs := flag.NewFlagSet("render-imex-procdevices", flag.ContinueOnError)
+	source := fs.String("source", "/proc/devices", "path to the real /proc/devices to derive from")
+	output := fs.String("output", "", "path to write the rendered file (required)")
+	imexMajor := fs.Int("imex-major", 235, "device major to advertise for "+render.IMEXChannelsDeviceName)
+	capsMajor := fs.Int("caps-major", 236, "device major to advertise for "+render.CapsDeviceName)
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *output == "" {
+		return fmt.Errorf("--output is required")
+	}
+
+	data, err := os.ReadFile(*source) //nolint:gosec // operator-supplied source path
+	if err != nil {
+		return fmt.Errorf("read %s: %w", *source, err)
+	}
+
+	rendered, err := render.ProcDevices(string(data), *imexMajor, *capsMajor)
+	if err != nil {
+		return fmt.Errorf("render from %s: %w", *source, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(*output), 0o755); err != nil {
+		return fmt.Errorf("create output directory for %s: %w", *output, err)
+	}
+	if err := os.WriteFile(*output, []byte(rendered), 0o644); err != nil { //nolint:gosec // world-readable by design: consumed by another container
+		return fmt.Errorf("write %s: %w", *output, err)
+	}
+
+	fmt.Printf("wrote %s (%s major=%d, %s major=%d)\n",
+		*output, render.IMEXChannelsDeviceName, *imexMajor, render.CapsDeviceName, *capsMajor)
+	return nil
+}

--- a/deployments/nvml-mock/Dockerfile
+++ b/deployments/nvml-mock/Dockerfile
@@ -28,6 +28,7 @@ RUN mkdir -p /out \
     && go build -mod=vendor -o /out/nvml-mock-nri ./cmd/nvml-mock-nri \
     && go build -mod=vendor -o /out/nvml-mock-ctl ./cmd/nvml-mock-ctl \
     && go build -mod=vendor -o /out/render-pci-sysfs ./cmd/render-pci-sysfs \
+    && go build -mod=vendor -o /out/render-imex-procdevices ./cmd/render-imex-procdevices \
     && go build -mod=vendor -o /out/nvidia-imex     ./cmd/fake-imex/daemon \
     && go build -mod=vendor -o /out/nvidia-imex-ctl ./cmd/fake-imex/ctl \
     && go build -mod=vendor -o /out/nv-fabricmanager     ./cmd/fake-fabricmanager/daemon \
@@ -47,6 +48,7 @@ COPY --from=builder /out/mock-ib /usr/local/bin/mock-ib
 COPY --from=builder /out/nvml-mock-nri /usr/local/bin/nvml-mock-nri
 COPY --from=builder /out/nvml-mock-ctl /usr/local/bin/nvml-mock-ctl
 COPY --from=builder /out/render-pci-sysfs /usr/local/bin/render-pci-sysfs
+COPY --from=builder /out/render-imex-procdevices /usr/local/bin/render-imex-procdevices
 # Fake IMEX binaries used for ComputeDomain simulation on KIND. Installed
 # at the same paths the upstream compute-domain-daemon expects in $PATH,
 # so the thin daemon image layer (Dockerfile.compute-domain-daemon) can

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -81,6 +81,18 @@ spec:
             # tree is not on a path it reads; see setup.sh step 7.
             - name: MOCK_NFD_PCI_LABEL
               value: {{ ternary "on" "off" .Values.nodeLabels.pciVendorPresent | quote }}
+            {{- if .Values.imex.mockChannels.enabled }}
+            # Mock IMEX capability surface for the DRA compute-domain plugin.
+            # See values.yaml imex.mockChannels and NVIDIA/k8s-test-infra#498.
+            - name: IMEX_MOCK_CHANNELS
+              value: "true"
+            - name: IMEX_CHANNEL_COUNT
+              value: "{{ .Values.imex.mockChannels.channelCount }}"
+            - name: IMEX_CHANNEL_MAJOR
+              value: "{{ .Values.imex.mockChannels.channelMajor }}"
+            - name: IMEX_CAPS_MAJOR
+              value: "{{ .Values.imex.mockChannels.capsMajor }}"
+            {{- end }}
             # Point the mock NVML library at the in-pod ConfigMap mount so any
             # nvidia-smi / NVML caller running INSIDE the daemonset pod
             # (e.g. `kubectl exec ds/nvml-mock -- nvidia-smi`) loads the same

--- a/deployments/nvml-mock/helm/nvml-mock/values.schema.json
+++ b/deployments/nvml-mock/helm/nvml-mock/values.schema.json
@@ -205,6 +205,43 @@
       }
     },
     "integrations": { "type": "object" },
+    "imex": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "IMEX simulation. enabled/stateDir cover the deprecated hostPath-backed fake IMEX daemons; mockChannels covers the capability surface the NVIDIA DRA driver's compute-domain kubelet plugin reads.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "stateDir": {
+          "type": "string",
+          "description": "HostPath directory for the fake IMEX daemons' marker files."
+        },
+        "mockChannels": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Renders a substitute /proc/devices, the fabric-imex-mgmt capability file, and the channel device nodes. Consumed via the DRA driver's altProcDevices value. See NVIDIA/k8s-test-infra#498.",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "channelCount": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Number of channel device nodes to create. 2048 matches getImexChannelCount() in the DRA driver's compute-domain kubelet plugin."
+            },
+            "channelMajor": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 4095,
+              "description": "Character-device major advertised for nvidia-caps-imex-channels. Must differ from capsMajor and must not collide with a major already present on the node; the renderer rejects both cases."
+            },
+            "capsMajor": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 4095,
+              "description": "Character-device major advertised for nvidia-caps. Must differ from channelMajor."
+            }
+          }
+        }
+      }
+    },
     "fabricmanager": {
       "type": "object",
       "additionalProperties": true,

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -241,6 +241,38 @@ imex:
   enabled: false
   stateDir: /var/lib/nvml-mock/imex-state
 
+  # Mock IMEX capability surface for the NVIDIA DRA driver's compute-domain
+  # kubelet plugin. That plugin reads a device major for
+  # nvidia-caps-imex-channels out of /proc/devices at startup; on a mock node
+  # there is no NVIDIA kernel module, so the entry is absent and the plugin
+  # aborts with "error parsing '/proc/devices': unexpected regex match: []".
+  #
+  # When enabled, the DaemonSet renders:
+  #   <hostPath>/imex/proc-devices                       substitute /proc/devices
+  #   <driverRoot>/proc/driver/nvidia/capabilities/...   fabric-imex-mgmt
+  #   <driverRoot>/dev/nvidia-caps-imex-channels/channelN  channel device nodes
+  #
+  # Pair it with the DRA driver, on a release that supports altProcDevices:
+  #   --set altProcDevices=/var/lib/nvml-mock/imex/proc-devices
+  #   --set resources.computeDomains.enabled=true
+  #
+  # NOTE: as of 2026-07-25 altProcDevices is on the DRA driver's main branch
+  # but is NOT in any release (absent at v25.12.0), so enabling this alone does
+  # not yet make ComputeDomains work with released artifacts. See
+  # NVIDIA/k8s-test-infra#498.
+  #
+  # Off by default: it creates channelCount device nodes per node.
+  mockChannels:
+    enabled: false
+    # Number of channel device nodes. 2048 matches getImexChannelCount() in the
+    # DRA driver's compute-domain kubelet plugin.
+    channelCount: 2048
+    # Device majors advertised in the rendered proc-devices file. Defaults match
+    # the DRA driver's own CI fixtures. They must differ from each other and
+    # must not collide with a major already present on the node.
+    channelMajor: 235
+    capsMajor: 236
+
 # Fake nvidia-fabricmanager. NVSwitch platforms (HGX H100 / GB200 / GB300)
 # run nvidia-fabricmanager to register GPUs with the NVSwitch fabric. When
 # enabled the entrypoint starts the fake nvidia-fabricmanager daemon (baked

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -66,6 +66,54 @@ mknod -m 666 "$DEV_ROOT/nvidiactl" c 195 255 2>/dev/null || true
 mknod -m 666 "$DEV_ROOT/nvidia-uvm" c 510 0 2>/dev/null || true
 mknod -m 666 "$DEV_ROOT/nvidia-uvm-tools" c 510 1 2>/dev/null || true
 
+# 3a. Mock IMEX capability surface (opt-in via IMEX_MOCK_CHANNELS).
+#     The NVIDIA DRA driver's compute-domain kubelet plugin reads a device major
+#     for nvidia-caps-imex-channels out of /proc/devices at startup. There is no
+#     NVIDIA kernel module here, so that entry does not exist and the plugin
+#     aborts. The DRA driver supports a substitute file via its chart's
+#     altProcDevices value (env ALT_PROC_DEVICES_PATH); this renders it.
+#
+#     Pair with, on the DRA driver release that supports it:
+#       --set altProcDevices=/var/lib/nvml-mock/imex/proc-devices
+#       --set resources.computeDomains.enabled=true
+#
+#     Bind-mounting over /proc/devices is not an option: runc rejects it
+#     ("cannot be mounted because it is inside /proc"), which is why the
+#     consumer uses an env-var indirection instead.
+if [ "${IMEX_MOCK_CHANNELS:-false}" = "true" ]; then
+  IMEX_DIR=$HOST/imex
+  IMEX_MAJOR=${IMEX_CHANNEL_MAJOR:-235}
+  CAPS_MAJOR=${IMEX_CAPS_MAJOR:-236}
+  IMEX_CHANNELS=${IMEX_CHANNEL_COUNT:-2048}
+
+  mkdir -p "$IMEX_DIR"
+  # Rendering is idempotent, so a DaemonSet restart re-runs this safely.
+  render-imex-procdevices \
+    --source /proc/devices \
+    --output "$IMEX_DIR/proc-devices" \
+    --imex-major "$IMEX_MAJOR" \
+    --caps-major "$CAPS_MAJOR"
+
+  # The plugin also reads the fabric IMEX management capability.
+  mkdir -p "$DRIVER_ROOT/proc/driver/nvidia/capabilities"
+  cat > "$DRIVER_ROOT/proc/driver/nvidia/capabilities/fabric-imex-mgmt" <<CAPS_EOF
+DeviceFileMinor: 512
+DeviceFileMode: 438
+DeviceFileModify: 0
+CAPS_EOF
+
+  # Channel device nodes, injected into workload pods by the compute-domain CDI
+  # spec. They must exist as character devices for that injection to succeed.
+  mkdir -p "$DEV_ROOT/nvidia-caps-imex-channels"
+  i=0
+  while [ "$i" -lt "$IMEX_CHANNELS" ]; do
+    mknod -m 666 "$DEV_ROOT/nvidia-caps-imex-channels/channel$i" c "$IMEX_MAJOR" "$i" 2>/dev/null || true
+    i=$((i + 1))
+  done
+
+  echo "Mock IMEX surface ready: $IMEX_CHANNELS channels, major $IMEX_MAJOR, proc-devices at $IMEX_DIR/proc-devices"
+fi
+
 # 3b. Generate CDI spec for nvidia-container-runtime CDI mode.
 #     This allows the toolkit to inject our mock libs into containers without
 #     needing libnvidia-container or kernel modules.

--- a/pkg/system/mockimex/render/procdevices.go
+++ b/pkg/system/mockimex/render/procdevices.go
@@ -1,0 +1,148 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// Package render generates the mock IMEX capability surface that the NVIDIA DRA
+// driver's compute-domain kubelet plugin needs on a node with no NVIDIA kernel
+// driver.
+//
+// The plugin reads a device major for "nvidia-caps-imex-channels" out of
+// /proc/devices at startup. On a Mokka node that entry does not exist, because
+// there is no kernel module, and the plugin aborts with:
+//
+//	error getting nvcap for IMEX channel '0': error getting device major:
+//	error parsing '/proc/devices': unexpected regex match: []
+//
+// The DRA driver supports pointing at a substitute file through the
+// ALT_PROC_DEVICES_PATH environment variable, wired by its chart's
+// altProcDevices value. This package renders that file.
+//
+// The output must satisfy the consumer's parser, which requires the entry to
+// appear between the "Character devices:" and "Block devices:" headers and to be
+// newline-terminated. See internal/common/nvcaps.go in
+// kubernetes-sigs/dra-driver-nvidia-gpu.
+package render
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Device names the DRA driver looks up.
+const (
+	IMEXChannelsDeviceName = "nvidia-caps-imex-channels"
+	CapsDeviceName         = "nvidia-caps"
+)
+
+const (
+	charDevicesHeader  = "Character devices:"
+	blockDevicesHeader = "Block devices:"
+
+	// maxDeviceMajor is the largest major this renderer will emit. Linux
+	// allocates majors well below this; keeping the bound tight makes a
+	// transposed or garbage value fail loudly rather than produce a file the
+	// consumer will parse into nonsense.
+	maxDeviceMajor = 4095
+)
+
+// entryPattern matches an existing "<major> <name>" line so re-rendering can
+// replace it instead of appending a duplicate.
+func entryPattern(name string) *regexp.Regexp {
+	return regexp.MustCompile(`(?m)^[ \t]*[0-9]+ ` + regexp.QuoteMeta(name) + `[ \t]*$` + "\n?")
+}
+
+// existingMajors returns every device major already listed in src.
+func existingMajors(src string) map[int]string {
+	majors := make(map[int]string)
+	re := regexp.MustCompile(`(?m)^[ \t]*([0-9]+) +(\S+)[ \t]*$`)
+	for _, m := range re.FindAllStringSubmatch(src, -1) {
+		major, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+		// Keep the first binding; a major can legitimately appear in both the
+		// character and block sections for different drivers.
+		if _, seen := majors[major]; !seen {
+			majors[major] = m[2]
+		}
+	}
+	return majors
+}
+
+// ProcDevices returns src with NVIDIA caps character-device entries inserted
+// into the character-devices section, so the DRA driver's compute-domain plugin
+// can resolve its majors.
+//
+// It is idempotent: rendering an already-rendered file is a no-op, and
+// re-rendering with a different major replaces the entry rather than appending
+// a second one.
+func ProcDevices(src string, imexMajor, capsMajor int) (string, error) {
+	if err := validateMajors(src, imexMajor, capsMajor); err != nil {
+		return "", err
+	}
+
+	charAt := strings.Index(src, charDevicesHeader)
+	if charAt < 0 {
+		return "", fmt.Errorf("input has no %q header, so the consumer's parser can never match", charDevicesHeader)
+	}
+	blockAt := strings.Index(src, blockDevicesHeader)
+	if blockAt < 0 {
+		return "", fmt.Errorf("input has no %q header, so the consumer's parser can never match", blockDevicesHeader)
+	}
+	if blockAt < charAt {
+		return "", fmt.Errorf("%q appears before %q, which is not a valid /proc/devices layout",
+			blockDevicesHeader, charDevicesHeader)
+	}
+
+	// Drop any previous rendering so a changed major replaces rather than
+	// duplicates. Only the character-devices section is rewritten.
+	charSection := src[:blockAt]
+	rest := src[blockAt:]
+	for _, name := range []string{IMEXChannelsDeviceName, CapsDeviceName} {
+		charSection = entryPattern(name).ReplaceAllString(charSection, "")
+	}
+
+	// Trim trailing blank lines from the character section, append the entries,
+	// then restore the blank-line separator before the block header.
+	charSection = strings.TrimRight(charSection, "\n \t")
+	entries := fmt.Sprintf("\n%3d %s\n%3d %s\n\n", imexMajor, IMEXChannelsDeviceName, capsMajor, CapsDeviceName)
+
+	return charSection + entries + rest, nil
+}
+
+func validateMajors(src string, imexMajor, capsMajor int) error {
+	for _, m := range []struct {
+		name  string
+		major int
+	}{
+		{IMEXChannelsDeviceName, imexMajor},
+		{CapsDeviceName, capsMajor},
+	} {
+		if m.major <= 0 || m.major > maxDeviceMajor {
+			return fmt.Errorf("device major %d for %s is out of range, want 1..%d",
+				m.major, m.name, maxDeviceMajor)
+		}
+	}
+
+	if imexMajor == capsMajor {
+		return fmt.Errorf("device majors for %s and %s must differ, both are %d",
+			IMEXChannelsDeviceName, CapsDeviceName, imexMajor)
+	}
+
+	inUse := existingMajors(src)
+	for _, m := range []struct {
+		name  string
+		major int
+	}{
+		{IMEXChannelsDeviceName, imexMajor},
+		{CapsDeviceName, capsMajor},
+	} {
+		if owner, taken := inUse[m.major]; taken && owner != m.name {
+			return fmt.Errorf("device major %d is already assigned to %q, refusing to reuse it for %s",
+				m.major, owner, m.name)
+		}
+	}
+
+	return nil
+}

--- a/pkg/system/mockimex/render/procdevices_test.go
+++ b/pkg/system/mockimex/render/procdevices_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package render
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// draParserOracle is a verbatim copy of the regex the NVIDIA DRA driver uses to
+// read a device major out of /proc/devices
+// (kubernetes-sigs/dra-driver-nvidia-gpu internal/common/nvcaps.go, getDeviceMajor).
+//
+// Using the consumer's own parser as the oracle is the point: it derives the
+// expected result by a different path from the implementation, so these tests
+// fail if the rendered file drifts out of the contract the DRA driver actually
+// enforces. Asserting only "the string contains nvidia-caps-imex-channels"
+// would pass against output the real parser rejects.
+func draParserOracle(t *testing.T, content, name string) (int, bool) {
+	t.Helper()
+
+	re := regexp.MustCompile(
+		"(?s)Character devices:.*?" +
+			"([0-9]+) " + regexp.QuoteMeta(name) +
+			"\n.*Block devices:",
+	)
+	matches := re.FindStringSubmatch(content)
+	if len(matches) != 2 {
+		return 0, false
+	}
+	major, err := strconv.Atoi(matches[1])
+	require.NoError(t, err)
+	return major, true
+}
+
+// realisticProcDevices mirrors the shape of a real /proc/devices on a node with
+// no NVIDIA kernel driver loaded, which is exactly the Mokka case.
+const realisticProcDevices = `Character devices:
+  1 mem
+  4 tty
+  5 /dev/tty
+ 10 misc
+ 13 input
+128 ptm
+136 pts
+
+Block devices:
+  7 loop
+  8 sd
+259 blkext
+`
+
+func TestProcDevicesOutputSatisfiesTheDRAParser(t *testing.T) {
+	t.Parallel()
+
+	out, err := ProcDevices(realisticProcDevices, 235, 236)
+	require.NoError(t, err)
+
+	major, ok := draParserOracle(t, out, IMEXChannelsDeviceName)
+	require.True(t, ok, "the DRA driver's own regex must find the IMEX channels entry")
+	assert.Equal(t, 235, major)
+
+	capsMajor, ok := draParserOracle(t, out, CapsDeviceName)
+	require.True(t, ok, "the DRA driver's own regex must also find the nvidia-caps entry")
+	assert.Equal(t, 236, capsMajor)
+}
+
+// The failure this reproduces is the one observed on the POC cluster:
+// "error parsing '/proc/devices': unexpected regex match: []".
+func TestUnmodifiedProcDevicesFailsTheDRAParser(t *testing.T) {
+	t.Parallel()
+
+	_, ok := draParserOracle(t, realisticProcDevices, IMEXChannelsDeviceName)
+
+	assert.False(t, ok,
+		"an unmodified /proc/devices must NOT satisfy the parser, otherwise this test proves nothing")
+}
+
+// The parser requires the entry to sit between the two section headers, so the
+// entry must land in the character-devices section and not be appended at the end.
+func TestEntriesLandBeforeTheBlockDevicesSection(t *testing.T) {
+	t.Parallel()
+
+	out, err := ProcDevices(realisticProcDevices, 235, 236)
+	require.NoError(t, err)
+
+	imexAt := strings.Index(out, IMEXChannelsDeviceName)
+	blockAt := strings.Index(out, "Block devices:")
+	require.NotEqual(t, -1, imexAt)
+	require.NotEqual(t, -1, blockAt)
+
+	assert.Less(t, imexAt, blockAt,
+		"the IMEX entry must precede the Block devices header or the parser will not match it")
+}
+
+func TestProcDevicesPreservesExistingEntries(t *testing.T) {
+	t.Parallel()
+
+	out, err := ProcDevices(realisticProcDevices, 235, 236)
+	require.NoError(t, err)
+
+	for _, keep := range []string{"1 mem", "4 tty", "136 pts", "7 loop", "259 blkext"} {
+		assert.Contains(t, out, keep, "existing entry %q must survive rendering", keep)
+	}
+}
+
+// setup.sh may re-run on DaemonSet restart, so rendering twice must not produce
+// a duplicate entry, which would make the parser's ".*?" match ambiguous.
+func TestProcDevicesIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	once, err := ProcDevices(realisticProcDevices, 235, 236)
+	require.NoError(t, err)
+	twice, err := ProcDevices(once, 235, 236)
+	require.NoError(t, err)
+
+	assert.Equal(t, once, twice, "rendering an already-rendered file must be a no-op")
+	assert.Equal(t, 1, strings.Count(twice, IMEXChannelsDeviceName),
+		"the IMEX entry must appear exactly once")
+}
+
+// Re-rendering with a different major must update rather than append, otherwise
+// the file would carry two conflicting majors.
+func TestProcDevicesReplacesAnExistingEntryWithADifferentMajor(t *testing.T) {
+	t.Parallel()
+
+	first, err := ProcDevices(realisticProcDevices, 235, 236)
+	require.NoError(t, err)
+	second, err := ProcDevices(first, 240, 241)
+	require.NoError(t, err)
+
+	major, ok := draParserOracle(t, second, IMEXChannelsDeviceName)
+	require.True(t, ok)
+	assert.Equal(t, 240, major, "the major must be updated, not duplicated")
+	assert.Equal(t, 1, strings.Count(second, IMEXChannelsDeviceName))
+}
+
+func TestProcDevicesRejectsInputWithoutBlockDevicesSection(t *testing.T) {
+	t.Parallel()
+
+	_, err := ProcDevices("Character devices:\n  1 mem\n", 235, 236)
+
+	require.Error(t, err, "without a Block devices section the DRA parser can never match")
+	assert.Contains(t, err.Error(), "Block devices")
+}
+
+func TestProcDevicesRejectsInputWithoutCharacterDevicesSection(t *testing.T) {
+	t.Parallel()
+
+	_, err := ProcDevices("Block devices:\n  7 loop\n", 235, 236)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Character devices")
+}
+
+func TestProcDevicesRejectsOutOfRangeMajors(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		imex, caps int
+	}{
+		{"imex zero", 0, 236},
+		{"imex negative", -1, 236},
+		{"caps zero", 235, 0},
+		{"imex too large", 1 << 20, 236},
+		{"imex equals caps", 235, 235},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := ProcDevices(realisticProcDevices, tc.imex, tc.caps)
+			assert.Error(t, err, "major pair (%d,%d) must be rejected", tc.imex, tc.caps)
+		})
+	}
+}
+
+// A major already claimed by another driver would make the mock entry collide
+// with a real device, so it must be refused rather than silently written.
+func TestProcDevicesRejectsAMajorAlreadyInUse(t *testing.T) {
+	t.Parallel()
+
+	_, err := ProcDevices(realisticProcDevices, 10, 236)
+
+	require.Error(t, err, "major 10 is already 'misc' in the fixture and must be refused")
+	assert.Contains(t, err.Error(), "10")
+}


### PR DESCRIPTION
## Problem

The NVIDIA DRA driver's compute-domain kubelet plugin reads a device major for `nvidia-caps-imex-channels` out of `/proc/devices` at startup. On a mock node there is no NVIDIA kernel module, so the entry is absent and the plugin aborts:

```
error parsing '/proc/devices': unexpected regex match: []
```

That is what blocks AICR's `dra-support` check under Mokka. The DRA driver already supports a substitute file through `ALT_PROC_DEVICES_PATH`, wired by its chart's `altProcDevices` value, and its own CI builds this surface against `nvml-mock`. Today that surface lives only in a consumer's CI scripts, so installing the `nvml-mock` chart alone cannot enable `resources.computeDomains`.

## Approach

Ships our half of the surface, opt-in behind `imex.mockChannels.enabled` (off by default, since it creates `channelCount` device nodes per node). When enabled the DaemonSet renders:

| Path | Purpose |
|---|---|
| `<hostPath>/imex/proc-devices` | substitute `/proc/devices` |
| `<driverRoot>/proc/driver/nvidia/capabilities/fabric-imex-mgmt` | fabric IMEX capability |
| `<driverRoot>/dev/nvidia-caps-imex-channels/channelN` | channel device nodes |

New `pkg/system/mockimex/render` does the proc-devices rewrite, driven by a `render-imex-procdevices` command. Rendering is idempotent, so a DaemonSet restart re-runs safely, and re-rendering with a different major replaces the entry rather than appending a second one.

Bind-mounting over `/proc/devices` is not an alternative — runc rejects it (`cannot be mounted because it is inside /proc`), which is exactly why the consumer uses an env-var indirection.

`values.schema.json` gains an `imex` block covering `mockChannels` plus the pre-existing `enabled`/`stateDir` keys, which had no schema. The major bounds mirror the renderer's own validation (1..4095), so an out-of-range value fails at `helm template` time.

## Testing done

The renderer tests use the DRA driver's own parsing regex as the oracle, copied verbatim from `internal/common/nvcaps.go` in `kubernetes-sigs/dra-driver-nvidia-gpu`. Deriving the expectation from the consumer's parser rather than from this implementation is what makes them discriminate.

Mutation-checked: appending the entries after the `Block devices:` header still contains the right text, and turns exactly 4 of the 15 tests RED.

```
go test -race ./...          rc=0, 25 packages ok, 0 FAIL
golangci-lint run ./...      0 issues
helm unittest                138/138 tests, 7 suites, 15 snapshots
```

Schema discrimination verified: `--set imex.mockChannels.channelMajor=9999` fails with `maximum: got 9,999, want 4,095`. With the value enabled the DaemonSet renders all four `IMEX_*` env vars; by default it renders none.

## Breaking changes

None. The value is off by default and the rendering is skipped entirely when disabled.

## Known limitation

This does not by itself make ComputeDomains work. `altProcDevices` is on the DRA driver's main branch but absent from v25.12.0, so no released driver can consume the file yet. Documented in `values.yaml`. The e2e that asserts the compute-domains container reaches Ready is tracked separately in #509 and waits on that upstream release.

Closes #498
