### PR TITLE
fix(e2e): assert GFD labels instead of warning about them

### DIFF
--- a/tests/e2e/go/assertions/gfd_labels.go
+++ b/tests/e2e/go/assertions/gfd_labels.go
@@ -1,22 +1,21 @@
-//go:build e2e
-
 // Copyright 2026 NVIDIA CORPORATION
 // SPDX-License-Identifier: Apache-2.0
 
 package assertions
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"strconv"
-	"time"
-
-	ginkgo "github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
-
-	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/kube"
 )
+
+// This file carries no build tag on purpose. The rest of the package is
+// //go:build e2e because it imports the Kubernetes client, which would drag a
+// cluster dependency into the normal unit-test run. The derivation and
+// comparison below need nothing but the standard library, so keeping them
+// untagged is what makes their tests run in the regular `go test ./...` job
+// rather than only under -tags e2e. The cluster-facing poll that consumes them
+// lives in gfd_labels_wait.go.
 
 // GFD label keys asserted against GPU Feature Discovery.
 const (
@@ -60,33 +59,4 @@ func DiffGFDLabels(want, got map[string]string) []string {
 	}
 
 	return problems
-}
-
-// WaitGFDLabels polls until the node carries every expected GFD label with the
-// expected value, and fails the spec otherwise.
-//
-// This replaces a warning-only check that could never fail: GPU Feature
-// Discovery could have been removed entirely and the scenario would still have
-// gone green. Labels are published asynchronously after the operator settles,
-// hence the poll rather than a single read.
-func WaitGFDLabels(ctx context.Context, k *kube.Client, node string, want map[string]string, timeout, poll time.Duration) {
-	ginkgo.GinkgoHelper()
-	ginkgo.By(fmt.Sprintf("waiting for GFD labels on %s", node))
-
-	var last []string
-	gomega.Eventually(func() ([]string, error) {
-		got := make(map[string]string, len(want))
-		for key := range want {
-			value, ok, err := k.NodeLabel(ctx, node, key)
-			if err != nil {
-				return nil, err
-			}
-			if ok {
-				got[key] = value
-			}
-		}
-		last = DiffGFDLabels(want, got)
-		return last, nil
-	}).WithContext(ctx).WithTimeout(timeout).WithPolling(poll).
-		Should(gomega.BeEmpty(), "GFD labels on node %s did not match the profile: %v", node, &last)
 }

--- a/tests/e2e/go/assertions/gfd_labels.go
+++ b/tests/e2e/go/assertions/gfd_labels.go
@@ -1,0 +1,92 @@
+//go:build e2e
+
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package assertions
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/kube"
+)
+
+// GFD label keys asserted against GPU Feature Discovery.
+const (
+	GFDLabelProduct = "nvidia.com/gpu.product"
+	GFDLabelMemory  = "nvidia.com/gpu.memory"
+	GFDLabelCount   = "nvidia.com/gpu.count"
+)
+
+// ExpectedGFDLabels derives the GFD labels a node must carry from the profile,
+// rather than from the node itself. Deriving them independently is what makes
+// the assertion discriminating: if GFD stopped reading the mock NVML, the count
+// would go absent or wrong and the comparison would catch it.
+func ExpectedGFDLabels(product string, memoryMiB, gpuCount int) map[string]string {
+	return map[string]string{
+		GFDLabelProduct: product,
+		GFDLabelMemory:  strconv.Itoa(memoryMiB),
+		GFDLabelCount:   strconv.Itoa(gpuCount),
+	}
+}
+
+// DiffGFDLabels returns one human-readable problem per expected label that is
+// missing or carries the wrong value. An empty result means the node matches.
+// It reports every problem rather than stopping at the first, so one run shows
+// the whole picture.
+func DiffGFDLabels(want, got map[string]string) []string {
+	keys := make([]string, 0, len(want))
+	for key := range want {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var problems []string
+	for _, key := range keys {
+		actual, present := got[key]
+		switch {
+		case !present || actual == "":
+			problems = append(problems, fmt.Sprintf("label %s missing (want %q)", key, want[key]))
+		case actual != want[key]:
+			problems = append(problems, fmt.Sprintf("label %s = %q, want %q", key, actual, want[key]))
+		}
+	}
+
+	return problems
+}
+
+// WaitGFDLabels polls until the node carries every expected GFD label with the
+// expected value, and fails the spec otherwise.
+//
+// This replaces a warning-only check that could never fail: GPU Feature
+// Discovery could have been removed entirely and the scenario would still have
+// gone green. Labels are published asynchronously after the operator settles,
+// hence the poll rather than a single read.
+func WaitGFDLabels(ctx context.Context, k *kube.Client, node string, want map[string]string, timeout, poll time.Duration) {
+	ginkgo.GinkgoHelper()
+	ginkgo.By(fmt.Sprintf("waiting for GFD labels on %s", node))
+
+	var last []string
+	gomega.Eventually(func() ([]string, error) {
+		got := make(map[string]string, len(want))
+		for key := range want {
+			value, ok, err := k.NodeLabel(ctx, node, key)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				got[key] = value
+			}
+		}
+		last = DiffGFDLabels(want, got)
+		return last, nil
+	}).WithContext(ctx).WithTimeout(timeout).WithPolling(poll).
+		Should(gomega.BeEmpty(), "GFD labels on node %s did not match the profile: %v", node, &last)
+}

