### PR TITLE
feat(nri): honour the device plugin's GPU allocation (MEP-0002)

### DIFF
--- a/cmd/nvml-mock-nri/main.go
+++ b/cmd/nvml-mock-nri/main.go
@@ -167,6 +167,14 @@ func fromNRI(pod *api.PodSandbox, container *api.Container) nvmlmock.Container {
 				Options:     append([]string(nil), mount.GetOptions()...),
 			})
 		}
+		// What the runtime already applied, so Adjust can tell whether the device
+		// plugin served this container. GetLinux() is nil-safe.
+		for _, device := range container.GetLinux().GetDevices() {
+			result.Devices = append(result.Devices, nvmlmock.Device{Path: device.GetPath()})
+		}
+		for _, device := range container.GetCDIDevices() {
+			result.CDIDevices = append(result.CDIDevices, device.GetName())
+		}
 	}
 	return result
 }

--- a/cmd/nvml-mock-nri/main_test.go
+++ b/cmd/nvml-mock-nri/main_test.go
@@ -188,6 +188,42 @@ func TestFromNRI(t *testing.T) {
 		}}, result.Mounts)
 	})
 
+	// MEP-0002: the suppression rule in nvmlmock.Adjust is inert unless fromNRI
+	// actually carries the incoming device state across. Verified against a real
+	// containerd 2.2.0 CreateContainer payload, which populates Linux.Devices with
+	// the device plugin's allocation and CDIDevices for the cdi-* strategies.
+	t.Run("copies the devices the runtime already applied", func(t *testing.T) {
+		t.Parallel()
+		container := &api.Container{
+			Linux: &api.LinuxContainer{
+				Devices: []*api.LinuxDevice{
+					{Path: "/dev/nvidia0", Type: "c", Major: 195, Minor: 0},
+					{Path: "/dev/fuse", Type: "c", Major: 10, Minor: 229},
+				},
+			},
+			CDIDevices: []*api.CDIDevice{{Name: "nvidia.com/gpu=0"}},
+		}
+
+		result := fromNRI(nil, container)
+
+		require.Equal(t, []nvmlmock.Device{
+			{Path: "/dev/nvidia0"},
+			{Path: "/dev/fuse"},
+		}, result.Devices)
+		require.Equal(t, []string{"nvidia.com/gpu=0"}, result.CDIDevices)
+	})
+
+	t.Run("tolerates a nil Linux block", func(t *testing.T) {
+		t.Parallel()
+		// NRI leaves Linux nil for non-Linux or minimal containers; a nil deref
+		// here takes the plugin down and stops injection node-wide.
+		require.NotPanics(t, func() {
+			result := fromNRI(nil, &api.Container{Env: []string{"PATH=/usr/bin"}})
+			require.Empty(t, result.Devices)
+			require.Empty(t, result.CDIDevices)
+		})
+	})
+
 	t.Run("does not alias the runtime's slices", func(t *testing.T) {
 		t.Parallel()
 		container := &api.Container{

--- a/pkg/nri/nvmlmock/adjust.go
+++ b/pkg/nri/nvmlmock/adjust.go
@@ -71,6 +71,13 @@ type Container struct {
 	PodAnnotations map[string]string
 	Env            []string
 	Mounts         []Mount
+
+	// Devices and CDIDevices are what the container already carries when the
+	// runtime asks the plugin to adjust it. The kubelet applies the device
+	// plugin's Allocate response before this point, so a non-empty NVIDIA entry
+	// here means the device plugin already served this container. See MEP-0002.
+	Devices    []Device
+	CDIDevices []string
 }
 
 // Adjustment is the mount/env/device delta that a runtime plugin applies.
@@ -128,15 +135,25 @@ func Adjust(cfg Config, container Container) (Adjustment, bool, error) {
 	}
 
 	if strings.EqualFold(container.PodAnnotations[cfg.DeviceAnnotation], "true") {
-		// Fail open: the device tree is staged by the main nvml-mock DaemonSet,
-		// and nothing orders this plugin's DaemonSet after it. If the tree is
-		// missing (fresh node) or unreadable, degrade to overlay-only injection
-		// rather than failing container creation for the whole pod.
-		devices, err := discoverDevices(cfg.DeviceHostPath)
-		if err != nil {
-			warnf("device injection requested but device tree at %s is unavailable (%v); injecting overlay only", cfg.DeviceHostPath, err)
-		} else {
-			adjustment.Devices = devices
+		switch {
+		case alreadyHasGPUDevices(container):
+			// MEP-0002: the device plugin allocated a specific GPU and the kubelet
+			// already applied it. Adding the whole device tree on top would widen
+			// the container past its allocation, and would defeat the mock
+			// engine's visibility filter, which derives the visible GPU set from
+			// which /dev/nvidiaN nodes are present.
+			warnf("device injection requested but the device plugin already served this container; leaving its allocation intact")
+		default:
+			// Fail open: the device tree is staged by the main nvml-mock DaemonSet,
+			// and nothing orders this plugin's DaemonSet after it. If the tree is
+			// missing (fresh node) or unreadable, degrade to overlay-only injection
+			// rather than failing container creation for the whole pod.
+			devices, err := discoverDevices(cfg.DeviceHostPath)
+			if err != nil {
+				warnf("device injection requested but device tree at %s is unavailable (%v); injecting overlay only", cfg.DeviceHostPath, err)
+			} else {
+				adjustment.Devices = devices
+			}
 		}
 	}
 
@@ -288,6 +305,26 @@ func shimPaths(cfg Config) []string {
 		paths = append(paths, filepath.Join(cfg.ContainerOverlayPath, shim))
 	}
 	return paths
+}
+
+// alreadyHasGPUDevices reports whether the container arrived carrying GPU
+// devices that something else put there — in practice the NVIDIA device plugin,
+// whose Allocate response the kubelet applies before the runtime asks this
+// plugin to adjust anything. It recognises both delivery mechanisms the plugin
+// supports: raw device nodes (--pass-device-specs) and CDI device references
+// (--device-list-strategy=cdi-*).
+func alreadyHasGPUDevices(container Container) bool {
+	for _, device := range container.Devices {
+		if strings.HasPrefix(device.Path, "/dev/nvidia") {
+			return true
+		}
+	}
+	for _, device := range container.CDIDevices {
+		if strings.HasPrefix(device, "nvidia.com/") {
+			return true
+		}
+	}
+	return false
 }
 
 func discoverDevices(deviceHostPath string) ([]Device, error) {

--- a/pkg/nri/nvmlmock/adjust_test.go
+++ b/pkg/nri/nvmlmock/adjust_test.go
@@ -171,6 +171,86 @@ func TestAdjustDeviceOptInFailsOpenWhenTreeMissing(t *testing.T) {
 	})
 }
 
+// TestAdjustSuppressesDeviceInjectionWhenDevicePluginServedContainer pins the
+// composition rule from MEP-0002. The device plugin delivers exactly the GPU the
+// scheduler allocated; blanket-injecting every /dev/nvidiaN on top of that makes
+// the mock engine's detectVisibleDevices filter see a full set, return nil, and
+// expose every GPU to a pod that was allocated one.
+func TestAdjustSuppressesDeviceInjectionWhenDevicePluginServedContainer(t *testing.T) {
+	deviceRoot := t.TempDir()
+	for _, name := range []string{"nvidia0", "nvidia1", "nvidiactl"} {
+		require.NoError(t, os.WriteFile(filepath.Join(deviceRoot, name), []byte{}, 0o644))
+	}
+
+	cfg := DefaultConfig()
+	cfg.DeviceHostPath = deviceRoot
+
+	tests := map[string]struct {
+		container       Container
+		wantSuppression bool
+	}{
+		"device plugin already supplied a gpu device node": {
+			container: Container{
+				Devices: []Device{{HostPath: "/var/lib/nvml-mock/driver/dev/nvidia0", Path: "/dev/nvidia0"}},
+			},
+			wantSuppression: true,
+		},
+		"device plugin already supplied an nvidia cdi device": {
+			container:       Container{CDIDevices: []string{"nvidia.com/gpu=0"}},
+			wantSuppression: true,
+		},
+		// Discrimination: a container carrying an unrelated device must still get
+		// the full opt-in injection, otherwise the guard is a constant.
+		"unrelated device node does not suppress": {
+			container: Container{
+				Devices: []Device{{HostPath: "/dev/fuse", Path: "/dev/fuse"}},
+			},
+			wantSuppression: false,
+		},
+		"unrelated cdi vendor does not suppress": {
+			container:       Container{CDIDevices: []string{"example.com/widget=0"}},
+			wantSuppression: false,
+		},
+		"no devices at all keeps the historical opt-in behaviour": {
+			container:       Container{},
+			wantSuppression: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			container := test.container
+			container.Namespace = "default"
+			container.PodAnnotations = map[string]string{"nvml-mock.nvidia.com/devices": "true"}
+
+			adjustment, ok, err := Adjust(cfg, container)
+			require.NoError(t, err)
+			require.True(t, ok, "the container must still be adjusted; only the device list is suppressed")
+
+			if test.wantSuppression {
+				require.Empty(t, adjustment.Devices,
+					"device plugin already served this container, so the plugin must not add device nodes")
+			} else {
+				require.ElementsMatch(t, []Device{
+					{HostPath: filepath.Join(deviceRoot, "nvidia0"), Path: "/dev/nvidia0"},
+					{HostPath: filepath.Join(deviceRoot, "nvidia1"), Path: "/dev/nvidia1"},
+					{HostPath: filepath.Join(deviceRoot, "nvidiactl"), Path: "/dev/nvidiactl"},
+				}, adjustment.Devices)
+			}
+
+			// Suppression is scoped to devices: the overlay and env still arrive,
+			// because the device plugin delivers neither.
+			require.Contains(t, adjustment.Mounts, Mount{
+				Source:      "/var/lib/nvml-mock",
+				Destination: "/opt/nvml-mock",
+				Type:        "bind",
+				Options:     []string{"rbind", "ro", "nosuid", "nodev"},
+			})
+			require.Contains(t, adjustment.Env, "MOCK_NVML_CONFIG=/opt/nvml-mock/driver/config/config.yaml")
+		})
+	}
+}
+
 func TestAdjustSkipsOptOutExcludedNamespaceAndExistingMount(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.ExcludedNamespaces = []string{"kube-system", "nvml-mock"}

--- a/tests/e2e/device-plugin-mock.yaml
+++ b/tests/e2e/device-plugin-mock.yaml
@@ -37,6 +37,13 @@ spec:
             - "--nvidia-driver-root=/var/lib/nvml-mock/driver"
             - "--driver-root-ctr-path=/var/lib/nvml-mock/driver"
             - "--device-discovery-strategy=nvml"
+            # MEP-0002: deliver the allocated GPU's device node into the
+            # container. The mock NVML engine derives a container's visible
+            # GPU set from which /dev/nvidiaN nodes are present, so without
+            # this a pod requesting nvidia.com/gpu:1 still sees every GPU.
+            # A real node gets this from the container runtime hook; a kind
+            # node has none, so the device plugin must do it directly.
+            - "--pass-device-specs=true"
           securityContext:
             privileged: true
           volumeMounts:

--- a/tests/e2e/go/assets/device-plugin-mock.yaml
+++ b/tests/e2e/go/assets/device-plugin-mock.yaml
@@ -37,6 +37,13 @@ spec:
             - "--nvidia-driver-root=/var/lib/nvml-mock/driver"
             - "--driver-root-ctr-path=/var/lib/nvml-mock/driver"
             - "--device-discovery-strategy=nvml"
+            # MEP-0002: deliver the allocated GPU's device node into the
+            # container. The mock NVML engine derives a container's visible
+            # GPU set from which /dev/nvidiaN nodes are present, so without
+            # this a pod requesting nvidia.com/gpu:1 still sees every GPU.
+            # A real node gets this from the container runtime hook; a kind
+            # node has none, so the device plugin must do it directly.
+            - "--pass-device-specs=true"
           securityContext:
             privileged: true
           volumeMounts:

--- a/tests/e2e/go/scenario_nri_test.go
+++ b/tests/e2e/go/scenario_nri_test.go
@@ -34,6 +34,8 @@ const (
 	nriAgentSelector  = "app=gpu-agent"
 	nriNRIDaemonSet   = "nvml-mock-nri"
 	nriPluginSelector = "app.kubernetes.io/name=nvml-mock-nri"
+	// Device-plugin composition (#440, MEP-0002).
+	nriWorkloadImage = "debian:bookworm-slim"
 
 	// nriDomainName / nriDomainUUID identify the single ComputeDomain the
 	// generated topology overlay declares. The UUID is arbitrary but must match
@@ -107,6 +109,137 @@ var _ = Describe("nvml-mock node-wide NRI injection", Label("nri"), Ordered, fun
 			})
 		})
 	}
