### PR TITLE
feat(nri): mock IMEX channel injection over NRI (#437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Mock IMEX channel injection through the NRI plugin. A pod annotated
+  `nvml-mock.nvidia.com/imex-channels: "true"` receives the mock
+  `/dev/nvidia-caps-imex-channels/channelN` nodes, so a ComputeDomain-style
+  workload can see an IMEX fabric surface on a node with no NVIDIA kernel
+  module. The channels come from the existing `imex.mockChannels` surface —
+  enable it too, or the annotation is a no-op that logs a warning and starts
+  the pod anyway. Injection is independent of the MEP-0002 device-plugin
+  suppression, because the device plugin never allocates an IMEX channel.
+  Configured by `nri.imexChannelAnnotation`. (#437)
+
+### Fixed
+- The NRI device opt-in no longer offers the `nvidia-caps-imex-channels`
+  DIRECTORY to the runtime as a device node. It sits inside the device root the
+  plugin scans and matched the `nvidia` prefix filter, so any annotated pod on a
+  node with `imex.mockChannels` enabled was affected. (#437)
+
 ## [0.3.0-rc1] - 2026-07-31
 
 ### Added

--- a/cmd/nvml-mock-nri/main.go
+++ b/cmd/nvml-mock-nri/main.go
@@ -44,6 +44,8 @@ func main() {
 	flag.StringVar(&cfg.DeviceHostPath, "device-host-path", envOr("NVML_MOCK_DEVICE_HOST_PATH", cfg.DeviceHostPath), "host path containing mock /dev/nvidia* nodes")
 	flag.StringVar(&cfg.OptOutAnnotation, "opt-out-annotation", envOr("NVML_MOCK_OPT_OUT_ANNOTATION", cfg.OptOutAnnotation), "pod annotation key; value false disables injection")
 	flag.StringVar(&cfg.DeviceAnnotation, "device-annotation", envOr("NVML_MOCK_DEVICE_ANNOTATION", cfg.DeviceAnnotation), "pod annotation key; value true adds /dev/nvidia* device nodes")
+	flag.StringVar(&cfg.ImexChannelAnnotation, "imex-channel-annotation", envOr("NVML_MOCK_IMEX_CHANNEL_ANNOTATION", cfg.ImexChannelAnnotation), "pod annotation key; value true adds /dev/nvidia-caps-imex-channels/* nodes")
+	flag.StringVar(&cfg.ImexChannelHostPath, "imex-channel-host-path", envOr("NVML_MOCK_IMEX_CHANNEL_HOST_PATH", cfg.ImexChannelHostPath), "host path containing the mock IMEX channel nodes staged by imex.mockChannels (defaults to <overlay-host-path>/driver/dev/nvidia-caps-imex-channels)")
 	excludedNamespaces := flag.String("excluded-namespaces", envOr("NVML_MOCK_EXCLUDED_NAMESPACES", strings.Join(cfg.ExcludedNamespaces, ",")), "comma-separated namespaces to skip")
 	shims := flag.String("ld-preload-shims", envOr("NVML_MOCK_LD_PRELOAD_SHIMS", strings.Join(cfg.Shims, ",")), "comma-separated LD_PRELOAD shim paths relative to the overlay mount or absolute paths")
 	flag.Parse()

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -877,6 +877,7 @@ namespace, on the pod IP where the kubelet reaches it.
 | `nri.overlay.hostPath` / `nri.overlay.mountPath` | `/var/lib/nvml-mock` / `/opt/nvml-mock` | Host overlay staged by the main DaemonSet, and the path it is injected at inside workloads |
 | `nri.optOutAnnotation` | `nvml-mock.nvidia.com/inject` | Pod annotation; value `false` disables injection for that pod |
 | `nri.deviceAnnotation` | `nvml-mock.nvidia.com/devices` | Pod annotation; value `true` adds mock `/dev/nvidia*` device nodes. Pod-authored, so treat it as part of the demo trust boundary |
+| `nri.imexChannelAnnotation` | `nvml-mock.nvidia.com/imex-channels` | Pod annotation; value `true` adds the mock `/dev/nvidia-caps-imex-channels/channelN` nodes staged by `imex.mockChannels`. A no-op when that is disabled. Same trust boundary as `nri.deviceAnnotation` |
 | `nri.excludedNamespaces` | `[]` | Extra namespaces to skip. The release namespace and `kube-system` are always excluded |
 | `nri.healthPort` | `8080` | Port serving `/healthz` and `/readyz`. Bound only in the pod's network namespace — this DaemonSet does not use `hostNetwork`, so nothing is exposed on the node |
 | `nri.readinessProbe` | `/readyz`, `periodSeconds: 10`, `failureThreshold: 2` | Detects that the node has stopped injecting. Set to `null` to drop. See [NRI plugin failure modes](#nri-plugin-failure-modes) |

--- a/deployments/nvml-mock/helm/nvml-mock/templates/nri-daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/nri-daemonset.yaml
@@ -48,6 +48,13 @@ spec:
             - --device-host-path={{ .Values.nri.overlay.hostPath }}/driver/dev
             - --opt-out-annotation={{ .Values.nri.optOutAnnotation }}
             - --device-annotation={{ .Values.nri.deviceAnnotation }}
+            # Mock IMEX channel delivery (#437). The nodes are staged by the
+            # main DaemonSet under imex.mockChannels; the plugin only injects
+            # them into pods carrying this annotation. Harmless when
+            # imex.mockChannels is disabled: the tree is absent, the plugin
+            # warns and injects everything else.
+            - --imex-channel-annotation={{ .Values.nri.imexChannelAnnotation }}
+            - --imex-channel-host-path={{ .Values.nri.overlay.hostPath }}/driver/dev/nvidia-caps-imex-channels
             - --excluded-namespaces={{ .Release.Namespace }},kube-system{{- range .Values.nri.excludedNamespaces }},{{ . }}{{- end }}
             # NODE_NAME (below) gates ComputeDomain topology injection: when
             # topology.enabled stages a topology document into the overlay,

--- a/deployments/nvml-mock/helm/nvml-mock/tests/nri_daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/nri_daemonset_test.yaml
@@ -131,6 +131,42 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --excluded-namespaces=NAMESPACE,kube-system,monitoring,gpu-system
 
+  # Mock IMEX channel delivery (#437). The channel nodes are staged by the main
+  # DaemonSet under imex.mockChannels; the plugin must read them from that one
+  # location. A host path that disagrees with where setup.sh writes them makes
+  # the annotation a silent no-op, so pin it against the overlay root.
+  - it: should point IMEX channel injection at the staged channel directory
+    set:
+      nri:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --imex-channel-annotation=nvml-mock.nvidia.com/imex-channels
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --imex-channel-host-path=/var/lib/nvml-mock/driver/dev/nvidia-caps-imex-channels
+
+  - it: should track a relocated overlay root for IMEX channels
+    set:
+      nri:
+        enabled: true
+        overlay:
+          hostPath: /custom/nvml-mock
+        imexChannelAnnotation: example.com/channels
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --imex-channel-annotation=example.com/channels
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --imex-channel-host-path=/custom/nvml-mock/driver/dev/nvidia-caps-imex-channels
+      # The GPU device root and the channel root must stay siblings under the
+      # same relocated overlay; they are staged by the same setup.sh run.
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --device-host-path=/custom/nvml-mock/driver/dev
+
   # A probe that cannot reach the plugin is worse than no probe: the pod never
   # goes Ready and the DaemonSet stalls. These pin the three values that have
   # to agree -- the flag the plugin binds, the declared containerPort, and the

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -128,6 +128,18 @@ nri:
   # device-node mounts from the staged mock overlay. Treat that pod-authored
   # control as part of the demo trust boundary and exclude namespaces as needed.
   deviceAnnotation: nvml-mock.nvidia.com/devices
+  # Workloads that set this pod annotation to "true" additionally get the mock
+  # IMEX channel nodes at /dev/nvidia-caps-imex-channels/channelN — the fabric
+  # surface a ComputeDomain workload expects. Same trust boundary as
+  # deviceAnnotation above.
+  #
+  # The channels themselves come from imex.mockChannels; this plugin only
+  # delivers what that already staged, so enable imex.mockChannels too or the
+  # annotation is a no-op (the plugin logs a warning and the pod still starts).
+  # Every channel staged on the node is injected, so a large
+  # imex.mockChannels.channelCount adds real container-start cost: creating the
+  # default 2048 nodes measures around one second.
+  imexChannelAnnotation: nvml-mock.nvidia.com/imex-channels
   excludedNamespaces: []
   resources: {}
   # Port serving the plugin's /healthz and /readyz endpoints. The NRI DaemonSet

--- a/pkg/nri/nvmlmock/adjust.go
+++ b/pkg/nri/nvmlmock/adjust.go
@@ -18,11 +18,21 @@ var warnf = func(format string, args ...any) {
 }
 
 const (
-	defaultHostOverlayPath      = "/var/lib/nvml-mock"
-	defaultContainerOverlayPath = "/opt/nvml-mock"
-	defaultDeviceHostPath       = "/var/lib/nvml-mock/driver/dev"
-	defaultOptOutAnnotation     = "nvml-mock.nvidia.com/inject"
-	defaultDeviceAnnotation     = "nvml-mock.nvidia.com/devices"
+	defaultHostOverlayPath       = "/var/lib/nvml-mock"
+	defaultContainerOverlayPath  = "/opt/nvml-mock"
+	defaultDeviceHostPath        = "/var/lib/nvml-mock/driver/dev"
+	defaultOptOutAnnotation      = "nvml-mock.nvidia.com/inject"
+	defaultDeviceAnnotation      = "nvml-mock.nvidia.com/devices"
+	defaultImexChannelAnnotation = "nvml-mock.nvidia.com/imex-channels"
+	// defaultImexChannelRelPath is where the main DaemonSet's setup.sh mknods
+	// the mock IMEX channel nodes, resolved relative to the host overlay path.
+	// It must track the imex.mockChannels surface in the chart: setup.sh writes
+	// them to $DRIVER_ROOT/dev/nvidia-caps-imex-channels.
+	defaultImexChannelRelPath = "driver/dev/nvidia-caps-imex-channels"
+	// imexChannelContainerDir is the fixed kernel location the channels must
+	// appear at inside the container. Consumers (nvidia-imex, the DRA driver's
+	// compute-domain plugin) hard-code this path.
+	imexChannelContainerDir = "/dev/nvidia-caps-imex-channels"
 	// defaultTopologyRelPath is where setup.sh stages the cluster-level
 	// ComputeDomain topology document inside the overlay tree. It is
 	// resolved relative to the host overlay path (for the existence
@@ -45,8 +55,18 @@ type Config struct {
 	DeviceHostPath       string
 	OptOutAnnotation     string
 	DeviceAnnotation     string
-	ExcludedNamespaces   []string
-	Shims                []string
+	// ImexChannelAnnotation is the pod annotation key whose value "true" opts a
+	// container into mock /dev/nvidia-caps-imex-channels/* injection. It is a
+	// separate opt-in from DeviceAnnotation because an IMEX channel is a fabric
+	// capability, not a GPU: a ComputeDomain workload may want channels without
+	// the whole mock GPU device tree, and vice versa.
+	ImexChannelAnnotation string
+	// ImexChannelHostPath is the host directory holding the mock channel nodes
+	// (channel0..N-1). The main nvml-mock DaemonSet stages them when
+	// imex.mockChannels.enabled is set; this plugin only consumes them.
+	ImexChannelHostPath string
+	ExcludedNamespaces  []string
+	Shims               []string
 
 	// NodeName is the Kubernetes node this plugin runs on. When set (and a
 	// topology document is staged in the overlay) it is injected as the
@@ -104,13 +124,15 @@ type Device struct {
 // DefaultConfig returns the overlay contract described by the NRI design.
 func DefaultConfig() Config {
 	return Config{
-		HostOverlayPath:      defaultHostOverlayPath,
-		ContainerOverlayPath: defaultContainerOverlayPath,
-		DeviceHostPath:       defaultDeviceHostPath,
-		OptOutAnnotation:     defaultOptOutAnnotation,
-		DeviceAnnotation:     defaultDeviceAnnotation,
-		ExcludedNamespaces:   []string{"kube-system"},
-		Shims:                append([]string(nil), defaultShims...),
+		HostOverlayPath:       defaultHostOverlayPath,
+		ContainerOverlayPath:  defaultContainerOverlayPath,
+		DeviceHostPath:        defaultDeviceHostPath,
+		OptOutAnnotation:      defaultOptOutAnnotation,
+		DeviceAnnotation:      defaultDeviceAnnotation,
+		ImexChannelAnnotation: defaultImexChannelAnnotation,
+		ImexChannelHostPath:   filepath.Join(defaultHostOverlayPath, defaultImexChannelRelPath),
+		ExcludedNamespaces:    []string{"kube-system"},
+		Shims:                 append([]string(nil), defaultShims...),
 	}
 }
 
@@ -157,6 +179,27 @@ func Adjust(cfg Config, container Container) (Adjustment, bool, error) {
 		}
 	}
 
+	// IMEX channels are a separate opt-in and deliberately outside the MEP-0002
+	// suppression above. That rule exists because the device plugin already
+	// delivered the GPUs the scheduler allocated, so re-injecting the GPU tree
+	// would widen the container past its allocation. The device plugin has no
+	// concept of an IMEX channel and never delivers one, so there is no
+	// allocation to widen — suppressing channels here would instead deny a
+	// ComputeDomain workload the fabric it explicitly asked for.
+	if strings.EqualFold(container.PodAnnotations[cfg.ImexChannelAnnotation], "true") {
+		// Fail open like the device path: channels are staged by the main
+		// DaemonSet's setup.sh (imex.mockChannels.enabled), and nothing orders
+		// this plugin's DaemonSet after it. They are also off by default, so an
+		// annotation on a node without them must not block the pod.
+		channels, err := discoverImexChannels(cfg.ImexChannelHostPath)
+		if err != nil {
+			warnf("imex channel injection requested but the channel tree at %s is unavailable (%v); "+
+				"injecting without channels (is imex.mockChannels.enabled set?)", cfg.ImexChannelHostPath, err)
+		} else {
+			adjustment.Devices = append(adjustment.Devices, channels...)
+		}
+	}
+
 	return adjustment, true, nil
 }
 
@@ -176,6 +219,12 @@ func withDefaults(cfg Config) Config {
 	}
 	if cfg.DeviceAnnotation == "" {
 		cfg.DeviceAnnotation = defaults.DeviceAnnotation
+	}
+	if cfg.ImexChannelAnnotation == "" {
+		cfg.ImexChannelAnnotation = defaults.ImexChannelAnnotation
+	}
+	if cfg.ImexChannelHostPath == "" {
+		cfg.ImexChannelHostPath = filepath.Join(cfg.HostOverlayPath, defaultImexChannelRelPath)
 	}
 	if len(cfg.Shims) == 0 {
 		cfg.Shims = defaults.Shims
@@ -327,21 +376,42 @@ func alreadyHasGPUDevices(container Container) bool {
 	return false
 }
 
+// discoverDevices lists the mock /dev/nvidia* nodes staged in the overlay.
 func discoverDevices(deviceHostPath string) ([]Device, error) {
-	entries, err := os.ReadDir(deviceHostPath)
+	return scanDeviceDir(deviceHostPath, "nvidia", "/dev")
+}
+
+// discoverImexChannels lists the mock IMEX channel nodes staged by
+// imex.mockChannels, mapping them onto the fixed kernel path consumers expect.
+func discoverImexChannels(channelHostPath string) ([]Device, error) {
+	return scanDeviceDir(channelHostPath, "channel", imexChannelContainerDir)
+}
+
+// scanDeviceDir collects the device nodes directly under hostDir whose names
+// carry prefix, mapping each onto containerDir inside the container.
+//
+// Directories are skipped: hostDir is a device root, not a tree to recurse, and
+// the mock device root holds a nvidia-caps-imex-channels DIRECTORY that matches
+// the "nvidia" prefix. Handing a directory to the runtime as a device node
+// cannot work, so it must never enter the adjustment.
+func scanDeviceDir(hostDir, prefix, containerDir string) ([]Device, error) {
+	entries, err := os.ReadDir(hostDir)
 	if err != nil {
 		return nil, err
 	}
 
 	devices := make([]Device, 0, len(entries))
 	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
 		name := entry.Name()
-		if !strings.HasPrefix(name, "nvidia") {
+		if !strings.HasPrefix(name, prefix) {
 			continue
 		}
 		devices = append(devices, Device{
-			HostPath: filepath.Join(deviceHostPath, name),
-			Path:     filepath.Join("/dev", name),
+			HostPath: filepath.Join(hostDir, name),
+			Path:     filepath.Join(containerDir, name),
 		})
 	}
 	sort.Slice(devices, func(i, j int) bool {

--- a/pkg/nri/nvmlmock/adjust_test.go
+++ b/pkg/nri/nvmlmock/adjust_test.go
@@ -319,3 +319,137 @@ func TestAdjustDeviceOptInAddsNvidiaDeviceEntries(t *testing.T) {
 		{HostPath: filepath.Join(deviceRoot, "nvidia-uvm"), Path: "/dev/nvidia-uvm"},
 	}, adjustment.Devices)
 }
+
+// TestDiscoverDevicesSkipsChannelDirectory pins a defect that predates IMEX
+// channel injection. imex.mockChannels (#541) mknods the channel nodes into a
+// nvidia-caps-imex-channels DIRECTORY inside the same device root the plugin
+// scans, and that directory name matches the "nvidia" prefix filter. Injecting
+// a directory as a LinuxDevice is not a device node, so the runtime cannot
+// create it in the container.
+func TestDiscoverDevicesSkipsChannelDirectory(t *testing.T) {
+	deviceRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(deviceRoot, "nvidia0"), []byte{}, 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(deviceRoot, "nvidia-caps-imex-channels"), 0o755))
+
+	cfg := DefaultConfig()
+	cfg.DeviceHostPath = deviceRoot
+
+	adjustment, ok, err := Adjust(cfg, Container{
+		Namespace:      "default",
+		PodAnnotations: map[string]string{"nvml-mock.nvidia.com/devices": "true"},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.Equal(t, []Device{
+		{HostPath: filepath.Join(deviceRoot, "nvidia0"), Path: "/dev/nvidia0"},
+	}, adjustment.Devices)
+}
+
+// TestAdjustImexChannelOptInAddsChannelDevices covers #437: an annotated pod
+// gets the channel nodes staged by imex.mockChannels at their real kernel path.
+func TestAdjustImexChannelOptInAddsChannelDevices(t *testing.T) {
+	channelRoot := t.TempDir()
+	for _, name := range []string{"channel0", "channel1", "channel2", "not-a-channel"} {
+		require.NoError(t, os.WriteFile(filepath.Join(channelRoot, name), []byte{}, 0o644))
+	}
+	require.NoError(t, os.Mkdir(filepath.Join(channelRoot, "channel-subdir"), 0o755))
+
+	cfg := DefaultConfig()
+	cfg.ImexChannelHostPath = channelRoot
+
+	adjustment, ok, err := Adjust(cfg, Container{
+		Namespace:      "default",
+		PodAnnotations: map[string]string{"nvml-mock.nvidia.com/imex-channels": "true"},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.Equal(t, []Device{
+		{HostPath: filepath.Join(channelRoot, "channel0"), Path: "/dev/nvidia-caps-imex-channels/channel0"},
+		{HostPath: filepath.Join(channelRoot, "channel1"), Path: "/dev/nvidia-caps-imex-channels/channel1"},
+		{HostPath: filepath.Join(channelRoot, "channel2"), Path: "/dev/nvidia-caps-imex-channels/channel2"},
+	}, adjustment.Devices)
+}
+
+// TestAdjustWithoutImexAnnotationInjectsNoChannels proves the opt-in gate is a
+// real gate: a fully staged channel tree must stay out of an unannotated pod.
+func TestAdjustWithoutImexAnnotationInjectsNoChannels(t *testing.T) {
+	channelRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(channelRoot, "channel0"), []byte{}, 0o644))
+
+	cfg := DefaultConfig()
+	cfg.ImexChannelHostPath = channelRoot
+
+	for name, annotations := range map[string]map[string]string{
+		"no annotations at all": nil,
+		"opt-in set to false":   {"nvml-mock.nvidia.com/imex-channels": "false"},
+		"only the device opt-in": {
+			"nvml-mock.nvidia.com/devices": "true",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := cfg
+			cfg.DeviceHostPath = t.TempDir()
+			adjustment, ok, err := Adjust(cfg, Container{Namespace: "default", PodAnnotations: annotations})
+			require.NoError(t, err)
+			require.True(t, ok)
+			require.Empty(t, adjustment.Devices)
+		})
+	}
+}
+
+// TestAdjustImexChannelOptInFailsOpenWhenTreeMissing mirrors the device path:
+// imex.mockChannels is off by default, so an annotation on a node that never
+// staged channels must degrade to overlay-only rather than block the pod.
+func TestAdjustImexChannelOptInFailsOpenWhenTreeMissing(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.ImexChannelHostPath = filepath.Join(t.TempDir(), "does-not-exist")
+
+	adjustment, ok, err := Adjust(cfg, Container{
+		Namespace:      "default",
+		PodAnnotations: map[string]string{"nvml-mock.nvidia.com/imex-channels": "true"},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Empty(t, adjustment.Devices)
+	require.Contains(t, adjustment.Mounts, Mount{
+		Source:      "/var/lib/nvml-mock",
+		Destination: "/opt/nvml-mock",
+		Type:        "bind",
+		Options:     []string{"rbind", "ro", "nosuid", "nodev"},
+	})
+}
+
+// TestAdjustImexChannelsSurviveDevicePluginAllocation pins the composition rule
+// against MEP-0002 (#548). The device plugin allocates GPUs; it has no concept
+// of an IMEX channel and never delivers one. Suppressing channels because a GPU
+// was allocated would deny a ComputeDomain workload the fabric it asked for, so
+// the GPU suppression must NOT extend to channels.
+func TestAdjustImexChannelsSurviveDevicePluginAllocation(t *testing.T) {
+	deviceRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(deviceRoot, "nvidia0"), []byte{}, 0o644))
+	channelRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(channelRoot, "channel0"), []byte{}, 0o644))
+
+	cfg := DefaultConfig()
+	cfg.DeviceHostPath = deviceRoot
+	cfg.ImexChannelHostPath = channelRoot
+
+	adjustment, ok, err := Adjust(cfg, Container{
+		Namespace: "default",
+		PodAnnotations: map[string]string{
+			"nvml-mock.nvidia.com/devices":       "true",
+			"nvml-mock.nvidia.com/imex-channels": "true",
+		},
+		// The kubelet already applied the device plugin's Allocate response.
+		Devices: []Device{{HostPath: filepath.Join(deviceRoot, "nvidia0"), Path: "/dev/nvidia0"}},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// The GPU tree is suppressed (MEP-0002) but the channel stays.
+	require.Equal(t, []Device{
+		{HostPath: filepath.Join(channelRoot, "channel0"), Path: "/dev/nvidia-caps-imex-channels/channel0"},
+	}, adjustment.Devices)
+}

--- a/tests/e2e/go/scenario_nri_test.go
+++ b/tests/e2e/go/scenario_nri_test.go
@@ -42,6 +42,17 @@ const (
 	// what check-fabric reports inside the injected pods.
 	nriDomainName = "node-wide-domain"
 	nriDomainUUID = "00000000-0000-0000-0000-0000000000cd"
+
+	// Mock IMEX channel injection (#437). imex.mockChannels defaults to 2048
+	// channels to match the DRA driver's getImexChannelCount(); the count is
+	// irrelevant to the injection path and every channel is a real mknod on
+	// every node, so the suite runs a small one.
+	nriImexChannelCount = 8
+	nriImexChannelDir   = "/dev/nvidia-caps-imex-channels"
+	nriImexAnnotation   = "nvml-mock.nvidia.com/imex-channels"
+	// nriImexChannelMajor must equal imex.mockChannels.channelMajor, which is
+	// also the major the rendered proc-devices advertises to the DRA driver.
+	nriImexChannelMajor = 235
 )
 
 // Go port of docs/demo/node-wide-injection/run.sh. A dedicated Kind cluster
@@ -241,6 +252,78 @@ var _ = Describe("nvml-mock node-wide NRI injection", Label("nri"), Ordered, fun
 		})
 	})
 
+	// Mock IMEX channel injection (#437). The NRI plugin already delivers the
+	// mock GPU tree; ComputeDomain workloads additionally need the IMEX channel
+	// nodes, which no mock node has because there is no NVIDIA kernel module to
+	// create them.
+	//
+	// This rides the cluster the specs above already built. An earlier revision
+	// of this work stood up a second five-node Kind cluster for the IMEX specs
+	// and exhausted the runner's disk during `kind load docker-image`, which
+	// surfaced as an unrelated-looking failure on whichever profile happened to
+	// be running when the disk filled.
+	Context("when a pod opts into mock IMEX channels", Label("nri-imex"), Ordered, func() {
+		var gpuNode string
+
+		BeforeAll(func(ctx SpecContext) {
+			Expect(selectedProfiles).NotTo(BeEmpty())
+			p := loadProfile(selectedProfiles[0])
+			installNRIChart(ctx, h, p, topoValues, p.HasFabric())
+			assertions.WaitDaemonSetReady(ctx, h.Kube, nvmlMockNamespace, "nvml-mock", config.ReadyTimeout(), config.PollInterval())
+			assertions.WaitDaemonSetReady(ctx, h.Kube, nvmlMockNamespace, nriNRIDaemonSet, config.ReadyTimeout(), config.PollInterval())
+			gpuNode = workers[0].Name
+		})
+
+		It("delivers every staged channel into an annotated pod", Label("imex-channels"), func(ctx SpecContext) {
+			pod := applyNRIWorkload(ctx, h,
+				nriImexPodManifest("nri-imex-annotated", gpuNode, true),
+				"nri-imex-annotated")
+
+			Expect(imexChannelNames(ctx, h, pod)).To(HaveLen(nriImexChannelCount),
+				"annotated pod should see all %d channels staged by imex.mockChannels", nriImexChannelCount)
+		})
+
+		// The opt-in has to be a real gate. Without this, a plugin that injected
+		// channels unconditionally would pass the spec above.
+		It("keeps channels out of a pod that did not ask for them", Label("imex-channels"), func(ctx SpecContext) {
+			pod := applyNRIWorkload(ctx, h,
+				nriImexPodManifest("nri-imex-plain", gpuNode, false),
+				"nri-imex-plain")
+
+			res, err := h.Kube.ExecSh(ctx, pod, `ls `+nriImexChannelDir+` 2>&1 || true`)
+			Expect(err).NotTo(HaveOccurred(), "probe %s in nri-imex-plain", nriImexChannelDir)
+			Expect(res.Combined()).To(ContainSubstring("No such file or directory"),
+				"an unannotated pod must not receive %s, got:\n%s", nriImexChannelDir, res.Combined())
+		})
+
+		// The invariant that keeps the mock self-consistent, and the reason this
+		// feature consumes imex.mockChannels instead of provisioning its own
+		// nodes. The DRA driver's compute-domain plugin reads the channel major
+		// out of the rendered proc-devices; the injected nodes must carry that
+		// same major. Two provisioning paths with different majors would leave
+		// the directory split across majors while proc-devices advertised one,
+		// and nothing else in the suite would notice.
+		It("injects channels whose major matches the advertised proc-devices major", Label("imex-channels"), func(ctx SpecContext) {
+			pod := applyNRIWorkload(ctx, h,
+				nriImexPodManifest("nri-imex-major", gpuNode, true),
+				"nri-imex-major")
+
+			advertised := advertisedImexMajor(ctx, h, gpuNode)
+			Expect(advertised).To(Equal(nriImexChannelMajor),
+				"rendered proc-devices should advertise the chart's channelMajor")
+
+			for _, name := range imexChannelNames(ctx, h, pod) {
+				res, err := h.Kube.ExecSh(ctx, pod, `stat -c %t `+nriImexChannelDir+`/`+name)
+				Expect(err).NotTo(HaveOccurred(), "stat %s: %s", name, res.Combined())
+				major, parseErr := strconv.ParseInt(strings.TrimSpace(res.Combined()), 16, 32)
+				Expect(parseErr).NotTo(HaveOccurred(), "parse major of %s from %q", name, res.Combined())
+				Expect(int(major)).To(Equal(advertised),
+					"%s carries major %d but proc-devices advertises %d; the node has more than one channel provisioner",
+					name, major, advertised)
+			}
+		})
+	})
+
 	// Failure-mode hardening (#434). Everything above asserts that injection
 	// works. This asserts what happens when it stops working mid-run.
 	//
@@ -428,6 +511,11 @@ func installNRIChart(ctx context.Context, h *harness.Harness, p profile.Profile,
 			"image.repository": repo,
 			"image.tag":        tag,
 			"nri.enabled":      "true",
+			// Stage the mock IMEX channel nodes so the NRI channel opt-in has
+			// something to deliver (#437). This is the ONLY mechanism that
+			// creates them; the NRI plugin consumes what this stages.
+			"imex.mockChannels.enabled":      "true",
+			"imex.mockChannels.channelCount": strconv.Itoa(nriImexChannelCount),
 		},
 		Wait:    true,
 		Timeout: config.HelmTimeout(),
@@ -571,6 +659,79 @@ spec:
       image: ` + nriWorkloadImage + `
       command: ["/bin/sh", "-c", "sleep 3600"]
 `)
+}
+
+// nriImexPodManifest renders a pod pinned to one node that optionally opts into
+// mock IMEX channel injection. It requests no GPU resources.
+func nriImexPodManifest(name, node string, wantChannels bool) []byte {
+	annotations := ""
+	if wantChannels {
+		annotations = "  annotations:\n    " + nriImexAnnotation + ": \"true\"\n"
+	}
+	return []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: ` + name + `
+  namespace: ` + nriWorkloadNS + `
+` + annotations + `spec:
+  restartPolicy: Never
+  nodeName: ` + node + `
+  containers:
+    - name: app
+      image: ` + nriWorkloadImage + `
+      command: ["/bin/sh", "-c", "sleep 3600"]
+`)
+}
+
+// imexChannelNames lists the channel nodes visible inside a pod.
+func imexChannelNames(ctx context.Context, h *harness.Harness, pod kube.PodRef) []string {
+	GinkgoHelper()
+	res, err := h.Kube.ExecSh(ctx, pod, `ls `+nriImexChannelDir)
+	Expect(err).NotTo(HaveOccurred(), "list %s in %s: %s", nriImexChannelDir, pod.Pod, res.Combined())
+	var names []string
+	for _, line := range strings.Split(res.Combined(), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "channel") {
+			names = append(names, line)
+		}
+	}
+	return names
+}
+
+// advertisedImexMajor reads the channel major out of the proc-devices file that
+// imex.mockChannels renders for the DRA driver, as staged on the node itself.
+func advertisedImexMajor(ctx context.Context, h *harness.Harness, node string) int {
+	GinkgoHelper()
+	pod := nriMockPodOnNode(ctx, h, node)
+	res, err := h.Kube.ExecSh(ctx, pod, `cat /host/var/lib/nvml-mock/imex/proc-devices`)
+	Expect(err).NotTo(HaveOccurred(), "read rendered proc-devices on %s: %s", node, res.Combined())
+
+	for _, line := range strings.Split(res.Combined(), "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) == 2 && fields[1] == "nvidia-caps-imex-channels" {
+			major, parseErr := strconv.Atoi(fields[0])
+			Expect(parseErr).NotTo(HaveOccurred(), "parse major from %q", line)
+			return major
+		}
+	}
+	Fail("rendered proc-devices carries no nvidia-caps-imex-channels entry:\n" + res.Combined())
+	return 0
+}
+
+// nriMockPodOnNode resolves the main nvml-mock DaemonSet pod on a given node.
+func nriMockPodOnNode(ctx context.Context, h *harness.Harness, node string) kube.PodRef {
+	GinkgoHelper()
+	names, err := h.Kube.RunningPodNames(ctx, nvmlMockNamespace, "app.kubernetes.io/name=nvml-mock")
+	Expect(err).NotTo(HaveOccurred(), "list nvml-mock pods")
+	for _, name := range names {
+		on, nodeErr := h.Kube.PodNode(ctx, nvmlMockNamespace, name)
+		Expect(nodeErr).NotTo(HaveOccurred(), "read node of %s", name)
+		if on == node {
+			return kube.PodRef{Namespace: nvmlMockNamespace, Pod: name}
+		}
+	}
+	Fail("no running nvml-mock pod on node " + node)
+	return kube.PodRef{}
 }
 
 // allocatedGPUUUID returns the UUID the device plugin allocated to the pod, as