--- a/tests/e2e/go/assertions/gfd_labels_test.go
+++ b/tests/e2e/go/assertions/gfd_labels_test.go
@@ -1,5 +1,3 @@
-//go:build e2e
-
 // Copyright 2026 NVIDIA CORPORATION
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/e2e/go/assertions/gfd_labels_test.go
+++ b/tests/e2e/go/assertions/gfd_labels_test.go
@@ -1,0 +1,119 @@
+//go:build e2e
+
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package assertions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These cover the pure derivation and comparison used by WaitGFDLabels, so they
+// run without a cluster. The cluster-facing poll is exercised by the
+// gpu-operator e2e scenario.
+
+func TestExpectedGFDLabelsDerivesCountAndProductFromProfile(t *testing.T) {
+	t.Parallel()
+
+	want := ExpectedGFDLabels("NVIDIA-GB200", 196608, 8)
+
+	assert.Equal(t, "NVIDIA-GB200", want[GFDLabelProduct])
+	assert.Equal(t, "196608", want[GFDLabelMemory])
+	assert.Equal(t, "8", want[GFDLabelCount])
+}
+
+// The count label is the one that actually discriminates: if GFD were removed or
+// stopped reading the mock NVML, the count would be absent or wrong. Deriving it
+// from the profile rather than reading it back off the node is what makes the
+// assertion real.
+func TestExpectedGFDLabelsCountTracksProfileNotAConstant(t *testing.T) {
+	t.Parallel()
+
+	four := ExpectedGFDLabels("NVIDIA-A100-SXM4-40GB", 40960, 4)
+	eight := ExpectedGFDLabels("NVIDIA-GB200", 196608, 8)
+
+	assert.Equal(t, "4", four[GFDLabelCount])
+	assert.Equal(t, "8", eight[GFDLabelCount])
+	assert.NotEqual(t, four[GFDLabelCount], eight[GFDLabelCount])
+	assert.NotEqual(t, four[GFDLabelProduct], eight[GFDLabelProduct])
+}
+
+func TestDiffGFDLabelsReportsMissingLabel(t *testing.T) {
+	t.Parallel()
+
+	want := ExpectedGFDLabels("NVIDIA-GB200", 196608, 8)
+	got := map[string]string{
+		GFDLabelProduct: "NVIDIA-GB200",
+		GFDLabelMemory:  "196608",
+		// gpu.count absent: this is what a removed or broken GFD looks like.
+	}
+
+	problems := DiffGFDLabels(want, got)
+
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], GFDLabelCount)
+	assert.Contains(t, problems[0], "missing")
+}
+
+func TestDiffGFDLabelsReportsWrongValue(t *testing.T) {
+	t.Parallel()
+
+	want := ExpectedGFDLabels("NVIDIA-GB200", 196608, 8)
+	got := map[string]string{
+		GFDLabelProduct: "NVIDIA-GB200",
+		GFDLabelMemory:  "196608",
+		GFDLabelCount:   "1", // GFD saw a different device count than the profile declares
+	}
+
+	problems := DiffGFDLabels(want, got)
+
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], GFDLabelCount)
+	assert.Contains(t, problems[0], `"1"`)
+	assert.Contains(t, problems[0], `"8"`)
+}
+
+func TestDiffGFDLabelsReturnsNothingWhenLabelsMatch(t *testing.T) {
+	t.Parallel()
+
+	want := ExpectedGFDLabels("NVIDIA-GB200", 196608, 8)
+	got := map[string]string{
+		GFDLabelProduct: "NVIDIA-GB200",
+		GFDLabelMemory:  "196608",
+		GFDLabelCount:   "8",
+	}
+
+	assert.Empty(t, DiffGFDLabels(want, got))
+}
+
+func TestDiffGFDLabelsReportsEveryProblemNotJustTheFirst(t *testing.T) {
+	t.Parallel()
+
+	want := ExpectedGFDLabels("NVIDIA-GB200", 196608, 8)
+
+	problems := DiffGFDLabels(want, map[string]string{})
+
+	assert.Len(t, problems, 3, "an empty label set must report all three labels, not stop at the first")
+}
+
+// A label that exists but carries no value must count as missing rather than
+// matching against an empty expectation.
+func TestDiffGFDLabelsTreatsEmptyValueAsMissing(t *testing.T) {
+	t.Parallel()
+
+	want := ExpectedGFDLabels("NVIDIA-GB200", 196608, 8)
+	got := map[string]string{
+		GFDLabelProduct: "",
+		GFDLabelMemory:  "196608",
+		GFDLabelCount:   "8",
+	}
+
+	problems := DiffGFDLabels(want, got)
+
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "missing")
+}