+
+	// Composition with the device plugin (#440, MEP-0002). Everything above
+	// covers pods that request no GPU resources. This covers the other half: a
+	// pod that goes through the scheduler must see exactly what it was
+	// allocated, not every GPU on the node.
+	//
+	// This is the only place the upstream device plugin and the NRI plugin run
+	// on the same nodes. Before MEP-0002 the two never met in CI, and the
+	// allocation was inert: NVIDIA_VISIBLE_DEVICES was set and nothing read it.
+	Context("when the device plugin also serves the node", Label("nri-device-plugin"), Ordered, func() {
+		var (
+			p       profile.Profile
+			gpuNode string
+		)
+
+		BeforeAll(func(ctx SpecContext) {
+			Expect(selectedProfiles).NotTo(BeEmpty())
+			p = loadProfile(selectedProfiles[0])
+			installNRIChart(ctx, h, p, topoValues, p.HasFabric())
+			assertions.WaitDaemonSetReady(ctx, h.Kube, nvmlMockNamespace, "nvml-mock", config.ReadyTimeout(), config.PollInterval())
+			assertions.WaitDaemonSetReady(ctx, h.Kube, nvmlMockNamespace, nriNRIDaemonSet, config.ReadyTimeout(), config.PollInterval())
+			deployDevicePluginOnWorkers(ctx, h, workers, p.ExpectedGPUs())
+			gpuNode = workers[0].Name
+		})
+
+		It("gives a resource-requested pod exactly its allocated GPU", Label("nri-dp-isolation"), func(ctx SpecContext) {
+			pod := applyNRIWorkload(ctx, h, nriRequestPodManifest("nri-dp-single", gpuNode, 1), "nri-dp-single")
+
+			allocated := allocatedGPUUUID(ctx, h, pod)
+			visible := visibleGPUUUIDs(ctx, h, pod)
+
+			Expect(visible).To(HaveLen(1),
+				"pod requested 1 %s but nvidia-smi reports %d GPUs; the delivery path ignored the allocation",
+				kube.GPUResourceName, len(visible))
+			Expect(visible[0]).To(Equal(allocated),
+				"pod was allocated %s but sees %s", allocated, visible[0])
+		})
+
+		// Two pods on ONE node must not see each other's GPU.
+		//
+		// This spec covers the --pass-device-specs half of MEP-0002, NOT the
+		// suppression rule in adjust.go: these pods carry no device annotation, so
+		// the NRI plugin never injects device nodes for them and there is nothing
+		// to suppress. Mutation-checked — it stays green with the suppression
+		// reverted. "keeps an annotated pod's allocation intact" below is the
+		// spec that covers suppression.
+		It("keeps two pods on one node isolated from each other", Label("nri-dp-isolation"), func(ctx SpecContext) {
+			if p.ExpectedGPUs() < 2 {
+				Skip("profile " + p.Name + " advertises fewer than 2 GPUs; isolation needs at least two")
+			}
+			first := applyNRIWorkload(ctx, h, nriRequestPodManifest("nri-dp-a", gpuNode, 1), "nri-dp-a")
+			second := applyNRIWorkload(ctx, h, nriRequestPodManifest("nri-dp-b", gpuNode, 1), "nri-dp-b")
+
+			firstVisible := visibleGPUUUIDs(ctx, h, first)
+			secondVisible := visibleGPUUUIDs(ctx, h, second)
+
+			Expect(firstVisible).To(HaveLen(1), "nri-dp-a should see exactly its allocated GPU")
+			Expect(secondVisible).To(HaveLen(1), "nri-dp-b should see exactly its allocated GPU")
+			Expect(firstVisible[0]).NotTo(Equal(secondVisible[0]),
+				"two pods on %s were each allocated one GPU but both see %s; the allocation is not isolating",
+				gpuNode, firstVisible[0])
+			Expect(firstVisible[0]).To(Equal(allocatedGPUUUID(ctx, h, first)))
+			Expect(secondVisible[0]).To(Equal(allocatedGPUUUID(ctx, h, second)))
+		})
+
+		// The spec that covers the suppression rule, and the only one that does.
+		// A pod carrying BOTH a resource request and the device opt-in is the
+		// collision MEP-0002 exists to resolve: the device plugin hands it one
+		// device node, and the plugin's opt-in would stage the whole tree on top,
+		// pushing the engine's visibility filter back to "all present" and
+		// exposing every GPU to a pod allocated one.
+		//
+		// Mutation-checked: reverting alreadyHasGPUDevices turns this red with
+		// nvidia-smi reporting every GPU instead of one.
+		It("keeps an annotated pod's allocation intact", Label("nri-dp-suppression"), func(ctx SpecContext) {
+			pod := applyNRIWorkload(ctx, h,
+				nriRequestPodManifest("nri-dp-annotated-request", gpuNode, 1,
+					map[string]string{"nvml-mock.nvidia.com/devices": "true"}),
+				"nri-dp-annotated-request")
+
+			allocated := allocatedGPUUUID(ctx, h, pod)
+			visible := visibleGPUUUIDs(ctx, h, pod)
+
+			Expect(visible).To(HaveLen(1),
+				"pod requested 1 %s and opted into device nodes; it must still see only its allocation, got %d GPUs",
+				kube.GPUResourceName, len(visible))
+			Expect(visible[0]).To(Equal(allocated),
+				"pod was allocated %s but sees %s", allocated, visible[0])
+		})
+
+		It("still gives an annotated pod with no request every GPU", Label("nri-dp-optin"), func(ctx SpecContext) {
+			pod := applyNRIWorkload(ctx, h, nriAnnotatedPodManifest("nri-dp-annotated"), "nri-dp-annotated")
+			// The opt-in path is unchanged: no resource request means the device
+			// plugin never served this container, so the plugin still stages the
+			// whole tree and every GPU stays visible.
+			Expect(visibleGPUUUIDs(ctx, h, pod)).To(HaveLen(p.ExpectedGPUs()),
+				"annotated pod with no %s request should keep seeing all %d GPUs",
+				kube.GPUResourceName, p.ExpectedGPUs())
+		})
+
+		It("leaves the scheduler gate intact once the node is saturated", Label("nri-dp-scheduling"), func(ctx SpecContext) {
+			// Ask for one more GPU than any node advertises. The pod must stay
+			// Pending on the SCHEDULER's verdict: a mock that over-advertises, or
+			// a plugin that hands out devices without accounting, would let it in.
+			//
+			// Deliberately unpinned. Setting nodeName bypasses scheduling entirely,
+			// so kubelet admits the pod and then rejects it with
+			// UnexpectedAdmissionError — which proves kubelet's device manager
+			// works, not that the extended resource gates scheduling.
+			name := "nri-dp-oversubscribed"
+			pod := nriRequestPodManifest(name, "", p.ExpectedGPUs()+1)
+			Expect(h.Kube.Apply(ctx, pod)).To(Succeed(), "apply %s", name)
+			DeferCleanup(func(ctx SpecContext) { _ = h.Kube.Delete(ctx, pod) })
+
+			Consistently(func() (string, error) {
+				return h.Kube.PodPhase(ctx, nriWorkloadNS, name)
+			}).WithContext(ctx).WithTimeout(30*time.Second).WithPolling(config.PollInterval()).
+				Should(Equal("Pending"),
+					"a pod requesting %d %s on a %d-GPU node must not schedule",
+					p.ExpectedGPUs()+1, kube.GPUResourceName, p.ExpectedGPUs())
+
+			// Pending alone is weak — an unschedulable pod and one stuck pulling an
+			// image look identical by phase. Pin the reason to the GPU resource.
+			out, err := h.Kube.KubectlCombined(ctx, "get", "events", "-n", nriWorkloadNS,
+				"--field-selector", "involvedObject.name="+name)
+			Expect(err).NotTo(HaveOccurred(), "read events for %s", name)
+			Expect(out).To(ContainSubstring("Insufficient "+kube.GPUResourceName),
+				"%s should be unschedulable on %s specifically, got events:\n%s",
+				name, kube.GPUResourceName, strings.TrimSpace(out))
+		})
+	})
 
 	// Failure-mode hardening (#434). Everything above asserts that injection
 	// works. This asserts what happens when it stops working mid-run.
