### PR TITLE
feat(demo): deliver compute-domain mocks through NRI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The ComputeDomain demo now runs real IMEX as a separate, ordinary workload;
+  NRI supplies its mock NVML overlay, per-node topology, and annotated channel
+  devices. Reruns deterministically reuse only compatible NRI-enabled Kind
+  clusters, while incompatible clusters require explicit recreation with
+  `FORCE_RECREATE=true`.
+
 ## [0.3.0] - 2026-08-01
 
 ### Added

--- a/deployments/nvml-mock/Dockerfile.compute-domain-daemon
+++ b/deployments/nvml-mock/Dockerfile.compute-domain-daemon
@@ -23,8 +23,8 @@
 #       --nogpu appended: the real daemon then runs the real gRPC peer
 #       protocol without GPUs.
 #
-#   demo — the same real-IMEX trio layered onto the nvml-mock image;
-#       used by docs/demo/compute-domain/run.sh Scenario 2.
+#   demo — compatibility target with the same real-IMEX trio layered
+#       onto the nvml-mock image; used by the local Tilt workflow.
 #
 # LOCAL BUILD ONLY — never publish these images: they repackage the
 # proprietary nvidia-imex binary (installed from Ubuntu jammy
@@ -81,7 +81,7 @@ COPY --from=shim /out/imex-nogpu-shim         /usr/bin/nvidia-imex
 # daemon (default target): real IMEX on top of the upstream
 # compute-domain-daemon image. Upstream renders its own imexd.cfg from
 # its template, so no config.cfg is copied here.
-FROM ${COMPUTE_DOMAIN_DAEMON_IMAGE}
+FROM ${COMPUTE_DOMAIN_DAEMON_IMAGE} AS daemon
 COPY --from=imex /usr/bin/nvidia-imex         /usr/bin/nvidia-imex.real
 COPY --from=imex /usr/bin/nvidia-imex-ctl     /usr/bin/nvidia-imex-ctl
 COPY --from=shim /out/imex-nogpu-shim         /usr/bin/nvidia-imex

--- a/deployments/nvml-mock/helm/nvml-mock/templates/network-policy-ibping.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/network-policy-ibping.yaml
@@ -4,16 +4,15 @@
 # The mock-ib TCP fabric listener binds 0.0.0.0:{{ .Values.infiniband.ping.port }}
 # with no authentication, and the DaemonSet runs privileged. This policy
 # limits the blast radius by allowing inbound fabric traffic only from peer
-# nvml-mock pods (the only legitimate clients) — it also admits the real
-# nvidia-imex NO GPU mode gRPC peer traffic (port 50000) and command/status
-# traffic (port 50005) between those same pods. Egress is left unrestricted
-# so DNS-based peer discovery and registration keep working.
+# nvml-mock pods (the only legitimate clients). Egress is left unrestricted so
+# DNS-based peer discovery and registration keep working.
 #
 # NOTE: kind's kindnetd ENFORCES NetworkPolicy on current kind releases, so
 # this allow-list is load-bearing on Kind, not just on Calico/Cilium clusters.
