### PR TITLE
fix(e2e): stop the Xid scenario racing the GPU Operator's reconcile

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -301,7 +301,8 @@ make e2e E2E_RUN_NGC=true E2E_GINKGO_FLAGS='--label-filter="validator"'
 | `E2E_RUN_NGC` | `false` | Run scenarios that need `nvcr.io` images, such as `validator`. |
 | `E2E_CLUSTER_TIMEOUT` | `5m` | Kind cluster setup timeout. |
 | `E2E_HELM_TIMEOUT` | `5m` | Helm install/upgrade timeout. |
-| `E2E_READY_TIMEOUT` | `2m` | Kubernetes readiness wait timeout. |
+| `E2E_READY_TIMEOUT` | `2m` | Kubernetes readiness wait timeout, sized for a single rollout. |
+| `E2E_OPERAND_SETTLE_TIMEOUT` | `5m` | Timeout for waits that must outlast a GPU Operator reconcile replacing its operands, not just one rollout. |
 | `E2E_POLL_INTERVAL` | `2s` | Polling interval for readiness checks. |
 
 ## CI Behavior

--- a/tests/e2e/go/assertions/dcgm.go
+++ b/tests/e2e/go/assertions/dcgm.go
@@ -106,14 +106,28 @@ func DCGMDeviceMetrics(ctx context.Context, k *kube.Client, ns, gpuName string, 
 
 // DCGMXidReported polls until at least one GPU reports xid as
 // DCGM_FI_DEV_XID_ERRORS (healthy default is 0).
+//
+// The exporter is a moving target here: the GPU Operator replaces its operands a
+// reconcile period after nvml-mock rolls, well after the caller's own rollouts
+// report success (#602). Readiness, pod identity and the scrape therefore share
+// one retry, which Eventually keeps driving through the errors a replaced pod
+// produces.
 func DCGMXidReported(ctx context.Context, k *kube.Client, ns string, xid int, timeout, poll time.Duration) {
 	ginkgo.GinkgoHelper()
 
-	WaitDaemonSetReady(ctx, k, ns, dcgmExporterDaemonSet, timeout, poll)
-	pod := dcgmExporterPod(ctx, k, ns)
-
 	ginkgo.By(fmt.Sprintf("waiting for %s == %d", fiDevXidErrors, xid))
 	gomega.Eventually(func() (bool, error) {
+		ready, err := k.DaemonSetReady(ctx, ns, dcgmExporterDaemonSet)
+		if err != nil {
+			return false, err
+		}
+		if !ready {
+			return false, nil
+		}
+		pod, err := k.FirstPodName(ctx, ns, dcgmExporterSelector)
+		if err != nil {
+			return false, err
+		}
 		metrics, err := scrapeDCGM(ctx, k, ns, pod)
 		if err != nil {
 			return false, err

--- a/tests/e2e/go/framework/config/config.go
+++ b/tests/e2e/go/framework/config/config.go
@@ -125,6 +125,13 @@ func HelmTimeout() time.Duration    { return durEnv("E2E_HELM_TIMEOUT", 5*time.M
 func ReadyTimeout() time.Duration   { return durEnv("E2E_READY_TIMEOUT", 2*time.Minute) }
 func PollInterval() time.Duration   { return durEnv("E2E_POLL_INTERVAL", 2*time.Second) }
 
+// OperandSettleTimeout bounds a wait that has to outlast a GPU Operator
+// reconcile replacing its operands, rather than the single rollout ReadyTimeout
+// is sized for.
+func OperandSettleTimeout() time.Duration {
+	return durEnv("E2E_OPERAND_SETTLE_TIMEOUT", 5*time.Minute)
+}
+
 func durEnv(key string, def time.Duration) time.Duration {
 	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {

--- a/tests/e2e/go/framework/kube/kube.go
+++ b/tests/e2e/go/framework/kube/kube.go
@@ -145,6 +145,9 @@ type envVar struct {
 }
 
 type daemonSetObj struct {
+	Metadata struct {
+		Generation int64 `json:"generation"`
+	} `json:"metadata"`
 	Spec struct {
 		Template struct {
 			Spec struct {
@@ -155,8 +158,10 @@ type daemonSetObj struct {
 		} `json:"template"`
 	} `json:"spec"`
 	Status struct {
-		DesiredNumberScheduled int `json:"desiredNumberScheduled"`
-		NumberReady            int `json:"numberReady"`
+		ObservedGeneration     int64 `json:"observedGeneration"`
+		DesiredNumberScheduled int   `json:"desiredNumberScheduled"`
+		UpdatedNumberScheduled int   `json:"updatedNumberScheduled"`
+		NumberReady            int   `json:"numberReady"`
 	} `json:"status"`
 }
 
@@ -321,14 +326,30 @@ func (c *Client) ConfigMapData(ctx context.Context, ns, name, key string) (strin
 	return v, nil
 }
 
-// DaemonSetReady reports whether all desired DaemonSet pods are ready.
+// rolledOutAndReady reports whether the DaemonSet's current spec is fully rolled
+// out and every desired pod is ready. A ready count alone would also accept a
+// DaemonSet that has not started rolling yet, whose ready pods still belong to
+// the previous generation.
+func (ds daemonSetObj) rolledOutAndReady() bool {
+	// A status the controller has not caught up to describes the previous spec,
+	// so it cannot answer whether this one rolled out.
+	if ds.Status.ObservedGeneration < ds.Metadata.Generation {
+		return false
+	}
+	d := ds.Status.DesiredNumberScheduled
+	return d > 0 &&
+		ds.Status.UpdatedNumberScheduled == d &&
+		ds.Status.NumberReady == d
+}
+
+// DaemonSetReady reports whether every desired DaemonSet pod is ready and
+// running the current spec.
 func (c *Client) DaemonSetReady(ctx context.Context, ns, name string) (bool, error) {
 	var ds daemonSetObj
 	if err := c.getJSON(ctx, &ds, "daemonset", "-n", ns, name); err != nil {
 		return false, err
 	}
-	d := ds.Status.DesiredNumberScheduled
-	return d > 0 && ds.Status.NumberReady == d, nil
+	return ds.rolledOutAndReady(), nil
 }
 
 // DaemonSetContainerEnv returns the value of an env var on the DaemonSet's

--- a/tests/e2e/go/framework/kube/kube_test.go
+++ b/tests/e2e/go/framework/kube/kube_test.go
@@ -10,9 +10,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"reflect"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // installFakeKubectl puts a stub `kubectl` at the front of PATH for the rest of
@@ -23,9 +23,7 @@ func installFakeKubectl(t *testing.T, script string) {
 	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "kubectl")
-	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script), 0o755); err != nil {
-		t.Fatalf("write fake kubectl: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"+script), 0o755), "write fake kubectl")
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
@@ -55,9 +53,7 @@ fi
 func newTestClient(t *testing.T) *Client {
 	t.Helper()
 	c, err := New("kind-nvml-mock-e2e")
-	if err != nil {
-		t.Fatalf("New default kubeconfig client: %v", err)
-	}
+	require.NoError(t, err, "New default kubeconfig client")
 	return c
 }
 
@@ -68,19 +64,13 @@ func TestLogsCapturesEveryContainerNotJustTheDefault(t *testing.T) {
 	installFakeKubectl(t, multiContainerLogs)
 
 	out, err := newTestClient(t).Logs(context.Background(), "gpu-operator", "app.kubernetes.io/name=nvml-mock", 100)
-	if err != nil {
-		t.Fatalf("Logs: %v", err)
-	}
-
-	if !strings.Contains(out, "[sidecar] watch-allocations: 8 GPUs, polling") {
-		t.Fatalf("sidecar container output missing from collected logs, got:\n%s", out)
-	}
-	if !strings.Contains(out, "[nvml-mock] mock ready") {
-		t.Fatalf("primary container output missing from collected logs, got:\n%s", out)
-	}
-	if strings.Contains(out, "Defaulted container") {
-		t.Fatalf("kubectl defaulted to one container instead of collecting all, got:\n%s", out)
-	}
+	require.NoError(t, err, "Logs")
+	require.Contains(t, out, "[sidecar] watch-allocations: 8 GPUs, polling",
+		"sidecar container output missing from collected logs")
+	require.Contains(t, out, "[nvml-mock] mock ready",
+		"primary container output missing from collected logs")
+	require.NotContains(t, out, "Defaulted container",
+		"kubectl defaulted to one container instead of collecting all")
 }
 
 func TestLogsArgsRequestAllContainersAndNotPreviousInstance(t *testing.T) {
@@ -91,9 +81,7 @@ func TestLogsArgsRequestAllContainersAndNotPreviousInstance(t *testing.T) {
 		"-l", "app.kubernetes.io/name=nvml-mock",
 		"--all-containers=true", "--tail=100",
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("expected kubectl logs args %#v, got %#v", want, got)
-	}
+	require.Equal(t, want, got, "kubectl logs args")
 }
 
 // `kubectl logs --previous` errors when a container has no previous instance,
@@ -107,9 +95,7 @@ func TestPreviousLogsArgsAskForPreviousInstance(t *testing.T) {
 		"-l", "app.kubernetes.io/name=nvml-mock",
 		"--all-containers=true", "--tail=100", "--previous",
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("expected kubectl logs args %#v, got %#v", want, got)
-	}
+	require.Equal(t, want, got, "kubectl logs args")
 }
 
 // podsJSON serves a two-container pod whose restart counts depend on the
@@ -133,20 +119,12 @@ func TestRestartedPodsGatesOnRestartCount(t *testing.T) {
 	c := newTestClient(t)
 
 	restarted, err := c.RestartedPods(context.Background(), "restarted", "app.kubernetes.io/name=nvml-mock")
-	if err != nil {
-		t.Fatalf("RestartedPods on a restarted pod: %v", err)
-	}
-	if !reflect.DeepEqual(restarted, []string{"nvml-mock-abcde"}) {
-		t.Fatalf("expected the restarted pod to be reported, got %#v", restarted)
-	}
+	require.NoError(t, err, "RestartedPods on a restarted pod")
+	require.Equal(t, []string{"nvml-mock-abcde"}, restarted, "restarted pod")
 
 	healthy, err := c.RestartedPods(context.Background(), "healthy", "app.kubernetes.io/name=nvml-mock")
-	if err != nil {
-		t.Fatalf("RestartedPods on a healthy pod: %v", err)
-	}
-	if len(healthy) != 0 {
-		t.Fatalf("expected no pods reported when nothing restarted, got %#v", healthy)
-	}
+	require.NoError(t, err, "RestartedPods on a healthy pod")
+	require.Empty(t, healthy, "pods reported when nothing restarted")
 }
 
 // profileConfigMapJSON answers only for the exact name FGO's loader Gets, and
@@ -170,16 +148,10 @@ func TestGetConfigMapReturnsLabelsAndData(t *testing.T) {
 	installFakeKubectl(t, profileConfigMapJSON)
 
 	cm, err := newTestClient(t).GetConfigMap(context.Background(), "nvml-mock-system", "gpu-profile-a100")
-	if err != nil {
-		t.Fatalf("GetConfigMap: %v", err)
-	}
-
-	if got := cm.Labels["fake-gpu-operator/gpu-profile"]; got != "true" {
-		t.Fatalf("expected the FGO discovery label to be readable, got %q", got)
-	}
-	if got := cm.Data["profile.yaml"]; got != "version: \"1.0\"\n" {
-		t.Fatalf("expected the profile.yaml body to be readable, got %q", got)
-	}
+	require.NoError(t, err, "GetConfigMap")
+	require.Equal(t, "true", cm.Labels["fake-gpu-operator/gpu-profile"],
+		"FGO discovery label")
+	require.Equal(t, "version: \"1.0\"\n", cm.Data["profile.yaml"], "profile.yaml body")
 }
 
 // A wrong name must surface as an error rather than an empty ConfigMap, or the
@@ -188,9 +160,7 @@ func TestGetConfigMapErrorsOnAMissingName(t *testing.T) {
 	installFakeKubectl(t, profileConfigMapJSON)
 
 	_, err := newTestClient(t).GetConfigMap(context.Background(), "nvml-mock-system", "nvml-mock-profile-a100")
-	if err == nil {
-		t.Fatal("expected an error for a ConfigMap name that does not exist, got nil")
-	}
+	require.Error(t, err, "missing ConfigMap name")
 }
 
 // Readiness has to mean "this spec rolled out and is ready", not "some pod is
@@ -240,9 +210,7 @@ func TestDaemonSetRolledOutAndReady(t *testing.T) {
 			ds.Status.UpdatedNumberScheduled = tc.updated
 			ds.Status.NumberReady = tc.ready
 
-			if got := ds.rolledOutAndReady(); got != tc.want {
-				t.Fatalf("rolledOutAndReady() = %t, want %t", got, tc.want)
-			}
+			require.Equal(t, tc.want, ds.rolledOutAndReady(), "rolledOutAndReady()")
 		})
 	}
 }
@@ -258,42 +226,28 @@ func TestDaemonSetObjDecodesRolloutFields(t *testing.T) {
 	}`
 
 	var ds daemonSetObj
-	if err := json.Unmarshal([]byte(payload), &ds); err != nil {
-		t.Fatalf("unmarshal daemonset: %v", err)
-	}
+	require.NoError(t, json.Unmarshal([]byte(payload), &ds), "unmarshal daemonset")
 
 	got := []int{
 		int(ds.Metadata.Generation), int(ds.Status.ObservedGeneration),
 		ds.Status.DesiredNumberScheduled, ds.Status.UpdatedNumberScheduled,
 		ds.Status.NumberReady,
 	}
-	if want := []int{5, 4, 3, 2, 1}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("decoded [generation observedGeneration desired updated ready] = %v, want %v", got, want)
-	}
+	require.Equal(t, []int{5, 4, 3, 2, 1}, got,
+		"decoded [generation observedGeneration desired updated ready]")
 }
 
 func TestBaseUsesDefaultKubeconfigWhenUnset(t *testing.T) {
 	c, err := New("kind-nvml-mock-e2e")
-	if err != nil {
-		t.Fatalf("New default kubeconfig client: %v", err)
-	}
+	require.NoError(t, err, "New default kubeconfig client")
 	args := c.base()
-
-	for _, arg := range args {
-		if arg == "--kubeconfig" {
-			t.Fatal("did not expect --kubeconfig when kubectl should use the default kubeconfig")
-		}
-	}
+	require.NotContains(t, args, "--kubeconfig",
+		"kubectl should use the default kubeconfig")
 }
 
 func TestBaseTargetsContext(t *testing.T) {
 	c, err := New("kind-nvml-mock-e2e")
-	if err != nil {
-		t.Fatalf("New default kubeconfig client: %v", err)
-	}
+	require.NoError(t, err, "New default kubeconfig client")
 	args := c.base()
-
-	if len(args) != 2 || args[0] != "--context" || args[1] != "kind-nvml-mock-e2e" {
-		t.Fatalf("expected kubectl context args, got %#v", args)
-	}
+	require.Equal(t, []string{"--context", "kind-nvml-mock-e2e"}, args, "kubectl context args")
 }

--- a/tests/e2e/go/framework/kube/kube_test.go
+++ b/tests/e2e/go/framework/kube/kube_test.go
@@ -7,6 +7,7 @@ package kube
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -189,6 +190,85 @@ func TestGetConfigMapErrorsOnAMissingName(t *testing.T) {
 	_, err := newTestClient(t).GetConfigMap(context.Background(), "nvml-mock-system", "nvml-mock-profile-a100")
 	if err == nil {
 		t.Fatal("expected an error for a ConfigMap name that does not exist, got nil")
+	}
+}
+
+// Readiness has to mean "this spec rolled out and is ready", not "some pod is
+// ready": a caller polling straight after a restart would otherwise be answered
+// by the very pod it asked to have replaced, then talk to it as it is deleted.
+// Every case here keeps numberReady == desiredNumberScheduled, which is exactly
+// the shape that fools a ready count. The settled case is the counterweight —
+// too strict and every wait built on this would simply hang.
+func TestDaemonSetRolledOutAndReady(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		generation int64
+		observed   int64
+		desired    int
+		updated    int
+		ready      int
+		want       bool
+	}{
+		{
+			name:       "fully rolled out",
+			generation: 3, observed: 3, desired: 1, updated: 1, ready: 1,
+			want: true,
+		},
+		{
+			name:       "new spec not rolled out yet",
+			generation: 3, observed: 3, desired: 1, updated: 0, ready: 1,
+			want: false,
+		},
+		{
+			name:       "status still describes the previous spec",
+			generation: 3, observed: 2, desired: 1, updated: 1, ready: 1,
+			want: false,
+		},
+		{
+			// Nothing scheduled at all: a DaemonSet whose node selector matches
+			// no node is vacuously "all ready" on counts alone.
+			name:       "nothing scheduled",
+			generation: 1, observed: 1, desired: 0, updated: 0, ready: 0,
+			want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var ds daemonSetObj
+			ds.Metadata.Generation = tc.generation
+			ds.Status.ObservedGeneration = tc.observed
+			ds.Status.DesiredNumberScheduled = tc.desired
+			ds.Status.UpdatedNumberScheduled = tc.updated
+			ds.Status.NumberReady = tc.ready
+
+			if got := ds.rolledOutAndReady(); got != tc.want {
+				t.Fatalf("rolledOutAndReady() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+// The predicate above reads five fields straight off `kubectl get -o json`, so a
+// mistyped tag would silently leave one at zero and skew every readiness wait
+// without failing to compile. Distinct values catch a swap between them too.
+func TestDaemonSetObjDecodesRolloutFields(t *testing.T) {
+	const payload = `{
+	  "metadata": {"name": "nvidia-dcgm-exporter", "generation": 5},
+	  "status": {"observedGeneration": 4, "desiredNumberScheduled": 3,
+	             "updatedNumberScheduled": 2, "numberReady": 1}
+	}`
+
+	var ds daemonSetObj
+	if err := json.Unmarshal([]byte(payload), &ds); err != nil {
+		t.Fatalf("unmarshal daemonset: %v", err)
+	}
+
+	got := []int{
+		int(ds.Metadata.Generation), int(ds.Status.ObservedGeneration),
+		ds.Status.DesiredNumberScheduled, ds.Status.UpdatedNumberScheduled,
+		ds.Status.NumberReady,
+	}
+	if want := []int{5, 4, 3, 2, 1}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("decoded [generation observedGeneration desired updated ready] = %v, want %v", got, want)
 	}
 }
 

--- a/tests/e2e/go/scenario_gpu_operator_test.go
+++ b/tests/e2e/go/scenario_gpu_operator_test.go
@@ -189,9 +189,10 @@ func assertRuntimeXidViaDCGM(ctx SpecContext, h *harness.Harness, xid int) {
 		config.ReadyTimeout(), config.PollInterval())
 }
 
-// injectXidAndValidate enables failure injection, rolls nvml-mock and
-// dcgm-exporter to reload the mock config, then asserts DCGM_FI_DEV_XID_ERRORS.
-// ecc_uncorrectable keeps the device scrapable while the Xid event fires.
+// injectXidAndValidate enables failure injection, restarts dcgm-exporter so
+// DCGM re-initialises against the new mock config, then asserts
+// DCGM_FI_DEV_XID_ERRORS. ecc_uncorrectable keeps the device scrapable while
+// the Xid event fires.
 func injectXidAndValidate(ctx context.Context, h *harness.Harness, xid int) {
 	GinkgoHelper()
 	By("enabling failure injection (ecc_uncorrectable, xid) on nvml-mock")
@@ -211,11 +212,12 @@ func injectXidAndValidate(ctx context.Context, h *harness.Harness, xid int) {
 		Timeout: config.HelmTimeout(),
 	})).To(Succeed(), "enable failure injection on nvml-mock")
 
-	rolloutRestart(ctx, h, nvmlMockNamespace, "nvml-mock")
+	// nvml-mock needs no explicit restart: the chart checksums the rendered GPU
+	// config into its pod template, so the --wait upgrade above already rolled it.
 	rolloutRestart(ctx, h, gpuOperatorNamespace, "nvidia-dcgm-exporter")
 
 	assertions.DCGMXidReported(ctx, h.Kube, gpuOperatorNamespace, xid,
-		config.ReadyTimeout(), config.PollInterval())
+		config.OperandSettleTimeout(), config.PollInterval())
 }
 
 // rolloutRestart restarts a DaemonSet and blocks until the rollout completes.


### PR DESCRIPTION
## What This PR Does
Enabling failure injection takes the node's mock GPUs away, so the operator replaces its operands a reconcile later, after the spec's own rollouts report success.

- Drop the explicit nvml-mock restart: the chart checksums the GPU config into the pod template, so the --wait upgrade already rolls it.
- Fold readiness, pod lookup and the scrape into one Eventually in DCGMXidReported, re-resolving the exporter pod as it is replaced.
- Give that path OperandSettleTimeout (5m, E2E_OPERAND_SETTLE_TIMEOUT) instead of the single-rollout ReadyTimeout.
- Require observedGeneration and updatedNumberScheduled in DaemonSetReady, so a DaemonSet that has not begun rolling is not reported ready.

## Why
Addresses #602.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`go test -v -race ./...`)
- [x] Linter passes (`golangci-lint run`)
- [] New code has SPDX license headers
- [x] Documentation updated (if applicable)
- [] CHANGELOG.md updated (if user-facing change)