### PR DESCRIPTION
## What this does

Lets a pod opt into the mock IMEX channel nodes through the NRI plugin. Annotate it
with `nvml-mock.nvidia.com/imex-channels: "true"` and it comes up with
`/dev/nvidia-caps-imex-channels/channelN`, which is the fabric surface a
ComputeDomain-style workload looks for and which no mock node has, because there is
no NVIDIA kernel module to create it.

This supersedes #466. Giulio designed this — the annotation, the two CLI flags, the
channel discovery shape and the directory-skip fix all come from his diff. He's on
PTO, so I re-landed it against current `main` rather than leave it sitting.

## Why this is a re-land and not a rebase

#466 branched at `e8282453`. `main` is 29 commits further on and 14 of the files it
touches have moved since, including every load-bearing one: `adjust.go`,
`scenario_nri_test.go`, both DaemonSet templates, `values.yaml` and `setup.sh`.
Resolving that by hand would very likely produce something that merges cleanly and is
subtly wrong against a foundation that now has #539's helpers, #540's health surface
and #548's device-plugin suppression rule.

The blocking reason, though, is that `main` already provisions IMEX channel nodes.

## The collision

#541 landed a mock IMEX surface on 2026-07-29, after #466 was written. Both create the
same device paths with different settings:

| | `main` (#541) | #466 |
|---|---|---|
| chart key | `imex.mockChannels` | `imexChannels` |
| env var | `IMEX_MOCK_CHANNELS` | `MOCK_IMEX_CHANNELS` |
| channel major | 235 | 240 |
| channel count | 2048 | 16 |
| also renders | proc-devices, fabric-imex-mgmt | nothing |

Both write to `$DEV_ROOT/nvidia-caps-imex-channels/channelN`, and `DEV_ROOT` is
`$DRIVER_ROOT/dev` in both — the same directory, so these are the same files.

`mknod` does not overwrite. It fails `EEXIST`, and `setup.sh` discards that with
`2>/dev/null || true`:

```
$ mknod -m 666 /tmp/d/channel0 c 235 0
$ mknod -m 666 /tmp/d/channel0 c 240 0
mknod: /tmp/d/channel0: File exists      # rc=1, swallowed by || true
$ ls -l /tmp/d/channel0
crw-rw-rw- 1 root root 235, 0 /tmp/d/channel0
```

So whichever block runs first wins each node. Landing both would leave channels 0-15 at
major 240 and 16-2047 at major 235, in one directory, while the `proc-devices` file
`main` renders advertises only 235 to the DRA driver. Silent, and exactly the kind of
mismatch this repo keeps getting bitten by.

So this keeps #466's injection half and drops its provisioning half entirely. One chart
key, one env var set, one major, one count — plus the new annotation and the injection
path. `imex.mockChannels` already tells a self-consistent story across proc-devices,
fabric-imex-mgmt and the device nodes; #437's actual contribution is getting those
existing nodes into annotated containers, so it consumes that surface instead of
standing up a rival.

## A bug this found on `main`

`discoverDevices` filtered on `strings.HasPrefix(name, "nvidia")` with no `IsDir` check.
`imex.mockChannels` creates `nvidia-caps-imex-channels/` **inside** the device root that
filter scans, and that name matches. So on any node with `imex.mockChannels` enabled, a
pod carrying the existing `nvml-mock.nvidia.com/devices` annotation was already being
handed a directory as a device node. Fixed here; `TestDiscoverDevicesSkipsChannelDirectory`
covers it.

## Composition with MEP-0002

Channel injection deliberately sits outside the device-plugin suppression #548 added.
That rule exists because the device plugin already delivered the GPUs the scheduler
allocated, so re-injecting the GPU tree would widen the container past its allocation.
The device plugin has no concept of an IMEX channel and never delivers one, so there is
nothing to widen — suppressing channels would instead deny a ComputeDomain workload the
fabric it explicitly asked for. `TestAdjustImexChannelsSurviveDevicePluginAllocation`
pins that, and goes red if the suppression is extended to channels.

## Scope — what this does *not* do

#437 asks for more than this: a mock `nvidia-imex` daemon on the mockib pattern, a
`nvidia-imex-ctl` status surface, and a multi-node ComputeDomain demo. #466 deliberately
narrowed to channel injection and I kept that narrowing.

**So this does not meet #437's stated acceptance on its own.** "A workload spanning two
kind nodes sees consistent mock IMEX channels" is covered — the e2e runs on the
multi-worker NRI cluster and the existing `compute-domain` spec already asserts
consistent clique identity. "And a healthy mock IMEX domain status" is not: nothing here
reports domain health. #466 addressed that half in a demo using the real
`nvidia-imex --nogpu` daemon; I left that out rather than ship 175 lines of shell I
could not execute here. #437 should stay open for it, or be closed partially — maintainer's
call, not mine.

## Testing

- `go test -race ./...` — rc=0, 0 failures
- `golangci-lint run ./...` — rc=0, 0 issues (`.golangci.yml` sets `build-tags: [e2e]`, so the e2e sources are covered)
- `helm unittest` — 140 passed, 15 snapshots
- `make e2e E2E_PROFILES=gb200 E2E_GINKGO_FLAGS=--label-filter=nri-imex` on a real kind
  cluster — **Ran 3 of 60 Specs, 3 Passed, 0 Failed**. The major-match spec read
  `235 nvidia-caps-imex-channels` out of the rendered proc-devices and confirmed all 8
  injected nodes carry it.

Mutation-checked, each reverted separately and re-run:

| reverted | goes red |
|---|---|
| the `IsDir` guard | `TestDiscoverDevicesSkipsChannelDirectory`, `TestAdjustImexChannelOptInAddsChannelDevices` |
| the injection block | `TestAdjustImexChannelOptInAddsChannelDevices`, `TestAdjustImexChannelsSurviveDevicePluginAllocation` |
| extending MEP-0002 suppression to channels | `TestAdjustImexChannelsSurviveDevicePluginAllocation` only |
| the chart's channel host path | 2 helm-unittest assertions |
| the injection block, **at e2e** | `delivers every staged channel into an annotated pod` |

## On #466's failing e2e leg

`e2e-nri (gb300)` was failing on run 29494248165. It was not the injection path and not
gb300 config:

```
kind load docker-image ... ctr images import ... exit status 1
##[error]No space left on device
```

#466's `scenario_imex_test.go` stands up a *second* five-node kind cluster
(`nvml-mock-imex`) next to the main e2e one, and the runner ran out of disk. gb300 is
just where the disk happened to give out. The specs here ride the cluster the NRI suite
already builds, so there is no second cluster.

Supersedes #466 — that PR is closed as superseded, not merged; the design credit is
Giulio's and the commits carry his `Co-authored-by`.

Part of #437. **Deliberately not `Closes #437`** — see the scope section above: the
domain-status half of its acceptance is not delivered here.