-# Any new pod-to-pod listener added to the mock stack must be allowed here —
-# the imex port below is required by the ComputeDomain demo's real
-# nvidia-imex daemons (NVIDIA/k8s-test-infra#304).
+# The IMEX ports remain for backwards compatibility and custom images that run
+# nvidia-imex inside this chart-managed daemon pod. The NRI-based ComputeDomain
+# demo runs IMEX in a separate workload selected by its own NetworkPolicy; this
+# chart policy neither selects nor admits that workload.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/docs/demo/compute-domain/Dockerfile
+++ b/docs/demo/compute-domain/Dockerfile
@@ -1,0 +1,41 @@
+# Copyright 2026 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# LOCAL BUILD ONLY — never publish this image: it repackages the proprietary
+# nvidia-imex binary installed from Ubuntu jammy multiverse.
+
+ARG GOLANG_VERSION=1.26.5
+
+# Jammy carries the 595 driver branch under this package name. Fail loudly if
+# the repository ever resolves it to a different branch.
+FROM ubuntu:22.04 AS imex
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends nvidia-imex-595 \
+ && rm -rf /var/lib/apt/lists/* \
+ && dpkg-query -W -f='${Version}\n' nvidia-imex-595 | tee /imex-version \
+ && grep -q '^595\.' /imex-version
+
+FROM golang:${GOLANG_VERSION} AS shim
+WORKDIR /src
+COPY go.mod go.sum ./
+COPY vendor/ vendor/
+COPY cmd/imex-nogpu-shim/ cmd/imex-nogpu-shim/
+RUN CGO_ENABLED=0 go build -mod=vendor -o /out/imex-nogpu-shim ./cmd/imex-nogpu-shim
+
+# Retain the package configuration and runtime dependencies while replacing
+# the daemon entry point with the NO GPU mode shim.
+FROM imex
+RUN mv /usr/bin/nvidia-imex /usr/bin/nvidia-imex.real
+COPY --from=shim /out/imex-nogpu-shim /usr/bin/nvidia-imex

--- a/docs/demo/compute-domain/README.md
+++ b/docs/demo/compute-domain/README.md
@@ -12,7 +12,11 @@ introduced by [NVIDIA/k8s-test-infra#304](https://github.com/NVIDIA/k8s-test-inf
   domains and which Kubernetes nodes belong to which clique. The mock
   NVML library overlays it on top of the per-profile YAML at
   `LoadConfig()` time.
-* **Real `nvidia-imex` in NO GPU mode** — the demo overlay image fronts
+* **NRI-delivered mock stack** — the chart stages mock files on every
+  node, and containerd NRI injects that overlay, the node-specific topology
+  environment, and annotated IMEX channel nodes into a separate demo workload
+  DaemonSet. The demo workload has no mock mounts or mock environment.
+* **Real `nvidia-imex` in NO GPU mode** — the demo workload image fronts
   the real daemon with `imex-nogpu-shim` (`/usr/bin/nvidia-imex` exec's
   `/usr/bin/nvidia-imex.real --nogpu`), so IMEX readiness is the real
   gRPC peer protocol over the pod network: `nvidia-imex-ctl -q` prints
@@ -38,21 +42,22 @@ The demo expects the following tools on `$PATH`:
 
 ## What the script does
 
-1. (Re)creates the dedicated Kind cluster (idempotent: an existing
-   `nvml-mock-compute-domain` cluster is reused).
-2. Builds and loads the `nvml-mock:compute-domain` image (bundles
-   `/usr/local/bin/check-fabric` on top of the standard nvml-mock
-   image), then builds the `nvml-mock:compute-domain-imex` overlay via
-   the `demo` target of
-   [`Dockerfile.compute-domain-daemon`](../../../deployments/nvml-mock/Dockerfile.compute-domain-daemon),
-   which layers the real `nvidia-imex` (NO GPU mode via
-   `imex-nogpu-shim`) on top — the image the DaemonSet actually runs.
+1. Creates the dedicated Kind cluster. An existing cluster is reused only when
+   containerd NRI is enabled on every expected node. A legacy cluster created
+   by an older version of the demo is rejected; set `FORCE_RECREATE=true` to
+   explicitly delete and recreate it.
+2. Builds and loads the standard `nvml-mock:compute-domain` image, then
+   builds the `nvml-mock:compute-domain-workload` image from the demo's
+   [`Dockerfile`](./Dockerfile). It contains the real `nvidia-imex` (NO GPU
+   mode via `imex-nogpu-shim`) but no mock GPU files.
 3. Installs the chart with:
 
    ```text
    gpu.profile=gb200
    topology.enabled=true
    topology.domains=<demo topology>
+   nri.enabled=true
+   imex.mockChannels.enabled=true
    ```
 
    This renders both ConfigMaps (`nvml-mock-config` and
@@ -67,13 +72,26 @@ The demo expects the following tools on `$PATH`:
    *stronger* evidence: every one of the 8 GPUs on each node must
    report the same `cliqueId` / `clusterUuid`, exercising the
    topology overlay over the full device list rather than a subset.
-4. **Scenario 1 — per-node fabric identity**. Runs `check-fabric`
-   inside one pod per worker and asserts:
+4. Recycles the staging and NRI DaemonSets in order, then creates a separate
+   `compute-domain-workload` namespace and deploys the freshly restarted
+   `compute-domain-demo-workload` DaemonSet. Its only mock-related configuration
+   is the `nvml-mock.nvidia.com/imex-channels: "true"` annotation. NRI supplies
+   the mock NVML overlay and per-node topology identity at container creation.
+   The demo workload manifest also installs its own ingress NetworkPolicy,
+   allowing TCP 50000 and 50005 only from peer
+   `app.kubernetes.io/name=compute-domain-demo-workload` pods in that same
+   namespace while leaving egress unrestricted.
+   Before installation the script selects two character-device majors unused
+   across every Kind node. This avoids collisions with host-kernel assignments
+   such as `hidraw` on major 236.
+5. **Scenario 1 — per-node fabric identity**. Runs NRI-injected
+   `check-fabric` inside one demo workload pod per worker and asserts:
    * `nvml-mock-compute-domain-worker` / `-worker2` report **clique 0**,
    * `-worker3` / `-worker4` report **clique 1**,
    * every node reports the demo cluster UUID
      `00000000-0000-0000-0000-0000000000ab` and `state=completed`.
-5. **Scenario 2 — real IMEX domain (NO GPU mode)**. Renders a per-pod
+6. **Scenario 2 — real IMEX domain (NO GPU mode)**. First verifies the
+   NRI-injected channel device, then renders a per-pod
    IMEX config, starts the real `nvidia-imex` (the shim appends
    `--nogpu`) in both clique-0 pods, and asserts three transitions:
    * daemon A alone → local `-q` probe `READY`, domain not `UP`,
@@ -81,7 +99,7 @@ The demo expects the following tools on `$PATH`:
      version `NO_GPU` (real gRPC over the pod network),
    * daemon B SIGTERMed → domain leaves `UP` (real liveness — the
      deprecated marker files couldn't detect a dead peer).
-6. **Scenario 3 — topology rebinding (no image rebuild)**. A
+7. **Scenario 3 — topology rebinding (no image rebuild)**. A
    `helm upgrade --reuse-values` swaps the topology document so every
    node is now a member of clique 99 in a brand-new domain UUID. After
    a forced DaemonSet recycle, `check-fabric` reflects the new
@@ -94,6 +112,17 @@ The demo expects the following tools on `$PATH`:
 ./docs/demo/compute-domain/run.sh
 ```
 
+To explicitly replace an existing cluster, including a legacy cluster that
+predates the demo's NRI configuration:
+
+```bash
+FORCE_RECREATE=true ./docs/demo/compute-domain/run.sh
+```
+
+`FORCE_RECREATE=true` deletes the entire `nvml-mock-compute-domain` Kind
+cluster before recreating it. The default is to preserve a compatible existing
+cluster and to stop with an actionable error for an incompatible one.
+
 The script locates the repository itself, so it works from any
 directory; the **manual-reproduction commands below assume you run
 them from the repository root**.
@@ -101,9 +130,9 @@ them from the repository root**.
 Expect roughly 10–20 minutes on a first run (Kind cluster creation
 plus two image builds dominate; Scenario 2's domain convergence alone
 may legitimately take up to 4 minutes — see Troubleshooting). Reruns
-are much faster: the script is idempotent, the existing cluster is
-reused, and `helm upgrade --install` covers both first-time install
-and follow-up upgrades.
+reuse the existing cluster and build caches, but deliberately recycle the
+staging, NRI, and demo workload DaemonSets so same-tag image rebuilds, restored
+topology, and cleanup after a failed run are deterministic.
 
 > **One runner per host.** The cluster name, Helm release, and image
 > tags are fixed, so two concurrent runs of this demo on the same
@@ -123,41 +152,111 @@ note at the end of this section if you need to rename it.
 kind create cluster --name nvml-mock-compute-domain \
     --config tests/e2e/kind-compute-domain-config.yaml
 
-# 2. Build the demo image (bundles check-fabric on top of the standard
-#    nvml-mock image), then layer the REAL nvidia-imex (NO GPU mode
-#    via imex-nogpu-shim) on top. nvidia-imex is proprietary but comes
+# 2. Build the standard mock image, then the separate real-IMEX demo workload
+#    image. nvidia-imex is proprietary but comes
 #    from the PUBLIC Ubuntu 22.04 multiverse repo (nvidia-imex-595) —
 #    no NVIDIA credentials or internal access needed. Local build only:
 #    never publish the resulting image.
 docker build -t nvml-mock:compute-domain -f deployments/nvml-mock/Dockerfile .
-docker build -t nvml-mock:compute-domain-imex \
-    --target demo \
-    --build-arg NVML_MOCK_IMAGE=nvml-mock:compute-domain \
+docker build -t nvml-mock:compute-domain-workload \
     --build-arg GOLANG_VERSION=$(hack/golang-version.sh) \
-    -f deployments/nvml-mock/Dockerfile.compute-domain-daemon .
+    -f docs/demo/compute-domain/Dockerfile .
 
-# 3. Load the demo image into the Kind cluster.
-kind load docker-image nvml-mock:compute-domain-imex --name nvml-mock-compute-domain
+# 3. Load both images into the Kind cluster.
+kind load docker-image nvml-mock:compute-domain nvml-mock:compute-domain-workload \
+    --name nvml-mock-compute-domain
 
-# 4. Install the chart. The --set image.* flags point the DaemonSet at
-#    the locally-loaded image (these are required — without them the
-#    chart pulls the default upstream image which does not have the
-#    real IMEX layer baked in).
-helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+# 4. Pick two character-device majors that are unused on every Kind node.
+#    Reusing a host-kernel major would make the mock /proc/devices inconsistent.
+KIND_NODES=(
+  nvml-mock-compute-domain-control-plane
+  nvml-mock-compute-domain-worker
+  nvml-mock-compute-domain-worker2
+  nvml-mock-compute-domain-worker3
+  nvml-mock-compute-domain-worker4
+)
+used_majors=$(for node in "${KIND_NODES[@]}"; do
+  docker exec "${node}" awk '$1 ~ /^[0-9]+$/ { print $1 }' /proc/devices
+done | sort -nu | tr '\n' ' ')
+
+for candidate in $(seq 240 4095); do
+  case " ${used_majors} " in
+    *" ${candidate} "*) ;;
+    *) IMEX_CHANNEL_MAJOR=${candidate}; break ;;
+  esac
+done
+if [[ -z "${IMEX_CHANNEL_MAJOR:-}" ]]; then
+  echo "Could not find an unused IMEX channel device major" >&2
+  exit 1
+fi
+used_majors="${used_majors} ${IMEX_CHANNEL_MAJOR}"
+
+for candidate in $(seq 240 4095); do
+  case " ${used_majors} " in
+    *" ${candidate} "*) ;;
+    *) IMEX_CAPS_MAJOR=${candidate}; break ;;
+  esac
+done
+if [[ -z "${IMEX_CAPS_MAJOR:-}" ]]; then
+  echo "Could not find an unused IMEX caps device major" >&2
+  exit 1
+fi
+printf 'Using IMEX device majors: channels=%s, caps=%s\n' \
+    "${IMEX_CHANNEL_MAJOR}" "${IMEX_CAPS_MAJOR}"
+
+# 5. Install mock staging + the node-local NRI plugin. The chart's
+#    DaemonSet uses the standard mock image; the real IMEX binary stays in a
+#    separate demo workload image.
+helm upgrade --install nvml-mock deployments/nvml-mock/helm/nvml-mock \
+    --kube-context kind-nvml-mock-compute-domain \
+    --namespace mokka --create-namespace \
     -f docs/demo/compute-domain/topology.yaml \
     --set image.repository=nvml-mock \
-    --set image.tag=compute-domain-imex \
+    --set image.tag=compute-domain \
     --set gpu.profile=gb200 \
+    --set nri.enabled=true \
+    --set imex.mockChannels.enabled=true \
+    --set imex.mockChannels.channelMajor="${IMEX_CHANNEL_MAJOR}" \
+    --set imex.mockChannels.capsMajor="${IMEX_CAPS_MAJOR}" \
+    --set-string updateStrategy.rollingUpdate.maxUnavailable=100% \
+    --set terminationGracePeriodSeconds=1 \
     --wait --timeout 180s
 
-# 5. Verify the per-node fabric overlay (Scenario 1).
-kubectl rollout status daemonset/nvml-mock --timeout=120s
+# 6. Refresh staging first and NRI second so the plugin registers the current
+#    files and topology before any demo workload container is created.
+kubectl --context kind-nvml-mock-compute-domain -n mokka \
+    rollout restart daemonset/nvml-mock
+kubectl --context kind-nvml-mock-compute-domain -n mokka \
+    rollout status daemonset/nvml-mock --timeout=180s
+kubectl --context kind-nvml-mock-compute-domain -n mokka \
+    rollout restart daemonset/nvml-mock-nri
+kubectl --context kind-nvml-mock-compute-domain -n mokka \
+    rollout status daemonset/nvml-mock-nri --timeout=180s
+
+# 7. Idempotently create the workload namespace, apply the demo workload
+#    and its namespace-local peer ingress policy, then restart the DaemonSet so
+#    reruns discard stale IMEX processes and injected data.
+kubectl --context kind-nvml-mock-compute-domain \
+    create namespace compute-domain-workload --dry-run=client -o yaml | \
+  kubectl --context kind-nvml-mock-compute-domain apply -f -
+kubectl --context kind-nvml-mock-compute-domain -n compute-domain-workload \
+    apply -f docs/demo/compute-domain/demo-workload.yaml
+kubectl --context kind-nvml-mock-compute-domain -n compute-domain-workload \
+    rollout restart daemonset/compute-domain-demo-workload
+kubectl --context kind-nvml-mock-compute-domain -n compute-domain-workload \
+    rollout status daemonset/compute-domain-demo-workload --timeout=180s
+
+# 8. Verify the NRI-delivered per-node fabric overlay (Scenario 1).
 for node in nvml-mock-compute-domain-{worker,worker2,worker3,worker4}; do
-  pod=$(kubectl get pods -l app.kubernetes.io/name=nvml-mock \
+  pod=$(kubectl --context kind-nvml-mock-compute-domain \
+    -n compute-domain-workload get pods \
+    -l app.kubernetes.io/name=compute-domain-demo-workload \
     --field-selector="spec.nodeName=${node},status.phase=Running" \
     -o jsonpath='{.items[0].metadata.name}')
   echo "=== ${node} (pod=${pod}) ==="
-  kubectl exec "${pod}" -- check-fabric | head -6
+  kubectl --context kind-nvml-mock-compute-domain \
+    -n compute-domain-workload exec "${pod}" -- \
+    sh -c 'test -c /dev/nvidia-caps-imex-channels/channel0 && check-fabric | head -6'
 done
 ```
 
@@ -197,25 +296,12 @@ protocol, no GPUs. Point its container image at the default (`daemon`)
 target of
 [`deployments/nvml-mock/Dockerfile.compute-domain-daemon`](../../../deployments/nvml-mock/Dockerfile.compute-domain-daemon).
 
-> **Heads up — patching the upstream chart.** The nvml-mock chart wires
-> `NODE_NAME` (downward API), `MOCK_TOPOLOGY_CONFIG`, and the topology
-> ConfigMap mount onto its own DaemonSet, which is why `check-fabric`
-> running inside the mock pod sees the per-node fabric identity for
-> free. The upstream `compute-domain-daemon` pod gets *none* of that
-> from its own chart, so if you swap its image for the
-> `Dockerfile.compute-domain-daemon` overlay above you also have to
-> patch the upstream values to:
->
-> 1. inject `NODE_NAME` via the downward API
->    (`fieldRef: spec.nodeName`),
-> 2. set `MOCK_TOPOLOGY_CONFIG=/config/topology.yaml` (or mount the
->    topology ConfigMap at whatever path you prefer and point this env
->    var at it),
-> 3. mount the `nvml-mock-topology` ConfigMap at that path.
->
-> Without those three additions the linked `libnvidia-ml.so` cannot
-> look up the node in the topology and falls back to the per-profile
-> defaults — the daemon will think every node is in the same clique.
+> **Using the upstream daemon chart.** With NRI enabled, its workload pod
+> does not need a mock driver mount, a topology ConfigMap mount, or manually
+> authored `NODE_NAME` / `MOCK_TOPOLOGY_CONFIG` variables: the node-local NRI
+> plugin injects those at container creation. It does need the
+> `nvml-mock.nvidia.com/imex-channels: "true"` annotation while the mock uses
+> channel nodes, and its namespace must not be one excluded by the NRI chart.
 
 ## Topology / clique layout used by the demo
 
@@ -242,20 +328,25 @@ list).
   failed peer connections with exponential backoff (15s, 31s, 62s,
   125s…). The script already waits up to 240s — let it finish before
   concluding failure. On timeout it prints the daemon log tail.
-* **Peers never connect at all.** The nvml-mock chart ships a
-  NetworkPolicy that allow-lists pod-to-pod ingress between nvml-mock
-  pods (TCP 18515 ibping, 50000 IMEX gRPC peer, 50005 IMEX
-  command/status). kindnetd **enforces** NetworkPolicy on current kind
-  releases, so if you add any new pod-to-pod listener to the stack it
-  must also be admitted in
-  `deployments/nvml-mock/helm/nvml-mock/templates/network-policy-ibping.yaml`
-  — otherwise its SYNs are silently dropped.
+* **Peers never connect at all.** The demo workload has its own NetworkPolicy
+  in [`demo-workload.yaml`](./demo-workload.yaml). It selects
+  `app.kubernetes.io/name=compute-domain-demo-workload` and admits TCP 50000
+  (IMEX gRPC peer) and 50005 (command/status) only from matching peer pods in
+  the same
+  `compute-domain-workload` namespace; egress remains unrestricted. kindnetd
+  **enforces** NetworkPolicy on current kind releases, so add any new workload
+  listener to that policy. The chart's separate `network-policy-ibping.yaml`
+  selects nvml-mock daemon pods, not this NRI-injected demo workload. Its IMEX
+  port allowances remain for backwards compatibility and custom chart images
+  that run IMEX inside the chart-managed DaemonSet.
 * **Rerunning after a failed Scenario 2.** A run that dies mid-scenario
-  leaves real `nvidia-imex` daemons holding port 50000 inside the pods,
-  and a rerun's daemons will fail to bind. Recycle the pods first:
-  `kubectl delete pods -l app.kubernetes.io/name=nvml-mock` (the
-  DaemonSet recreates them clean), or delete the cluster for a truly
-  fresh start. Successful runs clean up after themselves.
+  can leave real `nvidia-imex` daemons holding port 50000 inside the pods.
+  Normal reruns restart the `compute-domain-demo-workload` DaemonSet after
+  refreshing staging and NRI, so they discard those stale processes
+  automatically. To recycle the demo workload pods manually, run
+  `kubectl --context kind-nvml-mock-compute-domain -n compute-domain-workload
+  delete pods -l app.kubernetes.io/name=compute-domain-demo-workload`; the
+  DaemonSet recreates them clean.
 * **`nvidia-imex-ctl -N -j` shows the peer `UNAVAILABLE` with an empty
   version while connections look established.** Node status and version
   are exchanged over the IMEX *command* port (50005), separate from the
@@ -268,5 +359,5 @@ list).
 ```bash
 kind delete cluster --name nvml-mock-compute-domain
 # Optional: also remove the locally built demo images.
-docker rmi nvml-mock:compute-domain nvml-mock:compute-domain-imex
+docker rmi nvml-mock:compute-domain nvml-mock:compute-domain-workload
 ```

--- a/docs/demo/compute-domain/demo-workload.yaml
+++ b/docs/demo/compute-domain/demo-workload.yaml
@@ -1,0 +1,65 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# DaemonSet placement is intentional: scenarios 1 and 3 select pods by node and
+# require exactly one NRI-injected demo workload pod on every GPU worker.
+# The demo workload has no mock volume, mock environment variables, GPU request,
+# or RuntimeClass. containerd's NRI plugin supplies the mock overlay, topology
+# identity, and the annotated IMEX channel device nodes.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: compute-domain-demo-workload
+  labels:
+    app.kubernetes.io/name: compute-domain-demo-workload
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: compute-domain-demo-workload
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: compute-domain-demo-workload
+      annotations:
+        nvml-mock.nvidia.com/imex-channels: "true"
+    spec:
+      automountServiceAccountToken: false
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      containers:
+        - name: demo-workload
+          image: nvml-mock:compute-domain-workload
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+---
+# The real IMEX daemons listen on both the peer and command/status ports. A
+# podSelector-only peer is namespace-local, so only other pods from this
+# demo workload in compute-domain-workload can connect. Selecting Ingress alone
+# intentionally leaves all egress unrestricted.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: compute-domain-demo-workload
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: compute-domain-demo-workload
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: compute-domain-demo-workload
+      ports:
+        - port: 50000
+          protocol: TCP
+        - port: 50005
+          protocol: TCP

--- a/docs/demo/compute-domain/run.sh
+++ b/docs/demo/compute-domain/run.sh
@@ -42,10 +42,15 @@ set -euo pipefail
 CLUSTER_NAME="nvml-mock-compute-domain"
 KUBE_CONTEXT="kind-${CLUSTER_NAME}"
 IMAGE_NAME="nvml-mock:compute-domain"
-DEMO_IMAGE_NAME="nvml-mock:compute-domain-imex"
+WORKLOAD_IMAGE_NAME="nvml-mock:compute-domain-workload"
 RELEASE_NAME="nvml-mock"
+MOCK_NAMESPACE="mokka"
+WORKLOAD_NAMESPACE="compute-domain-workload"
+WORKLOAD_NAME="compute-domain-demo-workload"
+WORKLOAD_SELECTOR="app.kubernetes.io/name=${WORKLOAD_NAME}"
 CHART_PATH="deployments/nvml-mock/helm/nvml-mock"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+: "${FORCE_RECREATE:=false}"
 KIND_CONFIG="${REPO_ROOT}/tests/e2e/kind-compute-domain-config.yaml"
 TOPOLOGY_FILE="${REPO_ROOT}/docs/demo/compute-domain/topology.yaml"
 EXPECTED_DOMAIN_UUID="00000000-0000-0000-0000-0000000000ab"
@@ -55,6 +60,7 @@ WORKER1="${CLUSTER_NAME}-worker"
 WORKER2="${CLUSTER_NAME}-worker2"
 WORKER3="${CLUSTER_NAME}-worker3"
 WORKER4="${CLUSTER_NAME}-worker4"
+KIND_NODES=("${CLUSTER_NAME}-control-plane" "${WORKER1}" "${WORKER2}" "${WORKER3}" "${WORKER4}")
 
 ###############################################################################
 # Helpers
@@ -69,11 +75,65 @@ fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 # caller's current kubeconfig context.
 kubectl_ctx() { command kubectl --context "${KUBE_CONTEXT}" "$@"; }
 
+# A cluster created by an older version of this demo may lack the compatible
+# containerd NRI plugin configuration. Check every expected Kind node for both
+# the enabled plugin and the socket path used by the chart before reusing it.
+cluster_has_nri_enabled() {
+  local node
+  for node in "${KIND_NODES[@]}"; do
+    if ! docker exec "${node}" awk '
+      /^[[:space:]]*\[plugins\."io\.containerd\.nri\.v1\.nri"\][[:space:]]*$/ {
+        in_nri = 1
+        next
+      }
+      in_nri && /^[[:space:]]*\[/ { in_nri = 0 }
+      in_nri && /^[[:space:]]*disable[[:space:]]*=[[:space:]]*false[[:space:]]*$/ {
+        enabled = 1
+      }
+      in_nri && /^[[:space:]]*socket_path[[:space:]]*=[[:space:]]*"\/var\/run\/nri\/nri\.sock"[[:space:]]*$/ {
+        compatible_socket = 1
+      }
+      END { exit(enabled && compatible_socket ? 0 : 1) }
+    ' /etc/containerd/config.toml; then
+      sub "${node} does not have compatible containerd NRI config (requires disable=false and socket_path=\"/var/run/nri/nri.sock\")"
+      return 1
+    fi
+  done
+}
+
+# Pick two majors unused on every Kind node. The chart defaults are intended
+# for its DRA fixtures, but Kind's host kernel may already assign them (for
+# example, major 236 is hidraw on current nodes). Reusing one would make the
+# substitute /proc/devices lie, so setup.sh correctly rejects it.
+choose_imex_device_majors() {
+  local node candidate
+  local used_majors
+  used_majors=$(for node in "${KIND_NODES[@]}"; do
+    docker exec "${node}" awk '$1 ~ /^[0-9]+$/ { print $1 }' /proc/devices
+  done | sort -nu | tr '\n' ' ')
+
+  for candidate in $(seq 240 4095); do
+    case " ${used_majors} " in
+      *" ${candidate} "*) ;;
+      *) IMEX_CHANNEL_MAJOR=${candidate}; break ;;
+    esac
+  done
+  [[ -n "${IMEX_CHANNEL_MAJOR:-}" ]] || fail "could not find an unused IMEX channel device major"
+  used_majors="${used_majors} ${IMEX_CHANNEL_MAJOR}"
+
+  for candidate in $(seq 240 4095); do
+    case " ${used_majors} " in
+      *" ${candidate} "*) ;;
+      *) IMEX_CAPS_MAJOR=${candidate}; break ;;
+    esac
+  done
+  [[ -n "${IMEX_CAPS_MAJOR:-}" ]] || fail "could not find an unused IMEX caps device major"
+  sub "selected unused IMEX device majors: channels=${IMEX_CHANNEL_MAJOR}, caps=${IMEX_CAPS_MAJOR}"
+}
+
 command -v jq >/dev/null 2>&1 || fail "jq is required (Scenario 2 parses nvidia-imex-ctl JSON)"
 
-# pod_on_node: echo the name of the running nvml-mock pod scheduled on
-# the given Kubernetes node. Used both to query fabric info per node
-# and to drive the IMEX coordination test.
+# pod_on_node: echo the NRI-injected demo workload pod on the requested node.
 pod_on_node() {
   local node=$1
   # Poll briefly: the rollout settles before the API server's pod list
@@ -81,7 +141,7 @@ pod_on_node() {
   # reliable than a single shot.
   for _ in $(seq 1 30); do
     local name
-    name=$(kubectl_ctx get pods -l "app.kubernetes.io/name=${RELEASE_NAME}" \
+    name=$(kubectl_ctx -n "${WORKLOAD_NAMESPACE}" get pods -l "${WORKLOAD_SELECTOR}" \
       --field-selector="spec.nodeName=${node},status.phase=Running" \
       -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
     if [[ -n "${name}" ]]; then
@@ -93,18 +153,9 @@ pod_on_node() {
   return 1
 }
 
-# wait_for_rollout: block until every nvml-mock pod is Running, then
-# confirm at least one pod exists per worker (the topology overlay is
-# pulled on Init() per pod, so we can't verify clique assignment
-# before the pods are up).
-wait_for_rollout() {
-  kubectl_ctx rollout status "daemonset/${RELEASE_NAME}" --timeout=180s >/dev/null
-}
-
-# assert_clique: assert the check-fabric output from `node` reports
-# `expected_clique`. check-fabric prints one block per visible GPU; we
-# just spot-check GPU 0 since every GPU on a node shares the same
-# fabric identity by design.
+# assert_clique: assert every GPU reported by check-fabric on `node` has the
+# expected fabric identity. The discovered count, GPU indices, and complete
+# per-GPU blocks must agree so matches cannot be combined across devices.
 assert_clique() {
   local node=$1 expected_clique=$2 expected_uuid=$3
   local pod
@@ -112,20 +163,127 @@ assert_clique() {
   if [[ -z "${pod}" ]]; then
     fail "no running pod found on node ${node}"
   fi
-  sub "${node} (pod=${pod}) — running check-fabric"
-  local out
-  out=$(kubectl_ctx exec "${pod}" -- check-fabric 2>&1 || true)
+  sub "${node} (NRI-injected pod=${pod}) — running check-fabric"
+  local out command_status
+  if out=$(kubectl_ctx -n "${WORKLOAD_NAMESPACE}" exec "${pod}" -- check-fabric 2>&1); then
+    command_status=0
+  else
+    command_status=$?
+  fi
   printf '%s\n' "${out}" | sed 's/^/      /' >&2
-  if ! printf '%s\n' "${out}" | grep -q "cliqueId    : ${expected_clique}"; then
-    fail "${node}: expected cliqueId ${expected_clique} in check-fabric output"
+  if [[ ${command_status} -ne 0 ]]; then
+    fail "${node}: check-fabric exited with status ${command_status}"
   fi
-  if ! printf '%s\n' "${out}" | grep -qi "clusterUuid : ${expected_uuid}"; then
-    fail "${node}: expected clusterUuid ${expected_uuid} in check-fabric output"
+
+  local parsed_count
+  if ! parsed_count=$(printf '%s\n' "${out}" | awk \
+    -v expected_clique="${expected_clique}" \
+    -v expected_uuid="${expected_uuid}" '
+    function reject(message) {
+      print message
+      rejected = 1
+      exit 1
+    }
+    function finish_gpu() {
+      if (current_gpu < 0) {
+        return
+      }
+      if (!have_uuid || !have_clique || !have_state) {
+        reject("GPU " current_gpu " has an incomplete fabric-info block")
+      }
+      current_gpu = -1
+    }
+    BEGIN {
+      discovered = -1
+      current_gpu = -1
+      expected_uuid = tolower(expected_uuid)
+    }
+    /^Discovered [0-9][0-9]* GPU\(s\)$/ {
+      if (discovered >= 0) {
+        reject("multiple discovered-GPU count lines")
+      }
+      discovered = $2 + 0
+      if (discovered <= 0) {
+        reject("discovered GPU count must be positive")
+      }
+      next
+    }
+    /^Discovered / {
+      reject("malformed discovered-GPU count line: " $0)
+    }
+    /^GPU [0-9][0-9]* \(.*\)$/ {
+      if (discovered < 0) {
+        reject("GPU block appears before the discovered-GPU count")
+      }
+      finish_gpu()
+      current_gpu = $2 + 0
+      if (current_gpu >= discovered) {
+        reject("GPU index " current_gpu " is outside discovered count " discovered)
+      }
+      if (seen_gpu[current_gpu]) {
+        reject("duplicate GPU index " current_gpu)
+      }
+      seen_gpu[current_gpu] = 1
+      parsed++
+      have_uuid = have_clique = have_state = 0
+      next
+    }
+    /^GPU / {
+      reject("malformed GPU block header: " $0)
+    }
+    /^[[:space:]]*clusterUuid[[:space:]]*:/ {
+      if (current_gpu < 0 || have_uuid) {
+        reject("misplaced or duplicate clusterUuid field")
+      }
+      value = $0
+      sub(/^[^:]*:[[:space:]]*/, "", value)
+      if (tolower(value) != expected_uuid) {
+        reject("GPU " current_gpu " has clusterUuid " value ", expected " expected_uuid)
+      }
+      have_uuid = 1
+      next
+    }
+    /^[[:space:]]*cliqueId[[:space:]]*:/ {
+      if (current_gpu < 0 || have_clique) {
+        reject("misplaced or duplicate cliqueId field")
+      }
+      value = $0
+      sub(/^[^:]*:[[:space:]]*/, "", value)
+      if (value != expected_clique) {
+        reject("GPU " current_gpu " has cliqueId " value ", expected " expected_clique)
+      }
+      have_clique = 1
+      next
+    }
+    /^[[:space:]]*state[[:space:]]*:/ {
+      if (current_gpu < 0 || have_state) {
+        reject("misplaced or duplicate state field")
+      }
+      value = $0
+      sub(/^[^:]*:[[:space:]]*/, "", value)
+      if (value !~ /^completed[[:space:]]+\(3\)$/) {
+        reject("GPU " current_gpu " has state " value ", expected completed (3)")
+      }
+      have_state = 1
+      next
+    }
+    END {
+      if (rejected) {
+        exit 1
+      }
+      finish_gpu()
+      if (discovered < 0) {
+        reject("missing discovered-GPU count")
+      }
+      if (parsed != discovered) {
+        reject("parsed " parsed " GPU blocks, discovered count is " discovered)
+      }
+      print parsed
+    }
+  '); then
+    fail "${node}: invalid check-fabric output: ${parsed_count}"
   fi
