### PR TITLE
fix(e2e): collect logs from every container in diagnostics dumps

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -80,6 +80,16 @@ jobs:
     - name: Run mockpcisysfs integration tests
       run: go test -tags integration -v ./pkg/system/mockpcisysfs/...
 
+    # The tests/e2e harness packages sit behind the `e2e` build tag, so the
+    # untagged unit-test run above skips them -- `go list ./...` does not even
+    # match them. `make e2e` does not reach them either: it targets the Ginkgo
+    # suite package ./tests/e2e/go, not ./tests/e2e/go/... . Without this step
+    # the harness's own unit tests compile for nobody and rot silently, which is
+    # how the diagnostics collection path lost its sidecar logs unnoticed
+    # (#562). These are plain `go test` units -- no cluster, no kubectl.
+    - name: Run e2e framework unit tests
+      run: make test-e2e-framework
+
     - name: Run govulncheck
       run: |
         go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,15 @@ HELM_CHART_DIR := deployments/nvml-mock/helm/nvml-mock
 helm-unittest:
 	helm unittest $(HELM_CHART_DIR)
 
+# Unit tests for the e2e harness itself (framework/*). They are behind the `e2e`
+# build tag, so the untagged CI unit-test run skips them, and `make e2e` targets
+# only the Ginkgo suite package ./tests/e2e/go -- neither reaches these. They
+# need no cluster and no kubectl: the one that shells out substitutes a stub on
+# PATH.
+.PHONY: test-e2e-framework
+test-e2e-framework:
+	$(GO_CMD) test -tags e2e -race ./tests/e2e/go/framework/...
+
 .PHONY: generate
 generate:
 	go generate ./pkg/gpu/mocknvml/bridge/...

--- a/tests/e2e/go/framework/diagnostics/collect.go
+++ b/tests/e2e/go/framework/diagnostics/collect.go
@@ -55,6 +55,32 @@ func (c *Collector) Kubectl(ctx context.Context, name string, args ...string) {
 	c.write(name, out)
 }
 
