### PR TITLE
fix(helm): match fake-gpu-operator's profile discovery contract (#507)

### DIFF
--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -477,22 +477,24 @@ helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set integrations.fakeGpuOperator.enabled=true
 ```
 
-This creates per-profile ConfigMaps discoverable by fake-gpu-operator:
+This creates per-profile ConfigMaps in the shape fake-gpu-operator's loader reads:
 
 ```bash
-kubectl get cm -l run.ai/gpu-profile=true
+kubectl get cm -l fake-gpu-operator/gpu-profile=true
 ```
 
 ```
 NAME                              DATA   AGE
-nvml-mock-profile-a100            1      10s
-nvml-mock-profile-h100            1      10s
-nvml-mock-profile-b200            1      10s
-nvml-mock-profile-gb200           1      10s
-nvml-mock-profile-gb300           1      10s
-nvml-mock-profile-l40s            1      10s
-nvml-mock-profile-t4              1      10s
+gpu-profile-a100                  1      10s
+gpu-profile-h100                  1      10s
+gpu-profile-b200                  1      10s
+gpu-profile-gb200                 1      10s
+gpu-profile-gb300                 1      10s
+gpu-profile-l40s                  1      10s
+gpu-profile-t4                    1      10s
 ```
+
+FGO loads these by name from its own namespace, so set `integrations.fakeGpuOperator.targetNamespace` to FGO's release namespace for them to be found. That requires FGO's `builtinProfiles.enabled=false`, because their builtin set uses the same seven names. See the [integration guide](../../../../docs/integrations/fake-gpu-operator.md).
 
 ### Custom Labels
 
@@ -920,8 +922,9 @@ namespace, on the pod IP where the kubelet reaches it.
 | `tolerations` | `[{operator: Exists}]` | Pod tolerations (default: tolerate all) |
 | `nodeLabels.pciVendorPresent` | `true` | Write the NFD feature file that makes `feature.node.kubernetes.io/pci-10de.present=true` appear. The label is created by NFD, not by nvml-mock. Set to `false` when something else already supplies that key. See [Node Labels](#node-labels) |
 | `nodeLabels.featuresDir` | `/etc/kubernetes/node-feature-discovery/features.d` | Host directory NFD's local source reads feature files from. Override only if NFD runs with a non-default `featureFilesDir` |
-| `integrations.fakeGpuOperator.enabled` | `false` | Create per-profile ConfigMaps for fake-gpu-operator discovery |
-| `integrations.fakeGpuOperator.profileLabels` | `{"run.ai/gpu-profile": "true"}` | Labels on profile ConfigMaps for discovery |
+| `integrations.fakeGpuOperator.enabled` | `false` | Create per-profile ConfigMaps named `gpu-profile-<profile>`, keyed `profile.yaml`, in the shape fake-gpu-operator's loader reads |
+| `integrations.fakeGpuOperator.targetNamespace` | `""` (release namespace) | Namespace for the profile ConfigMaps. Set to FGO's release namespace for FGO to find them; requires FGO's `builtinProfiles.enabled=false` to avoid a Helm ownership collision on the same seven names |
+| `integrations.fakeGpuOperator.profileLabels` | `{"run.ai/gpu-profile": "true"}` | Extra labels on profile ConfigMaps. The contract labels `fake-gpu-operator/gpu-profile` and `nvml-mock/profile-name` are always emitted and cannot be removed here |
 | `infiniband.mockTier` | `""` (auto) | `MOCK_IB` tier: `off`, `sysfs`, or `full`. Empty auto-derives `full` for IB-enabled profiles and `sysfs` otherwise (keeps the `libibmocksys` redirect active so any real host IB is masked). `off` makes every shim a no-op and skips the daemon. An invalid value fails `helm template` |
 | `infiniband.ping.port` | `18515` | TCP port for fabric relay between nvml-mock pods (`mock-ib` / `ibping` always enabled) |
 | `infiniband.ping.networkPolicy.enabled` | `true` | Restrict inbound access to the fabric port to peer nvml-mock pods. No-op on CNIs that don't enforce NetworkPolicy (e.g. Kind's kindnet) |

--- a/deployments/nvml-mock/helm/nvml-mock/templates/integrations-fgo.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/integrations-fgo.yaml
@@ -1,7 +1,15 @@
 # Copyright 2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
+#
+# Profile ConfigMaps shaped for the fake-gpu-operator (FGO) loader. FGO reads
+# them with a direct `ConfigMaps(ns).Get("gpu-profile-" + name)` followed by a
+# read of the `profile.yaml` data key, so the name, the data key and the
+# namespace must each match exactly; a label selector is never used on that
+# path. See docs/integrations/fake-gpu-operator.md for the tested version pair
+# and for the builtinProfiles prerequisite that targetNamespace implies.
 {{- if .Values.integrations.fakeGpuOperator.enabled }}
 {{- $profiles := list "a100" "h100" "b200" "gb200" "gb300" "l40s" "t4" }}
+{{- $targetNS := default $.Release.Namespace $.Values.integrations.fakeGpuOperator.targetNamespace }}
 {{- range $profile := $profiles }}
 {{- $content := $.Files.Get (printf "profiles/%s.yaml" $profile) }}
 {{- if $content }}
@@ -9,15 +17,19 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "nvml-mock.fullname" $ }}-profile-{{ $profile }}
+  name: gpu-profile-{{ $profile }}
+  namespace: {{ $targetNS }}
   labels:
     {{- include "nvml-mock.labels" $ | nindent 4 }}
     nvml-mock/profile-name: {{ $profile | quote }}
+    # FGO's own LabelGpuProfile constant. Emitted unconditionally rather than
+    # through profileLabels so a profileLabels override cannot drop it.
+    fake-gpu-operator/gpu-profile: "true"
     {{- range $key, $value := $.Values.integrations.fakeGpuOperator.profileLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 data:
-  config.yaml: |
+  profile.yaml: |
     {{- $content | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/deployments/nvml-mock/helm/nvml-mock/tests/integrations_fgo_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/integrations_fgo_test.yaml
@@ -1,0 +1,146 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# The fake-gpu-operator (FGO) reads profile ConfigMaps with a direct
+# `ConfigMaps(ns).Get("gpu-profile-" + name)` and then reads the
+# `profile.yaml` data key — see internal/common/profile/profile.go:25,32 and
+# internal/common/profile/constants.go in run-ai/fake-gpu-operator. Name,
+# data key and namespace are each independently fatal to that lookup, so each
+# is asserted separately below rather than through a document count.
+suite: fake-gpu-operator integration profile ConfigMaps
+templates:
+  - templates/integrations-fgo.yaml
+tests:
+  - it: should not render when the integration is disabled (the default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render one ConfigMap per shipped profile when enabled
+    set:
+      integrations:
+        fakeGpuOperator:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 7
+
+  # FGO's CmNamePrefix. A Get by exact name means any other prefix is a
+  # NotFound, so the name is asserted literally rather than by pattern.
+  - it: should name ConfigMaps with FGO's gpu-profile- prefix
+    set:
+      integrations:
+        fakeGpuOperator:
+          enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: gpu-profile-a100
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: gpu-profile-h100
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: gpu-profile-t4
+        documentIndex: 6
+
+  # FGO's CmProfileKey. Load() errors with "missing key" on anything else.
+  - it: should key profile data under profile.yaml, not config.yaml
+    set:
+      integrations:
+        fakeGpuOperator:
+          enabled: true
+    asserts:
+      - exists:
+          path: data["profile.yaml"]
+        documentIndex: 0
+      - notExists:
+          path: data["config.yaml"]
+        documentIndex: 0
+      - matchRegex:
+          path: data["profile.yaml"]
+          pattern: "version:"
+        documentIndex: 0
+
+  - it: should carry FGO's declared discovery label
+    set:
+      integrations:
+        fakeGpuOperator:
+          enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels["fake-gpu-operator/gpu-profile"]
+          value: "true"
+        documentIndex: 0
+
+  # run.ai/gpu-profile predates the retarget and is what the demo, docs and
+  # e2e select on. Keep emitting it so those consumers survive the change.
+  - it: should keep emitting the pre-existing run.ai discovery label
+    set:
+      integrations:
+        fakeGpuOperator:
+          enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels["run.ai/gpu-profile"]
+          value: "true"
+        documentIndex: 0
+      - equal:
+          path: metadata.labels["nvml-mock/profile-name"]
+          value: a100
+        documentIndex: 0
+
+  # profileLabels is user-overridable; the contract label must not be
+  # reachable through it, or an override silently breaks discovery.
+  - it: should keep the contract label when profileLabels is overridden
+    set:
+      integrations:
+        fakeGpuOperator:
+          enabled: true
+          profileLabels:
+            my-org/custom-label: gpu-sim
+    asserts:
+      - equal:
+          path: metadata.labels["fake-gpu-operator/gpu-profile"]
+          value: "true"
+        documentIndex: 0
+      - equal:
+          path: metadata.labels["my-org/custom-label"]
+          value: gpu-sim
+        documentIndex: 0
+
+  # Namespace is the fourth, unlisted mismatch in issue #507: FGO reads its
+  # own release namespace via FAKE_GPU_OPERATOR_NAMESPACE, so the ConfigMaps
+  # must be placeable there.
+  - it: should default the ConfigMap namespace to the release namespace
+    release:
+      namespace: nvml-mock-system
+    set:
+      integrations:
+        fakeGpuOperator:
+          enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: nvml-mock-system
+        documentIndex: 0
+
+  - it: should place ConfigMaps in targetNamespace when set
+    release:
+      namespace: nvml-mock-system
+    set:
+      integrations:
+        fakeGpuOperator:
+          enabled: true
+          targetNamespace: gpu-operator
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: gpu-operator
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: gpu-operator
+        documentIndex: 6

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -359,6 +359,16 @@ fabricmanager:
 integrations:
   fakeGpuOperator:
     enabled: false
-    # Labels applied to per-profile ConfigMaps for discovery
+    # Namespace for the profile ConfigMaps. Empty means the release namespace.
+    # fake-gpu-operator loads profiles from its OWN release namespace, so set
+    # this to that namespace (their README installs into `gpu-operator`) for
+    # the ConfigMaps to be readable. Doing so requires FGO's
+    # `builtinProfiles.enabled=false`, because their builtin set uses the same
+    # seven names and is owned by their Helm release. See
+    # docs/integrations/fake-gpu-operator.md.
+    targetNamespace: ""
+    # Extra labels applied to per-profile ConfigMaps. The contract labels
+    # `fake-gpu-operator/gpu-profile` and `nvml-mock/profile-name` are always
+    # emitted by the template and cannot be removed through this map.
     profileLabels:
       run.ai/gpu-profile: "true"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -400,8 +400,9 @@ When deploying via Helm, additional values control integration with external pro
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `integrations.fakeGpuOperator.enabled` | `false` | Create per-profile ConfigMaps for fake-gpu-operator discovery |
-| `integrations.fakeGpuOperator.profileLabels` | `run.ai/gpu-profile: "true"` | Discovery labels on profile ConfigMaps |
+| `integrations.fakeGpuOperator.enabled` | `false` | Create per-profile ConfigMaps named `gpu-profile-<profile>`, keyed `profile.yaml`, in the shape fake-gpu-operator's loader reads |
+| `integrations.fakeGpuOperator.targetNamespace` | `""` (release namespace) | Namespace for the profile ConfigMaps. Set to FGO's release namespace for FGO to find them; requires FGO's `builtinProfiles.enabled=false` |
+| `integrations.fakeGpuOperator.profileLabels` | `run.ai/gpu-profile: "true"` | Extra labels on profile ConfigMaps. The contract labels are always emitted |
 
 See [fake-gpu-operator integration](integrations/fake-gpu-operator.md) for setup details.
 

--- a/docs/integrations/fake-gpu-operator.md
+++ b/docs/integrations/fake-gpu-operator.md
@@ -56,6 +56,26 @@ Together, they enable **mixed clusters** where a small set of real nodes run nvm
 +-----------------------------------------------------------------------+
 ```
 
