### PR TITLE
fix(nvml-mock): stage IB tool libraries and RPATH into the overlay

### DIFF
--- a/deployments/nvml-mock/Dockerfile
+++ b/deployments/nvml-mock/Dockerfile
@@ -66,6 +66,9 @@ COPY --from=builder /out/nv-fabricmanager-ctl /usr/bin/nv-fabricmanager-ctl
 # to confirm the topology overlay assigned the expected clique to each
 # node. See NVIDIA/k8s-test-infra#304.
 COPY --from=builder /out/check-fabric    /usr/local/bin/check-fabric
+# Copied ahead of the RUN below because that layer invokes it while patchelf is
+# still installed; /scripts/ arrives later, after patchelf has been purged.
+COPY deployments/nvml-mock/scripts/stage-ib-tools.sh /usr/local/bin/stage-ib-tools.sh
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends curl ca-certificates gnupg2 \
@@ -106,6 +109,13 @@ RUN set -eux; \
     # /var/lib/nvml-mock/driver/usr/bin/, and CDI-injected /usr/bin/.
     apt-get install -y --no-install-recommends patchelf; \
     patchelf --set-rpath '$ORIGIN/../lib64' /usr/local/bin/nvidia-smi; \
+    # Same treatment for the InfiniBand CLI tools, for the same reason: setup.sh
+    # relocates them into the node overlay, where their libibmad/libibumad/
+    # libibverbs/libnl dependencies are not on any default search path. The
+    # script stages that closure next to them and bakes in the RPATH. Injected
+    # containers therefore run them straight from a minimal image that ships no
+    # IB libraries at all. See NVIDIA/k8s-test-infra#438.
+    sh /usr/local/bin/stage-ib-tools.sh; \
     rm -rf /var/lib/apt/lists/*; \
     rm -rf /tmp/nvidia-utils /tmp/nvidia-utils-580*.deb \
            /usr/share/keyrings/nvidia.gpg /etc/apt/sources.list.d/nvidia.list; \

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -541,6 +541,30 @@ same port-level information (state, phys state, GID, LID, rate, link layer)
 is available through `ibstatus`, which reads it from the rendered sysfs
 tree.
 
+### In NRI-injected pods
+
+With `nri.enabled=true` the same tools are staged into the node overlay and
+reachable from any injected workload at
+`/opt/nvml-mock/driver/usr/bin/<tool>`. They carry their shared libraries
+(`libibmad`, `libibumad`, `libibverbs`, `libnl`) alongside them in
+`driver/usr/lib64` and an RPATH of `$ORIGIN/../lib64`, so they run from an
+image that ships no InfiniBand stack of its own — a distroless or scratch
+workload, not just a full distro image.
+
+Two limits apply there, both independent of the staging:
+
+- `ibstatus` is a `/bin/sh` script rather than an ELF binary, so it needs an
+  image with a shell.
+- `ibv_devinfo -l` reports `0 HCAs found` in an injected pod. Enumeration
+  needs libibverbs to match the device to a provider driver (`libmlx5`), and
+  the provider ships in the nvml-mock image rather than in the workload. Use
+  `ibstat -l`, which reads the rendered sysfs through `libibmocksys.so` and
+  lists every mock HCA.
+
+The tools are glibc binaries. On a musl image (Alpine) they fail to exec at
+all, because `PT_INTERP` names `/lib/ld-linux-*.so.*` by absolute path and no
+RPATH can redirect that.
+
 ### Defaults per profile
 
 | Profile | Enabled | HCA | Speed | HCAs per GPU |

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -347,11 +347,43 @@ chmod +x "$DRIVER_ROOT/usr/bin/nvidia-smi.sh"
 #     The NRI plugin mounts /var/lib/nvml-mock at /opt/nvml-mock in each
 #     workload, then prepends driver/usr/bin and driver/usr/lib64 and appends
 #     driver/usr/local/lib shims to LD_PRELOAD.
+#
+#     The ELF tools arrive pre-staged and pre-patched from the image build
+#     (stage-ib-tools.sh): each carries RPATH=$ORIGIN/../lib64 and its shared
+#     libraries sit alongside, so they resolve libibmad/libibumad/libibverbs/
+#     libnl from the overlay itself.
+#
+#     Before this, the overlay carried the binaries and none of their
+#     libraries, so an injected pod got "error while loading shared
+#     libraries" on the first tool it ran — measured on debian:bookworm-slim
+#     as well as on distroless, since neither that image nor ubuntu:22.04
+#     ships the IB stack. See NVIDIA/k8s-test-infra#438.
+if [ -d /usr/local/nvml-mock-ib/bin ]; then
+  cp -a /usr/local/nvml-mock-ib/bin/. "$DRIVER_ROOT/usr/bin/"
+  cp -a /usr/local/nvml-mock-ib/lib64/. "$DRIVER_ROOT/usr/lib64/"
+  echo "Staged IB CLI tools + shared libraries (RPATH-enabled)"
+else
+  echo "WARNING: no pre-staged IB tools in the image; falling back to unpatched copies" >&2
+fi
+# Anything the build did not pre-stage. In practice this is ibstatus, which is
+# a /bin/sh script rather than an ELF binary: there is no RPATH to give it, and
+# it only runs in images that ship a shell. Never overwrite a pre-staged tool —
+# the copy under /usr/sbin has no RPATH.
 for tool in ibnetdiscover ibstat iblinkinfo ibstatus sminfo ibping ibv_devinfo; do
-  if command -v "$tool" >/dev/null 2>&1; then
+  if [ ! -e "$DRIVER_ROOT/usr/bin/$tool" ] && command -v "$tool" >/dev/null 2>&1; then
     cp "$(command -v "$tool")" "$DRIVER_ROOT/usr/bin/$tool"
   fi
 done
+# Stage the ibverbs provider config. libibverbs reads this directory from a
+# compile-time absolute path (/etc/libibverbs.d) and offers no environment
+# override, so this copy does not redirect an injected container's lookup — the
+# mock answers the verbs API through the LD_PRELOAD shim libibmockverbs.so.1
+# and never consults it. It is here for consumers that mount the overlay as a
+# root, and so the provider set travels with the tools it belongs to.
+if [ -d /etc/libibverbs.d ]; then
+  mkdir -p "$DRIVER_ROOT/etc/libibverbs.d"
+  cp -a /etc/libibverbs.d/. "$DRIVER_ROOT/etc/libibverbs.d/" 2>/dev/null || true
+fi
 # Stage the fabric consumer so node-wide NRI-injected pods can verify their
 # per-node ComputeDomain identity (nvmlDeviceGetGpuFabricInfo) the same way the
 # compute-domain demo does inside the daemon pod. It resolves the mock NVML

--- a/deployments/nvml-mock/scripts/stage-ib-tools.sh
+++ b/deployments/nvml-mock/scripts/stage-ib-tools.sh
@@ -1,0 +1,144 @@
+#!/bin/sh
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Stages the InfiniBand CLI tools and their shared-library closure into a
+# self-contained tree, and gives every binary an RPATH relative to its own
+# location. Runs ONCE at image build time, from the Dockerfile.
+#
+# Build time is deliberate. setup.sh copies this tree into the node overlay at
+# runtime, where patchelf is not installed and the ordering of the injected
+# LD_LIBRARY_PATH would otherwise decide which library wins. Baking the RPATH
+# here is what makes each tool self-locating in every mount context, exactly
+# as the Dockerfile already does for nvidia-smi. See NVIDIA/k8s-test-infra#438.
+#
+# Layout produced (mirrors the overlay's driver/usr/{bin,lib64}):
+#   /usr/local/nvml-mock-ib/bin/<tool>     RPATH=$ORIGIN/../lib64
+#   /usr/local/nvml-mock-ib/lib64/<lib>    RPATH=$ORIGIN
+set -eu
+
+STAGE_ROOT=${STAGE_ROOT:-/usr/local/nvml-mock-ib}
+BIN_DIR="$STAGE_ROOT/bin"
+LIB_DIR="$STAGE_ROOT/lib64"
+
+# ELF tools only. ibstatus is a /bin/sh script: it has no RPATH to set and it
+# only runs in images that ship a shell, so setup.sh stages it separately.
+IB_TOOLS="ibnetdiscover ibstat iblinkinfo sminfo ibping ibv_devinfo"
+
+# Libraries every glibc image already provides. Staging these would put a
+# second copy of the C runtime ahead of the container's own on the search
+# path, which is how you get a binary running against a libc that does not
+# match its loader. The tools' own dependencies are what we stage.
+is_glibc_core() {
+	case "$1" in
+	libc.so.* | libm.so.* | libdl.so.* | librt.so.* | libpthread.so.* | \
+		ld-linux*.so.* | ld.so.* | linux-vdso.so.*)
+		return 0
+		;;
+	esac
+	return 1
+}
+
+mkdir -p "$BIN_DIR" "$LIB_DIR"
+
+# 1. Collect the tools.
+staged_tools=""
+for tool in $IB_TOOLS; do
+	path=$(command -v "$tool" 2>/dev/null) || {
+		echo "ERROR: $tool not found in PATH; the image must install infiniband-diags/ibverbs-utils" >&2
+		exit 1
+	}
+	cp "$path" "$BIN_DIR/$tool"
+	staged_tools="$staged_tools $tool"
+done
+
+# 2. Collect their dependency closure. ldd resolves transitively, so this
+#    picks up libnl-3/libnl-route-3, which no tool names directly — they
+#    arrive through libibverbs.
+for tool in $IB_TOOLS; do
+	ldd "$BIN_DIR/$tool"
+done | awk '/=>/ && $3 ~ /^\// {print $3}' | sort -u | while read -r lib; do
+	base=$(basename "$lib")
+	if is_glibc_core "$base"; then
+		continue
+	fi
+	# -L dereferences the SONAME symlink so the overlay gets a real file.
+	cp -aL "$lib" "$LIB_DIR/$base"
+done
+
+# 3. Set the RPATHs.
+#
+#    The hard case is a transitive dependency: ibv_devinfo names libnl
+#    nowhere, it reaches it through libibverbs. Two independent mechanisms
+#    resolve that, and this stages both:
+#
+#      a. --force-rpath writes DT_RPATH rather than patchelf's default
+#         DT_RUNPATH. DT_RUNPATH applies only to the direct dependencies of
+#         the object carrying it; DT_RPATH is inherited down the chain.
+#      b. $ORIGIN on each staged library, so a library resolves its own
+#         dependencies from the directory it was loaded out of.
+#
+#    Measured on distroless with libnl staged: strip (b) and keep (a) and
+#    ibv_devinfo loads; strip (a) and keep (b) and it loads; strip both and it
+#    dies with "libnl-route-3.so.200: cannot open shared object file". Either
+#    is sufficient alone, so keeping both means no single edit here silently
+#    reintroduces the bug.
+#    The single quotes below are deliberate and must stay. $ORIGIN is resolved
+#    by the dynamic loader at load time, not by this shell — expanding it here
+#    would bake in a build-time absolute path and defeat the entire point.
+# shellcheck disable=SC2016
+for tool in "$BIN_DIR"/*; do
+	patchelf --force-rpath --set-rpath '$ORIGIN/../lib64' "$tool"
+done
+staged_libs=""
+# shellcheck disable=SC2016
+for lib in "$LIB_DIR"/*; do
+	patchelf --force-rpath --set-rpath '$ORIGIN' "$lib"
+	staged_libs="$staged_libs $(basename "$lib")"
+done
+
+# 4. Self-verify. A partial run must not exit 0: without this, a tool whose
+#    dependency failed to copy still produces a plausible-looking tree and the
+#    breakage only surfaces at e2e as a missing-.so error inside a pod.
+#
+#    The allowlist below is spelled out again on purpose. An earlier revision
+#    called is_glibc_core() here too, and that made the check unable to fail:
+#    widening the staging filter widened the verifier with it, so a run that
+#    dropped libnl still exited 0. A verifier that shares its predicate with
+#    the step it verifies is not a verifier. Keep these two lists independent.
+needs_staging() {
+	case "$1" in
+	libc.so.* | libm.so.* | libdl.so.* | librt.so.* | libpthread.so.* | \
+		ld-linux*.so.* | ld.so.* | linux-vdso.so.*)
+		return 1
+		;;
+	esac
+	return 0
+}
+
+rc=0
+# shellcheck disable=SC2016 # literal $ORIGIN, see above
+for tool in "$BIN_DIR"/*; do
+	got=$(patchelf --print-rpath "$tool")
+	if [ "$got" != '$ORIGIN/../lib64' ]; then
+		echo "ERROR: $tool has RPATH '$got', want '\$ORIGIN/../lib64'" >&2
+		rc=1
+	fi
+done
+for obj in "$BIN_DIR"/* "$LIB_DIR"/*; do
+	for need in $(patchelf --print-needed "$obj"); do
+		if ! needs_staging "$need"; then
+			continue
+		fi
+		if [ ! -e "$LIB_DIR/$need" ]; then
+			echo "ERROR: $obj needs $need, which is not staged in $LIB_DIR" >&2
+			rc=1
+		fi
+	done
+done
+if [ "$rc" -ne 0 ]; then
+	exit "$rc"
+fi
+
+echo "Staged IB tools:$staged_tools"
+echo "Staged IB libraries:$staged_libs"

--- a/tests/e2e/go/scenario_nri_test.go
+++ b/tests/e2e/go/scenario_nri_test.go
@@ -36,6 +36,21 @@ const (
 	nriPluginSelector = "app.kubernetes.io/name=nvml-mock-nri"
 	// Device-plugin composition (#440, MEP-0002).
 	nriWorkloadImage = "debian:bookworm-slim"
+	// nriMinimalImage is the negative control for overlay self-containment
+	// (#438): glibc, so the tools' ELF interpreter resolves, but shipping no
+	// InfiniBand stack and no shell. Running the tools here proves they load
+	// their libraries from the overlay rather than from the image.
+	//
+	// Distroless and not Alpine, deliberately. These tools are glibc binaries
+	// with PT_INTERP=/lib/ld-linux-*.so.*, an absolute path that RPATH cannot
+	// redirect; on musl they fail to exec at all ("no such file or directory")
+	// no matter what the overlay stages. Alpine would need glibc itself
+	// staged, which is a different problem from this one.
+	nriMinimalImage = "gcr.io/distroless/base-debian12:latest"
+	// nriOverlayBinDir is where the NRI plugin mounts the staged tools. The
+	// pod names them by absolute path because a shell-less image has no PATH
+	// lookup to fall back on.
+	nriOverlayBinDir = "/opt/nvml-mock/driver/usr/bin"
 
 	// nriDomainName / nriDomainUUID identify the single ComputeDomain the
 	// generated topology overlay declares. The UUID is arbitrary but must match
@@ -110,6 +125,69 @@ var _ = Describe("nvml-mock node-wide NRI injection", Label("nri"), Ordered, fun
 
 			It("reports the profile GPUs via nvidia-smi in the injected pod", Label("nvidia-smi"), func(ctx SpecContext) {
 				assertAgentSeesGPUs(ctx, h, p.ExpectedGPUs())
+			})
+
+			// #438. The IB CLI tools are dynamically linked and setup.sh
+			// relocates them into the overlay, which until this change carried
+			// none of their libraries. Nothing in CI ran them from an injected
+			// pod, so the breakage was invisible.
+			//
+			// It was also wider than "minimal images only". Reverting the
+			// library staging and running ibstat from an injected
+			// debian:bookworm-slim pod reproduces the identical
+			// "libibmad.so.5: cannot open shared object file" — neither
+			// debian:bookworm-slim nor ubuntu:22.04 ships libibmad/libibumad/
+			// libibverbs. A minimal image is simply the honest place to assert
+			// it: nothing there can mask a missing library.
+			It("runs the IB CLI tools from an image that ships no IB libraries", Label("nri-ib-minimal"), func(ctx SpecContext) {
+				if !p.IBEnabled() {
+					Skip("profile " + name + " ships infiniband.enabled=false; it exposes no HCAs to enumerate")
+				}
+				for _, tc := range []struct {
+					name, tool     string
+					wantEnumerated bool
+				}{
+					// ibstat links libibmad/libibumad directly and reads the
+					// mock sysfs through the LD_PRELOAD shim, so it enumerates.
+					{"nri-ib-ibstat", "ibstat", true},
+					// ibv_devinfo covers the transitive dependency: it names
+					// libnl nowhere and reaches it through libibverbs, so it is
+					// the tool that catches a staging tree which resolves only
+					// direct dependencies.
+					//
+					// It is NOT asserted to enumerate. In an NRI-injected pod
+					// it reports "0 HCAs found" — and it does so identically on
+					// debian:bookworm-slim, which was measured on the same
+					// cluster. That gap predates this change and belongs to the
+					// verbs path (libibverbs discards a device it cannot match
+					// to a provider driver), not to library staging. Asserting
+					// enumeration here would be asserting a bug fix that this
+					// change does not make.
+					{"nri-ib-ibv-devinfo", "ibv_devinfo", false},
+				} {
+					phase, logs := runIBToolInMinimalImage(ctx, h, tc.name, tc.tool, "-l")
+
+					// The failure mode this issue is about, asserted by name so
+					// a regression reports the linkage error itself rather than
+					// a bare "substring not found".
+					Expect(logs).NotTo(ContainSubstring("error while loading shared libraries"),
+						"%s could not resolve its shared libraries from the overlay in %s:\n%s",
+						tc.tool, nriMinimalImage, logs)
+					Expect(phase).To(Equal("Succeeded"),
+						"%s exited non-zero in %s:\n%s", tc.tool, nriMinimalImage, logs)
+
+					if tc.wantEnumerated {
+						// Assert the mock HCA by name, not a zero exit. ibstat
+						// exits 0 while printing nothing when it finds no
+						// devices, so an exit-code assertion would hold even
+						// with the mock absent. The device name is what proves
+						// the binary both loaded its libraries and got an
+						// answer back.
+						Expect(logs).To(ContainSubstring("mlx5_0"),
+							"%s did not enumerate the mock HCA from %s\nphase=%s\noutput:\n%s",
+							tc.tool, nriMinimalImage, phase, logs)
+					}
+				}
 			})
 
 			It("carries per-node ComputeDomain fabric identity through NRI", Label("compute-domain"), func(ctx SpecContext) {
@@ -747,6 +825,58 @@ spec:
       image: ` + nriWorkloadImage + `
       command: ["/bin/sh", "-c", "sleep 3600"]
 `)
+}
+
+// nriMinimalIBPodManifest renders a run-to-completion pod on a minimal image
+// that invokes one IB tool from the overlay by absolute path. There is no
+// `sleep` wrapper and no `sh -c`: the image has no shell, which is the whole
+// point of using it.
+func nriMinimalIBPodManifest(name, tool string, args ...string) []byte {
+	argv := `"` + nriOverlayBinDir + "/" + tool + `"`
+	for _, a := range args {
+		argv += `, "` + a + `"`
+	}
+	return []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: ` + name + `
+  namespace: ` + nriWorkloadNS + `
+  labels:
+    app: ` + name + `
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    nvidia.com/gpu.present: "true"
+  containers:
+    - name: app
+      image: ` + nriMinimalImage + `
+      command: [` + argv + `]
+`)
+}
+
+// runIBToolInMinimalImage applies the pod, waits for it to terminate, and
+// returns its final phase together with its logs. It waits for a terminal
+// phase rather than Running because the pod is expected to run once and exit;
+// both outcomes are returned so the caller asserts on the output instead of on
+// the wait succeeding.
+func runIBToolInMinimalImage(ctx context.Context, h *harness.Harness, name, tool string, args ...string) (string, string) {
+	GinkgoHelper()
+	manifest := nriMinimalIBPodManifest(name, tool, args...)
+	Expect(h.Kube.Apply(ctx, manifest)).To(Succeed(), "apply %s", name)
+	DeferCleanup(func(ctx SpecContext) { _ = h.Kube.Delete(ctx, manifest) })
+
+	var phase string
+	Eventually(func() (string, error) {
+		var err error
+		phase, err = h.Kube.PodPhase(ctx, nriWorkloadNS, name)
+		return phase, err
+	}).WithContext(ctx).WithTimeout(config.ReadyTimeout()).WithPolling(config.PollInterval()).
+		Should(BeElementOf("Succeeded", "Failed"),
+			"%s never reached a terminal phase", name)
+
+	logs, err := h.Kube.Logs(ctx, nriWorkloadNS, "app="+name, 100)
+	Expect(err).NotTo(HaveOccurred(), "read logs from %s", name)
+	return phase, logs
 }
 
 // nriDeviceSource reads NVML_MOCK_DEVICE_SOURCE from inside the pod. The


### PR DESCRIPTION
## Problem

`setup.sh` relocates seven InfiniBand CLI tools into the node overlay for NRI
injection, but stages only the binaries. Their shared libraries — `libibmad`,
`libibumad`, `libibnetdisc`, `libibverbs`, and `libnl` reached transitively
through `libibverbs` — stay behind in the image, and the `LD_LIBRARY_PATH` the
NRI plugin injects covers only the NVML/CUDA directory. An injected pod fails on
the first tool it runs:

```
ibstat: error while loading shared libraries: libibmad.so.5: cannot open shared object file
```

Two corrections to the premise in #438, both from running it rather than reading
it:

- **This is not limited to minimal images.** Reverting the staging and running
  `ibstat` from an injected `debian:bookworm-slim` pod reproduces the identical
  error. Neither `debian:bookworm-slim` nor `ubuntu:22.04` ships the IB stack, so
  the tools worked in *no* injected pod. Nothing in CI ran them from inside an
  injected container, which is why it stayed invisible.
- **Alpine cannot be made to work here.** These are glibc binaries whose
  `PT_INTERP` names `/lib/ld-linux-*.so.*` as an absolute path that no RPATH
  redirects; on musl they fail to `exec` regardless of what the overlay stages.
  Distroless is the minimal image this is verified against.

## Approach

The same treatment `nvidia-smi` already gets, and in the same place — the
Dockerfile, at image build time, not `setup.sh` at runtime. Baking the RPATH at
build time is what makes a binary self-locating across every mount context, and
it keeps `patchelf` off the node.

A new `deployments/nvml-mock/scripts/stage-ib-tools.sh` runs once during the
image build and:

1. stages the six ELF tools plus their `ldd` closure, excluding the glibc core
   (staging a second libc ahead of the container's own is how you get a binary
   running against a libc that does not match its loader);
2. sets `RPATH=$ORIGIN/../lib64` on each tool and `$ORIGIN` on each staged
   library;
3. self-verifies, and exits non-zero if any dependency failed to stage.

Both RPATH mechanisms independently resolve the transitive `libnl` lookup —
measured: strip either one and `ibv_devinfo` still loads; strip both and it dies
with `libnl-route-3.so.200: cannot open shared object file`. Keeping both means
no single edit here silently reintroduces the bug.

`ibstatus` is a `/bin/sh` script rather than an ELF binary, so it is staged
unpatched and still needs an image with a shell.

`/etc/libibverbs.d` travels with the tools. `libibverbs` reads that path as a
compile-time absolute with no environment override, so this does not redirect an
injected container's lookup — the mock answers the verbs API through the
`libibmockverbs.so.1` preload shim and never consults it. Bind-mounting it over
the container's own copy was considered and rejected: it would shadow the
image's version on ubuntu for no measured gain.

## Testing done

All on the committed tree:

| Gate | Result |
|---|---|
| `go test -race ./...` | rc=0 — 26 ok, 0 FAIL |
| `golangci-lint run ./...` | rc=0 — 0 issues |
| `helm unittest deployments/nvml-mock/helm/nvml-mock` | rc=0 — 143/143, 15 snapshots |
| `make e2e E2E_PROFILES=a100 --label-filter=nri` | `Ran 16 of 63 Specs` — 16 Passed, 0 Failed |

New `e2e-nri` spec `nri-ib-minimal` runs the tools from
`gcr.io/distroless/base-debian12` — glibc, so the ELF interpreter resolves, but
shipping no IB stack and no shell.

**Mutation-checked.** Reverting the library staging (one verified line) turns the
new spec red: `Ran 1 of 63 Specs`, 0 Passed / 1 Failed, failing on
`ibstat: error while loading shared libraries: libibmad.so.5: cannot open shared
object file` — the real failure mode, not a bare non-zero exit.

The spec asserts `ibstat` enumerates `mlx5_0` rather than merely exiting zero,
since `ibstat` exits 0 while printing nothing when it finds no devices.

## Known limit, unchanged by this PR

`ibv_devinfo -l` reports `0 HCAs found` in an injected pod. It does so
identically on `debian:bookworm-slim`, before and after this change: enumeration
needs `libibverbs` to match the device to a provider driver that ships in the
nvml-mock image rather than in the workload. The spec therefore asserts that
`ibv_devinfo` *loads*, not that it enumerates — asserting the latter would be
claiming a fix this PR does not make. Documented in the chart README; worth its
own issue.

## Relationship to #479

No mechanism overlap. #479 provisions `/dev/infiniband` char devices and an NFD
`pci-15b3` label; its diff contains no `patchelf`, `RPATH`, `libibverbs.d`, or
`LD_LIBRARY_PATH`. The two are complementary — #479 supplies the device nodes,
this supplies the libraries to open them. They do both edit `setup.sh` §4b, so
#479 needs a rebase once this lands.

## Breaking changes

None. The overlay gains files; nothing is removed or renamed.

Part of #441.
Closes #438.
