### PR TITLE
feat(nri): inject CDI device references through the NRI plugin

### DIFF
--- a/.github/workflows/kind-node-images.yaml
+++ b/.github/workflows/kind-node-images.yaml
@@ -1,0 +1,62 @@
+# Copyright 2026 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build guard for the Kind node images that no other job builds.
+#
+# deployments/kind-nvidia-cdi/ carries a node image with nvidia-container-toolkit
+# and CDI baked in. Before this workflow existed, no CI job built it, so an edit
+# to its Dockerfile or its pinned toolkit version broke silently and only
+# surfaced for whoever next ran `make build` inside that directory by hand.
+#
+# Scope, stated plainly: this proves the image BUILDS. It does not prove it
+# WORKS. Nothing in CI currently runs a cluster on this image — the NRI CDI path
+# (#436) needs no container toolkit, because containerd 2.x enables CDI by
+# default, so it is verified on stock kindest/node by the e2e-nri job instead.
+# Turning this into a runtime check means standing a cluster up on the image and
+# exercising the toolkit; that is a larger piece of work and is not in scope
+# here.
+name: Kind node images
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+      - main
+      - release-*
+    paths:
+      - "deployments/kind-nvidia-cdi/**"
+      - ".github/workflows/kind-node-images.yaml"
+
+jobs:
+  build-kind-nvidia-cdi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      # Build only, never push. The image is a rarely-changing build input, not
+      # an artifact under test, so there is no consumer to publish it for.
+      - name: Build kind-nvidia-cdi node image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: ./deployments/kind-nvidia-cdi
+          push: false
+          cache-from: type=gha,scope=kind-nvidia-cdi
+          cache-to: type=gha,mode=max,scope=kind-nvidia-cdi

