### PR TITLE
docs,test(nri): document ambient injection behavior and cover plain pod

### DIFF
--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -33,7 +33,12 @@ When `nri.enabled=true` (opt-in; default `false`), the chart also deploys
 `nvml-mock-nri`, a node-local containerd NRI plugin. It mounts the host overlay
 into newly created containers at `/opt/nvml-mock` and injects the mock
 environment at runtime, so plain pods can run `nvidia-smi` without GPU resource
-requests or pod-spec mutation. Because it injects cluster-wide, it is off by
+requests or pod-spec mutation. The overlay and environment are injected ambiently into
+containers in non-excluded namespaces, while host device nodes (`/dev/nvidia*`) remain opt-in
+(via `nvidia.com/gpu` requests or the `nvml-mock.nvidia.com/devices: "true"` annotation).
+Unannotated pods without GPU requests will still report GPUs if `nvidia-smi` is run inside them.
+Test suites that rely on non-GPU pods seeing zero GPUs should either keep NRI disabled (`nri.enabled=false`)
+or run within an excluded namespace (`nri.excludedNamespaces`). Because it injects cluster-wide, it is off by
 default. Kind clusters must have containerd NRI enabled; see
 [`docs/demo/node-wide-injection`](../../../../docs/demo/node-wide-injection).
 
@@ -947,7 +952,7 @@ namespace, on the pod IP where the kubelet reaches it.
 | `infiniband.mockTier` | `""` (auto) | `MOCK_IB` tier: `off`, `sysfs`, or `full`. Empty auto-derives `full` for IB-enabled profiles and `sysfs` otherwise (keeps the `libibmocksys` redirect active so any real host IB is masked). `off` makes every shim a no-op and skips the daemon. An invalid value fails `helm template` |
 | `infiniband.ping.port` | `18515` | TCP port for fabric relay between nvml-mock pods (`mock-ib` / `ibping` always enabled) |
 | `infiniband.ping.networkPolicy.enabled` | `true` | Restrict inbound access to the fabric port to peer nvml-mock pods. No-op on CNIs that don't enforce NetworkPolicy (e.g. Kind's kindnet) |
-| `nri.enabled` | `false` | Deploy the `nvml-mock-nri` containerd NRI plugin DaemonSet. Injects cluster-wide at container-creation time, so it is opt-in. Requires containerd NRI enabled on every node |
+| `nri.enabled` | `false` | Deploy the `nvml-mock-nri` containerd NRI plugin DaemonSet. Injects mock overlay and environment cluster-wide into non-excluded namespaces. Always install into a dedicated namespace (`-n nvml-mock`) to avoid excluding `default`. Device node injection remains opt-in (`nvidia.com/gpu` request or `nvml-mock.nvidia.com/devices: "true"` annotation). |
 | `nri.socketPath` | `/var/run/nri/nri.sock` | NRI socket on the host. Its directory is hostPath-mounted into the plugin |
 | `nri.pluginName` / `nri.pluginIndex` | `nvml-mock` / `"10"` | NRI registration identity. The index orders this plugin against others |
 | `nri.overlay.hostPath` / `nri.overlay.mountPath` | `/var/lib/nvml-mock` / `/opt/nvml-mock` | Host overlay staged by the main DaemonSet, and the path it is injected at inside workloads |

--- a/docs/demo/node-wide-injection/README.md
+++ b/docs/demo/node-wide-injection/README.md
@@ -52,10 +52,7 @@ Install these tools locally before running the demo:
    are present, then runs `check-fabric`; the script asserts every node reports
    its assigned clique / cluster UUID (skip with `WITH_COMPUTE_DOMAIN=false`).
 