-  if ! printf '%s\n' "${out}" | grep -q 'state       : completed'; then
-    fail "${node}: expected state=completed in check-fabric output"
-  fi
-  ok "${node}: clique=${expected_clique} uuid=${expected_uuid} state=completed"
+  ok "${node}: ${parsed_count}/${parsed_count} GPUs have clique=${expected_clique} uuid=${expected_uuid} state=completed"
 }
 
 ###############################################################################
@@ -133,10 +291,20 @@ assert_clique() {
 ###############################################################################
 info "Creating Kind cluster: ${CLUSTER_NAME}"
 if kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
-  sub "Cluster already exists, reusing it"
+  if [[ "${FORCE_RECREATE}" == "true" ]]; then
+    sub "Cluster already exists; FORCE_RECREATE=true, deleting it"
+    kind delete cluster --name "${CLUSTER_NAME}"
+    kind create cluster --name "${CLUSTER_NAME}" --config="${KIND_CONFIG}"
+  elif cluster_has_nri_enabled; then
+    sub "Cluster already exists with containerd NRI enabled, reusing it"
+  else
+    fail "existing cluster '${CLUSTER_NAME}' is incompatible with this NRI-based demo; rerun with FORCE_RECREATE=true to delete and recreate it"
+  fi
 else
   kind create cluster --name "${CLUSTER_NAME}" --config="${KIND_CONFIG}"
 fi
+
+choose_imex_device_majors
 
 ###############################################################################
 # Step 2 — Build + load the image
@@ -145,20 +313,19 @@ info "Building image: ${IMAGE_NAME}"
 docker build -t "${IMAGE_NAME}" \
   -f "${REPO_ROOT}/deployments/nvml-mock/Dockerfile" "${REPO_ROOT}"
 
-# Layer the REAL nvidia-imex (NO GPU mode via imex-nogpu-shim) on top.
+# Build the demo workload with real nvidia-imex in NO GPU mode.
 # Local build only — this image repackages the proprietary nvidia-imex.
-info "Building demo overlay with real nvidia-imex: ${DEMO_IMAGE_NAME}"
-docker build -t "${DEMO_IMAGE_NAME}" \
-  --target demo \
-  --build-arg "NVML_MOCK_IMAGE=${IMAGE_NAME}" \
+info "Building demo workload image with real nvidia-imex: ${WORKLOAD_IMAGE_NAME}"
+docker build -t "${WORKLOAD_IMAGE_NAME}" \
   --build-arg "GOLANG_VERSION=$("${REPO_ROOT}/hack/golang-version.sh")" \
-  -f "${REPO_ROOT}/deployments/nvml-mock/Dockerfile.compute-domain-daemon" "${REPO_ROOT}"
+  -f "${REPO_ROOT}/docs/demo/compute-domain/Dockerfile" "${REPO_ROOT}"
 
-info "Loading image into Kind"
-kind load docker-image "${DEMO_IMAGE_NAME}" --name "${CLUSTER_NAME}"
+info "Loading images into Kind"
+kind load docker-image "${IMAGE_NAME}" "${WORKLOAD_IMAGE_NAME}" --name "${CLUSTER_NAME}"
 
 ###############################################################################
-# Step 3 — Install nvml-mock with gb200 + topology (real IMEX via demo image)
+# Step 3 — Stage nvml-mock and deploy the NRI-injected real-IMEX demo workload
+# with its namespace-local peer ingress policy
 ###############################################################################
 # NOTE: `--set-file topology.domains=...` cannot be used here. That
 # flag stuffs the raw file bytes in as a string literal, which would
@@ -166,7 +333,7 @@ kind load docker-image "${DEMO_IMAGE_NAME}" --name "${CLUSTER_NAME}"
 # as an indented block scalar instead of the structured array the
 # engine expects. Using `-f <values-file>` lets helm parse the file
 # normally and deep-merge it with the defaults.
-info "Installing chart (gb200 + topology; real IMEX via demo image)"
+info "Installing chart (gb200 + topology + NRI channel injection)"
 # NOTE: `--set gpu.count=...` is intentionally NOT passed. The flag
 # only controls the host-side CDI spec / /dev/nvidia* device nodes
 # emitted by setup.sh; the in-pod ConfigMap mounted at
@@ -178,28 +345,52 @@ info "Installing chart (gb200 + topology; real IMEX via demo image)"
 # the deeper the per-node device list goes.
 helm upgrade --install "${RELEASE_NAME}" "${REPO_ROOT}/${CHART_PATH}" \
   --kube-context "${KUBE_CONTEXT}" \
+  --namespace "${MOCK_NAMESPACE}" --create-namespace \
   -f "${TOPOLOGY_FILE}" \
   --set image.repository=nvml-mock \
-  --set image.tag=compute-domain-imex \
+  --set image.tag=compute-domain \
   --set gpu.profile=gb200 \
+  --set nri.enabled=true \
+  --set imex.mockChannels.enabled=true \
+  --set imex.mockChannels.channelMajor="${IMEX_CHANNEL_MAJOR}" \
+  --set imex.mockChannels.capsMajor="${IMEX_CAPS_MAJOR}" \
   --set-string updateStrategy.rollingUpdate.maxUnavailable=100% \
   --set terminationGracePeriodSeconds=1 \
   --wait --timeout 180s >/dev/null
 
-wait_for_rollout
+# Helm cannot detect that a same-tag local image was rebuilt, and changing the
+# topology ConfigMap does not rerun setup.sh or restart the demo workload.
+# Always recycle in dependency order so reruns stage the current topology and
+# image, register the current NRI plugin, and discard any IMEX process left by a
+# failed run. A fresh cluster pays for one redundant rollout; keeping one path
+# for fresh and reused clusters is the deliberate simplicity tradeoff.
+info "Refreshing staging and NRI DaemonSets"
+kubectl_ctx -n "${MOCK_NAMESPACE}" rollout restart "daemonset/${RELEASE_NAME}" >/dev/null
+kubectl_ctx -n "${MOCK_NAMESPACE}" rollout status "daemonset/${RELEASE_NAME}" --timeout=180s >/dev/null
+kubectl_ctx -n "${MOCK_NAMESPACE}" rollout restart "daemonset/${RELEASE_NAME}-nri" >/dev/null
+kubectl_ctx -n "${MOCK_NAMESPACE}" rollout status "daemonset/${RELEASE_NAME}-nri" --timeout=180s >/dev/null
+
+info "Deploying real-IMEX demo workload with peer-only ingress (mock delivery is entirely NRI)"
+kubectl_ctx create namespace "${WORKLOAD_NAMESPACE}" --dry-run=client -o yaml | kubectl_ctx apply -f - >/dev/null
+# This manifest contains both the DaemonSet and its own NetworkPolicy. The
+# chart's ibping policy selects nvml-mock daemon pods in ${MOCK_NAMESPACE}; it
+# does not govern this separate demo workload.
+kubectl_ctx -n "${WORKLOAD_NAMESPACE}" apply -f "${REPO_ROOT}/docs/demo/compute-domain/demo-workload.yaml" >/dev/null
+kubectl_ctx -n "${WORKLOAD_NAMESPACE}" rollout restart "daemonset/${WORKLOAD_NAME}" >/dev/null
+kubectl_ctx -n "${WORKLOAD_NAMESPACE}" rollout status "daemonset/${WORKLOAD_NAME}" --timeout=180s >/dev/null
 
 ###############################################################################
 # Step 4 — Verify the rendered topology ConfigMap
 ###############################################################################
 info "Rendered topology ConfigMap"
-kubectl_ctx get "configmap/${RELEASE_NAME}-topology" \
+kubectl_ctx -n "${MOCK_NAMESPACE}" get "configmap/${RELEASE_NAME}-topology" \
   -o jsonpath='{.data.topology\.yaml}' | sed 's/^/    /'
 echo
 
 ###############################################################################
 # Scenario 1 — Per-node clique assignment via mock NVML fabric API
 ###############################################################################
-info "Scenario 1: per-node fabric identity (cluster ${EXPECTED_DOMAIN_UUID})"
+info "Scenario 1: NRI-delivered per-node fabric identity (cluster ${EXPECTED_DOMAIN_UUID})"
 assert_clique "${WORKER1}" 0 "${EXPECTED_DOMAIN_UUID}"
 assert_clique "${WORKER2}" 0 "${EXPECTED_DOMAIN_UUID}"
 assert_clique "${WORKER3}" 1 "${EXPECTED_DOMAIN_UUID}"
@@ -208,20 +399,28 @@ assert_clique "${WORKER4}" 1 "${EXPECTED_DOMAIN_UUID}"
 ###############################################################################
 # Scenario 2 — Real IMEX domain (NO GPU mode) over the pod network
 ###############################################################################
-# The demo image carries the real nvidia-imex behind imex-nogpu-shim:
+# The demo workload image carries the real nvidia-imex behind imex-nogpu-shim;
+# NRI supplies the mock NVML overlay, topology environment, and IMEX channels.
 # /usr/bin/nvidia-imex exec's /usr/bin/nvidia-imex.real --nogpu. The
-# daemons below speak the real gRPC peer protocol (port 50000) across
-# pods — no shared hostPath, no marker files. This is the protocol the
-# upstream compute-domain-daemon drives; the fake marker binaries it
-# replaces are deprecated.
+# daemons below speak the real gRPC peer protocol (port 50000) and exchange
+# command/status data (port 50005) across pods. The demo workload's NetworkPolicy
+# admits those ports only from its peer pods in the same namespace and leaves
+# egress unrestricted. There is no shared hostPath or marker file. This is the
+# protocol the upstream compute-domain-daemon drives; the fake marker binaries
+# it replaces are deprecated.
 info "Scenario 2: real IMEX domain (NO GPU mode) over the pod network"
 
 POD_A=$(pod_on_node "${WORKER1}")
 POD_B=$(pod_on_node "${WORKER2}")
 sub "clique 0 pods: ${POD_A}, ${POD_B}"
 
-IP_A=$(kubectl_ctx get pod "${POD_A}" -o jsonpath='{.status.podIP}')
-IP_B=$(kubectl_ctx get pod "${POD_B}" -o jsonpath='{.status.podIP}')
+for pod in "${POD_A}" "${POD_B}"; do
+  kubectl_ctx -n "${WORKLOAD_NAMESPACE}" exec "${pod}" -- test -c /dev/nvidia-caps-imex-channels/channel0
+done
+ok "NRI injected mock IMEX channel nodes into both demo workload pods"
+
+IP_A=$(kubectl_ctx -n "${WORKLOAD_NAMESPACE}" get pod "${POD_A}" -o jsonpath='{.status.podIP}')
+IP_B=$(kubectl_ctx -n "${WORKLOAD_NAMESPACE}" get pod "${POD_B}" -o jsonpath='{.status.podIP}')
 sub "pod IPs: ${POD_A}=${IP_A}  ${POD_B}=${IP_B}"
 
 # Render a per-pod IMEX config: foreground daemon, our nodes file, a
@@ -229,7 +428,7 @@ sub "pod IPs: ${POD_A}=${IP_A}  ${POD_B}=${IP_B}"
 IMEX_CFG=/tmp/imex.cfg
 NODES_CFG=/tmp/nodes.cfg
 for pod in "${POD_A}" "${POD_B}"; do
-  kubectl_ctx exec "${pod}" -- sh -c "
+  kubectl_ctx -n "${WORKLOAD_NAMESPACE}" exec "${pod}" -- sh -c "
     printf '%s\n%s\n' '${IP_A}' '${IP_B}' > '${NODES_CFG}'
     sed -e 's/^DAEMONIZE=1/DAEMONIZE=0/' \
         -e 's|^IMEX_NODE_CONFIG_FILE=.*|IMEX_NODE_CONFIG_FILE=${NODES_CFG}|' \
@@ -239,7 +438,7 @@ done
 
 start_imex() {
   local pod=$1
-  kubectl_ctx exec "${pod}" -- sh -c \
+  kubectl_ctx -n "${WORKLOAD_NAMESPACE}" exec "${pod}" -- sh -c \
     "nvidia-imex -c ${IMEX_CFG} >/tmp/imex.stdout 2>&1 & echo \$! > /tmp/imex.pid"
 }
 
@@ -248,7 +447,7 @@ start_imex() {
 # still coming up.
 imex_domain_status() {
   local pod=$1
-  kubectl_ctx exec "${pod}" -- nvidia-imex-ctl -c "${IMEX_CFG}" -N -j 2>/dev/null \
+  kubectl_ctx -n "${WORKLOAD_NAMESPACE}" exec "${pod}" -- nvidia-imex-ctl -c "${IMEX_CFG}" -N -j 2>/dev/null \
     | jq -r '.status' 2>/dev/null || printf 'UNREACHABLE\n'
 }
 
@@ -264,7 +463,7 @@ wait_domain_status() {
     fi
     sleep 1
   done
-  kubectl_ctx exec "${pod}" -- sh -c 'tail -20 /tmp/nvidia-imex.log 2>/dev/null' >&2 || true
+  kubectl_ctx -n "${WORKLOAD_NAMESPACE}" exec "${pod}" -- sh -c 'tail -20 /tmp/nvidia-imex.log 2>/dev/null' >&2 || true
   fail "domain status never became ${want} ${reason}"
 }
 
@@ -275,7 +474,7 @@ sub "starting real nvidia-imex (--nogpu via shim) in ${POD_A}"
 start_imex "${POD_A}"
 Q_OUT=""
 for _ in $(seq 1 30); do
-  Q_OUT=$(kubectl_ctx exec "${POD_A}" -- nvidia-imex-ctl -c "${IMEX_CFG}" -q 2>/dev/null || true)
+  Q_OUT=$(kubectl_ctx -n "${WORKLOAD_NAMESPACE}" exec "${POD_A}" -- nvidia-imex-ctl -c "${IMEX_CFG}" -q 2>/dev/null || true)
   [[ "${Q_OUT}" == "READY" ]] && break
   sleep 1
 done
@@ -293,7 +492,7 @@ start_imex "${POD_B}"
 wait_domain_status "${POD_A}" "UP" "after both daemons started (real cross-node gRPC)"
 
 # Every member must be READY and report the NO_GPU version handshake.
-NODES_JSON=$(kubectl_ctx exec "${POD_A}" -- nvidia-imex-ctl -c "${IMEX_CFG}" -N -j 2>/dev/null)
+NODES_JSON=$(kubectl_ctx -n "${WORKLOAD_NAMESPACE}" exec "${POD_A}" -- nvidia-imex-ctl -c "${IMEX_CFG}" -N -j 2>/dev/null)
 READY_NODES=$(printf '%s' "${NODES_JSON}" | jq -r '[.nodes[] | select(.status=="READY")] | length')
 NOGPU_NODES=$(printf '%s' "${NODES_JSON}" | jq -r '[.nodes[] | select(.version=="NO_GPU")] | length')
 [[ "${READY_NODES}" == "2" ]] || fail "want 2 READY nodes, got ${READY_NODES}: ${NODES_JSON}"
@@ -304,7 +503,7 @@ ok "2/2 nodes READY, version NO_GPU — real IMEX domain over the pod network"
 # liveness detection — the property the deprecated marker files could
 # not provide (a SIGKILLed fake left its marker behind).
 sub "killing nvidia-imex in ${POD_B}"
-kubectl_ctx exec "${POD_B}" -- sh -c 'kill -TERM "$(cat /tmp/imex.pid)" 2>/dev/null || true'
+kubectl_ctx -n "${WORKLOAD_NAMESPACE}" exec "${POD_B}" -- sh -c 'kill -TERM "$(cat /tmp/imex.pid)" 2>/dev/null || true'
 STATUS_AFTER="UP"
 for _ in $(seq 1 60); do
   STATUS_AFTER=$(imex_domain_status "${POD_A}")
@@ -315,7 +514,7 @@ done
 ok "peer death detected: domain status=${STATUS_AFTER} (real liveness)"
 
 # Tidy up daemon A so Scenario 3's rollout starts clean.
-kubectl_ctx exec "${POD_A}" -- sh -c 'kill -TERM "$(cat /tmp/imex.pid)" 2>/dev/null || true' || true
+kubectl_ctx -n "${WORKLOAD_NAMESPACE}" exec "${POD_A}" -- sh -c 'kill -TERM "$(cat /tmp/imex.pid)" 2>/dev/null || true' || true
 
 ###############################################################################
 # Scenario 3 — Topology rebinding (helm upgrade, no image rebuild)
@@ -342,16 +541,21 @@ topology:
 EOF
 helm upgrade "${RELEASE_NAME}" "${REPO_ROOT}/${CHART_PATH}" \
   --kube-context "${KUBE_CONTEXT}" \
+  --namespace "${MOCK_NAMESPACE}" \
   --reuse-values \
   -f "${NEW_TOPO}" \
   --wait --timeout 180s >/dev/null
 
-# The engine reads MOCK_TOPOLOGY_CONFIG once at process start, so we
-# need to recycle every pod for the new clique to take effect.
-sub "evicting pods to re-read topology"
-kubectl_ctx delete pods -l "app.kubernetes.io/name=${RELEASE_NAME}" \
+# The staging DaemonSet copies the topology into the node overlay, and the
+# NRI-injected engine reads it once at process start. Recycle staging first,
+# then the demo workload, so every new container receives the new file.
+sub "recycling staging pods and NRI demo workload pods to re-read topology"
+kubectl_ctx -n "${MOCK_NAMESPACE}" delete pods -l "app.kubernetes.io/name=${RELEASE_NAME}" \
   --ignore-not-found >/dev/null
-wait_for_rollout
+kubectl_ctx -n "${MOCK_NAMESPACE}" rollout status "daemonset/${RELEASE_NAME}" --timeout=180s >/dev/null
+kubectl_ctx -n "${WORKLOAD_NAMESPACE}" delete pods -l "${WORKLOAD_SELECTOR}" \
+  --ignore-not-found >/dev/null
+kubectl_ctx -n "${WORKLOAD_NAMESPACE}" rollout status "daemonset/${WORKLOAD_NAME}" --timeout=180s >/dev/null
 
 assert_clique "${WORKER1}" 99 "${NEW_UUID}"
 assert_clique "${WORKER2}" 99 "${NEW_UUID}"

--- a/local/compute-domain/compute_domain.tiltfile
+++ b/local/compute-domain/compute_domain.tiltfile
@@ -87,12 +87,13 @@ def build_images(with_dra):
         # local/compute-domain/dra-driver.values.yaml so the DRA
         # driver's compute-domain-daemon pods run the shim'd real IMEX
         # in NO-GPU mode instead of the GPU-required upstream binary.
-        # The Dockerfile's last stage is unnamed, so target= is omitted;
-        # docker builds the last stage by default.
+        # Select the named daemon stage explicitly so later stage additions
+        # cannot silently change this build's output.
         docker_build(
             DAEMON_IMAGE,
             context='.',
             dockerfile=_OVERLAY_DOCKERFILE,
+            target='daemon',
             only=[
                 'go.mod',
                 'go.sum',

--- a/tests/e2e/kind-compute-domain-config.yaml
+++ b/tests/e2e/kind-compute-domain-config.yaml
@@ -1,18 +1,18 @@
 # Copyright 2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 #
-# Kind cluster config for ComputeDomain (NVLink fabric) simulation.
+# Kind cluster config for the NRI-based ComputeDomain (NVLink fabric) demo.
 #
-# The real nvidia-imex daemons (NO GPU mode via imex-nogpu-shim)
-# coordinate over the pod network, so no shared hostPath is required.
-# The mock NVML library reads the topology overlay (Helm value
-# topology.enabled=true) to learn its clique / cluster UUID.
+# containerd NRI injects the staged mock stack, node topology identity, and
+# annotated IMEX channel devices into ordinary workload pods. The real
+# nvidia-imex daemons (NO GPU mode via imex-nogpu-shim) coordinate over the
+# pod network.
 #
-# Pair with the gb200 profile and topology enabled:
-#   helm install nvml-mock deployments/nvml-mock/helm/nvml-mock \
-#     --set gpu.profile=gb200 \
-#     --set topology.enabled=true \
-#     -f docs/demo/compute-domain/topology.yaml
+# Install nvml-mock in the dedicated `mokka` namespace with the `gb200`
+# profile, `topology.enabled=true`, `nri.enabled=true`, and
+# `imex.mockChannels.enabled=true`. Mock channel/caps majors must be unused on
+# every Kind node; use docs/demo/compute-domain/run.sh, which selects them
+# dynamically and supplies the topology overlay.
 #
 # Cluster-name convention: Kind names each worker
 # `<cluster-name>-worker[N]`. The demo's topology.yaml lists nodes as
@@ -26,6 +26,9 @@ containerdConfigPatches:
   - |-
     [plugins."io.containerd.grpc.v1.cri"]
       enable_cdi = true
+    [plugins."io.containerd.nri.v1.nri"]
+      disable = false
+      socket_path = "/var/run/nri/nri.sock"
 nodes:
   - role: control-plane
   - role: worker


### PR DESCRIPTION
## What This PR Does

Reworks the ComputeDomain demo so containerd NRI delivers the mock GPU stack to
an ordinary real-IMEX workload instead of baking mock libraries, files, mounts,
and environment variables into that workload.

The demo now:

- keeps the chart-managed `nvml-mock:compute-domain` DaemonSet as the node-local
  staging layer;
- adds a `workload` image target with Ubuntu, real `nvidia-imex`, and
  `imex-nogpu-shim`, but no nvml-mock payload;
- deploys an ordinary IMEX DaemonSet in a separate namespace and lets the NRI
  plugin inject the staged mock overlay, topology configuration, and annotated
  IMEX channel devices;
- selects unused character-device majors across every Kind node before enabling
  mock IMEX channels;
- gives the workload a peer-only ingress policy for the IMEX ports;
- rejects reused legacy clusters whose containerd NRI configuration is disabled
  or uses an incompatible socket, with `FORCE_RECREATE=true` as an explicit
  destructive opt-in;
- restarts staging, NRI, and workload DaemonSets in dependency order so reruns
  pick up same-tag images and topology changes; and
- verifies the injected channel device and the complete fabric identity of every
  reported GPU before exercising IMEX peer formation, liveness, and topology
  rebinding.

## Why

The previous demo ran the real IMEX overlay inside the nvml-mock DaemonSet. It
proved that the mock and the real IMEX protocol could work together, but it did
not prove the intended integration: an otherwise ordinary workload receiving
the mock driver surface, per-node topology identity, and channel devices through
NRI at container creation.

Separating node-local staging from the workload more closely represents how the
upstream ComputeDomain components consume nvml-mock. The reuse checks and ordered
rollouts also make repeated demo runs deterministic instead of silently reusing
an incompatible cluster or stale workload state.

## Validation

- `bash -n docs/demo/compute-domain/run.sh`
- extracted and syntax-checked the README manual-reproduction Bash block
- `git diff --check upstream/main...HEAD`
- strict YAML/TOML parsing and typed Kubernetes decoding of the changed manifests
- safe stub coverage for compatible/legacy/forced cluster paths, dynamic majors,
  NRI socket parsing, and adversarial multi-GPU fabric output
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `make check-modules`
- built and inspected the `workload` image target: real IMEX, ctl, config, and
  shim are present; mock libraries, files, and `check-fabric` are absent

A full Kind demo and Helm/Tilt validation were not run locally because `kind`,
`kubectl`, `helm`, and `tilt` are unavailable in this workspace.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`go test -v -race ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] New code has SPDX license headers
- [x] Documentation updated (if applicable)
- [x] CHANGELOG.md updated (if user-facing change)