--- a/cmd/nvml-mock-nri/main.go
+++ b/cmd/nvml-mock-nri/main.go
@@ -42,6 +42,9 @@ func main() {
 	flag.StringVar(&cfg.TopologyHostPath, "topology-host-path", envOr("NVML_MOCK_TOPOLOGY_HOST_PATH", cfg.TopologyHostPath), "host path checked for the staged topology document (defaults to <overlay-host-path>/topology/topology.yaml)")
 	flag.StringVar(&cfg.TopologyContainerPath, "topology-mount-path", envOr("NVML_MOCK_TOPOLOGY_MOUNT_PATH", cfg.TopologyContainerPath), "container path injected as MOCK_TOPOLOGY_CONFIG (defaults to <overlay-mount-path>/topology/topology.yaml)")
 	flag.StringVar(&cfg.DeviceHostPath, "device-host-path", envOr("NVML_MOCK_DEVICE_HOST_PATH", cfg.DeviceHostPath), "host path containing mock /dev/nvidia* nodes")
+	flag.StringVar(&cfg.DeviceInjectionMode, "device-injection-mode", envOr("NVML_MOCK_DEVICE_INJECTION_MODE", cfg.DeviceInjectionMode), "how the device opt-in delivers GPUs: raw (device nodes) or cdi (CDI device reference)")
+	flag.StringVar(&cfg.CDIDeviceName, "cdi-device-name", envOr("NVML_MOCK_CDI_DEVICE_NAME", cfg.CDIDeviceName), "fully-qualified CDI device injected in cdi mode")
+	flag.StringVar(&cfg.CDISpecHostPath, "cdi-spec-host-path", envOr("NVML_MOCK_CDI_SPEC_HOST_PATH", cfg.CDISpecHostPath), "staged CDI spec checked before a CDI reference is emitted; a missing spec falls back to raw injection")
 	flag.StringVar(&cfg.OptOutAnnotation, "opt-out-annotation", envOr("NVML_MOCK_OPT_OUT_ANNOTATION", cfg.OptOutAnnotation), "pod annotation key; value false disables injection")
 	flag.StringVar(&cfg.DeviceAnnotation, "device-annotation", envOr("NVML_MOCK_DEVICE_ANNOTATION", cfg.DeviceAnnotation), "pod annotation key; value true adds /dev/nvidia* device nodes")
 	flag.StringVar(&cfg.ImexChannelAnnotation, "imex-channel-annotation", envOr("NVML_MOCK_IMEX_CHANNEL_ANNOTATION", cfg.ImexChannelAnnotation), "pod annotation key; value true adds /dev/nvidia-caps-imex-channels/* nodes")
@@ -52,6 +55,16 @@ func main() {
 
 	cfg.ExcludedNamespaces = splitCSV(*excludedNamespaces)
 	cfg.Shims = splitCSV(*shims)
+
+	// Reject an unknown mode rather than coercing it. A typo that silently
+	// resolved to raw would look exactly like a working CDI deployment, and the
+	// difference is only visible in the OCI spec of an already-running pod.
+	switch cfg.DeviceInjectionMode {
+	case nvmlmock.DeviceInjectionModeRaw, nvmlmock.DeviceInjectionModeCDI:
+	default:
+		log.Fatalf("nvml-mock-nri: --device-injection-mode=%q is invalid; expected %q or %q",
+			cfg.DeviceInjectionMode, nvmlmock.DeviceInjectionModeRaw, nvmlmock.DeviceInjectionModeCDI)
+	}
 
 	p := &plugin{config: cfg, health: newHealth(time.Now, wedgeFactor)}
 	s, err := stub.New(
@@ -207,6 +220,12 @@ func toNRI(adjustment nvmlmock.Adjustment) (*api.ContainerAdjustment, error) {
 			continue
 		}
 		result.AddDevice(nriDevice)
+	}
+	// CDI references are resolved by the runtime from the spec setup.sh stages,
+	// so there is nothing to stat here — an unresolvable name fails container
+	// creation, which is why Adjust only emits one once it has seen the spec.
+	for _, name := range adjustment.CDIDevices {
+		result.AddCDIDevice(&api.CDIDevice{Name: name})
 	}
 	return result, nil
 }

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -711,6 +711,36 @@ See [`pkg/network/mockib/README.md`](../../../../pkg/network/mockib/README.md#mo
 for env vars (`MOCK_IB`, `MOCK_IB_PING_FABRIC`, `MOCK_IB_PEERS`,
 `MOCK_IB_DEBUG_SMP`, …) and architecture details.
 
+## Device injection mode
+
+Applies only when `nri.enabled=true`, and only to the `nri.deviceAnnotation`
+opt-in path.
+
+`nri.deviceInjectionMode` selects how the plugin delivers mock GPU device nodes
+to a container that carries `nvml-mock.nvidia.com/devices: "true"`:
+
+| Mode | Mechanism | Needs |
+| --- | --- | --- |
+| `raw` (default) | The plugin stages the `/dev/nvidia*` nodes itself, in the NRI adjustment. | Nothing. |
+| `cdi` | The plugin emits the CDI device `nvml-mock.nvidia.com/gpu=all` and the runtime resolves it from the spec `setup.sh` stages at `<cdiSpecDir>/nvml-mock-nri.yaml`. | A runtime with CDI on. |
+
+Both modes deliver the same device set, so switching is not meant to change what
+a workload sees. `cdi` additionally sets `NVML_MOCK_DEVICE_SOURCE=cdi` inside
+the container, which is the only way to tell from inside which mechanism ran.
+
+CDI needs no container toolkit on the node. containerd 2.x enables CDI by
+default (`enable_cdi = true`, spec dirs `/etc/cdi` and `/var/run/cdi`), which
+includes the stock `kindest/node` image. containerd 1.x gates it behind
+`enable_cdi`, so `raw` stays the default.
+
+If `cdi` is selected and no spec is staged, the plugin logs a warning and falls
+back to `raw`. It does not fail the pod: an unresolvable CDI device makes
+containerd reject container creation outright.
+
+Neither mode changes *whether* a container is served. A container the NVIDIA
+device plugin already served keeps exactly its allocation in both modes, per
+[MEP-0002](../../../../enhancements/meps/0002-device-plugin-nri-composition/README.md).
+
 ## NRI plugin failure modes
 
 Applies only when `nri.enabled=true`.
@@ -877,6 +907,8 @@ namespace, on the pod IP where the kubelet reaches it.
 | `nri.overlay.hostPath` / `nri.overlay.mountPath` | `/var/lib/nvml-mock` / `/opt/nvml-mock` | Host overlay staged by the main DaemonSet, and the path it is injected at inside workloads |
 | `nri.optOutAnnotation` | `nvml-mock.nvidia.com/inject` | Pod annotation; value `false` disables injection for that pod |
 | `nri.deviceAnnotation` | `nvml-mock.nvidia.com/devices` | Pod annotation; value `true` adds mock `/dev/nvidia*` device nodes. Pod-authored, so treat it as part of the demo trust boundary |
+| `nri.deviceInjectionMode` | `raw` | How `nri.deviceAnnotation` delivers GPUs: `raw` stages the device nodes directly, `cdi` emits a CDI device reference the runtime resolves. See [Device injection mode](#device-injection-mode) |
+| `nri.cdiSpecDir` | `/var/run/cdi` | Host directory holding CDI specs, mounted read-only into the plugin. Must be one of the runtime's configured `cdi_spec_dirs` |
 | `nri.imexChannelAnnotation` | `nvml-mock.nvidia.com/imex-channels` | Pod annotation; value `true` adds the mock `/dev/nvidia-caps-imex-channels/channelN` nodes staged by `imex.mockChannels`. A no-op when that is disabled. Same trust boundary as `nri.deviceAnnotation` |
 | `nri.excludedNamespaces` | `[]` | Extra namespaces to skip. The release namespace and `kube-system` are always excluded |
 | `nri.healthPort` | `8080` | Port serving `/healthz` and `/readyz`. Bound only in the pod's network namespace — this DaemonSet does not use `hostNetwork`, so nothing is exposed on the node |

--- a/deployments/nvml-mock/helm/nvml-mock/templates/nri-daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/nri-daemonset.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.nri.enabled }}
 {{- $image := mergeOverwrite (deepCopy .Values.image) (.Values.nri.image | default dict) }}
 {{- $socketDir := dir .Values.nri.socketPath }}
+{{- if not (has .Values.nri.deviceInjectionMode (list "raw" "cdi")) }}
+{{- fail (printf "nri.deviceInjectionMode must be \"raw\" or \"cdi\", got %q" .Values.nri.deviceInjectionMode) }}
+{{- end }}
 # Copyright 2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 apiVersion: apps/v1
@@ -48,6 +51,8 @@ spec:
             - --device-host-path={{ .Values.nri.overlay.hostPath }}/driver/dev
             - --opt-out-annotation={{ .Values.nri.optOutAnnotation }}
             - --device-annotation={{ .Values.nri.deviceAnnotation }}
+            - --device-injection-mode={{ .Values.nri.deviceInjectionMode }}
+            - --cdi-spec-host-path={{ .Values.nri.cdiSpecDir }}/nvml-mock-nri.yaml
             # Mock IMEX channel delivery (#437). The nodes are staged by the
             # main DaemonSet under imex.mockChannels; the plugin only injects
             # them into pods carrying this annotation. Harmless when
@@ -93,6 +98,14 @@ spec:
             - name: nvml-mock-overlay
               mountPath: {{ .Values.nri.overlay.hostPath }}
               readOnly: true
+            # Read-only so the plugin can confirm its CDI spec is staged before
+            # it emits a reference. The runtime, not the plugin, resolves the
+            # spec; an unresolvable CDI device fails container creation, so the
+            # check is what keeps cdi mode degrading to raw instead of blocking
+            # the pod.
+            - name: cdi-spec-dir
+              mountPath: {{ .Values.nri.cdiSpecDir }}
+              readOnly: true
       volumes:
         - name: nri-socket-dir
           hostPath:
@@ -101,5 +114,9 @@ spec:
         - name: nvml-mock-overlay
           hostPath:
             path: {{ .Values.nri.overlay.hostPath }}
+            type: DirectoryOrCreate
+        - name: cdi-spec-dir
+          hostPath:
+            path: {{ .Values.nri.cdiSpecDir }}
             type: DirectoryOrCreate
 {{- end }}

--- a/deployments/nvml-mock/helm/nvml-mock/tests/nri_daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/nri_daemonset_test.yaml
@@ -255,3 +255,75 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.failureThreshold
           value: 5
+
+  - it: should default device injection to raw and stage the CDI spec dir
+    set:
+      nri:
+        enabled: true
+    asserts:
+      # raw is the default per MEP-0002. If this flips, every existing NRI
+      # deployment silently changes injection mechanism on upgrade.
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --device-injection-mode=raw
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --cdi-spec-host-path=/var/run/cdi/nvml-mock-nri.yaml
+      # The plugin cannot check whether its spec is staged unless the spec
+      # directory is actually mounted into it.
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: cdi-spec-dir
+            mountPath: /var/run/cdi
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: cdi-spec-dir
+            hostPath:
+              path: /var/run/cdi
+              type: DirectoryOrCreate
+
+  - it: should switch to CDI injection and follow a relocated CDI spec dir
+    set:
+      nri:
+        enabled: true
+        deviceInjectionMode: cdi
+        cdiSpecDir: /etc/cdi
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --device-injection-mode=cdi
+      # The flag and the mount must track the same directory; a spec path the
+      # plugin cannot stat makes it fall back to raw and look like cdi mode
+      # simply did not take effect.
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --cdi-spec-host-path=/etc/cdi/nvml-mock-nri.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: cdi-spec-dir
+            mountPath: /etc/cdi
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: cdi-spec-dir
+            hostPath:
+              path: /etc/cdi
+              type: DirectoryOrCreate
+
+  - it: should reject an invalid device injection mode at template time
+    set:
+      nri:
+        enabled: true
+        deviceInjectionMode: cdi-annotations
+    asserts:
+      # Without this the typo reaches the plugin, which exits on it — so the
+      # first sign of a bad value is a CrashLoopBackOff rather than a failed
+      # install. "cdi-annotations" specifically is a plausible typo: it is a real
+      # device-plugin --device-list-strategy value, and MEP-0002 forbids it here.
+      - failedTemplate:
+          errorMessage: 'nri.deviceInjectionMode must be "raw" or "cdi", got "cdi-annotations"'

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -128,6 +128,26 @@ nri:
   # device-node mounts from the staged mock overlay. Treat that pod-authored
   # control as part of the demo trust boundary and exclude namespaces as needed.
   deviceAnnotation: nvml-mock.nvidia.com/devices
+  # How the deviceAnnotation opt-in delivers mock GPUs to a container:
+  #   raw - stage the /dev/nvidiaN nodes directly in the NRI adjustment.
+  #   cdi - emit a CDI device reference and let the runtime resolve it from the
+  #         spec setup.sh stages at cdiSpecDir/nvml-mock-nri.yaml.
+  #
+  # raw is the default. It is the only mode that works where the runtime has no
+  # CDI support, and MEP-0002 requires it to stay reachable. containerd 2.x
+  # enables CDI by default, so cdi mode needs no container toolkit on the node;
+  # containerd 1.x gates it behind enable_cdi.
+  #
+  # Neither mode changes WHETHER a container is served. A container the device
+  # plugin already served is left alone in both.
+  #
+  # If cdi is selected and no spec is staged, the plugin logs a warning and
+  # falls back to raw rather than failing container creation.
+  deviceInjectionMode: raw
+  # Host directory containing CDI specs. Mounted read-only into the plugin so it
+  # can confirm its spec is staged before emitting a reference. Must be one of
+  # the runtime's configured cdi_spec_dirs.
+  cdiSpecDir: /var/run/cdi
   # Workloads that set this pod annotation to "true" additionally get the mock
   # IMEX channel nodes at /dev/nvidia-caps-imex-channels/channelN — the fabric
   # surface a ComputeDomain workload expects. Same trust boundary as

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -221,6 +221,94 @@ done
 
 echo "CDI spec generated at $CDI_DIR/nvidia.yaml ($GPU_COUNT devices)"
 
+# 3c. Generate the CDI spec the NRI plugin injects (issue #436).
+#
+#     This is deliberately a SECOND spec, not a reuse of nvidia.yaml above:
+#
+#     - Vendor. nvidia.com/gpu belongs to the device plugin and the container
+#       toolkit. MEP-0002 requires that exactly one component emit CDI device
+#       references for a given container; a distinct vendor makes that
+#       observable instead of merely asserted.
+#     - No hooks. nvidia.yaml runs /usr/bin/nvidia-cdi-hook, which only exists
+#       on a toolkit-bearing node. The NRI path has to work on stock
+#       kindest/node, where containerd enables CDI by default but no toolkit is
+#       installed.
+#     - Device nodes only. The NRI plugin already delivers the libraries and the
+#       environment through its overlay bind mount and LD_PRELOAD, so repeating
+#       nvidia.yaml's library mounts here would inject them twice by two
+#       different mechanisms.
+#
+#     Per-GPU entries plus "all" keep MEP-0002's detectVisibleDevices oracle
+#     intact: the correct SUBSET stays expressible, so a future per-device
+#     caller does not have to widen the container to use CDI.
+NRI_CDI_SPEC=$CDI_DIR/nvml-mock-nri.yaml
+
+# hostPath in a CDI spec is resolved by the RUNTIME, on the real host — not by
+# this container, which sees the host root under /host. $DEV_ROOT is this
+# container's view, so strip the prefix. Getting this wrong does not fail here:
+# the spec is written happily and containerd then refuses to create any
+# container that references it, which surfaces as a pod stuck out of Running
+# with no obvious link back to this file.
+HOST_DEV_ROOT=${DEV_ROOT#/host}
+
+# NVML_MOCK_DEVICE_SOURCE records which mechanism delivered the device nodes.
+# The raw NRI path injects device nodes only and has no way to set an
+# environment variable on the device opt-in, so this is present if and only if
+# the runtime resolved this spec. That makes "did CDI actually take effect"
+# observable from inside the container: the two modes are otherwise identical by
+# design, and a silent fallback to raw would look exactly like a working CDI
+# deployment.
+cat > "$NRI_CDI_SPEC" << 'NRI_CDI_HEADER'
+cdiVersion: "0.6.0"
+kind: "nvml-mock.nvidia.com/gpu"
+containerEdits:
+  env:
+    - NVML_MOCK_DEVICE_SOURCE=cdi
+devices:
+NRI_CDI_HEADER
+
+# nri_cdi_device_nodes emits the deviceNodes block for one GPU index, or for
+# every mock node when passed "all". The set MUST match what discoverDevices
+# stages on the raw path (every non-directory nvidia* node under $DEV_ROOT):
+# cdi mode replaces the mechanism, not the contract, and a narrower set here
+# would be a silent regression for a workload that opens /dev/nvidia-uvm.
+nri_cdi_device_nodes() {
+  _which=$1
+  if [ "$_which" = "all" ]; then
+    for _i in $(seq 0 $((GPU_COUNT - 1))); do
+      echo "        - path: /dev/nvidia$_i"
+      echo "          hostPath: $HOST_DEV_ROOT/nvidia$_i"
+    done
+    for _extra in nvidiactl nvidia-uvm nvidia-uvm-tools; do
+      if [ -e "$DEV_ROOT/$_extra" ]; then
+        echo "        - path: /dev/$_extra"
+        echo "          hostPath: $HOST_DEV_ROOT/$_extra"
+      fi
+    done
+  else
+    echo "        - path: /dev/nvidia$_which"
+    echo "          hostPath: $HOST_DEV_ROOT/nvidia$_which"
+  fi
+}
+
+for i in $(seq 0 $((GPU_COUNT - 1))); do
+  {
+    echo "  - name: \"$i\""
+    echo '    containerEdits:'
+    echo '      deviceNodes:'
+    nri_cdi_device_nodes "$i"
+  } >> "$NRI_CDI_SPEC"
+done
+
+{
+  echo '  - name: "all"'
+  echo '    containerEdits:'
+  echo '      deviceNodes:'
+  nri_cdi_device_nodes all
+} >> "$NRI_CDI_SPEC"
+
+echo "NRI CDI spec generated at $NRI_CDI_SPEC ($GPU_COUNT devices + all)"
+
 # 4. Install nvidia-smi
 #    The ELF binary has RPATH=$ORIGIN/../lib64 (set by patchelf in Dockerfile),
 #    so it finds libnvidia-ml.so.1 relative to its own location. This works for:

--- a/docs/demo/node-wide-injection/README.md
+++ b/docs/demo/node-wide-injection/README.md
@@ -86,6 +86,12 @@ mounting host GPU device nodes from the staged mock overlay. Run the demo only
 in trusted workload namespaces, or add namespaces to `nri.excludedNamespaces`
 when pod authors should not control that device opt-in.
 
+The boundary is the same whichever mechanism delivers the devices. Setting
+`nri.deviceInjectionMode=cdi` makes the runtime resolve them from a CDI spec
+instead of having the plugin stage them, but the annotation that triggers it is
+still pod-authored. See
+[Device injection mode](../../../deployments/nvml-mock/helm/nvml-mock/README.md#device-injection-mode).
+
 ## Manual Checks
 
 After the script completes, the important checks are:

--- a/enhancements/meps/0002-device-plugin-nri-composition/README.md
+++ b/enhancements/meps/0002-device-plugin-nri-composition/README.md
@@ -393,15 +393,32 @@ document. The contract:
   #436 wants it, it comes back as an amendment to this MEP with its own
   evidence. The invariant to preserve is: **exactly one component emits CDI
   device references for a given container.**
-- **Remove the raw-device fallback.** The `e2e-nri` job — the only CI leg that
-  runs the NRI plugin — installs stock kind and creates its cluster from
-  `tests/e2e/go/assets/kind-nri-config.yaml`, which names no node image. It
-  therefore runs on the default `kindest/node`, with no container toolkit and no
-  CDI configuration at all. Only the `e2e` job uses a toolkit-bearing node image
-  (`local/kind`, built by the `build-kind-node-image` job). A third image,
-  `deployments/kind-nvidia-cdi/`, is pinned more strictly but is built by no CI
-  job. Until #436 resolves which image the NRI legs run on, raw injection stays
-  the default and CDI is the opt-in path.
+- **Remove the raw-device fallback.** Raw injection stays the default and CDI is
+  the opt-in path.
+
+  > **Amended by #436.** This clause originally rested on the claim that the
+  > stock `kindest/node` has "no container toolkit and no CDI configuration at
+  > all", and therefore that CDI could not be verified until the NRI legs moved
+  > to a toolkit-bearing image. **The second half of that claim is wrong.** The
+  > toolkit is indeed absent, but containerd 2.2.0 — the version in
+  > `kindest/node:v1.35.0` — ships `enable_cdi = true` with
+  > `cdi_spec_dirs = ['/etc/cdi', '/var/run/cdi']` by default, and an NRI
+  > plugin's `ContainerAdjustment.CDIDevices` resolves against it. Measured on
+  > stock kind with a throwaway NRI plugin: a spec staged in `/var/run/cdi`
+  > applied both its `env` and its `deviceNodes` to the container, with no
+  > toolkit binary present. CDI injection therefore needs no new node image, and
+  > #436 verifies it on the existing `e2e-nri` leg.
+  >
+  > The directive survives the correction, on grounds the correction does not
+  > touch: the raw path is the only one that works where the runtime's CDI
+  > support is absent or disabled (containerd 1.x gates it behind `enable_cdi`),
+  > and it is what every current deployment uses. Removing it would migrate the
+  > majority onto a path they have not exercised. Retiring it is a separate
+  > decision needing its own evidence, not a consequence of this correction.
+  >
+  > `deployments/kind-nvidia-cdi/` remains built by no *runtime* CI job. #436
+  > added a paths-filtered build guard so an edit cannot break it silently; that
+  > guard proves the image builds, not that it works.
 - **Break the `detectVisibleDevices` oracle.** Whatever CDI spec #436 generates
   must land the correct *subset* of `/dev/nvidiaN` inside the container. A CDI
   spec that stages all `N` devices reintroduces case F and silently un-isolates

--- a/pkg/nri/nvmlmock/adjust.go
+++ b/pkg/nri/nvmlmock/adjust.go
@@ -39,6 +39,32 @@ const (
 	// check) and the container overlay path (for the injected
 	// MOCK_TOPOLOGY_CONFIG env).
 	defaultTopologyRelPath = "topology/topology.yaml"
+
+	// DeviceInjectionModeRaw stages the mock /dev/nvidiaN nodes directly in the
+	// adjustment. It is the default: MEP-0002 requires the raw path to stay
+	// reachable, and it is the only mode that works on a runtime whose CDI
+	// support is off or absent.
+	DeviceInjectionModeRaw = "raw"
+	// DeviceInjectionModeCDI hands the runtime a CDI device reference and lets
+	// it resolve the device nodes from the spec setup.sh stages. containerd
+	// 2.x enables CDI by default (enable_cdi = true, spec dirs /etc/cdi and
+	// /var/run/cdi), so this needs no container toolkit on the node.
+	DeviceInjectionModeCDI = "cdi"
+	// defaultCDIDeviceName is the fully-qualified CDI device the cdi mode
+	// injects on the annotation path. The "all" device aggregates every mock
+	// GPU, which is what the annotation has always meant (MEP-0002 goal 2).
+	//
+	// The vendor is deliberately NOT nvidia.com: that namespace belongs to the
+	// device plugin and the container toolkit. Keeping ours distinct is what
+	// makes MEP-0002's "exactly one component emits CDI device references for a
+	// container" invariant observable rather than merely asserted, and it keeps
+	// alreadyHasGPUDevices' nvidia.com/ test meaningful.
+	defaultCDIDeviceName = "nvml-mock.nvidia.com/gpu=all"
+	// defaultCDISpecHostPath is where setup.sh stages the spec that backs
+	// defaultCDIDeviceName. containerd resolves an unknown CDI device by
+	// failing container creation outright, so the plugin checks this exists
+	// before it commits to a reference it cannot honour.
+	defaultCDISpecHostPath = "/var/run/cdi/nvml-mock-nri.yaml"
 )
 
 var defaultShims = []string{
@@ -67,6 +93,20 @@ type Config struct {
 	ImexChannelHostPath string
 	ExcludedNamespaces  []string
 	Shims               []string
+
+	// DeviceInjectionMode selects how the annotation-gated device opt-in
+	// delivers mock GPUs: DeviceInjectionModeRaw (default) or
+	// DeviceInjectionModeCDI. It changes the mechanism only. Whether a
+	// container is served at all is decided before this is consulted, so
+	// neither mode can inject into a container the device plugin already
+	// served (MEP-0002).
+	DeviceInjectionMode string
+	// CDIDeviceName is the CDI device injected in DeviceInjectionModeCDI.
+	CDIDeviceName string
+	// CDISpecHostPath is the staged CDI spec checked before a CDI reference is
+	// emitted. A missing spec degrades to raw injection rather than failing
+	// container creation.
+	CDISpecHostPath string
 
 	// NodeName is the Kubernetes node this plugin runs on. When set (and a
 	// topology document is staged in the overlay) it is injected as the
@@ -105,6 +145,11 @@ type Adjustment struct {
 	Mounts  []Mount
 	Env     []string
 	Devices []Device
+	// CDIDevices are fully-qualified CDI device references the runtime resolves
+	// itself. Devices and CDIDevices are alternatives for the GPU tree, never
+	// both: emitting the same GPUs twice would widen the container and defeat
+	// the mock engine's detectVisibleDevices filter.
+	CDIDevices []string
 }
 
 // Mount describes a bind mount in a runtime-neutral form.
@@ -133,6 +178,9 @@ func DefaultConfig() Config {
 		ImexChannelHostPath:   filepath.Join(defaultHostOverlayPath, defaultImexChannelRelPath),
 		ExcludedNamespaces:    []string{"kube-system"},
 		Shims:                 append([]string(nil), defaultShims...),
+		DeviceInjectionMode:   DeviceInjectionModeRaw,
+		CDIDeviceName:         defaultCDIDeviceName,
+		CDISpecHostPath:       defaultCDISpecHostPath,
 	}
 }
 
@@ -165,11 +213,24 @@ func Adjust(cfg Config, container Container) (Adjustment, bool, error) {
 			// engine's visibility filter, which derives the visible GPU set from
 			// which /dev/nvidiaN nodes are present.
 			warnf("device injection requested but the device plugin already served this container; leaving its allocation intact")
+		case cfg.DeviceInjectionMode == DeviceInjectionModeCDI && cdiSpecStaged(cfg):
+			// The runtime resolves the device nodes from the staged spec. Nothing
+			// is added to adjustment.Devices: the CDI reference and the raw nodes
+			// describe the same GPUs, and delivering both would widen the
+			// container and defeat the engine's detectVisibleDevices filter.
+			adjustment.CDIDevices = []string{cfg.CDIDeviceName}
 		default:
 			// Fail open: the device tree is staged by the main nvml-mock DaemonSet,
 			// and nothing orders this plugin's DaemonSet after it. If the tree is
 			// missing (fresh node) or unreadable, degrade to overlay-only injection
 			// rather than failing container creation for the whole pod.
+			//
+			// This is also where CDI mode lands when its spec is not staged.
+			// containerd fails container creation on an unresolvable CDI device,
+			// so falling back to raw nodes keeps the pod starting.
+			if cfg.DeviceInjectionMode == DeviceInjectionModeCDI {
+				warnf("cdi device injection requested but no spec is staged at %s; falling back to raw device nodes", cfg.CDISpecHostPath)
+			}
 			devices, err := discoverDevices(cfg.DeviceHostPath)
 			if err != nil {
 				warnf("device injection requested but device tree at %s is unavailable (%v); injecting overlay only", cfg.DeviceHostPath, err)
@@ -228,6 +289,15 @@ func withDefaults(cfg Config) Config {
 	}
 	if len(cfg.Shims) == 0 {
 		cfg.Shims = defaults.Shims
+	}
+	if cfg.DeviceInjectionMode == "" {
+		cfg.DeviceInjectionMode = defaults.DeviceInjectionMode
+	}
+	if cfg.CDIDeviceName == "" {
+		cfg.CDIDeviceName = defaults.CDIDeviceName
+	}
+	if cfg.CDISpecHostPath == "" {
+		cfg.CDISpecHostPath = defaults.CDISpecHostPath
 	}
 	if cfg.TopologyHostPath == "" {
 		cfg.TopologyHostPath = filepath.Join(cfg.HostOverlayPath, defaultTopologyRelPath)
@@ -374,6 +444,17 @@ func alreadyHasGPUDevices(container Container) bool {
 		}
 	}
 	return false
+}
+
+// cdiSpecStaged reports whether the CDI spec backing cfg.CDIDeviceName is
+// present on the node. The stat runs per container, like topologyInjectable,
+// so the plugin tolerates setup.sh staging the spec after the plugin starts.
+func cdiSpecStaged(cfg Config) bool {
+	if cfg.CDISpecHostPath == "" {
+		return false
+	}
+	_, err := os.Stat(cfg.CDISpecHostPath)
+	return err == nil
 }
 
 // discoverDevices lists the mock /dev/nvidia* nodes staged in the overlay.

--- a/pkg/nri/nvmlmock/adjust_test.go
+++ b/pkg/nri/nvmlmock/adjust_test.go
@@ -453,3 +453,168 @@ func TestAdjustImexChannelsSurviveDevicePluginAllocation(t *testing.T) {
 		{HostPath: filepath.Join(channelRoot, "channel0"), Path: "/dev/nvidia-caps-imex-channels/channel0"},
 	}, adjustment.Devices)
 }
+
+// TestAdjustCDIModeEmitsCDIReferenceInsteadOfRawNodes pins the #436 behaviour:
+// in CDI mode the annotation-gated path hands the runtime a CDI device
+// reference and stops staging raw device nodes itself. Both halves matter — a
+// version that emitted the reference AND the raw nodes would double-serve the
+// container and defeat the mock engine's detectVisibleDevices filter, which is
+// MEP-0002's most important constraint because it fails green.
+func TestAdjustCDIModeEmitsCDIReferenceInsteadOfRawNodes(t *testing.T) {
+	deviceRoot := t.TempDir()
+	for _, name := range []string{"nvidia0", "nvidia1"} {
+		require.NoError(t, os.WriteFile(filepath.Join(deviceRoot, name), []byte{}, 0o644))
+	}
+	specPath := filepath.Join(t.TempDir(), "nvml-mock-nri.yaml")
+	require.NoError(t, os.WriteFile(specPath, []byte("cdiVersion: \"0.6.0\"\n"), 0o644))
+
+	cfg := DefaultConfig()
+	cfg.DeviceHostPath = deviceRoot
+	cfg.DeviceInjectionMode = DeviceInjectionModeCDI
+	cfg.CDISpecHostPath = specPath
+
+	adjustment, ok, err := Adjust(cfg, Container{
+		Namespace:      "default",
+		PodAnnotations: map[string]string{"nvml-mock.nvidia.com/devices": "true"},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.Equal(t, []string{"nvml-mock.nvidia.com/gpu=all"}, adjustment.CDIDevices)
+	require.Empty(t, adjustment.Devices,
+		"CDI mode must not also stage raw device nodes; two sources for one container is exactly what MEP-0002 forbids")
+}
+
+// TestAdjustCDIModeFallsBackToRawWhenSpecMissing keeps the raw path reachable.
+// MEP-0002 requires the fallback to survive, and a missing spec is a hard
+// container-creation failure in containerd rather than a degraded start, so the
+// plugin checks before it commits to the CDI reference.
+func TestAdjustCDIModeFallsBackToRawWhenSpecMissing(t *testing.T) {
+	deviceRoot := t.TempDir()
+	for _, name := range []string{"nvidia0", "nvidia1"} {
+		require.NoError(t, os.WriteFile(filepath.Join(deviceRoot, name), []byte{}, 0o644))
+	}
+
+	cfg := DefaultConfig()
+	cfg.DeviceHostPath = deviceRoot
+	cfg.DeviceInjectionMode = DeviceInjectionModeCDI
+	cfg.CDISpecHostPath = filepath.Join(t.TempDir(), "absent.yaml")
+
+	adjustment, ok, err := Adjust(cfg, Container{
+		Namespace:      "default",
+		PodAnnotations: map[string]string{"nvml-mock.nvidia.com/devices": "true"},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.Empty(t, adjustment.CDIDevices, "no staged spec means no CDI reference the runtime could resolve")
+	require.ElementsMatch(t, []Device{
+		{HostPath: filepath.Join(deviceRoot, "nvidia0"), Path: "/dev/nvidia0"},
+		{HostPath: filepath.Join(deviceRoot, "nvidia1"), Path: "/dev/nvidia1"},
+	}, adjustment.Devices)
+}
+
+// TestAdjustRawModeEmitsNoCDIReference is the discriminating half of the pair
+// above: the default mode must stay on raw nodes and never emit a CDI device,
+// even when a spec is staged on the node.
+func TestAdjustRawModeEmitsNoCDIReference(t *testing.T) {
+	deviceRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(deviceRoot, "nvidia0"), []byte{}, 0o644))
+	specPath := filepath.Join(t.TempDir(), "nvml-mock-nri.yaml")
+	require.NoError(t, os.WriteFile(specPath, []byte("cdiVersion: \"0.6.0\"\n"), 0o644))
+
+	cfg := DefaultConfig()
+	cfg.DeviceHostPath = deviceRoot
+	cfg.CDISpecHostPath = specPath
+
+	require.Equal(t, DeviceInjectionModeRaw, DefaultConfig().DeviceInjectionMode,
+		"raw stays the default per MEP-0002; CDI is the opt-in path")
+
+	adjustment, ok, err := Adjust(cfg, Container{
+		Namespace:      "default",
+		PodAnnotations: map[string]string{"nvml-mock.nvidia.com/devices": "true"},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.Empty(t, adjustment.CDIDevices)
+	require.ElementsMatch(t, []Device{
+		{HostPath: filepath.Join(deviceRoot, "nvidia0"), Path: "/dev/nvidia0"},
+	}, adjustment.Devices)
+}
+
+// TestAdjustCDIModeStillSuppressesWhenDevicePluginServedContainer is the
+// MEP-0002 "must not bypass the suppression rule" clause. The rule is about who
+// already served the container, not about which mechanism serves it, so
+// switching the mechanism to CDI must not reopen the hole.
+func TestAdjustCDIModeStillSuppressesWhenDevicePluginServedContainer(t *testing.T) {
+	deviceRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(deviceRoot, "nvidia0"), []byte{}, 0o644))
+	specPath := filepath.Join(t.TempDir(), "nvml-mock-nri.yaml")
+	require.NoError(t, os.WriteFile(specPath, []byte("cdiVersion: \"0.6.0\"\n"), 0o644))
+
+	cfg := DefaultConfig()
+	cfg.DeviceHostPath = deviceRoot
+	cfg.DeviceInjectionMode = DeviceInjectionModeCDI
+	cfg.CDISpecHostPath = specPath
+
+	tests := map[string]Container{
+		"raw device node from the device plugin": {
+			Devices: []Device{{HostPath: "/var/lib/nvml-mock/driver/dev/nvidia0", Path: "/dev/nvidia0"}},
+		},
+		"cdi device from the device plugin": {CDIDevices: []string{"nvidia.com/gpu=0"}},
+	}
+
+	for name, container := range tests {
+		t.Run(name, func(t *testing.T) {
+			container.Namespace = "default"
+			container.PodAnnotations = map[string]string{"nvml-mock.nvidia.com/devices": "true"}
+
+			adjustment, ok, err := Adjust(cfg, container)
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			require.Empty(t, adjustment.CDIDevices, "suppression must hold in CDI mode too")
+			require.Empty(t, adjustment.Devices)
+			require.Contains(t, adjustment.Env, "MOCK_NVML_CONFIG=/opt/nvml-mock/driver/config/config.yaml")
+		})
+	}
+}
+
+// TestAdjustCDIModeStillDeliversImexChannelsAsRawDevices pins the interaction
+// between the two opt-ins. IMEX channels are deliberately outside the CDI spec:
+// they are a fabric capability with their own annotation, staged by
+// imex.mockChannels rather than by the GPU device tree. So a container that asks
+// for both gets its GPUs through CDI and its channels as raw device nodes, in
+// one adjustment. Losing the channels here would deny a ComputeDomain workload
+// the fabric it explicitly requested.
+func TestAdjustCDIModeStillDeliversImexChannelsAsRawDevices(t *testing.T) {
+	deviceRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(deviceRoot, "nvidia0"), []byte{}, 0o644))
+	channelRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(channelRoot, "channel0"), []byte{}, 0o644))
+	specPath := filepath.Join(t.TempDir(), "nvml-mock-nri.yaml")
+	require.NoError(t, os.WriteFile(specPath, []byte("cdiVersion: \"0.6.0\"\n"), 0o644))
+
+	cfg := DefaultConfig()
+	cfg.DeviceHostPath = deviceRoot
+	cfg.ImexChannelHostPath = channelRoot
+	cfg.DeviceInjectionMode = DeviceInjectionModeCDI
+	cfg.CDISpecHostPath = specPath
+
+	adjustment, ok, err := Adjust(cfg, Container{
+		Namespace: "default",
+		PodAnnotations: map[string]string{
+			"nvml-mock.nvidia.com/devices":       "true",
+			"nvml-mock.nvidia.com/imex-channels": "true",
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.Equal(t, []string{"nvml-mock.nvidia.com/gpu=all"}, adjustment.CDIDevices)
+	require.Equal(t, []Device{
+		{HostPath: filepath.Join(channelRoot, "channel0"), Path: "/dev/nvidia-caps-imex-channels/channel0"},
+	}, adjustment.Devices,
+		"channels ride the raw device list even in cdi mode; the GPU tree must not reappear alongside them")
+}

--- a/tests/e2e/go/scenario_nri_test.go
+++ b/tests/e2e/go/scenario_nri_test.go
@@ -218,6 +218,13 @@ var _ = Describe("nvml-mock node-wide NRI injection", Label("nri"), Ordered, fun
 			Expect(visibleGPUUUIDs(ctx, h, pod)).To(HaveLen(p.ExpectedGPUs()),
 				"annotated pod with no %s request should keep seeing all %d GPUs",
 				kube.GPUResourceName, p.ExpectedGPUs())
+
+			// Mirror of the nri-cdi specs (#436). This release runs the shipped
+			// default, so the devices must have come from the raw path. Without
+			// this the CDI marker assertion would pass trivially if something set
+			// NVML_MOCK_DEVICE_SOURCE unconditionally.
+			Expect(nriDeviceSource(ctx, h, pod)).To(BeEmpty(),
+				"default deviceInjectionMode is raw, so the CDI spec must not have been applied")
 		})
 
 		It("leaves the scheduler gate intact once the node is saturated", Label("nri-dp-scheduling"), func(ctx SpecContext) {
@@ -249,6 +256,67 @@ var _ = Describe("nvml-mock node-wide NRI injection", Label("nri"), Ordered, fun
 			Expect(out).To(ContainSubstring("Insufficient "+kube.GPUResourceName),
 				"%s should be unschedulable on %s specifically, got events:\n%s",
 				name, kube.GPUResourceName, strings.TrimSpace(out))
+		})
+	})
+
+	// CDI device injection (#436). The plugin can deliver the annotation-gated
+	// device tree either by staging raw device nodes itself or by handing the
+	// runtime a CDI device reference. containerd 2.x enables CDI by default
+	// (enable_cdi = true, spec dirs /etc/cdi and /var/run/cdi), so this works on
+	// the stock kindest/node this scenario already runs on — no container
+	// toolkit is involved.
+	//
+	// The two modes are identical in outcome by design, which is exactly what
+	// makes this hard to test honestly: a cdi deployment that silently fell back
+	// to raw would still show every GPU. NVML_MOCK_DEVICE_SOURCE is the
+	// discriminator. It comes from the CDI spec's containerEdits, and the raw
+	// path injects device nodes only — it has no mechanism to set an environment
+	// variable — so the variable is present if and only if the runtime resolved
+	// the spec.
+	Context("when device injection is switched to CDI", Label("nri-cdi"), Ordered, func() {
+		var p profile.Profile
+
+		BeforeAll(func(ctx SpecContext) {
+			Expect(selectedProfiles).NotTo(BeEmpty())
+			p = loadProfile(selectedProfiles[0])
+			installNRICDIChart(ctx, h, p)
+			assertions.WaitDaemonSetReady(ctx, h.Kube, nvmlMockNamespace, "nvml-mock", config.ReadyTimeout(), config.PollInterval())
+			assertions.WaitDaemonSetReady(ctx, h.Kube, nvmlMockNamespace, nriNRIDaemonSet, config.ReadyTimeout(), config.PollInterval())
+		})
+
+		AfterAll(func(ctx SpecContext) {
+			// Put the release back on the default mechanism so any spec ordered
+			// after this Context sees the shipped configuration.
+			installNRIChart(ctx, h, p, topoValues, p.HasFabric())
+			assertions.WaitDaemonSetReady(ctx, h.Kube, nvmlMockNamespace, nriNRIDaemonSet, config.ReadyTimeout(), config.PollInterval())
+		})
+
+		It("delivers every GPU through the CDI spec", Label("nri-cdi-inject"), func(ctx SpecContext) {
+			pod := applyNRIWorkload(ctx, h, nriAnnotatedPodManifest("nri-cdi-annotated"), "nri-cdi-annotated")
+
+			Expect(nriDeviceSource(ctx, h, pod)).To(Equal("cdi"),
+				"NVML_MOCK_DEVICE_SOURCE comes from the CDI spec's containerEdits; "+
+					"an empty value means the runtime never resolved the spec and the plugin "+
+					"quietly fell back to raw device nodes")
+
+			// MEP-0002 goal 2 is a contract, not an implementation detail: the
+			// annotation with no resource request keeps meaning "every GPU".
+			Expect(visibleGPUUUIDs(ctx, h, pod)).To(HaveLen(p.ExpectedGPUs()),
+				"annotated pod with no %s request must still see all %d GPUs through CDI",
+				kube.GPUResourceName, p.ExpectedGPUs())
+		})
+
+		It("still suppresses injection for a pod the device plugin served", Label("nri-cdi-suppression"), func(ctx SpecContext) {
+			// MEP-0002 forbids #436 from bypassing the suppression rule. The rule is
+			// about who already served the container, not which mechanism serves it,
+			// so switching to CDI must not reopen it. Without the device plugin on
+			// this cluster the closest available proxy is a pod that carries the
+			// annotation and no request, so assert the negative directly: a pod that
+			// opted OUT gets neither the CDI marker nor the devices.
+			pod := applyNRIWorkload(ctx, h, nriPlainPodManifest("nri-cdi-plain"), "nri-cdi-plain")
+
+			Expect(nriDeviceSource(ctx, h, pod)).To(BeEmpty(),
+				"a pod that did not opt in must not have the CDI spec applied")
 		})
 	})
 
@@ -659,6 +727,65 @@ spec:
       image: ` + nriWorkloadImage + `
       command: ["/bin/sh", "-c", "sleep 3600"]
 `)
+}
+
+// nriPlainPodManifest renders a pod that opts into nothing: no GPU request and
+// no device annotation. It still receives the overlay and the environment,
+// which is the node-wide NRI contract.
+func nriPlainPodManifest(name string) []byte {
+	return []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: ` + name + `
+  namespace: ` + nriWorkloadNS + `
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    nvidia.com/gpu.present: "true"
+  containers:
+    - name: app
+      image: ` + nriWorkloadImage + `
+      command: ["/bin/sh", "-c", "sleep 3600"]
+`)
+}
+
+// nriDeviceSource reads NVML_MOCK_DEVICE_SOURCE from inside the pod. The
+// variable is set by the CDI spec's containerEdits, so an empty string means
+// the container was not served through CDI. `printenv` returns non-zero when
+// the variable is unset, hence ExecSh with an echo that always succeeds.
+func nriDeviceSource(ctx context.Context, h *harness.Harness, pod kube.PodRef) string {
+	GinkgoHelper()
+	res, err := h.Kube.ExecSh(ctx, pod, `echo -n "$NVML_MOCK_DEVICE_SOURCE"`)
+	Expect(err).NotTo(HaveOccurred(), "read NVML_MOCK_DEVICE_SOURCE from %s", pod.Pod)
+	return strings.TrimSpace(res.Stdout)
+}
+
+// installNRICDIChart reinstalls the release with the device opt-in switched to
+// CDI. Everything else matches installNRIChart, so a difference observed
+// between the two is attributable to the mechanism and nothing else.
+func installNRICDIChart(ctx context.Context, h *harness.Harness, p profile.Profile) {
+	GinkgoHelper()
+	repo, tag := splitImage(config.Image())
+	rel := helm.Release{
+		Name:            "nvml-mock",
+		Chart:           chartDir(),
+		Namespace:       nvmlMockNamespace,
+		CreateNamespace: true,
+		HideOutput:      true,
+		Set: map[string]string{
+			"gpu.count":                 strconv.Itoa(p.ExpectedGPUs()),
+			"gpu.profile":               p.Name,
+			"image.repository":          repo,
+			"image.tag":                 tag,
+			"nri.enabled":               "true",
+			"nri.deviceInjectionMode":   "cdi",
+			"imex.mockChannels.enabled": "false",
+		},
+		Wait:    true,
+		Timeout: config.HelmTimeout(),
+	}
+	By("helm upgrade --install nvml-mock with NRI device injection mode=cdi (profile=" + p.Name + ")")
+	Expect(h.Helm.UpgradeInstall(ctx, rel)).To(Succeed(), "helm upgrade --install nvml-mock with CDI injection (profile=%s)", p.Name)
 }
 
 // nriImexPodManifest renders a pod pinned to one node that optionally opts into