+## Tested Versions
+
+The discovery contract in this guide was derived on 2026-07-31 from these two trees. FGO is neither vendored nor pinned by this repository, so re-check their loader before you rely on any of it.
+
+| Side | Ref | Date |
+|---|---|---|
+| `run-ai/fake-gpu-operator` | `main` @ `cf586f41` | 2026-07-28 |
+| `NVIDIA/k8s-test-infra` | `main` @ `e9106453` | 2026-07-31 |
+
+What was verified against which:
+
+- **The contract fields** (`gpu-profile-<name>`, `profile.yaml`, the namespace env var) were read from FGO's loader source at `cf586f41`. FGO itself was not run.
+- **The emitted shape** was verified against `e9106453` by Helm render, by the `integrations_fgo_test.yaml` unit suite, and by the `fgo`-labelled end-to-end case on a live kind cluster.
+- **A live FGO-plus-nvml-mock interop run was not performed.** The two sides have not been exercised together in CI.
+
+Two known gaps on FGO's side, both current as of `cf586f41`:
+
+- FGO pins this project's image to `ghcr.io/nvidia/nvml-mock:sha-1706195`, with a comment that the v0.2.0 build broke their `e2e-mock` on `libnvidia-ml.so` loading. That report is not filed on this side.
+- FGO vendors this repository's GPU profiles into its chart from commit `497fa04` (2026-05-25), which is 78 commits behind `e9106453`. All seven profile files have changed since that pin.
+
 ## Setup
 
 ### Prerequisites
