### PR TITLE
Prevent dependabot from partial updates of codeql actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,12 @@ updates:
     target-branch: main
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+
+    groups:
+      codeql-action: # all CodeQL actions should be upgraded at the same time otherwise they fail partially
+        patterns:
+          - "github/codeql-action"
 
   - package-ecosystem: "docker"
     target-branch: main


### PR DESCRIPTION
## What This PR Does

Prevent dependabot from partial updates of codeql actions by forcing dependabot atomically upgrade them in one PR.

## Why

CodeQL actions fail when their version is out of sync e.g. upgraded in a different PRs:
- https://github.com/NVIDIA/k8s-test-infra/pull/608
- https://github.com/NVIDIA/k8s-test-infra/pull/607

## Checklist

- [ ] Commits are signed off (`git commit -s`)
- [ ] Tests pass (`go test -v -race ./...`)
- [ ] Linter passes (`golangci-lint run`)
- [ ] New code has SPDX license headers
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (if user-facing change)
