### PR TITLE
refactor: Use testify/require in the test suite

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,6 +69,14 @@ linters:
         - "-ST1000"
         - "-ST1003"
         - "-QF*"
+    testifylint:
+      # enable-all opts every testifylint check on -- expected-actual,
+      # require-error, error-nil, bool-compare, empty, len, formatter, the suite-*
+      # family, etc. Defaults cover most of these already; making the choice
+      # explicit prevents a quiet downgrade if a future edit drops the block, and
+      # keeps the migration from plain t.Fatal/Errorf gated by the strongest
+      # possible ruleset. The tree is clean under enable-all as of this commit.
+      enable-all: true
   exclusions:
     rules:
       # Ginkgo suites conventionally dot-import ginkgo and gomega, and

--- a/pkg/gpu/mocknvml/engine/config_override_merge_test.go
+++ b/pkg/gpu/mocknvml/engine/config_override_merge_test.go
@@ -13,19 +13,19 @@
 
 package engine
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestDeepMergeMaps_NestedOverrideAndPreserve(t *testing.T) {
 	dst := map[string]any{"ecc": map[string]any{"mode_current": "enabled", "default_mode": "enabled"}}
 	src := map[string]any{"ecc": map[string]any{"mode_current": "disabled"}}
 	deepMergeMaps(dst, src)
 	ecc := dst["ecc"].(map[string]any)
-	if ecc["mode_current"] != "disabled" {
-		t.Fatalf("mode_current not overridden: %v", ecc["mode_current"])
-	}
-	if ecc["default_mode"] != "enabled" {
-		t.Fatalf("default_mode should be preserved: %v", ecc["default_mode"])
-	}
+	require.Equal(t, "disabled", ecc["mode_current"], "mode_current not overridden")
+	require.Equal(t, "enabled", ecc["default_mode"], "default_mode should be preserved")
 }
 
 func TestDeviceConfigOverride_AllThenPerIndexPrecedence(t *testing.T) {
@@ -33,38 +33,31 @@ func TestDeviceConfigOverride_AllThenPerIndexPrecedence(t *testing.T) {
 		All:     map[string]any{"failure": map[string]any{"mode": "lost"}},
 		Devices: map[string]map[string]any{"0": {"failure": map[string]any{"mode": "ecc_uncorrectable"}}},
 	}
-	if got := o.DeviceConfigOverride(1)["failure"].(map[string]any)["mode"]; got != "lost" {
-		t.Fatalf("device 1 should inherit All: %v", got)
-	}
-	if got := o.DeviceConfigOverride(0)["failure"].(map[string]any)["mode"]; got != "ecc_uncorrectable" {
-		t.Fatalf("device 0 per-index should win: %v", got)
-	}
+	require.Equal(t, "lost",
+		o.DeviceConfigOverride(1)["failure"].(map[string]any)["mode"],
+		"device 1 should inherit All")
+	require.Equal(t, "ecc_uncorrectable",
+		o.DeviceConfigOverride(0)["failure"].(map[string]any)["mode"],
+		"device 0 per-index should win")
 }
 
 func TestMergeDeviceConfig_AppliesFailureMode(t *testing.T) {
 	base := &DeviceConfig{}
 	patch := map[string]any{"failure": map[string]any{"mode": "ecc_uncorrectable", "after_calls": 1}}
 	merged, err := MergeDeviceConfig(base, patch)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if merged.Failure == nil || merged.Failure.Mode != "ecc_uncorrectable" {
-		t.Fatalf("failure mode not applied: %+v", merged.Failure)
-	}
-	if base.Failure != nil {
-		t.Fatal("base must not be mutated")
-	}
+	require.NoError(t, err)
+	require.NotNil(t, merged.Failure, "failure mode not applied")
+	require.Equal(t, "ecc_uncorrectable", merged.Failure.Mode, "failure mode not applied")
+	require.Nil(t, base.Failure, "base must not be mutated")
 }
 
 func TestMergeDeviceConfig_RejectsUnknownField(t *testing.T) {
-	if _, err := MergeDeviceConfig(&DeviceConfig{}, map[string]any{"not_a_field": 1}); err == nil {
-		t.Fatal("expected error for unknown field")
-	}
+	_, err := MergeDeviceConfig(&DeviceConfig{}, map[string]any{"not_a_field": 1})
+	require.Error(t, err, "expected error for unknown field")
 }
 
 func TestParseConfigOverride_Empty(t *testing.T) {
 	o, err := ParseConfigOverride(nil)
-	if err != nil || o != nil {
-		t.Fatalf("empty config override should be (nil,nil): %v %v", o, err)
-	}
+	require.NoError(t, err, "empty config override should be (nil,nil)")
+	require.Nil(t, o, "empty config override should be (nil,nil)")
 }

--- a/pkg/gpu/mocknvml/engine/config_override_refresh_test.go
+++ b/pkg/gpu/mocknvml/engine/config_override_refresh_test.go
@@ -44,39 +44,29 @@ func newTestDevice(t *testing.T, base *DeviceConfig) (*ConfigurableDevice, strin
 
 func writeConfigOverride(t *testing.T, path, content string, clock *time.Time) {
 	t.Helper()
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 	*clock = clock.Add(2 * time.Second) // move past TTL
 }
 
 func TestRefresh_InjectsLostThenResets(t *testing.T) {
 	dev, path, clock := newTestDevice(t, &DeviceConfig{})
-	if dev.failureInjector() != nil {
-		t.Fatal("device should start healthy")
-	}
+	require.Nil(t, dev.failureInjector(), "device should start healthy")
 	writeConfigOverride(t, path, "devices:\n  \"0\":\n    failure:\n      mode: lost\n", clock)
 	fi := dev.failureInjector()
-	if fi == nil || fi.Mode() != FailureModeLost {
-		t.Fatalf("expected lost injector, got %+v", fi)
-	}
+	require.NotNil(t, fi, "expected lost injector")
+	require.Equal(t, FailureModeLost, fi.Mode(), "expected lost injector")
 	// Clear config override -> back to healthy.
-	if err := os.Remove(path); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Remove(path))
 	*clock = clock.Add(2 * time.Second)
-	if dev.failureInjector() != nil {
-		t.Fatal("device should recover to healthy after config override removed")
-	}
+	require.Nil(t, dev.failureInjector(), "device should recover to healthy after config override removed")
 }
 
 func TestRefresh_AllAppliesToDevice(t *testing.T) {
 	dev, path, clock := newTestDevice(t, &DeviceConfig{})
 	writeConfigOverride(t, path, "all:\n  failure:\n    mode: ecc_uncorrectable\n    after_calls: 1\n", clock)
 	fi := dev.failureInjector()
-	if fi == nil || fi.Mode() != FailureModeECCUncorrectable {
-		t.Fatalf("expected ecc_uncorrectable from all: %+v", fi)
-	}
+	require.NotNil(t, fi, "expected ecc_uncorrectable from all")
+	require.Equal(t, FailureModeECCUncorrectable, fi.Mode(), "expected ecc_uncorrectable from all")
 	_ = nvml.SUCCESS
 }
 
@@ -115,23 +105,21 @@ func TestRefresh_HotReloadsDynamicTemperature(t *testing.T) {
 	}
 	dev, path, clock := newTestDevice(t, base)
 