-The demo installs no device plugin, so nothing allocates GPUs and each pod sees
-all `GPU_COUNT` of them. Where the NVIDIA device plugin has already served a
-container, the NRI plugin leaves that allocation intact instead of widening it —
-see [Device injection mode](../../../deployments/nvml-mock/helm/nvml-mock/README.md#device-injection-mode).
+The demo installs no device plugin, so no component allocates GPUs. The NRI overlay and environment are injected ambiently into containers in non-excluded namespaces. Host device node injection remains opt-in (via `nvidia.com/gpu` requests or the `nvml-mock.nvidia.com/devices: "true"` annotation). Unannotated pods without GPU requests will still report GPUs if `nvidia-smi` is run inside them. Where the NVIDIA device plugin is installed and allocates GPUs, the NRI plugin leaves that allocation intact (MEP-0002). Tests expecting non-GPU pods to see zero GPUs should keep NRI disabled or run in an excluded namespace. See [Device injection mode](../../../deployments/nvml-mock/helm/nvml-mock/README.md#device-injection-mode).
 
 ## Quick Start
 

--- a/tests/e2e/go/scenario_nri_test.go
+++ b/tests/e2e/go/scenario_nri_test.go
@@ -377,6 +377,20 @@ var _ = Describe("nvml-mock node-wide NRI injection", Label("nri"), Ordered, fun
 				"default deviceInjectionMode is raw, so the CDI spec must not have been applied")
 		})
 
+		It("handles a plain unannotated pod with no GPU request", Label("nri-dp-plain"), func(ctx SpecContext) {
+			pod := applyNRIWorkload(ctx, h, nriPlainPodManifest("nri-dp-plain"), "nri-dp-plain")
+
+			// Verify ambient overlay injection is present.
+			res, err := h.Kube.ExecSh(ctx, pod, "test -d /opt/nvml-mock/driver")
+			Expect(err).NotTo(HaveOccurred(), "check overlay mount in nri-dp-plain: %s", res.Combined())
+
+			// Verify GPU visibility reported via nvidia-smi -L.
+			visible := visibleGPUUUIDs(ctx, h, pod)
+			Expect(visible).To(HaveLen(p.ExpectedGPUs()),
+				"plain unannotated pod on DP node receives ambient overlay and reports all %d profile GPUs",
+				p.ExpectedGPUs())
+		})
+
 		It("leaves the scheduler gate intact once the node is saturated", Label("nri-dp-scheduling"), func(ctx SpecContext) {
 			// Ask for one more GPU than any node advertises. The pod must stay
 			// Pending on the SCHEDULER's verdict: a mock that over-advertises, or


### PR DESCRIPTION
## What This PR Does

Fixes #585.

This PR addresses both gaps described in the issue:

- documents the user-visible behavior of ambient NRI injection in:
  - the Helm chart README,
  - the `nri.enabled` values table,
  - and the node-wide injection demo documentation.
- adds the missing e2e scenario covering an unannotated pod with no GPU request when the NVIDIA device plugin also serves the node.

The new test verifies:
- the ambient overlay is injected into the workload, and
- the runtime GPU visibility reported by `nvidia-smi -L`.

## Why

Issue #585 notes that:

- the documentation does not explain that workloads without GPU requests may still report mock GPUs when `nri.enabled=true`, and
- the composed device-plugin scenario for an unannotated pod without a GPU request was not covered by the e2e suite.

This PR documents that behavior and adds the missing test coverage.

## Testing

Executed locally:

- ✅ `go test ./pkg/nri/nvmlmock/... ./cmd/nvml-mock-nri/...`
- ✅ `go test -tags=e2e ./tests/e2e/go/framework/...`
- ✅ `go test -c -tags=e2e ./tests/e2e/go`
- ✅ Verified the new spec is selected by Ginkgo using `-ginkgo.label-filter=nri-dp-plain`

The full Kind-backed e2e scenario could not be executed locally because the required `kind` binary was not available.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [ ] Tests pass (`go test -v -race ./...`)
- [ ] Linter passes (`golangci-lint run`)
- [ ] New code has SPDX license headers (not applicable)
- [x] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (not user-facing)