### PR TITLE
test(e2e): move DRA driver and device plugin installs into BeforeAll

### DIFF
--- a/tests/e2e/go/scenario_dra_test.go
+++ b/tests/e2e/go/scenario_dra_test.go
@@ -53,6 +53,19 @@ var _ = Describe("nvml-mock DRA", Label("dra"), Ordered, func() {
 
 			BeforeAll(func(ctx SpecContext) {
 				p, pod, _ = setupStandaloneProfile(ctx, h, name)
+
+				// Setup, not a spec. Both DRA specs below read state that only
+				// the driver publishes: one reads its ResourceSlices, the other
+				// schedules against its DeviceClass. Installing from inside the
+				// first of them made the second depend on that spec being
+				// selected, so --focus on the scheduling spec alone left the pod
+				// Pending until the wait timed out (#565).
+				//
+				// Unlike the GPU Operator case (#561), no second readiness
+				// barrier moves with the install: installDRADriver already ends
+				// in waitDRAPodsReady, and the scheduling spec's own wait for
+				// Running absorbs the gap until the kubelet plugin publishes.
+				installDRADriver(ctx, h)
 			})
 
 			It("lays out the mock driver files for DRA", func(ctx SpecContext) {
@@ -69,7 +82,6 @@ var _ = Describe("nvml-mock DRA", Label("dra"), Ordered, func() {
 			})
 
 			It("publishes DRA ResourceSlices for the profile GPUs", func(ctx SpecContext) {
-				installDRADriver(ctx, h)
 				assertions.WaitResourceSliceTotal(ctx, h.Kube, p.ExpectedGPUs(), config.ReadyTimeout(), config.PollInterval())
 			})
 

--- a/tests/e2e/go/scenario_multi_node_test.go
+++ b/tests/e2e/go/scenario_multi_node_test.go
@@ -56,6 +56,20 @@ var _ = Describe("nvml-mock multi-node", Label("multi-node"), Ordered, func() {
 		installProfileOnNode(ctx, h, t4ReleaseName, "t4", "t4")
 		a100Pod = firstReleasePod(ctx, h, a100ReleaseName)
 		t4Pod = firstReleasePod(ctx, h, t4ReleaseName)
+
+		// Setup, not a spec. The scheduling spec below requests
+		// nvidia.com/gpu, and the only device plugin in this scenario comes
+		// from here — the nvml-mock chart ships none. Deploying it from inside
+		// a spec made the scheduling spec depend on that spec being selected,
+		// so --focus on it alone failed with "Insufficient nvidia.com/gpu",
+		// which reads as a capacity problem rather than skipped setup (#565).
+		//
+		// deployDevicePlugin carries its own readiness barrier: it waits for
+		// the DaemonSet and for the A100 worker to advertise its GPUs, so the
+		// scheduling spec has a node to land on. The T4 worker is deliberately
+		// left to the spec below, which is the assertion this container makes
+		// about heterogeneity.
+		deployDevicePlugin(ctx, h, workers[0].Name, a100.ExpectedGPUs())
 	})
 
 	It("validates mock files and InfiniBand behavior on both workers", func(ctx SpecContext) {
@@ -65,8 +79,10 @@ var _ = Describe("nvml-mock multi-node", Label("multi-node"), Ordered, func() {
 		assertions.IBStat(ctx, h.Kube, t4Pod, t4)
 	})
 
-	It("registers heterogeneous allocatable GPUs via the device plugin", func(ctx SpecContext) {
-		deployDevicePlugin(ctx, h, workers[0].Name, a100.ExpectedGPUs())
+	// The A100 worker's count is already established in BeforeAll, so the
+	// assertion that carries weight here is the T4 worker reporting its own,
+	// different count off the same DaemonSet.
+	It("registers the T4 worker's own allocatable GPU count", func(ctx SpecContext) {
 		assertions.WaitAllocatableGPU(ctx, h.Kube, workers[1].Name, t4.ExpectedGPUs(), config.ReadyTimeout(), config.PollInterval())
 	})
 


### PR DESCRIPTION
## Problem

Two scenarios had a spec performing a setup side effect that a later spec depends on, instead of that setup living in `BeforeAll` — the same defect #564 fixed for the GPU Operator scenario.

- `scenario_dra_test.go` — `installDRADriver` ran inside `It("publishes DRA ResourceSlices for the profile GPUs")`. The next spec applies a `ResourceClaimTemplate` and waits for its pod to reach `Running`, which cannot happen without the driver's `DeviceClass` and `ResourceSlices`.
- `scenario_multi_node_test.go` — `deployDevicePlugin` ran inside `It("registers heterogeneous allocatable GPUs via the device plugin")`. The next spec schedules a pod requesting `nvidia.com/gpu: "1"`, and this scenario's only device plugin comes from that call; the nvml-mock chart ships none.

Neither is reachable through `--label-filter`, because these specs carry no individual labels — only their containers do. Both are reachable through `--focus`, which is a normal way to narrow an inner loop. Both failures diagnose badly: the DRA pod just sits `Pending`, and the multi-node pod reports `Insufficient nvidia.com/gpu`, which reads as a capacity problem rather than as skipped setup.

## Approach

Move each install into its container's `BeforeAll` and leave the specs asserting on the result.

Point 1 of the issue asked whether a second readiness barrier has to move with the install, as `waitOperatorValidatorRunning` did in #564. It does not here, and this was checked rather than assumed: `installDRADriver` already ends in `waitDRAPodsReady`, and `deployDevicePlugin` already ends in `WaitDaemonSetReady` + `WaitAllocatableGPU`. Both are self-contained, and the `--focus` runs below confirm it.

The multi-node spec is renamed, per point 2, since it no longer deploys the plugin. Its A100 assertion now lives in the `BeforeAll` barrier, so the spec keeps the T4 worker — the assertion that still discriminates, since nothing in setup waits for it. The DRA spec keeps its title: it already described the assertion rather than the install.

Per-spec labels are deliberately **not** included. They change which specs a filter can select, which is a separate concern with its own review, and the regression evidence below needs only `--focus`.

## Testing done

The discriminating run is the `--focus` selection, before and after. Every run below was executed from `.worktrees/fix-565` with the head commit printed alongside it.

| run | DRA | multi-node |
|---|---|---|
| **before** (`f7746de1`, clean tree) | `Ran 1 of 64` — 0 Passed \| 1 Failed, exit 2 | `Ran 1 of 107` — 0 Passed \| 1 Failed, exit 2 |
| **after** | `Ran 1 of 64` — 1 Passed \| 0 Failed, exit 0 | `Ran 1 of 107` — 1 Passed \| 0 Failed, exit 0 |

```
make e2e E2E_GINKGO_FLAGS='--label-filter=dra --focus="schedules a pod with a DRA ResourceClaim"'
make e2e E2E_PROFILES=a100,t4 E2E_GINKGO_FLAGS='--label-filter=multi-node --focus="schedules a GPU workload on the heterogeneous fleet"'
```

Before, the failures were exactly the ones the issue predicts: `DRA test pod did not reach Running (last phase="Pending")`, and `0/3 nodes are available: 1 node(s) had untolerated taint(s), 2 Insufficient nvidia.com/gpu`. The spec denominators are identical before and after (64 and 107), so the selection surface did not move.

The CI path is unaffected:

| gate | result |
|---|---|
| `go test -race ./...` | exit 0, 28 packages ok |
| `golangci-lint run ./...` | exit 0, 0 issues (`.golangci.yml` declares the `e2e` tag, so these files are covered) |
| `make e2e-dra` | exit 0 — `Ran 5 of 64`, 5 Passed \| 0 Failed |
| `make e2e-multi-node` | exit 0 — `Ran 3 of 107`, 3 Passed \| 0 Failed |

## Breaking changes

None. One spec is renamed: `registers heterogeneous allocatable GPUs via the device plugin` becomes `registers the T4 worker's own allocatable GPU count`. No CI job selects specs by name.

Closes #565