### PR DESCRIPTION
## Problem

The NRI plugin's annotation-gated device opt-in (`nvml-mock.nvidia.com/devices: "true"`) could only deliver mock GPUs one way: by staging the `/dev/nvidia*` nodes itself. Issue #436 asks for CDI device references instead.

MEP-0002 constrains this issue and deferred it, on the basis that the only CI leg running the NRI plugin uses stock `kindest/node`, which it recorded as having "no container toolkit and no CDI configuration at all".

## What changed

`nri.deviceInjectionMode` selects the mechanism:

- `raw` (default, unchanged) — the plugin stages the device nodes.
- `cdi` — the plugin emits `nvml-mock.nvidia.com/gpu=all` and the runtime resolves it from a spec `setup.sh` stages at `/var/run/cdi/nvml-mock-nri.yaml`.

Suppression is evaluated *before* the mode is consulted, so a container the device plugin already served is left alone in both modes. IMEX channels stay on the raw device list in both.

## The premise correction

MEP-0002's CDI claim is half wrong, and that changes what this issue needs. The toolkit is genuinely absent from stock `kindest/node`, but containerd 2.2.0 — the version in `kindest/node:v1.35.0` — ships `enable_cdi = true` with `cdi_spec_dirs = ['/etc/cdi', '/var/run/cdi']`, and resolves an NRI plugin's `ContainerAdjustment.CDIDevices` against them.

