### PR TITLE
test(e2e): move GPU Operator install into BeforeAll

### DIFF
--- a/tests/e2e/go/scenario_gpu_operator_test.go
+++ b/tests/e2e/go/scenario_gpu_operator_test.go
@@ -59,11 +59,23 @@ var _ = Describe("nvml-mock GPU Operator", Label("gpu-operator"), Ordered, func(
 				Expect(err).NotTo(HaveOccurred())
 				podName = cp.Name
 				verifyGPUOperatorNodeSetup(ctx, podName)
-			})
 
-			It("installs GPU Operator and publishes GPUs", Label("device-plugin"), func(ctx SpecContext) {
+				// Setup, not a spec. Every spec below reads state that only the
+				// operator publishes, so installing from inside one spec made the
+				// others depend on that spec being selected: any label filter
+				// narrower than `gpu-operator` false-reds with `namespaces
+				// "gpu-operator" not found` (#561).
+				//
+				// The validator wait belongs here for the same reason. `helm
+				// --wait` covers only the operator's own release; the specs assert
+				// on the ClusterPolicy operands (device plugin, GFD,
+				// dcgm-exporter), which the operator creates afterwards. Without
+				// this barrier a narrow run races the operand rollout.
 				installGPUOperator(ctx, h)
 				waitOperatorValidatorRunning(ctx, h)
+			})
+
+			It("publishes GFD labels and allocatable GPUs", Label("device-plugin"), func(ctx SpecContext) {
 				// Hard assertion, derived from the profile rather than read back
 				// off the node. The previous warning-only check could never fail,
 				// so GPU Feature Discovery could have been removed entirely and


### PR DESCRIPTION
## Problem

`installGPUOperator` was called from inside a spec rather than from the container's `BeforeAll`. The other five specs in the `gpu-operator` container all read state that only the operator publishes, so they depended on that one spec's side effect.

Any label filter that selected a sibling without also selecting `device-plugin` ran against a cluster where the operator was never installed:

```
[FAILED] Timed out after 120.001s.
daemonset gpu-operator/nvidia-dcgm-exporter not ready
Error from server (NotFound): namespaces "gpu-operator" not found
```

That reads as a product bug rather than a harness one. It only worked because `make e2e-gpu-operator` always passes `--label-filter=gpu-operator`, which selects the whole container including the installer. Anyone narrowing the filter for a faster inner loop got a false red.

## Approach

Move `installGPUOperator` into the per-profile `BeforeAll`.

The `waitOperatorValidatorRunning` barrier moves with it. `helm --wait` covers only the operator's own release, not the ClusterPolicy operands (device plugin, GFD, dcgm-exporter) that the specs actually assert on — the operator creates those afterwards. Leaving that wait inside a spec would have left the same class of defect behind in a narrower form: a filtered run racing the operand rollout against the 2 minute ready timeout.

The spec keeps both of its publication assertions (`WaitGFDLabels`, `WaitAllocatableGPU`) and is renamed to `publishes GFD labels and allocatable GPUs`, since it no longer installs anything. No coverage is dropped — the install and the validator wait still run for every profile, as setup.

## Testing done

The discriminating run is a filter narrower than `gpu-operator`. `--label-filter="gpu-operator && runtime-control"` selects the three `dcgm`+`runtime-control` siblings and *not* the installer:

| | before | after |
|---|---|---|
| `gpu-operator && runtime-control` | `Ran 1 of 64 Specs` / `0 Passed \| 1 Failed` / exit 2 | `Ran 3 of 64 Specs` / `3 Passed \| 0 Failed` / exit 0 |

Before the change only one of the three selected specs ran, because `Ordered` aborts the rest once the first fails.

Also run on the fixed tree:

- `make e2e-gpu-operator` (the path CI uses) — see the checklist below
- `go test -race ./...` — pass
- `golangci-lint run ./...` — `0 issues.` (`.golangci.yml` declares the `e2e` build tag, so this does lint the changed file)

## Audit — other scenarios

Issue #561 asks whether other scenarios share the shape. I checked all seven scenario files. Two do, and neither is reachable through a label filter today because the relevant specs carry no individual labels:

- `scenario_dra_test.go` — `installDRADriver` runs inside `publishes DRA ResourceSlices`; `schedules a pod with a DRA ResourceClaim` depends on it.
- `scenario_multi_node_test.go` — `deployDevicePlugin` runs inside `registers heterogeneous allocatable GPUs`; `schedules a GPU workload on the heterogeneous fleet` applies a pod requesting `nvidia.com/gpu: "1"`, which needs it.

Both are latent rather than live: only `--focus` can reach them today, and they would become live the moment per-spec labels are added, which every other scenario already has. Left out of this PR to keep it to one concern; worth a follow-up issue.

Clean: `standalone` (the unlabeled baseline spec is a pure assertion, and the Helm-driven injections each do their own upgrade), `validator` (all setup in `BeforeAll` — the model shape), `nri` (all five Contexts set up in their own `BeforeAll`; the CDI Context restores state in `AfterAll`), `nfd` (ordered by design — the NFD install must stay inside the third spec, since the first two assert the pre-install state, and all three share one label).

There is no `scenario_imex_test.go`; IMEX is a Context inside `scenario_nri_test.go` and is one of the clean ones.

Closes #561