-	if got, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU); ret != nvml.SUCCESS || got != 50 {
-		t.Fatalf("baseline temperature = %d (ret=%v), want 50", got, ret)
-	}
+	got, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU)
+	require.Equal(t, nvml.SUCCESS, ret, "baseline GetTemperature ret")
+	require.Equal(t, uint32(50), got, "baseline temperature")
 
 	writeConfigOverride(t, path, "devices:\n  \"0\":\n    dynamic_metrics:\n      temperature:\n        base_c: 85\n", clock)
-	if got, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU); ret != nvml.SUCCESS || got != 85 {
-		t.Fatalf("after config override temperature = %d (ret=%v), want 85", got, ret)
-	}
+	got, ret = dev.GetTemperature(nvml.TEMPERATURE_GPU)
+	require.Equal(t, nvml.SUCCESS, ret, "after config override GetTemperature ret")
+	require.Equal(t, uint32(85), got, "after config override temperature")
 
 	// Clearing the config override reverts to the base config's simulator.
-	if err := os.Remove(path); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Remove(path))
 	*clock = clock.Add(2 * time.Second)
-	if got, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU); ret != nvml.SUCCESS || got != 50 {
-		t.Fatalf("after reset temperature = %d (ret=%v), want 50", got, ret)
-	}
+	got, ret = dev.GetTemperature(nvml.TEMPERATURE_GPU)
+	require.Equal(t, nvml.SUCCESS, ret, "after reset GetTemperature ret")
+	require.Equal(t, uint32(50), got, "after reset temperature")
 }
 
 // Memory literals taken from the shipped a100 profile

--- a/pkg/gpu/mocknvml/engine/config_override_store_test.go
+++ b/pkg/gpu/mocknvml/engine/config_override_store_test.go
@@ -18,24 +18,20 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfigOverridePathFor_SiblingDefault(t *testing.T) {
 	t.Setenv("MOCK_NVML_OVERRIDES", "")
-	got := ConfigOverridePathFor("/x/config/config.yaml")
-	if got != "/x/config/overrides.yaml" {
-		t.Fatalf("got %q", got)
-	}
+	require.Equal(t, "/x/config/overrides.yaml", ConfigOverridePathFor("/x/config/config.yaml"))
 }
 
 func TestConfigOverridePathFor_EnvWins(t *testing.T) {
 	t.Setenv("MOCK_NVML_OVERRIDES", "/custom/o.yaml")
-	if got := ConfigOverridePathFor("/x/config/config.yaml"); got != "/custom/o.yaml" {
-		t.Fatalf("got %q", got)
-	}
+	require.Equal(t, "/custom/o.yaml", ConfigOverridePathFor("/x/config/config.yaml"))
 }
 
-//nolint:cyclop // existing complexity; refactor deferred
 func TestConfigOverrideStore_GenBumpsOnChange(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "overrides.yaml")
@@ -43,40 +39,31 @@ func TestConfigOverrideStore_GenBumpsOnChange(t *testing.T) {
 	s := newConfigOverrideStoreAt(func() string { return path }, func() time.Time { return now })
 
 	// Absent file: gen 0, nil doc.
-	if gen, doc := s.snapshot(); gen != 0 || doc != nil {
-		t.Fatalf("absent config override: gen=%d doc=%v", gen, doc)
-	}
+	gen, doc := s.snapshot()
+	require.Zero(t, gen, "absent config override gen")
+	require.Nil(t, doc, "absent config override doc")
 
 	// Write a file; TTL not elapsed yet -> still cached as absent.
-	if err := os.WriteFile(path, []byte("all:\n  failure:\n    mode: lost\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if gen, _ := s.snapshot(); gen != 0 {
-		t.Fatalf("within TTL gen should stay 0, got %d", gen)
-	}
+	require.NoError(t, os.WriteFile(path, []byte("all:\n  failure:\n    mode: lost\n"), 0o644))
+	gen, _ = s.snapshot()
+	require.Zero(t, gen, "within TTL gen should stay 0")
 
 	// Advance beyond TTL -> re-read, gen bumps, doc parsed.
 	now = now.Add(2 * time.Second)
-	gen, doc := s.snapshot()
-	if gen != 1 || doc == nil {
-		t.Fatalf("after change: gen=%d doc=%v", gen, doc)
-	}
-	if doc.All["failure"].(map[string]any)["mode"] != "lost" {
-		t.Fatalf("parsed wrong: %+v", doc.All)
-	}
+	gen, doc = s.snapshot()
+	require.Equal(t, uint64(1), gen, "after change gen")
+	require.NotNil(t, doc, "after change doc")
+	require.Equal(t, "lost", doc.All["failure"].(map[string]any)["mode"], "parsed wrong")
 
 	// No change -> gen stable across TTL windows.
 	now = now.Add(2 * time.Second)
-	if gen2, _ := s.snapshot(); gen2 != 1 {
-		t.Fatalf("unchanged file should keep gen=1, got %d", gen2)
-	}
+	gen, _ = s.snapshot()
+	require.Equal(t, uint64(1), gen, "unchanged file should keep gen=1")
 
 	// Remove file -> gen bumps again, doc nil.
-	if err := os.Remove(path); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Remove(path))
 	now = now.Add(2 * time.Second)
-	if gen3, doc3 := s.snapshot(); gen3 != 2 || doc3 != nil {
-		t.Fatalf("after removal: gen=%d doc=%v", gen3, doc3)
-	}
+	gen, doc = s.snapshot()
+	require.Equal(t, uint64(2), gen, "after removal gen")
+	require.Nil(t, doc, "after removal doc")
 }