@@ -67,12 +87,14 @@ Together, they enable **mixed clusters** where a small set of real nodes run nvm
 
 ### Step 1: Install nvml-mock with FGO Integration
 
-Enable the FGO integration flag when installing the Helm chart. This creates GPU profile ConfigMaps that FGO can discover and use for its topology.
+Enable the FGO integration flag when installing the Helm chart. This creates GPU profile ConfigMaps in the shape FGO's loader reads.
 
 ```bash
 helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set integrations.fakeGpuOperator.enabled=true
 ```
+
+The ConfigMaps land in the nvml-mock release namespace by default. FGO loads profiles from its own namespace, so see [Targeting FGO's namespace](#targeting-fgos-namespace) before you rely on FGO reading them.
 
 ### Step 2: Configure FGO Topology
 
@@ -117,29 +139,54 @@ MODEL:.metadata.labels.nvidia\.com/gpu\.product
 
 ## GPU Profile Discovery
 
-When `integrations.fakeGpuOperator.enabled=true` is set, the Helm chart creates ConfigMaps labeled with `run.ai/gpu-profile=true`. FGO watches for these ConfigMaps and uses them to populate its topology with accurate GPU specifications.
+When `integrations.fakeGpuOperator.enabled=true` is set, the Helm chart creates one profile ConfigMap per shipped GPU profile.
 
-List discovered profiles:
+FGO does not watch for these ConfigMaps and does not select them by label. Its loader (`internal/common/profile/profile.go`) does a direct `Get` by name and then reads one data key. Three fields must therefore match exactly, and each one is fatal on its own:
+
+| Field | Value | Why it matters |
+|---|---|---|
+| Name | `gpu-profile-<profile>` | The loader builds this literal from `CmNamePrefix`. Any other name is a `NotFound`. |
+| Data key | `profile.yaml` | Read from `CmProfileKey`. A different key is a "missing key" error. |
+| Namespace | FGO's own release namespace | Read from `FAKE_GPU_OPERATOR_NAMESPACE`. The loader has no cross-namespace fallback. |
+
+The chart also emits `fake-gpu-operator/gpu-profile: "true"`, which is FGO's published discovery label, and keeps `run.ai/gpu-profile: "true"` for the demo scripts and examples in this repository. Neither label is on FGO's load path today.
+
+List the profile ConfigMaps:
 
 ```bash
-kubectl get cm -l run.ai/gpu-profile=true
+kubectl get cm -l fake-gpu-operator/gpu-profile=true
 ```
 
 The following profiles are created by default:
 
 | ConfigMap Name | GPU Model | Memory |
 |---|---|---|
-| `nvml-mock-profile-a100` | NVIDIA A100-SXM4-40GB | 40 GiB |
-| `nvml-mock-profile-h100` | NVIDIA H100 80GB HBM3 | 80 GiB |
-| `nvml-mock-profile-b200` | NVIDIA B200 | 192 GiB |
-| `nvml-mock-profile-gb200` | NVIDIA GB200 NVL | 192 GiB |
-| `nvml-mock-profile-gb300` | NVIDIA GB300 NVL | 288 GiB |
-| `nvml-mock-profile-l40s` | NVIDIA L40S | 48 GiB |
-| `nvml-mock-profile-t4` | NVIDIA T4 | 16 GiB |
+| `gpu-profile-a100` | NVIDIA A100-SXM4-40GB | 40 GiB |
+| `gpu-profile-h100` | NVIDIA H100 80GB HBM3 | 80 GiB |
+| `gpu-profile-b200` | NVIDIA B200 | 192 GiB |
+| `gpu-profile-gb200` | NVIDIA GB200 NVL | 192 GiB |
+| `gpu-profile-gb300` | NVIDIA GB300 NVL | 288 GiB |
+| `gpu-profile-l40s` | NVIDIA L40S | 48 GiB |
+| `gpu-profile-t4` | NVIDIA T4 | 16 GiB |
+
+These names carry no release prefix, because FGO's `Get` is for that literal name. Two nvml-mock releases in one namespace therefore collide on these seven ConfigMaps. Enable the integration on one release per namespace, or give each release its own `targetNamespace`.
+
+### Targeting FGO's namespace
+
+By default the ConfigMaps land in the nvml-mock release namespace, where FGO's loader does not look. To make them loadable, point them at FGO's release namespace:
+
+```yaml
+integrations:
+  fakeGpuOperator:
+    enabled: true
+    targetNamespace: gpu-operator
+```
+
+**Warning: set FGO's `builtinProfiles.enabled=false` before you do this.** FGO ships its own builtin profiles under the same seven names, owned by its own Helm release. Helm 3 refuses to adopt resources owned by another release, so whichever chart installs second fails with an `invalid ownership metadata` error. The two profile sets are alternatives, not complements.
 
 ## Custom Labels
 
-You can override the labels applied to profile ConfigMaps to match your FGO topology requirements:
+`profileLabels` adds labels to the profile ConfigMaps. It cannot remove the contract labels `fake-gpu-operator/gpu-profile` and `nvml-mock/profile-name`, which the template always emits, so an override here cannot break discovery:
 
 ```yaml
 # values.yaml
@@ -184,13 +231,25 @@ helm upgrade nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
 
 ### FGO Does Not Pick Up Profiles
 
-Ensure the ConfigMaps have the correct label that FGO watches for:
+FGO looks up profiles by name in its own namespace, so check the name and the namespace, not the label. Substitute FGO's release namespace and the profile you referenced in the topology:
 
 ```bash
-kubectl get cm -l run.ai/gpu-profile=true -o name
+kubectl get cm gpu-profile-a100 -n gpu-operator -o name
 ```
 
-If ConfigMaps exist but FGO is not using them, check that FGO is configured to read profiles from the same namespace where nvml-mock is installed. Restart the FGO controller pod after correcting the namespace configuration:
+A `NotFound` here means one of three things:
+
+- The ConfigMaps are still in the nvml-mock release namespace. Set `integrations.fakeGpuOperator.targetNamespace` to FGO's release namespace.
+- The name is wrong. FGO reads `gpu-profile-<profile>` exactly.
+- The install failed with an ownership error. FGO's own builtin profiles use the same names; set FGO's `builtinProfiles.enabled=false`.
+
+If the ConfigMap exists under the right name and namespace, confirm the body is under the `profile.yaml` key:
+
+```bash
+kubectl get cm gpu-profile-a100 -n gpu-operator -o jsonpath='{.data.profile\.yaml}' | head -5
+```
+
+Restart the FGO controller pod after correcting any of the above:
 
 ```bash
 kubectl rollout restart deployment fake-gpu-operator -n gpu-operator

--- a/local/fgo/nvml-mock.values.yaml
+++ b/local/fgo/nvml-mock.values.yaml
@@ -2,8 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # nvml-mock overlay for FGO integration.
-# Pins nvml-mock to the integration node pool and enables per-profile
-# ConfigMaps that FGO uses to discover GPU profiles (label: run.ai/gpu-profile=true).
+# Pins nvml-mock to the integration node pool and enables the per-profile
+# ConfigMaps shaped for FGO's loader (name gpu-profile-<profile>, data key
+# profile.yaml). They stay in this release's namespace; set targetNamespace to
+# FGO's release namespace for FGO to load them, which needs FGO's
+# builtinProfiles.enabled=false. See docs/integrations/fake-gpu-operator.md.
 
 integrations:
   fakeGpuOperator:

--- a/tests/e2e/go/assertions/configmaps.go
+++ b/tests/e2e/go/assertions/configmaps.go
@@ -8,6 +8,7 @@ package assertions
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -15,15 +16,34 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/kube"
 )
 