@@ -358,6 +491,119 @@ func assertNodeCliqueIdentities(ctx context.Context, h *harness.Harness, workers
 		Expect(strings.ToLower(out)).To(ContainSubstring(strings.ToLower("clusterUuid : "+nriDomainUUID)),
 			"%s: expected clusterUuid %s from check-fabric\n%s", w.Name, nriDomainUUID, strings.TrimSpace(out))
 	}
+}
+
+// deployDevicePluginOnWorkers reuses the validator scenario's device-plugin
+// deployment and extends the capacity wait to every worker, so the composition
+// specs can pin pods to a node knowing it advertises the full profile count.
+func deployDevicePluginOnWorkers(ctx SpecContext, h *harness.Harness, workers []cluster.Node, expectedGPUs int) {
+	GinkgoHelper()
+	By("deploying the upstream device plugin alongside the NRI plugin")
+	deployDevicePlugin(ctx, h, workers[0].Name, expectedGPUs)
+	for _, w := range workers[1:] {
+		assertions.WaitAllocatableGPU(ctx, h.Kube, w.Name, expectedGPUs, config.ReadyTimeout(), config.PollInterval())
+	}
+}
+
+// applyNRIWorkload applies a manifest, waits for the pod to run, and registers
+// cleanup so the next spec starts from a known allocation state.
+func applyNRIWorkload(ctx context.Context, h *harness.Harness, manifest []byte, name string) kube.PodRef {
+	GinkgoHelper()
+	Expect(h.Kube.Apply(ctx, manifest)).To(Succeed(), "apply workload %s", name)
+	DeferCleanup(func(ctx SpecContext) { _ = h.Kube.Delete(ctx, manifest) })
+	Eventually(func() (string, error) {
+		return h.Kube.PodPhase(ctx, nriWorkloadNS, name)
+	}).WithContext(ctx).WithTimeout(config.ReadyTimeout()).WithPolling(config.PollInterval()).
+		Should(Equal("Running"), "workload %s never reached Running", name)
+	return kube.PodRef{Namespace: nriWorkloadNS, Pod: name}
+}
+
+// nriRequestPodManifest renders a plain GPU-requesting pod: a resource request
+// and nothing else. No hostPath, no MOCK_* env, no runtimeClassName, no
+// annotation. This is the shape MEP-0002 exists to make work.
+func nriRequestPodManifest(name, node string, gpus int, annotations ...map[string]string) []byte {
+	nodeLine := ""
+	if node != "" {
+		nodeLine = "  nodeName: " + node + "\n"
+	}
+	annotationBlock := ""
+	for _, set := range annotations {
+		for key, value := range set {
+			if annotationBlock == "" {
+				annotationBlock = "  annotations:\n"
+			}
+			annotationBlock += "    " + key + ": \"" + value + "\"\n"
+		}
+	}
+	return []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: ` + name + `
+  namespace: ` + nriWorkloadNS + `
+` + annotationBlock + `spec:
+  restartPolicy: Never
+` + nodeLine + `  containers:
+    - name: app
+      image: ` + nriWorkloadImage + `
+      command: ["/bin/sh", "-c", "sleep 3600"]
+      resources:
+        limits:
+          nvidia.com/gpu: "` + strconv.Itoa(gpus) + `"
+`)
+}
+
+// nriAnnotatedPodManifest renders a pod that opts into device nodes via the
+// annotation and requests no GPU resources.
+func nriAnnotatedPodManifest(name string) []byte {
+	return []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: ` + name + `
+  namespace: ` + nriWorkloadNS + `
+  annotations:
+    nvml-mock.nvidia.com/devices: "true"
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    nvidia.com/gpu.present: "true"
+  containers:
+    - name: app
+      image: ` + nriWorkloadImage + `
+      command: ["/bin/sh", "-c", "sleep 3600"]
+`)
+}
+
+// allocatedGPUUUID returns the UUID the device plugin allocated to the pod, as
+// the kubelet wrote it into the container environment.
+func allocatedGPUUUID(ctx context.Context, h *harness.Harness, pod kube.PodRef) string {
+	GinkgoHelper()
+	res, err := h.Kube.ExecSh(ctx, pod, `printf %s "${NVIDIA_VISIBLE_DEVICES:-}"`)
+	Expect(err).NotTo(HaveOccurred(), "read NVIDIA_VISIBLE_DEVICES in %s: %s", pod.Pod, res.Combined())
+	uuid := strings.TrimSpace(res.Combined())
+	Expect(uuid).NotTo(BeEmpty(), "device plugin set no NVIDIA_VISIBLE_DEVICES on %s", pod.Pod)
+	return uuid
+}
+
+// visibleGPUUUIDs returns the UUIDs nvidia-smi reports inside the pod.
+func visibleGPUUUIDs(ctx context.Context, h *harness.Harness, pod kube.PodRef) []string {
+	GinkgoHelper()
+	res, err := h.Kube.Exec(ctx, pod, "nvidia-smi", "-L")
+	Expect(err).NotTo(HaveOccurred(), "nvidia-smi -L in %s: %s", pod.Pod, res.Combined())
+	var uuids []string
+	for _, line := range strings.Split(res.Combined(), "\n") {
+		if !strings.HasPrefix(strings.TrimSpace(line), "GPU ") {
+			continue
+		}
+		_, rest, ok := strings.Cut(line, "(UUID: ")
+		if !ok {
+			continue
+		}
+		uuid, _, ok := strings.Cut(rest, ")")
+		if ok {
+			uuids = append(uuids, strings.TrimSpace(uuid))
+		}
+	}
+	return uuids
 }
 
 func firstNRIAgentPod(ctx context.Context, h *harness.Harness) kube.PodRef {


### PR DESCRIPTION
Implements [MEP-0002](https://github.com/NVIDIA/k8s-test-infra/blob/main/enhancements/meps/0002-device-plugin-nri-composition/README.md) (merged in #547).

## The problem

On an NRI-enabled node the upstream device plugin and our NRI plugin both act on
the same container without knowing about each other. Measured on kind, they don't
actually conflict in the OCI spec — they write disjoint fields. The real defect is
quieter: **the allocation never reaches the workload.** A pod requesting
`nvidia.com/gpu: 1` sees every GPU on the node.

`NVIDIA_VISIBLE_DEVICES` gets set and nothing reads it. Three probes inside a
running pod confirm the mock ignores it: unsetting it, setting it to `all`, and
setting it to a *different* GPU's UUID all leave `nvidia-smi -L` unchanged.

## The fix, which adds no new component

The engine already ships the mechanism. `detectVisibleDevicesAt` derives a
container's visible GPU set from which `/dev/nvidiaN` nodes are present —
mimicking the cgroup isolation of a real node. Nothing triggered it.

1. **`--pass-device-specs=true`** on both device-plugin manifests, so the plugin
   delivers the allocated device node from the mock driver root. A real node gets
   this from the container runtime hook; a kind node has none.

2. **`Adjust` suppresses its own device injection** when the container already
   carries NVIDIA device nodes or `nvidia.com/` CDI devices. The kubelet applies
   `Allocate` before the runtime asks NRI to adjust, so that state is already on
   the `CreateContainer` payload — I confirmed this against containerd 2.2.0 with
   a throwaway NRI plugin, which showed `Linux.Devices` populated with the
   allocation. `fromNRI` now carries both fields across; without that the rule is
   inert.

Suppression is scoped to devices only. The overlay mount and env still reach every
container, so node-wide injection for pods with no resource request is unchanged.

## Testing

New e2e context — the first place the device plugin and the NRI plugin run on the
same nodes. `scenario_nri_test.go` never deployed the device plugin and
`scenario_multi_node_test.go` never enabled NRI, so this interaction had no
coverage at all. Five specs, 5/5 green on kind (a100, 8 GPUs).

Mutation-checked at both layers:

- unit: forcing `alreadyHasGPUDevices` to return true turns the three
  discrimination cases red;
- e2e: against an image built with the guard reverted, the annotated-request spec
  fails with `got 8 GPUs` instead of 1 — the collision the MEP describes,
  reproduced live.

Also `gofmt`, `go vet -tags e2e`, `go test -race`, `golangci-lint run` (0 issues).

## Three things a reviewer should know

**The `cuda-vectorAdd` check is not cleared, and CI cannot clear it.** MEP-0002
flagged `validator-mock.yaml` as the blocking risk, since it requests a GPU and
runs the real CUDA sample. It fails on my arm64 dev host with `CUDA driver version
is insufficient for CUDA runtime version` — but a controlled A/B on one cluster
shows the *identical* failure with and without `--pass-device-specs`, so this
change isn't implicated.

Note that **no CI job runs the validator scenario**: `E2E_DEFAULT_LABEL_FILTER` in
the Makefile excludes `validator`, and nothing sets `E2E_RUN_NGC=true` (#446). A
green matrix on this PR is therefore *silent* on this risk rather than clearance
for it. Answering it properly needs a deliberate `E2E_RUN_NGC=true` run on amd64 —
and `gfd-mock.yaml` has to be fixed first (see below), or the scenario dies in
`BeforeAll` before `cuda-vectorAdd` is ever reached.

**Not every spec covers the suppression rule.** The two-pod isolation spec stays
green with the guard reverted, because those pods carry no device annotation and
there's nothing to suppress — it covers `--pass-device-specs` and the visibility
filter. Only `keeps an annotated pod's allocation intact` covers suppression. The
comments say so rather than claiming coverage they don't have.

**`gfd-mock.yaml` is broken on `main`, separately.** It passes
`--nvidia-driver-root` to GFD v0.8.2, which rejects it (`flag provided but not
defined`), so the DaemonSet crashloops and the whole validator scenario dies in
`BeforeAll`. Byte-identical to `main`, invisible because the scenario is gated
behind `E2E_RUN_NGC=true` (#446). Left alone here — it wants its own PR.

## Breaking changes

The `nvml-mock.nvidia.com/devices` annotation narrows: it now means "give me every
device node **unless** the device plugin already gave me some". A pod that wants
every device and wants to consume capacity can request `nvidia.com/gpu: <count>`
and get the same result. Worth a release note.

Closes #440