--- a/pkg/gpu/mocknvml/engine/config_test.go
+++ b/pkg/gpu/mocknvml/engine/config_test.go
@@ -202,17 +202,18 @@ devices:
     processes: []
 `
 	var yc YAMLConfig
-	if err := yaml.Unmarshal([]byte(y), &yc); err != nil {
-		t.Fatalf("yaml decode: %v", err)
-	}
+	require.NoError(t, yaml.Unmarshal([]byte(y), &yc), "yaml decode")
 	c := &Config{YAMLConfig: &yc}
-	if d := c.GetDeviceConfig(0); len(d.Processes) != 1 || d.Processes[0].PID != 4242 || d.Processes[0].SmUtil != 75 {
-		t.Fatalf("device 0 (override): %+v", d.Processes)
-	}
-	if d := c.GetDeviceConfig(1); len(d.Processes) != 0 { // processes: [] clears the default
-		t.Fatalf("device 1 (explicit clear): %+v", d.Processes)
-	}
-	if d := c.GetDeviceConfig(2); len(d.Processes) != 1 || d.Processes[0].PID != 1 { // no override -> inherit
-		t.Fatalf("device 2 (inherit): %+v", d.Processes)
-	}
+
+	d0 := c.GetDeviceConfig(0)
+	require.Len(t, d0.Processes, 1, "device 0 (override) len")
+	require.Equal(t, uint32(4242), d0.Processes[0].PID, "device 0 (override) PID")
+	require.Equal(t, uint32(75), d0.Processes[0].SmUtil, "device 0 (override) SmUtil")
+
+	d1 := c.GetDeviceConfig(1) // processes: [] clears the default
+	require.Empty(t, d1.Processes, "device 1 (explicit clear)")
+
+	d2 := c.GetDeviceConfig(2) // no override -> inherit
+	require.Len(t, d2.Processes, 1, "device 2 (inherit) len")
+	require.Equal(t, uint32(1), d2.Processes[0].PID, "device 2 (inherit) PID")
 }

--- a/pkg/gpu/mocknvml/engine/device_test.go
+++ b/pkg/gpu/mocknvml/engine/device_test.go
@@ -511,36 +511,18 @@ func TestConfigurableDevice_GetProcessUtilization_WithConfig(t *testing.T) {
 	})
 
 	utils, ret := dev.GetProcessUtilization(0)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetProcessUtilization failed: %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetProcessUtilization failed")
 	// Both compute and graphics/video processes report utilization, like real NVML
 	// (unlike GetComputeRunningProcesses, which is compute-only).
-	if len(utils) != 2 {
-		t.Fatalf("Expected 2 utilization samples, got %d", len(utils))
-	}
-	if utils[0].Pid != 1234 {
-		t.Errorf("Expected PID 1234, got %d", utils[0].Pid)
-	}
-	if utils[0].SmUtil != 75 {
-		t.Errorf("Expected SmUtil 75, got %d", utils[0].SmUtil)
-	}
-	if utils[0].MemUtil != 40 {
-		t.Errorf("Expected MemUtil 40, got %d", utils[0].MemUtil)
-	}
-	if utils[0].TimeStamp == 0 {
-		t.Errorf("Expected a non-zero timestamp")
-	}
+	require.Len(t, utils, 2, "Expected 2 utilization samples")
+	require.Equal(t, uint32(1234), utils[0].Pid, "Expected PID 1234")
+	require.Equal(t, uint32(75), utils[0].SmUtil, "Expected SmUtil 75")
+	require.Equal(t, uint32(40), utils[0].MemUtil, "Expected MemUtil 40")
+	require.NotZero(t, utils[0].TimeStamp, "Expected a non-zero timestamp")
 	// The graphics/video process is reported too, carrying encoder/decoder util.
-	if utils[1].Pid != 9999 {
-		t.Errorf("Expected PID 9999, got %d", utils[1].Pid)
-	}
-	if utils[1].EncUtil != 60 {
-		t.Errorf("Expected EncUtil 60, got %d", utils[1].EncUtil)
-	}
-	if utils[1].DecUtil != 30 {
-		t.Errorf("Expected DecUtil 30, got %d", utils[1].DecUtil)
-	}
+	require.Equal(t, uint32(9999), utils[1].Pid, "Expected PID 9999")
+	require.Equal(t, uint32(60), utils[1].EncUtil, "Expected EncUtil 60")
+	require.Equal(t, uint32(30), utils[1].DecUtil, "Expected DecUtil 30")
 }
 
 // =============================================================================
@@ -1066,9 +1048,7 @@ func newFabricEngine(t *testing.T) *Engine {
 		},
 	}
 	e := NewEngine(cfg)
-	if ret := e.Init(); ret != nvml.SUCCESS {
-		t.Fatalf("engine init: %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, e.Init(), "engine init")
 	t.Cleanup(func() { _ = e.Shutdown() })
 	return e
 }
@@ -1077,62 +1057,54 @@ func fabricDevice(t *testing.T, e *Engine, index int) *ConfigurableDevice {
 	t.Helper()
 	handle, _ := e.DeviceGetHandleByIndex(index)
 	cd, ok := e.LookupDevice(handle).(*ConfigurableDevice)
-	if !ok {
-		t.Fatalf("device %d is not a ConfigurableDevice", index)
-	}
+	require.True(t, ok, "device %d is not a ConfigurableDevice", index)
 	return cd
 }
 
-//nolint:cyclop // existing complexity; refactor deferred
 func TestConfigurableDevice_NvLinkGetters_PerDevice(t *testing.T) {
 	e := newFabricEngine(t)
 	d0 := fabricDevice(t, e, 0)
 	d1 := fabricDevice(t, e, 1)
 
-	if st, ret := d0.GetNvLinkState(0); ret != nvml.SUCCESS || st != nvml.FEATURE_ENABLED {
-		t.Errorf("d0.GetNvLinkState(0): got st=%d ret=%v, want ENABLED/SUCCESS", st, ret)
-	}
+	st, ret := d0.GetNvLinkState(0)
+	require.Equal(t, nvml.SUCCESS, ret, "d0.GetNvLinkState(0) ret")
+	require.Equal(t, nvml.FEATURE_ENABLED, st, "d0.GetNvLinkState(0) state")
 	// Link in range but not configured on device 0.
-	if st, ret := d0.GetNvLinkState(7); ret != nvml.SUCCESS || st != nvml.FEATURE_DISABLED {
-		t.Errorf("d0.GetNvLinkState(7): got st=%d ret=%v, want DISABLED/SUCCESS", st, ret)
-	}
+	st, ret = d0.GetNvLinkState(7)
+	require.Equal(t, nvml.SUCCESS, ret, "d0.GetNvLinkState(7) ret")
+	require.Equal(t, nvml.FEATURE_DISABLED, st, "d0.GetNvLinkState(7) state")
 	// Device 1 has no links of its own.
-	if st, ret := d1.GetNvLinkState(0); ret != nvml.SUCCESS || st != nvml.FEATURE_DISABLED {
-		t.Errorf("d1.GetNvLinkState(0): got st=%d ret=%v, want DISABLED/SUCCESS", st, ret)
-	}
+	st, ret = d1.GetNvLinkState(0)
+	require.Equal(t, nvml.SUCCESS, ret, "d1.GetNvLinkState(0) ret")
+	require.Equal(t, nvml.FEATURE_DISABLED, st, "d1.GetNvLinkState(0) state")
 	// Out-of-range link index.
-	if _, ret := d0.GetNvLinkState(-1); ret != nvml.ERROR_INVALID_ARGUMENT {
-		t.Errorf("d0.GetNvLinkState(-1): got %v, want INVALID_ARGUMENT", ret)
-	}
-	if _, ret := d0.GetNvLinkState(99); ret != nvml.ERROR_INVALID_ARGUMENT {
-		t.Errorf("d0.GetNvLinkState(99): got %v, want INVALID_ARGUMENT", ret)
-	}
+	_, ret = d0.GetNvLinkState(-1)
+	require.Equal(t, nvml.ERROR_INVALID_ARGUMENT, ret, "d0.GetNvLinkState(-1)")
+	_, ret = d0.GetNvLinkState(99)
+	require.Equal(t, nvml.ERROR_INVALID_ARGUMENT, ret, "d0.GetNvLinkState(99)")
 
-	if v, ret := d0.GetNvLinkVersion(0); ret != nvml.SUCCESS || v != 5 {
-		t.Errorf("d0.GetNvLinkVersion(0): got v=%d ret=%v, want 5/SUCCESS", v, ret)
-	}
+	v, ret := d0.GetNvLinkVersion(0)
+	require.Equal(t, nvml.SUCCESS, ret, "d0.GetNvLinkVersion(0) ret")
+	require.Equal(t, uint32(5), v, "d0.GetNvLinkVersion(0) version")
 
-	if capability, ret := d0.GetNvLinkCapability(0, nvml.NVLINK_CAP_P2P_SUPPORTED); ret != nvml.SUCCESS || capability != 1 {
-		t.Errorf("d0.GetNvLinkCapability(0,P2P): got %d ret=%v, want 1/SUCCESS", capability, ret)
-	}
+	capability, ret := d0.GetNvLinkCapability(0, nvml.NVLINK_CAP_P2P_SUPPORTED)
+	require.Equal(t, nvml.SUCCESS, ret, "d0.GetNvLinkCapability(0,P2P) ret")
+	require.Equal(t, uint32(1), capability, "d0.GetNvLinkCapability(0,P2P) capability")
 
 	// Remote device type: link 0 is a switch, link 2 is a GPU.
-	if dt, ret := d0.GetNvLinkRemoteDeviceType(0); ret != nvml.SUCCESS || dt != nvml.NVLINK_DEVICE_TYPE_SWITCH {
-		t.Errorf("d0.GetNvLinkRemoteDeviceType(0): got %d ret=%v, want SWITCH/SUCCESS", dt, ret)
-	}
-	if dt, ret := d0.GetNvLinkRemoteDeviceType(2); ret != nvml.SUCCESS || dt != nvml.NVLINK_DEVICE_TYPE_GPU {
-		t.Errorf("d0.GetNvLinkRemoteDeviceType(2): got %d ret=%v, want GPU/SUCCESS", dt, ret)
-	}
+	dt, ret := d0.GetNvLinkRemoteDeviceType(0)
+	require.Equal(t, nvml.SUCCESS, ret, "d0.GetNvLinkRemoteDeviceType(0) ret")
+	require.Equal(t, nvml.NVLINK_DEVICE_TYPE_SWITCH, dt, "d0.GetNvLinkRemoteDeviceType(0) type")
+	dt, ret = d0.GetNvLinkRemoteDeviceType(2)
+	require.Equal(t, nvml.SUCCESS, ret, "d0.GetNvLinkRemoteDeviceType(2) ret")
+	require.Equal(t, nvml.NVLINK_DEVICE_TYPE_GPU, dt, "d0.GetNvLinkRemoteDeviceType(2) type")
 
 	// Remote PCI info: link 2 points at device 1's BDF.
 	pci, ret := d0.GetNvLinkRemotePciInfo(2)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("d0.GetNvLinkRemotePciInfo(2): %v", ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "d0.GetNvLinkRemotePciInfo(2)")
 	busID := busIDString(pci.BusId[:])
-	if !containsPrefix(busID, "0000:0B") && !containsPrefix(busID, "0000:0b") {
-		t.Errorf("d0 link2 remote BusId: got %q, want 0000:0B prefix", busID)
-	}
+	require.True(t, containsPrefix(busID, "0000:0B") || containsPrefix(busID, "0000:0b"),
+		"d0 link2 remote BusId: got %q, want 0000:0B prefix", busID)
 }
 
 func TestConfigurableDevice_TopologyCommonAncestor_Pairwise(t *testing.T) {
@@ -1142,31 +1114,26 @@ func TestConfigurableDevice_TopologyCommonAncestor_Pairwise(t *testing.T) {
 
 	// Same root complex => TOPOLOGY_SINGLE.
 	lvl, ret := d0.GetTopologyCommonAncestor(d1)
-	if ret != nvml.SUCCESS || lvl != nvml.TOPOLOGY_SINGLE {
-		t.Errorf("d0->d1 topo: got lvl=%d ret=%v, want SINGLE/SUCCESS", lvl, ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "d0->d1 topo ret")
+	require.Equal(t, nvml.TOPOLOGY_SINGLE, lvl, "d0->d1 topo level")
 }
 
 func TestConfigurableDevice_Affinity_FromFabric(t *testing.T) {
 	e := newFabricEngine(t)
 	d0 := fabricDevice(t, e, 0)
 
-	if node, ret := d0.GetNumaNodeId(); ret != nvml.SUCCESS || node != 0 {
-		t.Errorf("d0.GetNumaNodeId: got %d ret=%v, want 0/SUCCESS", node, ret)
-	}
+	node, ret := d0.GetNumaNodeId()
+	require.Equal(t, nvml.SUCCESS, ret, "d0.GetNumaNodeId ret")
+	require.Zero(t, node, "d0.GetNumaNodeId node")
 
 	mask, ret := d0.GetCpuAffinity(2)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("d0.GetCpuAffinity: %v", ret)
-	}
-	if len(mask) != 2 || mask[0] != 0xFF {
-		t.Errorf("d0 cpu affinity: got %v, want word0=0xFF", mask)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "d0.GetCpuAffinity")
+	require.Len(t, mask, 2, "d0 cpu affinity length")
+	require.Equal(t, uint(0xFF), mask[0], "d0 cpu affinity word0")
 
 	mem, ret := d0.GetMemoryAffinity(1, nvml.AFFINITY_SCOPE_NODE)
-	if ret != nvml.SUCCESS || len(mem) != 1 || mem[0] != 1 {
-		t.Errorf("d0 memory affinity: got %v ret=%v, want [1]/SUCCESS", mem, ret)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "d0 memory affinity ret")
+	require.Equal(t, []uint{1}, mem, "d0 memory affinity mask")
 }
 
 func TestConfigurableDevice_NvLinkUtilizationCounter_Grows(t *testing.T) {
@@ -1174,19 +1141,11 @@ func TestConfigurableDevice_NvLinkUtilizationCounter_Grows(t *testing.T) {
 	d0 := fabricDevice(t, e, 0)
 
 	rx, tx, ret := d0.GetNvLinkUtilizationCounter(0, 0)
-	if ret != nvml.SUCCESS {
-		t.Fatalf("GetNvLinkUtilizationCounter: %v", ret)
-	}
-	if rx != tx {
-		t.Errorf("rx (%d) != tx (%d)", rx, tx)
-	}
+	require.Equal(t, nvml.SUCCESS, ret, "GetNvLinkUtilizationCounter")
+	require.Equal(t, tx, rx, "rx must equal tx")
 	// Freeze/Reset are no-op successes.
-	if r := d0.FreezeNvLinkUtilizationCounter(0, 0, nvml.FEATURE_ENABLED); r != nvml.SUCCESS {
-		t.Errorf("Freeze: got %v, want SUCCESS", r)
-	}
-	if r := d0.ResetNvLinkUtilizationCounter(0, 0); r != nvml.SUCCESS {
-		t.Errorf("Reset: got %v, want SUCCESS", r)
-	}
+	require.Equal(t, nvml.SUCCESS, d0.FreezeNvLinkUtilizationCounter(0, 0, nvml.FEATURE_ENABLED), "Freeze")
+	require.Equal(t, nvml.SUCCESS, d0.ResetNvLinkUtilizationCounter(0, 0), "Reset")
 }
 
 // busIDString decodes the NVML PciInfo.BusId char array (go-nvml v0.13.1-0

--- a/pkg/network/mockib/daemon/server_test.go
+++ b/pkg/network/mockib/daemon/server_test.go
@@ -235,7 +235,7 @@ func TestServer_handleRecv_CtxCancelReturnsTimeout(t *testing.T) {
 	case err := <-done:
 		require.NoError(t, err)
 	case <-time.After(5 * time.Second):
-		t.Fatal("handleRecv did not return after ctx cancellation")
+		require.Fail(t, "handleRecv did not return after ctx cancellation")
 	}
 	require.Less(t, time.Since(start), 5*time.Second,
 		"handleRecv must return promptly on ctx cancel, not at the recv timeout cap")
@@ -264,7 +264,7 @@ func readRecvResp(t *testing.T, c net.Conn, timeout time.Duration) protocol.Recv
 		require.NoError(t, protocol.DecodeBody(r.env, &resp))
 		return resp
 	case <-time.After(timeout):
-		t.Fatalf("no recv response within %v", timeout)
+		require.Failf(t, "no recv response", "within %v", timeout)
 		return protocol.RecvResp{}
 	}
 }

--- a/pkg/nri/nvmlmock/adjust_test.go
+++ b/pkg/nri/nvmlmock/adjust_test.go
@@ -144,7 +144,7 @@ func requireNoEnvKey(t *testing.T, env []string, key string) {
 	t.Helper()
 	for _, item := range env {
 		if name, _, ok := strings.Cut(item, "="); ok && name == key {
-			t.Fatalf("expected env not to contain key %q, got %q", key, item)
+			require.Failf(t, "unexpected env key", "expected env not to contain key %q, got %q", key, item)
 		}
 	}
 }

--- a/tests/e2e/go/e2e_suite_unit_test.go
+++ b/tests/e2e/go/e2e_suite_unit_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDemoReleaseTargetsDedicatedNamespace(t *testing.T) {
@@ -20,27 +22,15 @@ func TestDemoReleaseTargetsDedicatedNamespace(t *testing.T) {
 
 	rel := demoRelease("a100", 8)
 
-	if rel.Namespace == "" {
-		t.Fatal("expected nvml-mock release to target a dedicated namespace, got empty namespace")
-	}
-	if rel.Namespace == "default" {
-		t.Fatal("expected nvml-mock release not to target default namespace")
-	}
-	if rel.Namespace != nvmlMockNamespace {
-		t.Fatalf("expected nvml-mock release namespace %q, got %q", nvmlMockNamespace, rel.Namespace)
-	}
-	if !rel.CreateNamespace {
-		t.Fatal("expected nvml-mock release to create its dedicated namespace")
-	}
-	if !rel.HideOutput {
-		t.Fatal("expected nvml-mock release to hide Helm output")
-	}
-	if got := rel.Set["updateStrategy.rollingUpdate.maxUnavailable"]; got != "100%" {
-		t.Fatalf("expected maxUnavailable 100%% for fast scenario rollouts, got %q", got)
-	}
-	if got := rel.Set["terminationGracePeriodSeconds"]; got != "1" {
-		t.Fatalf("expected terminationGracePeriodSeconds=1 for fast scenario rollouts, got %q", got)
-	}
+	require.NotEmpty(t, rel.Namespace, "expected nvml-mock release to target a dedicated namespace, got empty namespace")
+	require.NotEqual(t, "default", rel.Namespace, "expected nvml-mock release not to target default namespace")
+	require.Equal(t, nvmlMockNamespace, rel.Namespace, "expected nvml-mock release namespace")
+	require.True(t, rel.CreateNamespace, "expected nvml-mock release to create its dedicated namespace")
+	require.True(t, rel.HideOutput, "expected nvml-mock release to hide Helm output")
+	require.Equal(t, "100%", rel.Set["updateStrategy.rollingUpdate.maxUnavailable"],
+		"expected maxUnavailable 100%% for fast scenario rollouts")
+	require.Equal(t, "1", rel.Set["terminationGracePeriodSeconds"],
+		"expected terminationGracePeriodSeconds=1 for fast scenario rollouts")
 }
 
 func TestKindConfigPathForProfileUsesProfileOverride(t *testing.T) {
@@ -50,13 +40,9 @@ func TestKindConfigPathForProfileUsesProfileOverride(t *testing.T) {
 	withRepoRoot(t, root)
 
 	got, err := kindConfigPathForProfile("gb200")
-	if err != nil {
-		t.Fatalf("kind config path for profile: %v", err)
-	}
-	want := filepath.Join(root, "docs", "demo", "kind-gb200.yaml")
-	if got != want {
-		t.Fatalf("expected profile-specific kind config %q, got %q", want, got)
-	}
+	require.NoError(t, err, "kind config path for profile")
+	require.Equal(t, filepath.Join(root, "docs", "demo", "kind-gb200.yaml"), got,
+		"expected profile-specific kind config")
 }
 
 func TestKindConfigPathForProfileFallsBackToDefault(t *testing.T) {
@@ -65,13 +51,9 @@ func TestKindConfigPathForProfileFallsBackToDefault(t *testing.T) {
 	withRepoRoot(t, root)
 
 	got, err := kindConfigPathForProfile("a100")
-	if err != nil {
-		t.Fatalf("kind config path for profile: %v", err)
-	}
-	want := filepath.Join(root, "docs", "demo", "kind.yaml")
-	if got != want {
-		t.Fatalf("expected default kind config %q, got %q", want, got)
-	}
+	require.NoError(t, err, "kind config path for profile")
+	require.Equal(t, filepath.Join(root, "docs", "demo", "kind.yaml"), got,
+		"expected default kind config")
 }
 
 func TestSelectedKindConfigPathRejectsMixedConfigs(t *testing.T) {
@@ -80,9 +62,8 @@ func TestSelectedKindConfigPathRejectsMixedConfigs(t *testing.T) {
 	writeKindConfig(t, root, "kind-gb200.yaml")
 	withRepoRoot(t, root)
 
-	if _, err := selectedKindConfigPath([]string{"a100", "gb200"}); err == nil {
-		t.Fatal("expected mixed profile-specific Kind configs to fail")
-	}
+	_, err := selectedKindConfigPath([]string{"a100", "gb200"})
+	require.Error(t, err, "expected mixed profile-specific Kind configs to fail")
 }
 
 func withRepoRoot(t *testing.T, root string) {
@@ -97,10 +78,7 @@ func withRepoRoot(t *testing.T, root string) {
 func writeKindConfig(t *testing.T, root, name string) {
 	t.Helper()
 	dir := filepath.Join(root, "docs", "demo")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("mkdir docs/demo: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, name), []byte("kind: Cluster\n"), 0o644); err != nil {
-		t.Fatalf("write %s: %v", name, err)
-	}
+	require.NoError(t, os.MkdirAll(dir, 0o755), "mkdir docs/demo")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("kind: Cluster\n"), 0o644),
+		"write %s", name)
 }

--- a/tests/e2e/go/framework/cluster/cluster_test.go
+++ b/tests/e2e/go/framework/cluster/cluster_test.go
@@ -5,48 +5,32 @@
 
 package cluster
 
-import "testing"
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestCreateArgsUseStdinForKindConfig(t *testing.T) {
 	args := createArgs("nvml-mock-e2e", true)
 
-	for i, arg := range args {
-		if arg != "--config" {
-			continue
-		}
-		if i+1 >= len(args) {
-			t.Fatal("--config is missing its value")
-		}
-		if got := args[i+1]; got != kindConfigStdinPath {
-			t.Fatalf("expected Kind config to use stdin path %q, got %q", kindConfigStdinPath, got)
-		}
-		return
-	}
-	t.Fatal("expected --config when Kind config YAML is provided")
+	idx := slices.Index(args, "--config")
+	require.NotEqual(t, -1, idx, "expected --config when Kind config YAML is provided")
+	require.Less(t, idx+1, len(args), "--config is missing its value")
+	require.Equal(t, kindConfigStdinPath, args[idx+1], "expected Kind config to use stdin path")
 }
 
 func TestCreateArgsOmitConfigWithoutKindConfig(t *testing.T) {
 	args := createArgs("nvml-mock-e2e", false)
-
-	for _, arg := range args {
-		if arg == "--config" {
-			t.Fatal("did not expect --config when Kind config YAML is empty")
-		}
-	}
+	require.NotContains(t, args, "--config", "did not expect --config when Kind config YAML is empty")
 }
 
 func TestCreateArgsUseDefaultKubeconfig(t *testing.T) {
 	args := createArgs("nvml-mock-e2e", true)
-
-	for _, arg := range args {
-		if arg == "--kubeconfig" {
-			t.Fatal("did not expect --kubeconfig; e2e should use the default kubeconfig")
-		}
-	}
+	require.NotContains(t, args, "--kubeconfig", "did not expect --kubeconfig; e2e should use the default kubeconfig")
 }
 
 func TestKindContext(t *testing.T) {
-	if got := KindContext("nvml-mock-e2e"); got != "kind-nvml-mock-e2e" {
-		t.Fatalf("expected Kind context %q, got %q", "kind-nvml-mock-e2e", got)
-	}
+	require.Equal(t, "kind-nvml-mock-e2e", KindContext("nvml-mock-e2e"), "expected Kind context")
 }

--- a/tests/e2e/go/framework/config/config_test.go
+++ b/tests/e2e/go/framework/config/config_test.go
@@ -5,56 +5,38 @@
 
 package config
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestSelectedProfileNamesDefaultsToGB200(t *testing.T) {
 	t.Setenv("E2E_PROFILES", "")
-
-	got := SelectedProfileNames()
-	if len(got) != 1 || got[0] != "gb200" {
-		t.Fatalf("expected default profile [gb200], got %#v", got)
-	}
+	require.Equal(t, []string{"gb200"}, SelectedProfileNames(), "expected default profile [gb200]")
 }
 
 func TestSelectedProfileNamesHonorsExplicitProfiles(t *testing.T) {
 	t.Setenv("E2E_PROFILES", "a100, h100")
-
-	got := SelectedProfileNames()
-	want := []string{"a100", "h100"}
-	if len(got) != len(want) {
-		t.Fatalf("expected profiles %#v, got %#v", want, got)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("expected profiles %#v, got %#v", want, got)
-		}
-	}
+	require.Equal(t, []string{"a100", "h100"}, SelectedProfileNames(), "expected explicit profiles")
 }
 
 func TestKeepClusterDefaultsToTrue(t *testing.T) {
 	t.Setenv("E2E_KEEP_CLUSTER", "")
-
-	if !KeepCluster() {
-		t.Fatal("expected Kind cluster preservation to be enabled by default")
-	}
+	require.True(t, KeepCluster(), "expected Kind cluster preservation to be enabled by default")
 }
 
 func TestKeepClusterCanBeDisabled(t *testing.T) {
 	for _, value := range []string{"0", "false", "no"} {
 		t.Run(value, func(t *testing.T) {
 			t.Setenv("E2E_KEEP_CLUSTER", value)
-
-			if KeepCluster() {
-				t.Fatalf("expected E2E_KEEP_CLUSTER=%q to disable Kind cluster preservation", value)
-			}
+			require.False(t, KeepCluster(),
+				"expected E2E_KEEP_CLUSTER=%q to disable Kind cluster preservation", value)
 		})
 	}
 }
 
 func TestArtifactsDirDefaultsToGoHarnessPath(t *testing.T) {
 	t.Setenv("E2E_ARTIFACTS", "")
-
-	if got := ArtifactsDir(); got != "artifacts/e2e/go" {
-		t.Fatalf("expected default artifacts dir %q, got %q", "artifacts/e2e/go", got)
-	}
+	require.Equal(t, "artifacts/e2e/go", ArtifactsDir(), "expected default artifacts dir")
 }

--- a/tests/e2e/go/framework/diagnostics/collect_test.go
+++ b/tests/e2e/go/framework/diagnostics/collect_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/kube"
 )
@@ -69,26 +70,20 @@ func newCollector(t *testing.T) (*Collector, string) {
 	t.Helper()
 	dir := t.TempDir()
 	bin := filepath.Join(dir, "kubectl")
-	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"+fakeKubectl), 0o755); err != nil {
-		t.Fatalf("write fake kubectl: %v", err)
-	}
+	require.NoError(t, os.WriteFile(bin, []byte("#!/bin/sh\n"+fakeKubectl), 0o755), "write fake kubectl")
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	calls := filepath.Join(dir, "calls.log")
 	t.Setenv("FAKE_KUBECTL_LOG", calls)
 
 	k, err := kube.New("kind-nvml-mock-e2e")
-	if err != nil {
-		t.Fatalf("kube.New: %v", err)
-	}
+	require.NoError(t, err, "kube.New")
 	return &Collector{Dir: filepath.Join(t.TempDir(), "artifacts"), Kube: k}, calls
 }
 
 func read(t *testing.T, c *Collector, name string) string {
 	t.Helper()
 	b, err := os.ReadFile(filepath.Join(c.Dir, name))
-	if err != nil {
-		t.Fatalf("read collected %s: %v", name, err)
-	}
+	require.NoError(t, err, "read collected %s", name)
 	return string(b)
 }
 
@@ -104,13 +99,10 @@ func TestPodLogsCollectsEverySidecarContainer(t *testing.T) {
 		"[nvml-mock] mock ready",
 		"[sidecar] watch-allocations: 8 GPUs, polling",
 	} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("collected logs missing %q, got:\n%s", want, got)
-		}
+		require.Contains(t, got, want, "collected logs missing %q, got:\n%s", want, got)
 	}
-	if strings.Contains(got, "Defaulted container") {
-		t.Fatalf("kubectl defaulted to one container instead of collecting all, got:\n%s", got)
-	}
+	require.NotContains(t, got, "Defaulted container",
+		"kubectl defaulted to one container instead of collecting all, got:\n%s", got)
 }
 
 // A restarted container is the only case where --previous can succeed, and it
@@ -121,9 +113,8 @@ func TestPodLogsCollectsPreviousInstanceAfterARestart(t *testing.T) {
 	c.PodLogs(context.Background(), "nvml-mock", "gpu-operator", "app.kubernetes.io/name=nvml-mock", 100)
 
 	got := read(t, c, "nvml-mock-logs-previous.txt")
-	if want := "[sidecar] dial /var/lib/kubelet/pod-resources: connection refused"; !strings.Contains(got, want) {
-		t.Fatalf("previous-instance logs missing %q, got:\n%s", want, got)
-	}
+	want := "[sidecar] dial /var/lib/kubelet/pod-resources: connection refused"
+	require.Contains(t, got, want, "previous-instance logs missing %q, got:\n%s", want, got)
 }
 
 // The trap: `kubectl logs --previous` errors when no previous instance exists,
@@ -134,19 +125,16 @@ func TestPodLogsSkipsPreviousInstanceOnHealthyPods(t *testing.T) {
 
 	c.PodLogs(context.Background(), "nvml-mock", "healthy", "app.kubernetes.io/name=nvml-mock", 100)
 
-	if got := read(t, c, "nvml-mock-logs.txt"); !strings.Contains(got, "[sidecar] watch-allocations") {
-		t.Fatalf("healthy-pod dump lost the sidecar, got:\n%s", got)
-	}
-	if _, err := os.Stat(filepath.Join(c.Dir, "nvml-mock-logs-previous.txt")); !os.IsNotExist(err) {
-		t.Fatalf("expected no previous-instance dump for a pod that never restarted (stat err: %v)", err)
-	}
+	got := read(t, c, "nvml-mock-logs.txt")
+	require.Contains(t, got, "[sidecar] watch-allocations",
+		"healthy-pod dump lost the sidecar, got:\n%s", got)
+	_, statErr := os.Stat(filepath.Join(c.Dir, "nvml-mock-logs-previous.txt"))
+	require.True(t, os.IsNotExist(statErr),
+		"expected no previous-instance dump for a pod that never restarted (stat err: %v)", statErr)
 	// The gate itself: asking at all would have failed the request. Tolerating
 	// that error yields the same files, so assert on the call that was skipped.
 	made, err := os.ReadFile(calls)
-	if err != nil {
-		t.Fatalf("read kubectl call log: %v", err)
-	}
-	if strings.Contains(string(made), "--previous") {
-		t.Fatalf("expected no --previous request for a pod that never restarted, kubectl calls were:\n%s", made)
-	}
+	require.NoError(t, err, "read kubectl call log")
+	require.NotContains(t, string(made), "--previous",
+		"expected no --previous request for a pod that never restarted, kubectl calls were:\n%s", made)
 }

--- a/tests/e2e/go/framework/harness/harness_test.go
+++ b/tests/e2e/go/framework/harness/harness_test.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/cluster"
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/kube"
 )
@@ -24,13 +26,7 @@ func TestAttachClusterPropagatesKubeClientError(t *testing.T) {
 		return nil, wantErr
 	})
 
-	if !errors.Is(err, wantErr) {
-		t.Fatalf("expected kube client error %v, got %v", wantErr, err)
-	}
-	if h.Cluster == nil {
-		t.Fatal("expected cluster to remain attached for cleanup")
-	}
-	if h.Kube != nil {
-		t.Fatalf("expected kube client to remain nil, got %#v", h.Kube)
-	}
+	require.ErrorIs(t, err, wantErr, "expected kube client error")
+	require.NotNil(t, h.Cluster, "expected cluster to remain attached for cleanup")
+	require.Nil(t, h.Kube, "expected kube client to remain nil")
 }

--- a/tests/e2e/go/framework/helm/helm_test.go
+++ b/tests/e2e/go/framework/helm/helm_test.go
@@ -9,25 +9,21 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/runner"
 )
 
 func TestBaseUsesDefaultKubeconfigWhenUnset(t *testing.T) {
 	args := New("kind-nvml-mock-e2e").base()
-
-	for _, arg := range args {
-		if arg == "--kubeconfig" {
-			t.Fatal("did not expect --kubeconfig when Helm should use the default kubeconfig")
-		}
-	}
+	require.NotContains(t, args, "--kubeconfig",
+		"did not expect --kubeconfig when Helm should use the default kubeconfig")
 }
 
 func TestBaseTargetsKubeContext(t *testing.T) {
 	args := New("kind-nvml-mock-e2e").base()
-
-	if len(args) != 2 || args[0] != "--kube-context" || args[1] != "kind-nvml-mock-e2e" {
-		t.Fatalf("expected Helm kube context args, got %#v", args)
-	}
+	require.Equal(t, []string{"--kube-context", "kind-nvml-mock-e2e"}, args,
+		"expected Helm kube context args")
 }
 
 func TestRunPinsChartVersionOnlyWhenSet(t *testing.T) {
@@ -54,9 +50,7 @@ func TestRunPinsChartVersionOnlyWhenSet(t *testing.T) {
 				Chart:   "nfd/node-feature-discovery",
 				Version: tc.version,
 			})
-			if err != nil {
-				t.Fatalf("expected helm install to succeed, got %v", err)
-			}
+			require.NoError(t, err, "expected helm install to succeed")
 
 			flag := -1
 			for i, arg := range args {
@@ -67,17 +61,14 @@ func TestRunPinsChartVersionOnlyWhenSet(t *testing.T) {
 			}
 
 			if !tc.wantVersion {
-				if flag != -1 {
-					t.Fatalf("expected no --version for a release without a pinned version, got %#v", args)
-				}
+				require.Equal(t, -1, flag,
+					"expected no --version for a release without a pinned version, got %#v", args)
 				return
 			}
-			if flag == -1 {
-				t.Fatalf("expected --version in the helm argv, got %#v", args)
-			}
-			if flag+1 >= len(args) || args[flag+1] != tc.version {
-				t.Fatalf("expected --version to be followed by %q, got %#v", tc.version, args)
-			}
+			require.NotEqual(t, -1, flag, "expected --version in the helm argv, got %#v", args)
+			require.Less(t, flag+1, len(args), "--version has no value, got %#v", args)
+			require.Equal(t, tc.version, args[flag+1],
+				"expected --version to be followed by %q, got %#v", tc.version, args)
 		})
 	}
 }
@@ -105,13 +96,7 @@ func TestRunHidesReleaseOutputWhenRequested(t *testing.T) {
 		Chart:      "chart",
 		HideOutput: true,
 	})
-	if err != nil {
-		t.Fatalf("expected quiet helm release to succeed, got %v", err)
-	}
-	if loudRuns != 0 {
-		t.Fatalf("expected quiet release not to use loud runner, got %d loud runs", loudRuns)
-	}
-	if quietRuns != 1 {
-		t.Fatalf("expected quiet release to use quiet runner once, got %d quiet runs", quietRuns)
-	}
+	require.NoError(t, err, "expected quiet helm release to succeed")
+	require.Zero(t, loudRuns, "expected quiet release not to use loud runner")
+	require.Equal(t, 1, quietRuns, "expected quiet release to use quiet runner once")
 }

--- a/tests/e2e/go/framework/runner/runner_test.go
+++ b/tests/e2e/go/framework/runner/runner_test.go
@@ -8,6 +8,8 @@ package runner
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestLineLimitWriterWritesOnlyFirstLines(t *testing.T) {
@@ -16,20 +18,11 @@ func TestLineLimitWriterWritesOnlyFirstLines(t *testing.T) {
 	w := &lineLimitWriter{dst: &out, remaining: 2}
 
 	n, err := w.Write(input)
-	if err != nil {
-		t.Fatalf("lineLimitWriter write: %v", err)
-	}
-	if n != len(input) {
-		t.Fatalf("expected writer to accept %d bytes, got %d", len(input), n)
-	}
-	if got, want := out.String(), "one\ntwo\n"; got != want {
-		t.Fatalf("expected truncated output %q, got %q", want, got)
-	}
+	require.NoError(t, err, "lineLimitWriter write")
+	require.Equal(t, len(input), n, "expected writer to accept %d bytes", len(input))
+	require.Equal(t, "one\ntwo\n", out.String(), "expected truncated output")
 
-	if _, err := w.Write([]byte("four\n")); err != nil {
-		t.Fatalf("lineLimitWriter second write: %v", err)
-	}
-	if got, want := out.String(), "one\ntwo\n"; got != want {
-		t.Fatalf("expected output to stay truncated at %q, got %q", want, got)
-	}
+	_, err = w.Write([]byte("four\n"))
+	require.NoError(t, err, "lineLimitWriter second write")
+	require.Equal(t, "one\ntwo\n", out.String(), "expected output to stay truncated")
 }

--- a/tests/e2e/go/ibutil/ibutil_test.go
+++ b/tests/e2e/go/ibutil/ibutil_test.go
@@ -3,7 +3,11 @@
 
 package ibutil
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestNormalizeLID(t *testing.T) {
 	cases := []struct {
@@ -19,15 +23,18 @@ func TestNormalizeLID(t *testing.T) {
 		{"", "", true},
 		{"0xZZ", "", true},
 	}
+	// Each case is a named subtest so all rows still run when one fails, while
+	// require.* stays compatible with testifylint's require-error check.
 	for _, c := range cases {
-		got, err := NormalizeLID(c.in)
-		if (err != nil) != c.wantErr {
-			t.Errorf("NormalizeLID(%q) err=%v wantErr=%v", c.in, err, c.wantErr)
-			continue
-		}
-		if err == nil && got != c.want {
-			t.Errorf("NormalizeLID(%q) = %q, want %q", c.in, got, c.want)
-		}
+		t.Run(c.in, func(t *testing.T) {
+			got, err := NormalizeLID(c.in)
+			if c.wantErr {
+				require.Error(t, err, "NormalizeLID(%q) should fail", c.in)
+				return
+			}
+			require.NoError(t, err, "NormalizeLID(%q)", c.in)
+			require.Equal(t, c.want, got, "NormalizeLID(%q)", c.in)
+		})
 	}
 }
 
@@ -45,13 +52,14 @@ func TestNormalizeGUID(t *testing.T) {
 		{"", "", true},
 	}
 	for _, c := range cases {
-		got, err := NormalizeGUID(c.in)
-		if (err != nil) != c.wantErr {
-			t.Errorf("NormalizeGUID(%q) err=%v wantErr=%v", c.in, err, c.wantErr)
-			continue
-		}
-		if err == nil && got != c.want {
-			t.Errorf("NormalizeGUID(%q) = %q, want %q", c.in, got, c.want)
-		}
+		t.Run(c.in, func(t *testing.T) {
+			got, err := NormalizeGUID(c.in)
+			if c.wantErr {
+				require.Error(t, err, "NormalizeGUID(%q) should fail", c.in)
+				return
+			}
+			require.NoError(t, err, "NormalizeGUID(%q)", c.in)
+			require.Equal(t, c.want, got, "NormalizeGUID(%q)", c.in)
+		})
 	}
 }

--- a/tests/e2e/go/profile/profile_test.go
+++ b/tests/e2e/go/profile/profile_test.go
@@ -3,7 +3,12 @@
 
 package profile
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 // profilesDir is the chart profiles directory relative to this test package
 // (tests/e2e/go/profile -> repo root -> deployments/...). `go test` runs with the
@@ -41,9 +46,7 @@ func TestDerivations(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			p, err := Load(profilesDir, c.name)
-			if err != nil {
-				t.Fatalf("Load(%q): %v", c.name, err)
-			}
+			require.NoError(t, err, "Load(%q)", c.name)
 			// One named subtest per derivation so the test output lists every
 			// check explicitly (e.g. TestDerivations/a100/ExpectedNV), instead
 			// of hiding them inside a single per-profile pass/fail.
@@ -63,9 +66,7 @@ func TestDerivations(t *testing.T) {
 			}
 			for _, ck := range checks {
 				t.Run(ck.name, func(t *testing.T) {
-					if ck.got != ck.want {
-						t.Errorf("%s() = %v, want %v", ck.name, ck.got, ck.want)
-					}
+					require.Equal(t, ck.want, ck.got, "%s()", ck.name)
 				})
 			}
 		})
@@ -77,37 +78,21 @@ func TestDerivations(t *testing.T) {
 // while asserting NV0; l40s/t4 must report 0 HCAs AND NV0.
 func TestNegativeControlsAreIndependent(t *testing.T) {
 	b200, err := Load(profilesDir, "b200")
-	if err != nil {
-		t.Fatalf("Load(b200): %v", err)
-	}
-	if b200.ExpectedNV() != 0 {
-		t.Errorf("b200 ExpectedNV() = %d, want 0 (standalone, no NVSwitch)", b200.ExpectedNV())
-	}
-	if b200.ExpectedHCAs() == 0 {
-		t.Errorf("b200 ExpectedHCAs() = 0, want > 0 (IB is enabled on b200)")
-	}
+	require.NoError(t, err, "Load(b200)")
+	require.Zero(t, b200.ExpectedNV(), "b200 ExpectedNV() want 0 (standalone, no NVSwitch)")
+	require.NotZero(t, b200.ExpectedHCAs(), "b200 ExpectedHCAs() want > 0 (IB is enabled on b200)")
 
 	for _, name := range []string{"l40s", "t4"} {
 		p, err := Load(profilesDir, name)
-		if err != nil {
-			t.Fatalf("Load(%s): %v", name, err)
-		}
-		if p.ExpectedHCAs() != 0 {
-			t.Errorf("%s ExpectedHCAs() = %d, want 0 (IB disabled)", name, p.ExpectedHCAs())
-		}
-		if p.ExpectedNV() != 0 {
-			t.Errorf("%s ExpectedNV() = %d, want 0 (no NVSwitch)", name, p.ExpectedNV())
-		}
+		require.NoError(t, err, "Load(%s)", name)
+		assert.Zero(t, p.ExpectedHCAs(), "%s ExpectedHCAs() want 0 (IB disabled)", name)
+		assert.Zero(t, p.ExpectedNV(), "%s ExpectedNV() want 0 (no NVSwitch)", name)
 	}
 }
 
 // TestAll ensures every shipped profile loads cleanly.
 func TestAll(t *testing.T) {
 	ps, err := All(profilesDir)
-	if err != nil {
-		t.Fatalf("All(): %v", err)
-	}
-	if len(ps) != len(KnownProfiles) {
-		t.Fatalf("All() returned %d profiles, want %d", len(ps), len(KnownProfiles))
-	}
+	require.NoError(t, err, "All()")
+	require.Len(t, ps, len(KnownProfiles), "All() returned wrong count")
 }


### PR DESCRIPTION
## What This PR Does

Use testify/require in the test suite. Setup GolangCI Lint to enforce testify/require usage.

## Why

Bare `t.Fail()`, `t.Fatal()` methods were used inconsistently in a portion of the codebase. Fixing this to simplify how our tests  are read.

## Checklist

- [ ] Commits are signed off (`git commit -s`)
- [ ] Tests pass (`go test -v -race ./...`)
- [ ] Linter passes (`make lint-fix`)
- [ ] New code has SPDX license headers
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (if user-facing change)
