### PR TITLE
docs(e2e): correct the device plugin's CI status in VERSION-MATRIX

### DIFF
--- a/tests/e2e/VERSION-MATRIX.md
+++ b/tests/e2e/VERSION-MATRIX.md
@@ -12,7 +12,7 @@ Discovery is pinned (`scenario_nfd_test.go:126`).
 
 | Component | Version | Chart / Image | Status |
 |---|---|---|---|
-| NVIDIA Device Plugin (standalone) | v0.18.2 | `nvcr.io/nvidia/k8s-device-plugin:v0.18.2` | Pinned, **not run in CI** — see below |
+| NVIDIA Device Plugin (standalone) | v0.18.2 | `nvcr.io/nvidia/k8s-device-plugin:v0.18.2` | **Pinned** + runs in CI (`e2e-nri` ×6 profiles, `e2e-multi-node`) |
 | NVIDIA Device Plugin (GPU Operator operand) | floats — v0.19.3 observed 2026-07-29 | from the `gpu-operator` chart | Not pinned; runs in CI |
 | DRA Driver (GPU) | floats — chart carries no `--version` | `nvidia/nvidia-dra-driver-gpu` (Helm) | Not pinned; runs in CI |
 | GPU Feature Discovery (standalone) | v0.8.2 | `nvcr.io/nvidia/gpu-feature-discovery:v0.8.2` | Pinned, **not run in CI** — see below |
@@ -31,18 +31,18 @@ named — does not resolve.
 ## Component Coverage
 
 ### Tested in CI
-- **DRA Driver** (Helm chart): discovers mock GPUs via NVML, publishes ResourceSlices (`e2e-dra`, 6 profiles)
+- **Device Plugin** (standalone DaemonSet, `device-plugin-mock.yaml`): the pinned upstream `k8s-device-plugin:v0.18.2` discovers mock GPUs via NVML and registers the `nvidia.com/gpu` resource. Applied by `deployDevicePlugin`, which has three callers — `scenario_nri_test.go` (`e2e-nri`, 6 profiles), `scenario_multi_node_test.go` (`e2e-multi-node`, in `BeforeAll`), and the gated validator scenario. The first two run on every pipeline. The `e2e-nri` legs additionally assert MEP-0002 composition: a requesting pod sees exactly its allocated GPU, two pods on one node stay isolated, and the suppression rule is mutation-checked.
+- **DRA Driver** (Helm chart): discovers mock GPUs via NVML, publishes ResourceSlices, and schedules a pod with a ResourceClaim (`e2e-dra`, 6 profiles)
 - **Node Feature Discovery** (Helm chart): derives the PCI vendor label from the feature file nvml-mock writes, not nvml-mock itself (`e2e-nfd`)
-- **GPU Operator** (Helm chart + values overlay): device plugin, GFD, dcgm-exporter and validator operands (`e2e-gpu-operator`, 6 profiles) — see the overlay section below
+- **GPU Operator** (Helm chart + values overlay): its own device plugin, GFD, dcgm-exporter and validator operands, at unpinned versions (`e2e-gpu-operator`, 6 profiles) — see the overlay section below
 
 ### Written but NOT run in CI
 
-Three scenarios live in `scenario_validator_test.go` and are excluded **twice
+Two scenarios live in `scenario_validator_test.go` and are excluded **twice
 over**: `BeforeAll` skips unless `E2E_RUN_NGC=true`, which is set in no
 workflow, and the default label filter (`Makefile`, `E2E_DEFAULT_LABEL_FILTER`)
-leads with `!validator`. A green pipeline says nothing about any of them.
+leads with `!validator`. A green pipeline says nothing about either of them.
 
-- **Device Plugin** (standalone DaemonSet, `device-plugin-mock.yaml`): would discover mock GPUs via NVML and register the `nvidia.com/gpu` resource. The device plugin CI *does* exercise is the GPU Operator's operand, at a different and unpinned version.
 - **GPU Feature Discovery** (standalone DaemonSet, `gfd-mock.yaml`): would read GPU attributes via NVML and label nodes. The GFD CI *does* exercise is the GPU Operator's operand.
 - **CUDA Validator** (Job, `validator-mock.yaml`): runs vectorAdd against the mock `libcuda.so`. This one would **fail** if the gate were opened — the mock exports one of the 450 driver entry points that image resolves. See [`docs/cuda-mock.md`](../../docs/cuda-mock.md).
 


### PR DESCRIPTION
The `v0.3.0` release-prep commit rewrote `tests/e2e/VERSION-MATRIX.md`, corrected five genuinely wrong rows, and introduced a sixth. It filed the standalone NVIDIA device plugin under **Written but NOT run in CI**, reasoning that `deployDevicePlugin` lives in `scenario_validator_test.go`, which is gated behind `E2E_RUN_NGC` and the leading `!validator` label filter.

That confused where the helper is *defined* with where it is *called*. It has three callers:

```
scenario_nri_test.go:814         -> e2e-nri, 6 profiles       runs
scenario_multi_node_test.go:72   -> e2e-multi-node, BeforeAll runs
scenario_validator_test.go:57    -> the gated scenario        does not run
```

The first two run on every pipeline, so the pinned upstream `k8s-device-plugin:v0.18.2` is exercised on **seven legs per pipeline**, not zero.

Verified against run [30705506429](https://github.com/NVIDIA/k8s-test-infra/actions/runs/30705506429): the `nvidia-device-plugin-mock` DaemonSet appears in both the `e2e-nri (a100)` and `e2e-multi-node` job logs, and all six `when the device plugin also serves the node` specs executed. Those legs additionally assert MEP-0002 composition — a resource-requested pod sees exactly its allocated GPU, two pods on one node stay isolated, and the suppression rule is mutation-checked.

Independent corroboration: #446 is titled *"Track standalone GFD and CUDA validator E2E enablement"* — it names two components, not three. The device plugin was never behind that gate.

GFD and the CUDA validator stay under **NOT run in CI**; both are genuinely gated, and `deployGPUFeatureDiscovery` has exactly one caller, which is the gated one.

### Why it matters

`VERSION-MATRIX.md` is the document a downstream consumer reads to decide what this project actually verifies. Understating the suite there is the same defect class the pre-`v0.3.0` audit kept finding, and this one was introduced by the commit that was fixing the others.

### Blast radius

Docs-only. `tests/e2e/VERSION-MATRIX.md` is not packaged in the chart or the image, so no published artifact carried the error. It is wrong for anyone reading the repo at the `v0.3.0` tag.

### Testing done

No code change. Claims re-derived from source and from the CI logs of the release commit, as quoted above.