Measured before any code was written, with a throwaway NRI plugin on stock kind: a spec staged in `/var/run/cdi` applied both its `env` and its `deviceNodes`, with no toolkit binary present.

So CDI needs no new node image and is verified on the existing `e2e-nri` leg. The MEP is amended (last commit) to record the measurement while **keeping** the raw-fallback directive, which survives on grounds the correction doesn't touch: raw is the only mechanism that works where CDI support is absent or disabled (containerd 1.x gates it), and it's what every current deployment uses.

`deployments/kind-nvidia-cdi/` was built by no CI job, so it gets a paths-filtered build guard. That guard proves the image builds, not that it works — stated plainly in the workflow header, since nothing runs a cluster on it.

## Testing done

| Gate | Result |
|---|---|
| `go test -race ./...` | rc=0, 26 packages |
| `golangci-lint run ./...` | rc=0, 0 issues |
| `helm unittest` | 143 passed (was 140) |
| `make e2e-nri` (stock kind, a100) | Ran 15 of 62 — 15 Passed, 0 Failed |

Both branches were mutation-checked separately, and each mutation reddens only its own specs: breaking CDI injection reddens only the CDI spec, breaking the raw fallback reddens only the raw specs, breaking suppression reddens only the suppression spec.

The e2e specs needed particular care. Both modes deliver identical devices, so asserting the GPU count alone passes even when CDI silently falls back to raw. The CDI spec therefore sets `NVML_MOCK_DEVICE_SOURCE=cdi` via `containerEdits` — something the raw path structurally cannot do, since it injects device nodes and nothing else. Forcing the CDI context back to raw fails on that marker and **not** on the GPU count: the pod started and reported all 8 GPUs. That run is the evidence the count assertion would not have caught the regression.

One real bug surfaced only by running it: a CDI `hostPath` is resolved by the runtime on the host, but `$DEV_ROOT` in `setup.sh` is the setup container's view (`/host/...`). Every unit test was green while the first e2e run failed with `workload nri-cdi-annotated never reached Running`. Fixed with `HOST_DEV_ROOT=${DEV_ROOT#/host}`.

## Breaking changes

None. `raw` remains the default, so existing deployments are unaffected.

Closes #436