--- a/tests/e2e/go/assertions/gfd_labels_wait.go
+++ b/tests/e2e/go/assertions/gfd_labels_wait.go
@@ -1,0 +1,49 @@
+//go:build e2e
+
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package assertions
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/kube"
+)
+
+// WaitGFDLabels polls until the node carries every expected GFD label with the
+// expected value, and fails the spec otherwise.
+//
+// This replaces a warning-only check that could never fail: GPU Feature
+// Discovery could have been removed entirely and the scenario would still have
+// gone green. Labels are published asynchronously after the operator settles,
+// hence the poll rather than a single read.
+//
+// The expectation and comparison it uses live in gfd_labels.go, which is
+// untagged so they stay unit-testable without a cluster.
+func WaitGFDLabels(ctx context.Context, k *kube.Client, node string, want map[string]string, timeout, poll time.Duration) {
+	ginkgo.GinkgoHelper()
+	ginkgo.By(fmt.Sprintf("waiting for GFD labels on %s", node))
+
+	var last []string
+	gomega.Eventually(func() ([]string, error) {
+		got := make(map[string]string, len(want))
+		for key := range want {
+			value, ok, err := k.NodeLabel(ctx, node, key)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				got[key] = value
+			}
+		}
+		last = DiffGFDLabels(want, got)
+		return last, nil
+	}).WithContext(ctx).WithTimeout(timeout).WithPolling(poll).
+		Should(gomega.BeEmpty(), "GFD labels on node %s did not match the profile: %v", node, &last)
+}