-// ProfileConfigMaps ports the demo's "Profile ConfigMaps" step: when the fake
-// GPU operator integration is enabled the chart renders one per-profile
-// ConfigMap (labeled run.ai/gpu-profile=true) for fake-gpu-operator discovery.
-// The demo asserts at least `atLeast` (6); the chart ships 7.
-func ProfileConfigMaps(ctx context.Context, k *kube.Client, ns, selector string, atLeast int) {
+// FGOProfileConfigMaps asserts that every named profile is published in the
+// shape the fake-gpu-operator's loader reads: a ConfigMap named
+// `gpu-profile-<profile>`, carrying `fake-gpu-operator/gpu-profile: "true"`,
+// with the profile body under the `profile.yaml` data key.
+//
+// Each ConfigMap is fetched by exact name, which is what makes the name half
+// of the contract testable: FGO does a Get, not a List by label, so a rename
+// is a NotFound rather than a smaller result set. The previous version of this
+// assertion counted ConfigMaps carrying a label we control and required only
+// 6 of the 7 — it could not fail on any of the three fields that govern
+// interop, and stayed green throughout the period the integration was broken.
+func FGOProfileConfigMaps(ctx context.Context, k *kube.Client, ns string, profiles []string) {
 	ginkgo.GinkgoHelper()
-	ginkgo.By(fmt.Sprintf("at least %d ConfigMaps labeled %q in %s", atLeast, selector, ns))
-	n, err := k.CountConfigMaps(ctx, ns, selector)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "counting profile ConfigMaps")
-	gomega.Expect(n).To(gomega.BeNumerically(">=", atLeast),
-		"expected >= %d profile ConfigMaps (%s), found %d", atLeast, selector, n)
+
+	gomega.Expect(profiles).NotTo(gomega.BeEmpty(),
+		"no profiles to assert; the contract check would be vacuous")
+
+	for _, p := range profiles {
+		name := FGOProfileConfigMapName(p)
+		ginkgo.By(fmt.Sprintf("%s/%s matches the fake-gpu-operator discovery contract", ns, name))
+
+		cm, err := k.GetConfigMap(ctx, ns, name)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+			"fake-gpu-operator loads profile %q with a Get on %q; that name must exist in %s", p, name, ns)
+
+		problems := DiffFGOProfileConfigMap(p, name, cm.Labels, cm.Data)
+		gomega.Expect(problems).To(gomega.BeEmpty(),
+			"ConfigMap %s/%s departs from the fake-gpu-operator contract:\n  %s",
+			ns, name, strings.Join(problems, "\n  "))
+	}
 }