+// PodLogs dumps <name>-logs.txt holding the current logs of every container of
+// every pod matching selector.
+//
+// When a container has restarted it also dumps <name>-logs-previous.txt, which
+// is where the cause of a crash loop actually lives — the current instance of a
+// restarting container has usually logged nothing yet. That second dump is
+// gated on an observed restart because `kubectl logs --previous` errors when no
+// previous instance exists, and it is still best-effort on top of the gate: a
+// pod where only one of several containers restarted can fail the request even
+// though the gate passed.
+func (c *Collector) PodLogs(ctx context.Context, name, ns, selector string, tail int) {
+	if c.Kube == nil {
+		return
+	}
+	if out, err := c.Kube.Logs(ctx, ns, selector, tail); err == nil {
+		c.write(name+"-logs.txt", out)
+	}
+	restarted, err := c.Kube.RestartedPods(ctx, ns, selector)
+	if err != nil || len(restarted) == 0 {
+		return
+	}
+	if out, err := c.Kube.PreviousLogs(ctx, ns, selector, tail); err == nil {
+		c.write(name+"-logs-previous.txt", out)
+	}
+}
+
 // Common dumps the dump set shared by every job's failure block.
 func (c *Collector) Common(ctx context.Context) {
 	if c.Kube == nil {
@@ -66,7 +92,5 @@ func (c *Collector) Common(ctx context.Context) {
 	if c.NvmlMockNamespace == "" {
 		return
 	}
-	if out, err := c.Kube.Logs(ctx, c.NvmlMockNamespace, "app.kubernetes.io/name=nvml-mock", 100); err == nil {
-		c.write("nvml-mock-logs.txt", out)
-	}
+	c.PodLogs(ctx, "nvml-mock", c.NvmlMockNamespace, "app.kubernetes.io/name=nvml-mock", 100)
 }

--- a/tests/e2e/go/framework/diagnostics/collect_test.go
+++ b/tests/e2e/go/framework/diagnostics/collect_test.go
@@ -1,0 +1,152 @@
+//go:build e2e
+
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package diagnostics
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/kube"
+)
+
+// fakeKubectl stands in for the kubectl binary — the outermost boundary — so
+// the Collector and kube.Client underneath it run for real.
+//
+// It reproduces the two behaviours that matter here:
+//   - asked for a multi-container pod's logs WITHOUT --all-containers, kubectl
+//     silently picks the default container and says so (issue #562);
+//   - asked for --previous when no previous instance exists, it fails.
+//
+// Restart counts follow the requested namespace so one stub covers both sides
+// of the gate.
+// Every invocation is appended to $FAKE_KUBECTL_LOG so a test can assert on the
+// calls that were NOT made — the restart gate is otherwise invisible, because
+// tolerating the error produces the same files as never asking.
+const fakeKubectl = `
+echo "$*" >> "${FAKE_KUBECTL_LOG:-/dev/null}"
+case "$*" in
+  *" logs "*)
+    all=""; prev=""
+    for arg in "$@"; do
+      case "$arg" in
+        --all-containers=true) all=1 ;;
+        --previous) prev=1 ;;
+      esac
+    done
+    case "$*" in *" -n healthy "*) restarted="" ;; *) restarted=1 ;; esac
+    if [ -n "$prev" ] && [ -z "$restarted" ]; then
+      echo 'error: previous terminated container "sidecar" not found' >&2
+      exit 1
+    fi
+    if [ -z "$all" ]; then
+      echo 'Defaulted container "nvml-mock" out of: nvml-mock, sidecar'
+      echo "[nvml-mock] mock ready"
+      exit 0
+    fi
+    if [ -n "$prev" ]; then
+      echo "[sidecar] dial /var/lib/kubelet/pod-resources: connection refused"
+    else
+      echo "[nvml-mock] mock ready"
+      echo "[sidecar] watch-allocations: 8 GPUs, polling"
+    fi
+    ;;
+  *)
+    case "$*" in *" -n healthy "*) n=0 ;; *) n=3 ;; esac
+    echo "{\"items\": [{\"metadata\": {\"name\": \"nvml-mock-abcde\"}, \"status\": {\"phase\": \"Running\", \"containerStatuses\": [{\"name\": \"nvml-mock\", \"restartCount\": 0}, {\"name\": \"sidecar\", \"restartCount\": $n}]}}]}"
+    ;;
+esac
+`
+
+// newCollector returns a Collector wired to the stub kubectl, plus the path of
+// the file recording every kubectl invocation it makes.
+func newCollector(t *testing.T) (*Collector, string) {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "kubectl")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"+fakeKubectl), 0o755); err != nil {
+		t.Fatalf("write fake kubectl: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	calls := filepath.Join(dir, "calls.log")
+	t.Setenv("FAKE_KUBECTL_LOG", calls)
+
+	k, err := kube.New("kind-nvml-mock-e2e")
+	if err != nil {
+		t.Fatalf("kube.New: %v", err)
+	}
+	return &Collector{Dir: filepath.Join(t.TempDir(), "artifacts"), Kube: k}, calls
+}
+
+func read(t *testing.T, c *Collector, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(c.Dir, name))
+	if err != nil {
+		t.Fatalf("read collected %s: %v", name, err)
+	}
+	return string(b)
+}
+
+// The defect: the dump held only the default container, so a sidecar failure
+// was invisible in CI. Assert the collected FILE carries both containers.
+func TestPodLogsCollectsEverySidecarContainer(t *testing.T) {
+	c, _ := newCollector(t)
+
+	c.PodLogs(context.Background(), "nvml-mock", "gpu-operator", "app.kubernetes.io/name=nvml-mock", 100)
+
+	got := read(t, c, "nvml-mock-logs.txt")
+	for _, want := range []string{
+		"[nvml-mock] mock ready",
+		"[sidecar] watch-allocations: 8 GPUs, polling",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("collected logs missing %q, got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "Defaulted container") {
+		t.Fatalf("kubectl defaulted to one container instead of collecting all, got:\n%s", got)
+	}
+}
+
+// A restarted container is the only case where --previous can succeed, and it
+// is where a crash loop's cause lives.
+func TestPodLogsCollectsPreviousInstanceAfterARestart(t *testing.T) {
+	c, _ := newCollector(t)
+
+	c.PodLogs(context.Background(), "nvml-mock", "gpu-operator", "app.kubernetes.io/name=nvml-mock", 100)
+
+	got := read(t, c, "nvml-mock-logs-previous.txt")
+	if want := "[sidecar] dial /var/lib/kubelet/pod-resources: connection refused"; !strings.Contains(got, want) {
+		t.Fatalf("previous-instance logs missing %q, got:\n%s", want, got)
+	}
+}
+
+// The trap: `kubectl logs --previous` errors when no previous instance exists,
+// which is the normal case. The healthy path must not ask for it, and must
+// still produce the current-log dump.
+func TestPodLogsSkipsPreviousInstanceOnHealthyPods(t *testing.T) {
+	c, calls := newCollector(t)
+
+	c.PodLogs(context.Background(), "nvml-mock", "healthy", "app.kubernetes.io/name=nvml-mock", 100)
+
+	if got := read(t, c, "nvml-mock-logs.txt"); !strings.Contains(got, "[sidecar] watch-allocations") {
+		t.Fatalf("healthy-pod dump lost the sidecar, got:\n%s", got)
+	}
+	if _, err := os.Stat(filepath.Join(c.Dir, "nvml-mock-logs-previous.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected no previous-instance dump for a pod that never restarted (stat err: %v)", err)
+	}
+	// The gate itself: asking at all would have failed the request. Tolerating
+	// that error yields the same files, so assert on the call that was skipped.
+	made, err := os.ReadFile(calls)
+	if err != nil {
+		t.Fatalf("read kubectl call log: %v", err)
+	}
+	if strings.Contains(string(made), "--previous") {
+		t.Fatalf("expected no --previous request for a pod that never restarted, kubectl calls were:\n%s", made)
+	}
+}

--- a/tests/e2e/go/framework/kube/kube.go
+++ b/tests/e2e/go/framework/kube/kube.go
@@ -93,15 +93,35 @@ type nodeObj struct {
 	} `json:"status"`
 }
 