--- a/tests/e2e/go/profile/gfd_test.go
+++ b/tests/e2e/go/profile/gfd_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package profile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The expected values are the ones GPU Feature Discovery actually published on a
+// live gb200 Mokka cluster on 2026-07-25:
+//
+//	nvidia.com/gpu.product=NVIDIA-GB200
+//	nvidia.com/gpu.memory=196608
+//	nvidia.com/gpu.count=8
+//
+// Deriving them from the profile and comparing against those observed literals
+// is what makes the e2e GFD assertion discriminating.
+func TestGB200ProfileDerivesObservedGFDLabelValues(t *testing.T) {
+	t.Parallel()
+
+	p, err := Load(profilesDir, "gb200")
+	require.NoError(t, err)
+
+	assert.Equal(t, "NVIDIA-GB200", p.GFDProductName())
+	assert.Equal(t, 196608, p.MemoryMiB())
+	assert.Equal(t, 8, p.ExpectedGPUs())
+}
+
+func TestGFDProductNameReplacesSpacesWithDashes(t *testing.T) {
+	t.Parallel()
+
+	p, err := Load(profilesDir, "a100")
+	require.NoError(t, err)
+
+	// device_defaults.name is "NVIDIA A100-SXM4-40GB"; GFD publishes it dashed.
+	assert.Equal(t, "NVIDIA-A100-SXM4-40GB", p.GFDProductName())
+	assert.NotContains(t, p.GFDProductName(), " ")
+}
+
+// Memory must come from the profile rather than a constant, or the assertion
+// would not notice a profile whose device memory changed.
+func TestMemoryMiBDiffersAcrossProfiles(t *testing.T) {
+	t.Parallel()
+
+	gb200, err := Load(profilesDir, "gb200")
+	require.NoError(t, err)
+	a100, err := Load(profilesDir, "a100")
+	require.NoError(t, err)
+
+	assert.Positive(t, gb200.MemoryMiB())
+	assert.Positive(t, a100.MemoryMiB())
+	assert.Greater(t, gb200.MemoryMiB(), a100.MemoryMiB(),
+		"GB200 carries more device memory than A100; if these match, memory is not being read from the profile")
+}
+
+// Every shipped profile must yield usable GFD expectations, otherwise the
+// gpu-operator scenario would silently assert against a zero value.
+func TestEveryKnownProfileYieldsNonZeroGFDExpectations(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range KnownProfiles {
+		p, err := Load(profilesDir, name)
+		require.NoError(t, err, "load profile %s", name)
+
+		assert.NotEmpty(t, p.GFDProductName(), "profile %s has no product name", name)
+		assert.Positive(t, p.MemoryMiB(), "profile %s reports zero device memory", name)
+		assert.Positive(t, p.ExpectedGPUs(), "profile %s reports zero GPUs", name)
+	}
+}

