### PR TITLE
ci(e2e): cancel in-progress Go E2E runs on the same ref

### DIFF
--- a/.github/workflows/nvml-mock-e2e-go.yaml
+++ b/.github/workflows/nvml-mock-e2e-go.yaml
@@ -32,6 +32,10 @@
 # nvml-mock. Other jobs still use kindest/node directly and don't need this.
 name: nvml-mock E2E (Go)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary
- Add a `concurrency` group to `nvml-mock-e2e-go.yaml` keyed by workflow + ref
- Set `cancel-in-progress: true` so newer runs cancel pending/in-progress ones (same pattern as `helm.yaml`)

## Test plan
- [ ] Open/update a PR that triggers Go E2E and push a second commit while the first run is pending or in progress
- [ ] Confirm the earlier workflow run is cancelled and the latest run proceeds