### PR TITLE
fix(nvml-mock): ship pciutils and set script mode via COPY --chmod

### DIFF
--- a/deployments/nvml-mock/Dockerfile
+++ b/deployments/nvml-mock/Dockerfile
@@ -121,5 +121,4 @@ RUN set -eux; \
     rm -rf /tmp/nvidia-utils /tmp/nvidia-utils-580*.deb \
            /usr/share/keyrings/nvidia.gpg /etc/apt/sources.list.d/nvidia.list; \
     apt-get purge -y --auto-remove curl ca-certificates gnupg2 patchelf
-COPY deployments/nvml-mock/scripts/ /scripts/
-RUN chmod +x /scripts/*.sh
+COPY --chmod=755 deployments/nvml-mock/scripts/ /scripts/

--- a/deployments/nvml-mock/Dockerfile
+++ b/deployments/nvml-mock/Dockerfile
@@ -72,6 +72,7 @@ COPY deployments/nvml-mock/scripts/stage-ib-tools.sh /usr/local/bin/stage-ib-too
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends curl ca-certificates gnupg2 \
+        pciutils \
         infiniband-diags rdma-core ibverbs-utils ibverbs-providers; \
     rm -rf /var/lib/apt/lists/*; \
     # libibverbs prints "couldn't open config directory '/etc/libibverbs.d'"


### PR DESCRIPTION
## Summary
- Install `pciutils` in the nvml-mock runtime image so `lspci` is available for PCI enumeration checks
- Replace `COPY` + `RUN chmod +x /scripts/*.sh` with `COPY --chmod=755` to set script permissions without an extra layer

## Test plan
- [ ] Build the nvml-mock image and confirm `lspci` is present (`lspci --version` / `/usr/bin/lspci`)
- [ ] Confirm `/scripts/*.sh` are executable after the image build
- [ ] Spot-check that existing InfiniBand package installs in the same `apt-get` layer still succeed