--- a/tests/e2e/go/profile/profile.go
+++ b/tests/e2e/go/profile/profile.go
@@ -47,6 +47,9 @@ type rawProfile struct {
 		Fabric *struct {
 			State string `json:"state"`
 		} `json:"fabric"`
+		Memory struct {
+			TotalBytes int64 `json:"total_bytes"`
+		} `json:"memory"`
 	} `json:"device_defaults"`
 	Devices []struct {
 		Index int `json:"index"`
@@ -83,7 +86,23 @@ type Profile struct {
 	fabricAuto  bool
 	hasFabric   bool
 	pciRoots    int
+	memoryBytes int64
 }
+
+// bytesPerMiB is the divisor GPU Feature Discovery uses when it publishes
+// nvidia.com/gpu.memory, which is reported in MiB.
+const bytesPerMiB = 1024 * 1024
+
+// GFDProductName is DisplayName in the form GPU Feature Discovery publishes as
+// nvidia.com/gpu.product: spaces become dashes. For example "NVIDIA GB200"
+// becomes "NVIDIA-GB200".
+func (p Profile) GFDProductName() string {
+	return strings.ReplaceAll(p.DisplayName, " ", "-")
+}
+
+// MemoryMiB is per-device memory in MiB, matching what GFD publishes as
+// nvidia.com/gpu.memory.
+func (p Profile) MemoryMiB() int { return int(p.memoryBytes / bytesPerMiB) }
 
 // Load reads profilesDir/<name>.yaml and returns the typed Profile.
 func Load(profilesDir, name string) (Profile, error) {
@@ -111,6 +130,7 @@ func Load(profilesDir, name string) (Profile, error) {
 		hcasPerGPU:  raw.Infiniband.HCAsPerGPU,
 		linksPerGPU: raw.NVLink.LinksPerGPU,
 		hasSwitches: len(raw.NVLink.Switches) > 0,
+		memoryBytes: raw.DeviceDefaults.Memory.TotalBytes,
 	}
 	if raw.DeviceDefaults.Fabric != nil {
 		p.hasFabric = true

--- a/tests/e2e/go/scenario_gpu_operator_test.go
+++ b/tests/e2e/go/scenario_gpu_operator_test.go
@@ -64,9 +64,13 @@ var _ = Describe("nvml-mock GPU Operator", Label("gpu-operator"), Ordered, func(
 			It("installs GPU Operator and publishes GPUs", Label("device-plugin"), func(ctx SpecContext) {
 				installGPUOperator(ctx, h)
 				waitOperatorValidatorRunning(ctx, h)
-				for _, label := range []string{"nvidia.com/gpu.product", "nvidia.com/gpu.memory", "nvidia.com/gpu.count"} {
-					assertions.NodeLabelSoft(ctx, h.Kube, node, label)
-				}
+				// Hard assertion, derived from the profile rather than read back
+				// off the node. The previous warning-only check could never fail,
+				// so GPU Feature Discovery could have been removed entirely and
+				// this scenario would still have gone green.
+				assertions.WaitGFDLabels(ctx, h.Kube, node,
+					assertions.ExpectedGFDLabels(p.GFDProductName(), p.MemoryMiB(), p.ExpectedGPUs()),
+					config.ReadyTimeout(), config.PollInterval())
 				assertions.WaitAllocatableGPU(ctx, h.Kube, node, p.ExpectedGPUs(), config.ReadyTimeout(), config.PollInterval())
 			})
 


### PR DESCRIPTION
## Problem

The GPU Operator scenario checked three GPU Feature Discovery labels through `assertions.NodeLabelSoft`, which only prints a WARNING line and carries no gomega assertion in any branch:

```go
case !ok || v == "":
    _, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "WARNING: label %s not set on %s (soft)\n", key, node)
```

The check could not fail. GFD could have been removed entirely and the scenario would still have gone green — which also inflates confidence in the AICR checks sitting downstream of node labelling.

## Approach

Two commits, one concern each.

**1. Assert the labels hard**, with expected values derived from the chart profile rather than read back off the node. Reading the labels off the node and asserting they equal themselves would be the same theater in a different shape.

| Helper | Role |
|---|---|
| `profile.GFDProductName()` | renders `device_defaults.name` the way GFD publishes it, spaces dashed |
| `profile.MemoryMiB()` | converts `device_defaults.memory.total_bytes` to the MiB value GFD publishes |
| `assertions.ExpectedGFDLabels(...)` | builds the expected set |
| `assertions.WaitGFDLabels(...)` | polls until the node matches, reporting every mismatching label rather than the first |

**2. Make the new unit tests actually run.** The `assertions` package is `//go:build e2e` because it imports the Kubernetes client, and `gfd_labels_test.go` inherited that tag — so its seven tests ran nowhere in CI: the unit job invokes `go test` untagged, and `make e2e-gpu-operator` targets the Ginkgo suite package rather than this subpackage's `Test*` funcs. That is the same defect class this PR fixes; a check that cannot fail and a check that never runs both contribute no signal.

`ExpectedGFDLabels` and `DiffGFDLabels` need nothing but the standard library, so they move to an untagged `gfd_labels.go` while the cluster-facing `WaitGFDLabels` stays in a tagged `gfd_labels_wait.go`.

## Testing done

Expected literals are the values GFD actually published on a `gb200` Mokka cluster on 2026-07-25 — `NVIDIA-GB200`, `196608`, `8` — and unit tests pin them.

Mutation-checked in both directions:

- Making `DiffGFDLabels` return nil unconditionally, which restores the original never-fails behaviour, turns 4 of the 7 tests RED under plain `go test`.
- Breaking `GFDProductName()` so spaces are not dashed turns 2 profile tests RED.

```
go test -race ./...          rc=0, 25 packages ok, 0 FAIL
golangci-lint run ./...      0 issues
helm unittest                138/138 tests, 7 suites, 15 snapshots
go vet -tags e2e ./tests/... rc=0  (Ginkgo suite still compiles)
```

The `assertions` package now appears in `go list ./...`; the unit run went from 24 to 25 packages.

## Breaking changes

None. `NodeLabelSoft` is left in place for other callers.

Closes #500