--- a/tests/e2e/go/assertions/fgo_contract.go
+++ b/tests/e2e/go/assertions/fgo_contract.go
@@ -1,0 +1,62 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package assertions
+
+import "fmt"
+
+// This file carries no build tag on purpose, for the reason spelled out in
+// gfd_labels.go: the contract below needs nothing but the standard library, so
+// keeping it untagged is what makes its tests run in the regular
+// `go test ./...` job rather than only under -tags e2e. The cluster-facing
+// assertion that consumes it lives in configmaps.go.
+
+// The fake-gpu-operator's discovery contract, mirrored from
+// run-ai/fake-gpu-operator internal/common/profile/constants.go. Their loader
+// (internal/common/profile/profile.go) does
+// `ConfigMaps(ns).Get(CmNamePrefix + name)` and then reads `CmProfileKey`, so
+// the name and the data key are each independently fatal to the lookup. The
+// label is NOT on that code path — it is declared and used only by their own
+// chart and tests — but it is their published discovery label, so we emit and
+// assert it to keep the artifact self-describing.
+const (
+	FGOConfigMapNamePrefix = "gpu-profile-"
+	FGOProfileDataKey      = "profile.yaml"
+	FGODiscoveryLabel      = "fake-gpu-operator/gpu-profile"
+)
+
+// FGOProfileConfigMapName returns the ConfigMap name the fake-gpu-operator's
+// loader Gets for a profile. Built the same way their loader builds it.
+func FGOProfileConfigMapName(profile string) string {
+	return FGOConfigMapNamePrefix + profile
+}
+
+// DiffFGOProfileConfigMap reports every way a rendered ConfigMap departs from
+// the fake-gpu-operator's discovery contract. An empty result means it matches.
+//
+// Name, label and data key are checked separately and all problems are
+// returned, so a drift in one field cannot be masked by another field still
+// being correct.
+func DiffFGOProfileConfigMap(profile, name string, labels, data map[string]string) []string {
+	var problems []string
+
+	if want := FGOProfileConfigMapName(profile); name != want {
+		problems = append(problems, fmt.Sprintf("name is %q, want %q", name, want))
+	}
+
+	switch value, present := labels[FGODiscoveryLabel]; {
+	case !present || value == "":
+		problems = append(problems, fmt.Sprintf("label %s missing (want %q)", FGODiscoveryLabel, "true"))
+	case value != "true":
+		problems = append(problems, fmt.Sprintf("label %s = %q, want %q", FGODiscoveryLabel, value, "true"))
+	}
+
+	switch body, present := data[FGOProfileDataKey]; {
+	case !present:
+		problems = append(problems, fmt.Sprintf("data key %q missing", FGOProfileDataKey))
+	case body == "":
+		problems = append(problems, fmt.Sprintf("data key %q is empty", FGOProfileDataKey))
+	}
+
+	return problems
+}

