### PR TITLE
fix(build): propagate the e2e suite's exit status on GNU Make 3.81

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 SHELL := /usr/bin/env bash
+# NOTE: GNU Make only honours .SHELLFLAGS from 3.82 onward. macOS ships 3.81,
+# which treats the line below as an ordinary variable and runs recipes with a
+# bare `-c`. Any recipe whose exit status depends on these flags must set them
+# itself — see the `e2e` and `.mod-verify` targets.
 .SHELLFLAGS := -o pipefail -ec
 
 .PHONY: build fmt verify release lint vendor check-vendor helm-unittest e2e e2e-dra e2e-gpu-operator e2e-multi-node e2e-nri e2e-nfd
@@ -71,7 +75,7 @@ modules:  | .mod-tidy .mod-vendor .mod-verify
 .mod-verify:
 	@for mod in $$(find . -name go.mod -not -path "./testdata/*" -not -path "./third_party/*"); do \
 	    echo "Verifying $$mod..."; ( \
-	        cd $$(dirname $$mod) && go mod verify | sed 's/^/  /g' \
+	        set -o pipefail; cd $$(dirname $$mod) && go mod verify | sed 's/^/  /g' \
 	    ) || exit 1; \
 	done
 
@@ -168,8 +172,12 @@ E2E_TIMEOUT ?= 90m
 E2E_DEFAULT_LABEL_FILTER ?= !validator && !dra && !gpu-operator && !multi-node && !nri && !nfd
 E2E_GINKGO_FLAGS ?= --label-filter='$(E2E_DEFAULT_LABEL_FILTER)'
 
+# `set -o pipefail` is inline on purpose; do not drop it as redundant with
+# .SHELLFLAGS. GNU Make ignores .SHELLFLAGS before 3.82 and macOS ships 3.81,
+# so on a developer machine this recipe otherwise returns tee's status and a
+# failed suite exits 0 — see issue #560 and tests/makefile/makefile_test.go.
 e2e:
-	$(GINKGO) --tags=e2e -v --timeout=$(E2E_TIMEOUT) $(E2E_GINKGO_FLAGS) ./tests/e2e/go | tee e2e.log
+	set -o pipefail; $(GINKGO) --tags=e2e -v --timeout=$(E2E_TIMEOUT) $(E2E_GINKGO_FLAGS) ./tests/e2e/go | tee e2e.log
 
 e2e-dra:
 	$(MAKE) e2e E2E_GINKGO_FLAGS='--label-filter=dra'

--- a/tests/makefile/makefile_test.go
+++ b/tests/makefile/makefile_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package makefile guards build-system invariants that no Go unit test covers.
+//
+// The `e2e` target pipes ginkgo through `tee`, so the recipe's exit status is
+// tee's unless the shell runs with `pipefail`. The Makefile sets `.SHELLFLAGS
+// := -o pipefail -ec`, but GNU Make only added `.SHELLFLAGS` in 3.82. macOS
+// ships 3.81, which parses the line as an ordinary variable and invokes the
+// shell with a bare `-c`. On such a host a red suite exited 0, and `make e2e &&
+// git push` pushed on a failing suite (issue #560).
+//
+// These tests therefore assert the FAILING direction: a red suite must produce
+// a non-zero status. The `without_shellflags` case neutralizes `.SHELLFLAGS`
+// from the command line so the guard reproduces the 3.81 behaviour on any make
+// version, including the 4.x used by CI.
+package makefile
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// repoRoot resolves the repository root from this source file's own location.
+// Deriving it from the working directory or from $HOME would let the test
+// green-light a different checkout than the one it ships beside.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller could not locate this test file")
+
+	root := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	require.FileExists(t, filepath.Join(root, "Makefile"),
+		"repo root %q does not hold a Makefile", root)
+
+	return root
+}
+
+// writeGinkgoStub writes an executable that mimics a ginkgo run: it prints the
+// suite banner and exits with exitCode. It replaces $(GINKGO) so the target
+// runs without a Kind cluster.
+func writeGinkgoStub(t *testing.T, dir string, exitCode int) string {
+	t.Helper()
+
+	body := "#!/bin/sh\n" +
+		"echo 'Ran 16 of 63 Specs in 263.999 seconds'\n"
+	if exitCode == 0 {
+		body += "echo 'SUCCESS! -- 16 Passed | 0 Failed | 0 Pending | 47 Skipped'\n"
+	} else {
+		body += "echo 'FAIL! -- 15 Passed | 1 Failed | 0 Pending | 47 Skipped'\n"
+	}
+	body += "exit " + strconv.Itoa(exitCode) + "\n"
+
+	path := filepath.Join(dir, "ginkgo-stub")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o755))
+
+	return path
+}
+
+// runE2E runs the real `e2e` target against a stub ginkgo and reports the exit
+// code make returned. It runs make in a scratch directory via -C so the
+// recipe's `tee e2e.log` cannot clobber the developer's own e2e.log.
+func runE2E(t *testing.T, exitCode int, extraArgs ...string) (int, string) {
+	t.Helper()
+
+	makeBin, err := exec.LookPath("make")
+	require.NoError(t, err, "make is required to build this repository")
+
+	work := t.TempDir()
+	stub := writeGinkgoStub(t, work, exitCode)
+
+	args := append([]string{
+		"-C", work,
+		"-f", filepath.Join(repoRoot(t), "Makefile"),
+		"e2e",
+		"GINKGO=" + stub,
+	}, extraArgs...)
+
+	out, err := exec.Command(makeBin, args...).CombinedOutput()
+	if err == nil {
+		return 0, string(out)
+	}
+
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr, "make failed to run: %v", err)
+
+	return exitErr.ExitCode(), string(out)
+}
+
+// TestE2EPropagatesSuiteFailure is the regression guard for issue #560.
+func TestE2EPropagatesSuiteFailure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("red suite fails with the Makefile's own shell flags", func(t *testing.T) {
+		t.Parallel()
+
+		code, out := runE2E(t, 1)
+		require.NotZero(t, code,
+			"`make e2e` reported success for a failing suite; a red suite must not exit 0.\n%s", out)
+	})
+
+	// The load-bearing case. Neutralizing .SHELLFLAGS reproduces GNU Make 3.81,
+	// which ignores it, and proves the recipe carries its own pipefail rather
+	// than depending on a global set 150 lines away.
+	t.Run("red suite fails without .SHELLFLAGS", func(t *testing.T) {
+		t.Parallel()
+
+		code, out := runE2E(t, 1, ".SHELLFLAGS=-c")
+		require.NotZero(t, code,
+			"`make e2e` reported success for a failing suite when .SHELLFLAGS was ignored, "+
+				"which is what GNU Make 3.81 (stock on macOS) always does.\n%s", out)
+	})
+
+	// Guards against a degenerate fix that makes the target always fail.
+	t.Run("green suite still succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		code, out := runE2E(t, 0, ".SHELLFLAGS=-c")
+		require.Zero(t, code, "`make e2e` failed for a passing suite.\n%s", out)
+	})
+}