+type containerStatus struct {
+	Name         string `json:"name"`
+	RestartCount int    `json:"restartCount"`
+}
+
 type podObj struct {
 	Metadata objectMeta `json:"metadata"`
 	Spec     struct {
 		NodeName string `json:"nodeName"`
 	} `json:"spec"`
 	Status struct {
-		Phase string `json:"phase"`
-		PodIP string `json:"podIP"`
+		Phase                 string            `json:"phase"`
+		PodIP                 string            `json:"podIP"`
+		ContainerStatuses     []containerStatus `json:"containerStatuses"`
+		InitContainerStatuses []containerStatus `json:"initContainerStatuses"`
 	} `json:"status"`
+}
+
+// restarted reports whether any container of the pod has been restarted, which
+// is the precondition for `kubectl logs --previous` having anything to return.
+func (p podObj) restarted() bool {
+	for _, group := range [][]containerStatus{p.Status.InitContainerStatuses, p.Status.ContainerStatuses} {
+		for _, cs := range group {
+			if cs.RestartCount > 0 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 type configMapObj struct {
@@ -424,10 +444,62 @@ func (c *Client) DescribePod(ctx context.Context, ns, name string) (string, erro
 	return res.Combined(), err
 }
 
-// Logs returns pod logs for a label selector (best-effort diagnostics).
+// logsArgs builds the `kubectl logs` argv for a label selector.
+//
+// --all-containers is unconditional. Without it kubectl silently picks a
+// multi-container pod's default container and prints `Defaulted container "x"
+// out of: x, y`, so every sidecar's output is lost from the diagnostics dump.
+// The nvml-mock pod is multi-container whenever an optional feature is enabled,
+// and any sidecar added later inherits the same blind spot.
+//
+// --previous is opt-in: it errors when a container has no previous instance,
+// which is the normal case. See PreviousLogs.
+func logsArgs(ns, selector string, tail int, previous bool) []string {
+	args := []string{
+		"logs", "-n", ns,
+		"-l", selector,
+		"--all-containers=true", fmt.Sprintf("--tail=%d", tail),
+	}
+	if previous {
+		args = append(args, "--previous")
+	}
+	return args
+}
+
+// Logs returns current pod logs for a label selector, across every container of
+// every matching pod (best-effort diagnostics).
 func (c *Client) Logs(ctx context.Context, ns, selector string, tail int) (string, error) {
-	res, err := c.kubectl(ctx, "logs", "-n", ns, "-l", selector, fmt.Sprintf("--tail=%d", tail))
+	res, err := c.kubectl(ctx, logsArgs(ns, selector, tail, false)...)
 	return res.Combined(), err
+}
+
+// PreviousLogs returns the logs of the PREVIOUS instance of every container of
+// every matching pod — the only way to see why a container that is now
+// restarting died.
+//
+// Callers must gate this on RestartedPods: kubectl fails the request outright
+// when a container has no previous instance, so calling it unconditionally
+// turns a working diagnostic into a failing one on every healthy pod. Treat a
+// returned error as "no previous logs available", never as a spec failure.
+func (c *Client) PreviousLogs(ctx context.Context, ns, selector string, tail int) (string, error) {
+	res, err := c.kubectl(ctx, logsArgs(ns, selector, tail, true)...)
+	return res.Combined(), err
+}
+
+// RestartedPods returns the names of pods matching selector that have at least
+// one container with a non-zero restart count.
+func (c *Client) RestartedPods(ctx context.Context, ns, selector string) ([]string, error) {
+	var pl podList
+	if err := c.getJSON(ctx, &pl, "pods", "-n", ns, "-l", selector); err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, p := range pl.Items {
+		if p.restarted() {
+			out = append(out, p.Metadata.Name)
+		}
+	}
+	return out, nil
 }
 
 // KubectlCombined runs an arbitrary kubectl subcommand and returns combined

--- a/tests/e2e/go/framework/kube/kube_test.go
+++ b/tests/e2e/go/framework/kube/kube_test.go
@@ -5,7 +5,148 @@
 
 package kube
 
-import "testing"
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// installFakeKubectl puts a stub `kubectl` at the front of PATH for the rest of
+// the test. The framework shells out to kubectl by name, so this substitutes
+// the external binary — the outermost boundary — and leaves every layer inside
+// it (kube.Client, runner.Run) running for real.
+func installFakeKubectl(t *testing.T, script string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kubectl")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script), 0o755); err != nil {
+		t.Fatalf("write fake kubectl: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// multiContainerLogs reproduces the real kubectl behaviour behind issue #562:
+// asked for a multi-container pod's logs WITHOUT --all-containers, kubectl
+// silently picks the default container and prints a "Defaulted container"
+// notice; asked WITH it, every container's output appears.
+const multiContainerLogs = `
+all=""
+prev=""
+for arg in "$@"; do
+  case "$arg" in
+    --all-containers=true) all=1 ;;
+    --previous) prev=1 ;;
+  esac
+done
+if [ -n "$prev" ]; then echo "--- previous instance ---"; fi
+if [ -n "$all" ]; then
+  echo "[nvml-mock] mock ready"
+  echo "[sidecar] watch-allocations: 8 GPUs, polling"
+else
+  echo 'Defaulted container "nvml-mock" out of: nvml-mock, sidecar'
+  echo "[nvml-mock] mock ready"
+fi
+`
+
+func newTestClient(t *testing.T) *Client {
+	t.Helper()
+	c, err := New("kind-nvml-mock-e2e")
+	if err != nil {
+		t.Fatalf("New default kubeconfig client: %v", err)
+	}
+	return c
+}
+
+// The defect: a sidecar's output never reached the diagnostics dump, so a
+// watcher crash was invisible in CI. Assert on content from BOTH containers —
+// exit status alone cannot tell the two cases apart.
+func TestLogsCapturesEveryContainerNotJustTheDefault(t *testing.T) {
+	installFakeKubectl(t, multiContainerLogs)
+
+	out, err := newTestClient(t).Logs(context.Background(), "gpu-operator", "app.kubernetes.io/name=nvml-mock", 100)
+	if err != nil {
+		t.Fatalf("Logs: %v", err)
+	}
+
+	if !strings.Contains(out, "[sidecar] watch-allocations: 8 GPUs, polling") {
+		t.Fatalf("sidecar container output missing from collected logs, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[nvml-mock] mock ready") {
+		t.Fatalf("primary container output missing from collected logs, got:\n%s", out)
+	}
+	if strings.Contains(out, "Defaulted container") {
+		t.Fatalf("kubectl defaulted to one container instead of collecting all, got:\n%s", out)
+	}
+}
+
+func TestLogsArgsRequestAllContainersAndNotPreviousInstance(t *testing.T) {
+	got := logsArgs("gpu-operator", "app.kubernetes.io/name=nvml-mock", 100, false)
+
+	want := []string{
+		"logs", "-n", "gpu-operator",
+		"-l", "app.kubernetes.io/name=nvml-mock",
+		"--all-containers=true", "--tail=100",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected kubectl logs args %#v, got %#v", want, got)
+	}
+}
+
+// `kubectl logs --previous` errors when a container has no previous instance,
+// which is the normal case. Adding it unconditionally would turn a working
+// diagnostic into a failing one on every healthy pod.
+func TestPreviousLogsArgsAskForPreviousInstance(t *testing.T) {
+	got := logsArgs("gpu-operator", "app.kubernetes.io/name=nvml-mock", 100, true)
+
+	want := []string{
+		"logs", "-n", "gpu-operator",
+		"-l", "app.kubernetes.io/name=nvml-mock",
+		"--all-containers=true", "--tail=100", "--previous",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected kubectl logs args %#v, got %#v", want, got)
+	}
+}
+
+// podsJSON serves a two-container pod whose restart counts depend on the
+// requested namespace, so one fake covers both sides of the gate.
+const podsJSON = `
+ns=""
+next=""
+for arg in "$@"; do
+  if [ "$next" = "1" ]; then ns="$arg"; next=""; fi
+  if [ "$arg" = "-n" ]; then next=1; fi
+done
+if [ "$ns" = "restarted" ]; then counts='0, "x": 0}, {"name": "sidecar", "restartCount": 3'; else counts='0, "x": 0}, {"name": "sidecar", "restartCount": 0'; fi
+cat <<EOF
+{"items": [{"metadata": {"name": "nvml-mock-abcde"},
+ "status": {"phase": "Running", "containerStatuses": [{"name": "nvml-mock", "restartCount": $counts}]}}]}
+EOF
+`
+
+func TestRestartedPodsGatesOnRestartCount(t *testing.T) {
+	installFakeKubectl(t, podsJSON)
+	c := newTestClient(t)
+
+	restarted, err := c.RestartedPods(context.Background(), "restarted", "app.kubernetes.io/name=nvml-mock")
+	if err != nil {
+		t.Fatalf("RestartedPods on a restarted pod: %v", err)
+	}
+	if !reflect.DeepEqual(restarted, []string{"nvml-mock-abcde"}) {
+		t.Fatalf("expected the restarted pod to be reported, got %#v", restarted)
+	}
+
+	healthy, err := c.RestartedPods(context.Background(), "healthy", "app.kubernetes.io/name=nvml-mock")
+	if err != nil {
+		t.Fatalf("RestartedPods on a healthy pod: %v", err)
+	}
+	if len(healthy) != 0 {
+		t.Fatalf("expected no pods reported when nothing restarted, got %#v", healthy)
+	}
+}
 
 func TestBaseUsesDefaultKubeconfigWhenUnset(t *testing.T) {
 	c, err := New("kind-nvml-mock-e2e")


### PR DESCRIPTION
## Problem

`kubectl logs -l <selector>` without `--all-containers` silently picks a multi-container pod's default container:

```
Defaulted container "nvml-mock" out of: nvml-mock, allocation-watcher
```

So the `allocation-watcher` sidecar (#559) produced **zero** output in CI diagnostics. Debugging a real failure on 2026-07-30 gave no sidecar lines, no `watch-allocations:` banner, and five copies of that notice — the cause had to be inferred from a pod scheduling event.

Closes #562.

## Approach

Fixed the collection primitive, not the watcher. `kube.Logs` now always passes `--all-containers=true`, so both of its callers benefit and any sidecar added later is covered. Nothing in the fix names `allocation-watcher`.

`--previous` is the trap in this issue: it **errors** when a container has no previous instance, which is the normal case, so adding it unconditionally would turn a working diagnostic into a failing one on every healthy pod. The new `Collector.PodLogs` gates it on an observed `restartCount > 0` and still tolerates failure on top of that gate — a pod where only one of several containers restarted can fail the request even though the gate passed. On a restart it writes `<name>-logs-previous.txt`, where a crash loop's cause actually lives.

## Also here, and why

The framework's own unit tests sit behind the `e2e` build tag. The untagged CI unit-test run never matched them (`go list ./...` does not even return those packages) and `make e2e` targets the Ginkgo suite package `./tests/e2e/go`, not `./tests/e2e/go/...`. They compiled for nobody — which is how this path rotted unnoticed. This adds `make test-e2e-framework` and a CI step, resurrecting six test files that were already dead weight.

## Testing done

New tests substitute a stub `kubectl` on PATH — the outermost boundary — so `Collector`, `kube.Client` and `runner` all run for real. They assert on collected **content from both containers**, not on exit status.

Mutation-checked, 6 mutants, each turning the intended test red:

| Mutant | Result |
|---|---|
| drop `--all-containers=true` (kube) | red: `sidecar container output missing` |
| always append `--previous` | red: argv assertion |
| `restarted()` always true | red: healthy pod reported |
| drop `--all-containers=true` (diagnostics) | red: reproduces the `Defaulted container` notice |
| remove the restart gate | red: unexpected `--previous` request |
| never collect previous logs | red: missing previous dump |

Gates: `go test -race ./...` exit 0 · `golangci-lint run ./...` 0 issues · `helm unittest` 147/147 · `go vet` (tagged and untagged) exit 0 · `make e2e-nri` (`allocationWatcher.enabled=true`) **18 Passed | 0 Failed**.

End-to-end evidence — the artifact collected by this code on a real cluster of 5 two-container pods:

| marker | before | after |
|---|---|---|
| `Defaulted container` | 5 | 0 |
| `watch-allocations:` (sidecar) | 0 | 5 |

No previous-instance dump was written, which is correct: nothing had restarted.

## Breaking changes

None. `kube.Logs` keeps its signature.