### PR TITLE
chore(deps): dependabot merge train 2026-08-01

### DIFF
--- a/.github/workflows/code_scanning.yaml
+++ b/.github/workflows/code_scanning.yaml
@@ -48,6 +48,6 @@ jobs:
         run: go mod download
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: "/language:go"

--- a/.github/workflows/code_scanning.yaml
+++ b/.github/workflows/code_scanning.yaml
@@ -40,7 +40,7 @@ jobs:
           go-version: ${{ inputs.golang_version }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: go
 

--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -82,7 +82,7 @@ jobs:
       # `helm registry login` does not write; without this login the
       # signature blob upload is rejected with UNAUTHORIZED.
       - name: Log in to GHCR for cosign
-        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/nvml-mock-publish.yaml
+++ b/.github/workflows/nvml-mock-publish.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -33,6 +33,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -18,7 +18,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v11
         with:
           # --- thresholds (policy) ---
           days-before-issue-stale: 90


### PR DESCRIPTION
## Problem

Five Dependabot PRs are queued against `main`, all GitHub Actions bumps. Merging
them one at a time costs a full CI matrix per PR.

Two of them cannot merge at all on their own. Dependabot raised
`github/codeql-action/init` (#554) and `github/codeql-action/analyze` (#553) as
separate PRs, but CodeQL requires both steps to run the same version. Each PR in
isolation puts one step on 4.37.4 and leaves the other on 4.37.3, and the run
fails in the `analyze` post-step:

```
##[error]Loaded a configuration file for version '4.37.3', but running version '4.37.4'
CodeQL job status was configuration error.
```

That is why #553 and #554 both sit at `UNSTABLE`. They only go green together.

## Approach

Cherry-picked all five Dependabot commits onto current `main` so the pair lands
atomically. Cherry-pick keeps `dependabot[bot]` as author, preserves the original
commit messages and `updated-dependencies` trailers, and keeps history linear.

| PR | Bump | Type |
|----|------|------|
| #537 | `actions/stale` 10 → 11 | major |
| #555 | `docker/login-action` 4.5.1 → 4.6.0 | minor |
| #556 | `github/codeql-action/upload-sarif` 4.37.3 → 4.37.4 | patch |
| #554 | `github/codeql-action/init` 4.37.3 → 4.37.4 | patch |
| #553 | `github/codeql-action/analyze` 4.37.3 → 4.37.4 | patch |

### Conflict resolution

#553 and #554 both edit `code_scanning.yaml`. The hunks are adjacent but do not
overlap (line 43 `init`, line 51 `analyze`), so git auto-merged them. After the
merge both steps pin the same digest, which is what removes the skew:

```
43:  uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38    # v4.37.4
51:  uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
```

No other conflicts. No `go.mod` PRs were in this batch, so there is no module
resolution to review and no vendor churn.

## Testing done

- Every pinned digest resolved against its upstream repo to confirm the version
  comment is accurate, both the version being replaced and the new one:

  | action | tag | commit |
  |---|---|---|
  | `github/codeql-action` | v4.37.3 (old) | `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` |
  | `github/codeql-action` | v4.37.4 (new) | `f205ea1c3313d32999d8d6a48b4f6530d4437b38` |
  | `docker/login-action` | v4.5.1 (old) | `abd2ef45e78c5afb21d64d4ca52ee8550d9572c7` |
  | `docker/login-action` | v4.6.0 (new) | `dbcb813823bdd20940b903addbd779551569679f` |

- `actionlint` on the branch reports the same three findings as pristine `main`
  (`golang.yaml`, `variables.yaml` — neither touched here). Zero new findings.
  The five changed files are clean.
- All five workflow files parse as YAML.
- Diff is 6 lines across 5 files, all under `.github/workflows/`. No Go sources,
  no `go.mod`, no `go.sum`, no `vendor/`.
- All five commits are GPG-signed and carry both DCO sign-offs.

## Breaking changes

None expected.

`actions/stale` v11 is a major bump, but the only change in the release is
[Migrate to ESM and update dependencies](https://github.com/actions/stale/pull/1350)
plus a transitive `brace-expansion` security bump. That is internal packaging —
no input or output was renamed or removed. `stale.yaml` uses only standard
inputs, all still supported.

`docker/login-action` v4.6.0 is buildx config-path hardening and dependency
bumps.

## Note for a follow-up

`stale.yaml` pins by tag (`actions/stale@v11`), while every other action in this
repo pins by commit digest. That inconsistency predates this PR and I have left
Dependabot's commit untouched, but it is worth pinning by digest for the
OpenSSF Scorecard `Pinned-Dependencies` check.

## Superseded

Supersedes #537, #553, #554, #555, #556. These are pull requests, so `Closes` will
not auto-close them; they need closing explicitly once this merges.