### PR DESCRIPTION
## Problem

`make e2e` could exit 0 on a failing suite. A run printing

```
Ran 16 of 63 Specs in 263.999 seconds
FAIL! -- 15 Passed | 1 Failed | 0 Pending | 47 Skipped
```

returned status 0, so `make e2e && git push` pushes on a red suite.

## The cause is not the one in the issue

#560 attributes this to a missing `pipefail` and proposes adding one. `pipefail` was
already declared — `Makefile:12` has had `.SHELLFLAGS := -o pipefail -ec` since e8282453
(2026-07-16), two weeks before the observation. Applying the proposed fix would have
closed the issue and left the defect live.

The real cause: **GNU Make only honours `.SHELLFLAGS` from 3.82 onward, and macOS ships
3.81.** On 3.81 the line parses as an ordinary variable and every recipe runs with a bare
`-c`. A fake shell logging its own argv shows what make actually passes:

```
ARGC=2
  argv[0]=<-c>
  argv[1]=<false | tee /dev/null>
```

No `-o pipefail`, no `-e`. The flags themselves are fine —
`/usr/bin/env bash -o pipefail -ec 'false | tee /dev/null'` returns 1 on its own. Make just
never delivers them, so the recipe returns `tee`'s status.

Linux CI runs make 4.3 and was protected, but only by a flag set 160 lines away from the
recipe it protects. Six e2e jobs depend on it.

## Fix

`set -o pipefail` inline in the `e2e` recipe, so it no longer depends on `.SHELLFLAGS`.

The audit of other piped recipes turned up one more instance of the same shape:
`.mod-verify` runs `go mod verify | sed`, where `sed`'s status masked a verify failure
(measured: rc 0 before, 2 after). Fixed the same way.

## Testing

Real `e2e` target, `$(GINKGO)` replaced by a stub that prints the banner above and exits 1:

| | make exit status |
|---|---|
| before (`upstream/main` @ 4b3225fd) | **0** |
| after (this branch) | **2** |

`tests/makefile` guards the failing direction — a red suite must not exit 0. Its
load-bearing case neutralizes `.SHELLFLAGS` from the command line, which reproduces 3.81
behaviour on any make version, so the guard is not inert on Linux CI.

Mutation check, removing only the inline `set -o pipefail` (one-line diff):

| host | fixed | mutant |
|---|---|---|
| macOS, GNU Make 3.81 | pass | **fail** |
| `golang:1.26-bookworm`, GNU Make 4.3 | pass | **fail** (`red_suite_fails_without_.SHELLFLAGS`) |

Without that second subtest the mutant passes on make 4.3, since `.SHELLFLAGS` still covers
there — which is why it exists.

Gates: `go test -race ./...` exit 0 (28 packages), `golangci-lint run ./...` exit 0,
0 issues. No go.mod/go.sum/vendor drift.

## Breaking changes

None. The target now reports the status it always should have.

Closes #560