--- a/tests/e2e/go/assertions/fgo_contract_test.go
+++ b/tests/e2e/go/assertions/fgo_contract_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package assertions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFGOProfileConfigMapNameUsesLoaderPrefix(t *testing.T) {
+	t.Parallel()
+
+	// The literal FGO's loader builds: CmNamePrefix + profileName.
+	assert.Equal(t, "gpu-profile-a100", FGOProfileConfigMapName("a100"))
+	assert.Equal(t, "gpu-profile-gb200", FGOProfileConfigMapName("gb200"))
+}
+
+// A conformant ConfigMap must produce no problems, or every negative case
+// below would pass for the wrong reason.
+func TestDiffFGOProfileConfigMapAcceptsAConformantConfigMap(t *testing.T) {
+	t.Parallel()
+
+	problems := DiffFGOProfileConfigMap(
+		"a100",
+		"gpu-profile-a100",
+		map[string]string{FGODiscoveryLabel: "true", "run.ai/gpu-profile": "true"},
+		map[string]string{FGOProfileDataKey: "version: \"1.0\"\n"},
+	)
+
+	assert.Empty(t, problems)
+}
+
+// Each of the three contract fields must be caught on its own. A single
+// combined check would let two of them drift undetected.
+func TestDiffFGOProfileConfigMapCatchesEachContractFieldIndependently(t *testing.T) {
+	t.Parallel()
+
+	conformantLabels := map[string]string{FGODiscoveryLabel: "true"}
+	conformantData := map[string]string{FGOProfileDataKey: "version: \"1.0\"\n"}
+
+	for _, tc := range []struct {
+		name    string
+		cmName  string
+		labels  map[string]string
+		data    map[string]string
+		wantSub string
+	}{
+		{
+			name:    "name carries the pre-retarget prefix",
+			cmName:  "nvml-mock-profile-a100",
+			labels:  conformantLabels,
+			data:    conformantData,
+			wantSub: `name is "nvml-mock-profile-a100", want "gpu-profile-a100"`,
+		},
+		{
+			name:    "discovery label absent",
+			cmName:  "gpu-profile-a100",
+			labels:  map[string]string{"run.ai/gpu-profile": "true"},
+			data:    conformantData,
+			wantSub: `label fake-gpu-operator/gpu-profile missing (want "true")`,
+		},
+		{
+			name:    "discovery label present with the wrong value",
+			cmName:  "gpu-profile-a100",
+			labels:  map[string]string{FGODiscoveryLabel: "false"},
+			data:    conformantData,
+			wantSub: `label fake-gpu-operator/gpu-profile = "false", want "true"`,
+		},
+		{
+			name:    "data keyed under the pre-retarget config.yaml",
+			cmName:  "gpu-profile-a100",
+			labels:  conformantLabels,
+			data:    map[string]string{"config.yaml": "version: \"1.0\"\n"},
+			wantSub: `data key "profile.yaml" missing`,
+		},
+		{
+			name:    "data key present but empty",
+			cmName:  "gpu-profile-a100",
+			labels:  conformantLabels,
+			data:    map[string]string{FGOProfileDataKey: ""},
+			wantSub: `data key "profile.yaml" is empty`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			problems := DiffFGOProfileConfigMap("a100", tc.cmName, tc.labels, tc.data)
+
+			require.Len(t, problems, 1, "expected exactly one problem, got %#v", problems)
+			assert.Equal(t, tc.wantSub, problems[0])
+		})
+	}
+}
+
+// Reporting only the first problem would hide the rest behind a fix-one-rerun
+// loop; a wholly wrong ConfigMap should show all three at once.
+func TestDiffFGOProfileConfigMapReportsEveryProblemAtOnce(t *testing.T) {
+	t.Parallel()
+
+	problems := DiffFGOProfileConfigMap(
+		"t4",
+		"nvml-mock-profile-t4",
+		map[string]string{"run.ai/gpu-profile": "true"},
+		map[string]string{"config.yaml": "version: \"1.0\"\n"},
+	)
+
+	assert.Len(t, problems, 3)
+}

--- a/tests/e2e/go/framework/kube/kube.go
+++ b/tests/e2e/go/framework/kube/kube.go
@@ -125,6 +125,9 @@ func (p podObj) restarted() bool {
 }
 
 type configMapObj struct {
+	Metadata struct {
+		Labels map[string]string `json:"labels"`
+	} `json:"metadata"`
 	Data map[string]string `json:"data"`
 }
 
@@ -285,16 +288,24 @@ func (c *Client) PodNode(ctx context.Context, ns, name string) (string, error) {
 	return p.Spec.NodeName, nil
 }
 
-// CountConfigMaps returns the number of ConfigMaps in ns matching the selector
-// (parity with the demo's `kubectl get cm -l run.ai/gpu-profile=true | wc -l`).
-func (c *Client) CountConfigMaps(ctx context.Context, ns, selector string) (int, error) {
-	var list struct {
-		Items []json.RawMessage `json:"items"`
+// ConfigMap is the subset of a ConfigMap the assertions need: the labels it
+// carries and its data keys. Fetched by exact name, the same way a consumer
+// doing a `Get` would see it — a List by label selector would not notice a
+// wrong name, which is one of the fields under test.
+type ConfigMap struct {
+	Labels map[string]string
+	Data   map[string]string
+}
+
+// GetConfigMap returns a single ConfigMap by exact name. The error surfaces
+// kubectl's own NotFound, so a caller can tell "wrong name" from "wrong
+// contents".
+func (c *Client) GetConfigMap(ctx context.Context, ns, name string) (*ConfigMap, error) {
+	var cm configMapObj
+	if err := c.getJSON(ctx, &cm, "configmap", "-n", ns, name); err != nil {
+		return nil, err
 	}
-	if err := c.getJSON(ctx, &list, "configmaps", "-n", ns, "-l", selector); err != nil {
-		return 0, err
-	}
-	return len(list.Items), nil
+	return &ConfigMap{Labels: cm.Metadata.Labels, Data: cm.Data}, nil
 }
 
 // ConfigMapData returns a single key from a ConfigMap's data field.

--- a/tests/e2e/go/framework/kube/kube_test.go
+++ b/tests/e2e/go/framework/kube/kube_test.go
@@ -148,6 +148,50 @@ func TestRestartedPodsGatesOnRestartCount(t *testing.T) {
 	}
 }
 
+// profileConfigMapJSON answers only for the exact name FGO's loader Gets, and
+// exits non-zero for anything else — the same way kubectl reports NotFound.
+// Without that branch a test asserting the name would pass against any name.
+const profileConfigMapJSON = `
+name=""
+for arg in "$@"; do name="$arg"; done
+if [ "$name" != "gpu-profile-a100" ]; then
+  echo "Error from server (NotFound): configmaps \"$name\" not found" >&2
+  exit 1
+fi
+cat <<EOF
+{"metadata": {"name": "gpu-profile-a100",
+  "labels": {"fake-gpu-operator/gpu-profile": "true", "run.ai/gpu-profile": "true"}},
+ "data": {"profile.yaml": "version: \"1.0\"\n"}}
+EOF
+`
+
+func TestGetConfigMapReturnsLabelsAndData(t *testing.T) {
+	installFakeKubectl(t, profileConfigMapJSON)
+
+	cm, err := newTestClient(t).GetConfigMap(context.Background(), "nvml-mock-system", "gpu-profile-a100")
+	if err != nil {
+		t.Fatalf("GetConfigMap: %v", err)
+	}
+
+	if got := cm.Labels["fake-gpu-operator/gpu-profile"]; got != "true" {
+		t.Fatalf("expected the FGO discovery label to be readable, got %q", got)
+	}
+	if got := cm.Data["profile.yaml"]; got != "version: \"1.0\"\n" {
+		t.Fatalf("expected the profile.yaml body to be readable, got %q", got)
+	}
+}
+
+// A wrong name must surface as an error rather than an empty ConfigMap, or the
+// name half of the contract check would silently pass.
+func TestGetConfigMapErrorsOnAMissingName(t *testing.T) {
+	installFakeKubectl(t, profileConfigMapJSON)
+
+	_, err := newTestClient(t).GetConfigMap(context.Background(), "nvml-mock-system", "nvml-mock-profile-a100")
+	if err == nil {
+		t.Fatal("expected an error for a ConfigMap name that does not exist, got nil")
+	}
+}
+
 func TestBaseUsesDefaultKubeconfigWhenUnset(t *testing.T) {
 	c, err := New("kind-nvml-mock-e2e")
 	if err != nil {

--- a/tests/e2e/go/scenario_standalone_test.go
+++ b/tests/e2e/go/scenario_standalone_test.go
@@ -21,11 +21,6 @@ import (
 const (
 	ibPingRetries    = 5
 	ibPingRetrySleep = 10 * time.Second
-
-	// fgoProfileSelector matches the per-profile ConfigMaps the fake GPU
-	// operator integration renders; the chart ships 7, demo asserts >= 6.
-	fgoProfileSelector  = "run.ai/gpu-profile=true"
-	fgoProfileConfigMin = 6
 )
 
 // Go port of docs/demo/standalone/demo.sh. ONE shared multi-node cluster is
@@ -68,8 +63,8 @@ var _ = Describe("nvml-mock standalone", Ordered, func() {
 				assertions.NodeLabelEquals(ctx, h.Kube, node, "nvidia.com/gpu.present", "true")
 			})
 
-			It("renders the fake-GPU-operator profile ConfigMaps", Label("fgo"), func(ctx SpecContext) {
-				assertions.ProfileConfigMaps(ctx, h.Kube, nvmlMockNamespace, fgoProfileSelector, fgoProfileConfigMin)
+			It("publishes profile ConfigMaps in the fake-GPU-operator's discovery shape", Label("fgo"), func(ctx SpecContext) {
+				assertions.FGOProfileConfigMaps(ctx, h.Kube, nvmlMockNamespace, profile.KnownProfiles)
 			})
 
 			It("lays out the mock driver files on the profile node", Label("mockfiles"), func(ctx SpecContext) {


### PR DESCRIPTION
## Problem

The `integrations.fakeGpuOperator` ConfigMaps have never been loadable by the fake-gpu-operator. Its loader ([`internal/common/profile/profile.go`](https://github.com/run-ai/fake-gpu-operator/blob/main/internal/common/profile/profile.go)) does a direct `ConfigMaps(ns).Get(CmNamePrefix + name)` and then reads `CmProfileKey`. Three fields govern interop and each is fatal on its own:

| Field | FGO reads | We emitted |
|---|---|---|
| Name | `gpu-profile-<p>` | `nvml-mock-profile-<p>` |
| Data key | `profile.yaml` | `config.yaml` |
| Namespace | its own release namespace | none set, so ours |

### Issue #507's table is wrong on two counts

Both re-derived against FGO `cf586f41` (2026-07-28), confirmed by API and a fresh clone:

- **The label mismatch it calls fatal is on no code path.** FGO never selects these by label. `LabelGpuProfile` appears only in its own declaration and 5 `_test.go` files — zero non-test Go consumers. The label-selector call sites in `reconciler.go` select FGO's own managed DaemonSets via `LabelManagedBy`, not profiles.
- **Namespace is a fourth mismatch the issue does not list**, and it is fatal alone.

The issue also gives our label as `nvml-mock/profile-name`, which has exactly **one** reference repo-wide — the line that emits it. The label with all 16 consumers (docs, demo, e2e, values) is `run.ai/gpu-profile`.

The data key the issue flagged as unconfirmed **is confirmed**: `profile.yaml`.

## Approach

Emit the name, data key and label FGO publishes, and add `integrations.fakeGpuOperator.targetNamespace` so the ConfigMaps can be placed where the loader looks. All behind the existing `enabled: false` toggle, so opt-out users see no change.

`run.ai/gpu-profile` stays on every ConfigMap — 16 consumers, none of which should break. The contract labels are emitted by the template rather than through `profileLabels`, so a user override cannot silently drop discovery.

### Known constraint, documented rather than left to fail

Pointing `targetNamespace` at FGO's namespace requires FGO's `builtinProfiles.enabled=false`. Their builtin set uses the same seven names (`a100 b200 gb200 gb300 h100 l40s t4`) under their own Helm release, and Helm 3 refuses cross-release adoption. The safe default (release namespace) is also the non-functional one; that trade-off is stated in `values.yaml` and the integration guide.

## The e2e could not fail on any of this

The old assertion counted ConfigMaps carrying a label **we** control and required 6 of 7. It could not detect a name, key or namespace drift, and stayed green throughout the period the integration was broken.

It now fetches each of the seven profiles by exact name and diffs against the contract. The comparison is a pure function in an untagged file (following `gfd_labels.go`), so it runs in the normal unit job rather than only under `-tags e2e`.

## Documentation

`docs/integrations/fake-gpu-operator.md` claimed "FGO watches for these ConfigMaps and uses them to populate its topology." There is no watch, no selector and no read. Replaced with the loader's actual mechanics, plus a Tested Versions section recording the version pair and, explicitly, that a live FGO-plus-nvml-mock interop run was **not** performed.

Two open gaps on FGO's side are now recorded there: they pin our image at `sha-1706195` because our v0.2.0 broke their `e2e-mock` on `libnvidia-ml.so` loading (never filed on our side), and their vendored copy of our profiles is 78 commits stale with all seven profile files changed since.

Closes #507
