### PR TITLE
fix(mocknvml): derive Board ID and report Device/Host Max PCIe generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `FORCE_RECREATE=true`.
 
 ### Fixed
+- mocknvml: `nvidia-smi` no longer reports impossible per-GPU PCIe identity
+  values. `Board ID` is derived from the device's PCI address the way NVML does
+  — `(domain << 16) | (bus << 8) | (device << 3)`, so a GPU at `0000:07:00.0`
+  reports `0x700` — instead of `0x0` for every GPU, which left an eight-GPU node
+  indistinguishable by board ID. `nvmlDeviceGetGpuMaxPcieLinkGeneration` is now
+  hand-written in the bridge, so the `Device Max` PCIe generation reads Gen3 on
+  `t4` through Gen6 on Blackwell instead of `N/A`. `Host Max` now matches the
+  device maximum instead of an impossible Gen0: no public NVML API exposes a
+  host-side maximum, and nvidia-smi reads it through a slot of the internal
+  export table whose catch-all stub wrote a zero count over the caller's
+  reading — the same class of bug as the phantom processes above. All three
+  maxima now agree in `nvidia-smi -q`, `-q -x` (`<max_host_link_gen>`) and
+  `--query-gpu=pcie.link.gen.hostmax`. (#638)
 - Wire eight NVML device exports that already had engine implementations but
   were still generated stubs (`GetEncoderStats`, `GetFBCStats`,
   `GetAccountingBufferSize`, `GetEncoderCapacity`, `GetEncoderSessions`,

--- a/pkg/gpu/mocknvml/bridge/device.go
+++ b/pkg/gpu/mocknvml/bridge/device.go
@@ -78,6 +78,7 @@
 // - nvmlDeviceGetCurrPcieLinkGeneration
 // - nvmlDeviceGetCurrPcieLinkWidth
 // - nvmlDeviceGetMaxPcieLinkGeneration
+// - nvmlDeviceGetGpuMaxPcieLinkGeneration
 // - nvmlDeviceGetMaxPcieLinkWidth
 // - nvmlDeviceGetPcieReplayCounter
 // - nvmlDeviceGetPcieThroughput
@@ -1887,6 +1888,27 @@ func nvmlDeviceGetMaxPcieLinkGeneration(device C.nvmlDevice_t, maxLinkGen *C.uin
 		return toReturn(ret)
 	}
 	*maxLinkGen = C.uint(val)
+	return C.NVML_SUCCESS
+}
+
+//export nvmlDeviceGetGpuMaxPcieLinkGeneration
+func nvmlDeviceGetGpuMaxPcieLinkGeneration(device C.nvmlDevice_t, maxLinkGenDevice *C.uint) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetGpuMaxPcieLinkGeneration"); !ok {
+		return ret
+	}
+	if maxLinkGenDevice == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := unsafe.Pointer(device.handle)
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	val, ret := dev.GetGpuMaxPcieLinkGeneration()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	*maxLinkGenDevice = C.uint(val)
 	return C.NVML_SUCCESS
 }
 

--- a/pkg/gpu/mocknvml/bridge/internal.go
+++ b/pkg/gpu/mocknvml/bridge/internal.go
@@ -37,6 +37,10 @@ extern int mockInternalIsDeviceHandle(void* handle);
 // written. The entry layout is documented on the Go side.
 extern unsigned int mockInternalFillProcessList(void* handle, void* buf, unsigned int capacity);
 
+// Forward declaration of the host-side max PCIe link generation lookup (defined
+// below in Go). Returns 0 when the device is unknown or configures no PCIe block.
+extern unsigned int mockInternalHostMaxPcieLinkGen(void* handle);
+
 // Debug mode - check MOCK_NVML_DEBUG env var once at startup
 static int debugChecked = 0;
 static int debugEnabled = 0;
@@ -58,6 +62,7 @@ static int isDebugEnabled() {
 #define MOCK_SLOT_DEVICE_HANDLE_BY_INDEX 81
 #define MOCK_SLOT_PROCESS_LIST_FIRST 213
 #define MOCK_SLOT_PROCESS_LIST_LAST 215
+#define MOCK_SLOT_HOST_MAX_PCIE_LINK_GEN 230
 
 // C stub function for internal export table
 // This gets called by nvidia-smi via the export table function pointers
@@ -111,6 +116,29 @@ static nvmlReturn_t internalStubFunction(unsigned int slot, void* arg0, void* ar
             if (isDebugEnabled()) {
                 fprintf(stderr, "[C-STUB] slot %u process list (handle=%p) -> %u entries\n",
                         slot, arg0, n);
+            }
+            return NVML_SUCCESS;
+        }
+    }
+
+    // Host-side max PCIe link generation: fn(nvmlDevice_t device, unsigned int* out).
+    // nvidia-smi's "Host Max" row comes from here, not from any public NVML API
+    // -- none exposes a host-side maximum. Falling through to the zero write
+    // below is what made every profile report an impossible Gen0 (issue #638).
+    // Slot located by its position in the -q call sequence: it fires between
+    // nvmlDeviceGetGpuMaxPcieLinkGeneration ("Device Max") and
+    // nvmlDeviceGetMaxPcieLinkWidth, and writing a marker value here moves the
+    // Host Max row of `-q`, the <max_host_link_gen> element of `-q -x` and the
+    // pcie.link.gen.hostmax query field together.
+    if (slot == MOCK_SLOT_HOST_MAX_PCIE_LINK_GEN) {
+        unsigned int gen = mockInternalHostMaxPcieLinkGen(arg0);
+        // Leave an unconfigured profile on the zero-count path rather than
+        // inventing a generation for it.
+        if (gen > 0) {
+            *(unsigned int*)arg1 = gen;
+            if (isDebugEnabled()) {
+                fprintf(stderr, "[C-STUB] slot %u host max PCIe link gen (handle=%p) -> %u\n",
+                        slot, arg0, gen);
             }
             return NVML_SUCCESS;
         }
@@ -175,6 +203,21 @@ func mockInternalIsDeviceHandle(handle unsafe.Pointer) C.int {
 		return 1
 	}
 	return 0
+}
+
+// mockInternalHostMaxPcieLinkGen returns the host-side maximum PCIe link
+// generation for the device nvidia-smi passed through the internal export
+// table, or 0 when the handle is unknown or the profile configures no PCIe
+// block. This is the only path to nvidia-smi's "Host Max" row; the semantics of
+// the value live on engine.ConfigurableDevice.HostMaxPcieLinkGeneration.
+//
+//export mockInternalHostMaxPcieLinkGen
+func mockInternalHostMaxPcieLinkGen(handle unsafe.Pointer) C.uint {
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return 0
+	}
+	return C.uint(dev.HostMaxPcieLinkGeneration())
 }
 
 // Layout of one entry in the internal process-list array, recovered by probing

--- a/pkg/gpu/mocknvml/bridge/stubs_generated.go
+++ b/pkg/gpu/mocknvml/bridge/stubs_generated.go
@@ -21,7 +21,7 @@ package main
 */
 import "C"
 
-// 271 stub functions for unimplemented NVML functions.
+// 270 stub functions for unimplemented NVML functions.
 // These return NVML_ERROR_NOT_SUPPORTED (3).
 
 //export nvmlComputeInstanceDestroy
@@ -292,11 +292,6 @@ func nvmlDeviceGetGpuInstanceRemainingCapacity(device C.nvmlDevice_t, profileId 
 //export nvmlDeviceGetGpuInstances
 func nvmlDeviceGetGpuInstances(device C.nvmlDevice_t, profileId C.uint, gpuInstances *C.nvmlGpuInstance_t, count *C.uint) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetGpuInstances")
-}
-
-//export nvmlDeviceGetGpuMaxPcieLinkGeneration
-func nvmlDeviceGetGpuMaxPcieLinkGeneration(device C.nvmlDevice_t, maxLinkGenDevice *C.uint) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetGpuMaxPcieLinkGeneration")
 }
 
 //export nvmlDeviceGetGraphicsRunningProcesses_v1

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -59,6 +59,7 @@ type ConfigurableDevice struct {
 	// Cached computed values
 	bar1Memory nvml.BAR1Memory
 	pciInfo    nvml.PciInfo
+	boardID    uint32
 
 	// Mutable in-memory state (not persisted across restarts)
 	persistenceModeOverride *nvml.EnableState
@@ -316,7 +317,6 @@ func (d *ConfigurableDevice) initPciInfo(config *DeviceConfig) {
 			debugLog("[DEVICE %d] Warning: %v, using defaults\n", d.index, err)
 			// Use default values (zeros) on parse failure
 		}
-		_ = function // unused in pciInfo struct
 	}
 
 	d.pciInfo = nvml.PciInfo{
@@ -324,6 +324,7 @@ func (d *ConfigurableDevice) initPciInfo(config *DeviceConfig) {
 		Bus:    bus,
 		Device: device,
 	}
+	d.boardID = deriveBoardID(domain, bus, device, function)
 
 	// Set PCI device ID from config or default
 	if config != nil && config.PCI != nil {
@@ -345,6 +346,17 @@ func (d *ConfigurableDevice) initPciInfo(config *DeviceConfig) {
 	// from nvmlPciInfo_t.busIdLegacy — get an empty string otherwise.
 	writeBusID(d.pciInfo.BusId[:], d.PciBusID)
 	writeBusID(d.pciInfo.BusIdLegacy[:], d.PciBusID)
+}
+
+// deriveBoardID encodes a PCI address the way NVML derives nvmlDeviceGetBoardId:
+// the domain in the upper half, and the Linux devfn encoding (device in the
+// upper 5 bits of the low byte, function in the lower 3) below it. A GPU at
+// 0000:07:00.0 therefore reports 0x700, which is what nvidia-smi prints as
+// "Board ID" on real hardware. Distinct GPUs sit on distinct buses, so the
+// derivation also keeps board IDs unique across a node — a fleet of mock GPUs
+// all reporting 0x0 is indistinguishable to consumers. See issue #638.
+func deriveBoardID(domain, bus, device, function uint32) uint32 {
+	return domain<<16 | bus<<8 | (device&0x1f)<<3 | function&0x7
 }
 
 // writeBusID copies an ASCII PCI bus-ID string into an NVML C char array
@@ -1014,6 +1026,45 @@ func (d *ConfigurableDevice) GetMaxPcieLinkGeneration() (int, nvml.Return) {
 	return gen, nvml.SUCCESS
 }
 
+// GetGpuMaxPcieLinkGeneration returns the maximum PCIe link generation the GPU
+// itself supports, independent of the host. nvidia-smi renders this as the
+// "Device Max" row, which degraded to N/A while this was a generated stub. The
+// mock has no separate host-side limit, so the device maximum is the configured
+// max_link_gen — the same value GetMaxPcieLinkGeneration reports for the
+// system-wide "Max" row.
+func (d *ConfigurableDevice) GetGpuMaxPcieLinkGeneration() (int, nvml.Return) {
+	gen := 0
+	if c := d.cfg(); c.PCIe != nil {
+		gen = c.PCIe.MaxLinkGen
+	}
+	debugLog("[NVML] nvmlDeviceGetGpuMaxPcieLinkGeneration -> %d\n", gen)
+	if gen == 0 {
+		return 0, nvml.ERROR_NOT_SUPPORTED
+	}
+	return gen, nvml.SUCCESS
+}
+
+// HostMaxPcieLinkGeneration reports the maximum PCIe link generation the host
+// side of the link supports, which nvidia-smi renders as the "Host Max" row.
+//
+// This is deliberately not a Get* NVML method: no public NVML API exposes a
+// host-side maximum, and nvidia-smi instead reads it through a slot of the
+// internal export table (see the bridge's internal.go). The mock models a host
+// that keeps up with the GPU, so the host maximum is the configured
+// max_link_gen — keeping nvidia-smi's Max, Device Max and Host Max rows
+// consistent, since the negotiable Max cannot exceed either endpoint.
+//
+// Returns 0 when the profile configures no PCIe block, which the bridge treats
+// as "unknown" and leaves the reading untouched.
+func (d *ConfigurableDevice) HostMaxPcieLinkGeneration() int {
+	gen := 0
+	if c := d.cfg(); c.PCIe != nil {
+		gen = c.PCIe.MaxLinkGen
+	}
+	debugLog("[NVML] hostMaxPcieLinkGeneration -> %d\n", gen)
+	return gen
+}
+
 // GetCurrPcieLinkWidth returns current PCIe link width
 func (d *ConfigurableDevice) GetCurrPcieLinkWidth() (int, nvml.Return) {
 	width := 0
@@ -1191,10 +1242,10 @@ func (d *ConfigurableDevice) GetMultiGpuBoard() (int, nvml.Return) {
 	return 0, nvml.SUCCESS
 }
 
-// GetBoardId returns the board ID
+// GetBoardId returns the board ID derived from the device's PCI address.
 func (d *ConfigurableDevice) GetBoardId() (uint32, nvml.Return) {
-	debugLog("[NVML] nvmlDeviceGetBoardId -> 0\n")
-	return 0, nvml.SUCCESS
+	debugLog("[NVML] nvmlDeviceGetBoardId -> %#x\n", d.boardID)
+	return d.boardID, nvml.SUCCESS
 }
 
 // GetMemoryBusWidth returns the memory bus width in bits.

--- a/pkg/gpu/mocknvml/engine/device_pcie_identity_test.go
+++ b/pkg/gpu/mocknvml/engine/device_pcie_identity_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
+)
+
+// pcieIdentityEngine builds an engine from shared device defaults plus
+// per-device overrides, mirroring how the shipped profiles are shaped: the
+// pcie block lives in device_defaults, bus_id is per device.
+func pcieIdentityEngine(t *testing.T, defaults DeviceConfig, devices ...DeviceOverride) *Engine {
+	t.Helper()
+	cfg := &Config{
+		NumDevices:    len(devices),
+		DriverVersion: "550.163.01",
+		YAMLConfig: &YAMLConfig{
+			System:         SystemConfig{DriverVersion: "550.163.01", NumDevices: len(devices)},
+			DeviceDefaults: defaults,
+			Devices:        devices,
+		},
+	}
+	e := NewEngine(cfg)
+	require.Equal(t, nvml.SUCCESS, e.Init(), "engine Init failed")
+	t.Cleanup(func() { _ = e.Shutdown() })
+	return e
+}
+
+func pcieIdentityDevice(t *testing.T, e *Engine, index int) *ConfigurableDevice {
+	t.Helper()
+	handle, ret := e.DeviceGetHandleByIndex(index)
+	require.Equal(t, nvml.SUCCESS, ret, "DeviceGetHandleByIndex(%d) failed", index)
+	cd, ok := e.LookupDevice(handle).(*ConfigurableDevice)
+	require.True(t, ok, "device %d is not a *ConfigurableDevice", index)
+	return cd
+}
+
+// TestConfigurableDevice_GetGpuMaxPcieLinkGeneration reports the profile's
+// configured max PCIe generation. nvidia-smi renders this as the "Device Max"
+// row; when the query fails it prints its zero-initialised buffer, so a missing
+// implementation shows an impossible PCIe generation of 0. "Host Max" is a
+// separate reading — see TestConfigurableDevice_HostMaxPcieLinkGeneration.
+// Issue #638.
+func TestConfigurableDevice_GetGpuMaxPcieLinkGeneration(t *testing.T) {
+	e := pcieIdentityEngine(t,
+		DeviceConfig{PCIe: &PCIeConfig{MaxLinkGen: 4, CurrentLinkGen: 4}},
+		DeviceOverride{Index: 0})
+
+	gen, ret := pcieIdentityDevice(t, e, 0).GetGpuMaxPcieLinkGeneration()
+	require.Equal(t, nvml.SUCCESS, ret, "GetGpuMaxPcieLinkGeneration failed")
+	require.Equal(t, 4, gen, "device max PCIe generation")
+}
+
+// TestConfigurableDevice_GetGpuMaxPcieLinkGeneration_Gen6 pins the value to
+// config rather than a hardcoded constant.
+func TestConfigurableDevice_GetGpuMaxPcieLinkGeneration_Gen6(t *testing.T) {
+	e := pcieIdentityEngine(t,
+		DeviceConfig{PCIe: &PCIeConfig{MaxLinkGen: 6, CurrentLinkGen: 6}},
+		DeviceOverride{Index: 0})
+
+	gen, ret := pcieIdentityDevice(t, e, 0).GetGpuMaxPcieLinkGeneration()
+	require.Equal(t, nvml.SUCCESS, ret, "GetGpuMaxPcieLinkGeneration failed")
+	require.Equal(t, 6, gen, "device max PCIe generation")
+}
+
+// TestConfigurableDevice_GetGpuMaxPcieLinkGeneration_Unconfigured degrades to
+// NOT_SUPPORTED — which nvidia-smi renders as N/A — rather than reporting 0.
+// This matches GetMaxPcieLinkGeneration's existing behaviour.
+func TestConfigurableDevice_GetGpuMaxPcieLinkGeneration_Unconfigured(t *testing.T) {
+	e := pcieIdentityEngine(t, DeviceConfig{}, DeviceOverride{Index: 0})
+
+	gen, ret := pcieIdentityDevice(t, e, 0).GetGpuMaxPcieLinkGeneration()
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret, "unconfigured max_link_gen should not be supported")
+	require.Zero(t, gen, "no generation reported when unsupported")
+}
+
+// TestConfigurableDevice_HostMaxPcieLinkGeneration backs nvidia-smi's "Host Max"
+// row, which reads the host side of the link through an internal export-table
+// slot rather than any public NVML API. The mock models a host that keeps up
+// with the GPU, so it reports the configured max_link_gen. Issue #638.
+func TestConfigurableDevice_HostMaxPcieLinkGeneration(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		pcie *PCIeConfig
+		want int
+	}{
+		{name: "gen4", pcie: &PCIeConfig{MaxLinkGen: 4, CurrentLinkGen: 4}, want: 4},
+		{name: "gen6", pcie: &PCIeConfig{MaxLinkGen: 6, CurrentLinkGen: 6}, want: 6},
+		// Unknown rather than an impossible Gen0: the bridge leaves the reading
+		// alone when the profile configures no PCIe block.
+		{name: "unconfigured", pcie: nil, want: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := pcieIdentityEngine(t, DeviceConfig{PCIe: tc.pcie}, DeviceOverride{Index: 0})
+
+			require.Equal(t, tc.want, pcieIdentityDevice(t, e, 0).HostMaxPcieLinkGeneration(),
+				"host max PCIe generation")
+		})
+	}
+}
+
+// TestConfigurableDevice_HostMaxPcieLinkGeneration_MatchesDeviceMax pins the
+// invariant nvidia-smi's three generation rows have to satisfy: the negotiable
+// "Max" can never exceed either endpoint's capability.
+func TestConfigurableDevice_HostMaxPcieLinkGeneration_MatchesDeviceMax(t *testing.T) {
+	e := pcieIdentityEngine(t,
+		DeviceConfig{PCIe: &PCIeConfig{MaxLinkGen: 5, CurrentLinkGen: 4}},
+		DeviceOverride{Index: 0})
+	dev := pcieIdentityDevice(t, e, 0)
+
+	deviceMax, ret := dev.GetGpuMaxPcieLinkGeneration()
+	require.Equal(t, nvml.SUCCESS, ret, "GetGpuMaxPcieLinkGeneration failed")
+	linkMax, ret := dev.GetMaxPcieLinkGeneration()
+	require.Equal(t, nvml.SUCCESS, ret, "GetMaxPcieLinkGeneration failed")
+
+	hostMax := dev.HostMaxPcieLinkGeneration()
+	require.Equal(t, deviceMax, hostMax, "host and device max should agree")
+	require.LessOrEqual(t, linkMax, min(deviceMax, hostMax), "link max exceeds an endpoint capability")
+}
+
+// TestConfigurableDevice_GetBoardId derives the board ID from the configured
+// PCI address the way real NVML does: (domain << 16) | (bus << 8) | (device <<
+// 3). A GPU at 0000:07:00.0 therefore reports 0x700, matching what nvidia-smi
+// prints on real hardware. See issue #638.
+func TestConfigurableDevice_GetBoardId(t *testing.T) {
+	for _, tc := range []struct {
+		busID string
+		want  uint32
+	}{
+		{busID: "0000:07:00.0", want: 0x0700},
+		{busID: "0000:BD:00.0", want: 0xBD00},
+		{busID: "0001:4A:00.0", want: 0x14A00},
+		{busID: "0000:3B:01.0", want: 0x3B08},
+	} {
+		t.Run(tc.busID, func(t *testing.T) {
+			e := pcieIdentityEngine(t, DeviceConfig{}, DeviceOverride{
+				Index:        0,
+				DeviceConfig: DeviceConfig{PCI: &PCIConfig{BusID: tc.busID}},
+			})
+
+			boardID, ret := pcieIdentityDevice(t, e, 0).GetBoardId()
+			require.Equal(t, nvml.SUCCESS, ret, "GetBoardId failed")
+			require.Equal(t, tc.want, boardID, "board ID for %s", tc.busID)
+		})
+	}
+}
+
+// TestConfigurableDevice_GetBoardId_UniquePerDevice guards the property that
+// actually matters to consumers: an eight-GPU node must not present eight
+// identical board IDs.
+func TestConfigurableDevice_GetBoardId_UniquePerDevice(t *testing.T) {
+	busIDs := []string{
+		"0000:07:00.0", "0000:0F:00.0", "0000:47:00.0", "0000:4E:00.0",
+		"0000:87:00.0", "0000:90:00.0", "0000:B7:00.0", "0000:BD:00.0",
+	}
+	devices := make([]DeviceOverride, 0, len(busIDs))
+	for i, busID := range busIDs {
+		devices = append(devices, DeviceOverride{
+			Index:        i,
+			DeviceConfig: DeviceConfig{PCI: &PCIConfig{BusID: busID}},
+		})
+	}
+	e := pcieIdentityEngine(t, DeviceConfig{}, devices...)
+
+	seen := make(map[uint32]string, len(busIDs))
+	for i, busID := range busIDs {
+		boardID, ret := pcieIdentityDevice(t, e, i).GetBoardId()
+		require.Equal(t, nvml.SUCCESS, ret, "GetBoardId failed for device %d", i)
+		require.NotZero(t, boardID, "device %d (%s) reports board ID 0x0", i, busID)
+		prev, dup := seen[boardID]
+		require.False(t, dup, "device %d (%s) duplicates board ID %#x of %s", i, busID, boardID, prev)
+		seen[boardID] = busID
+	}
+}
+
+// TestConfigurableDevice_GetBoardId_AutoAssignedBusID covers profiles that omit
+// bus_id: the engine auto-assigns 0000:<index+1>:00.0, so board IDs stay
+// non-zero and distinct without any PCI configuration.
+func TestConfigurableDevice_GetBoardId_AutoAssignedBusID(t *testing.T) {
+	e := NewEngine(&Config{NumDevices: 4, DriverVersion: "550.163.01"})
+	require.Equal(t, nvml.SUCCESS, e.Init(), "engine Init failed")
+	t.Cleanup(func() { _ = e.Shutdown() })
+
+	seen := make(map[uint32]bool, 4)
+	for i := range 4 {
+		boardID, ret := pcieIdentityDevice(t, e, i).GetBoardId()
+		require.Equal(t, nvml.SUCCESS, ret, "GetBoardId failed for device %d", i)
+		require.NotZero(t, boardID, "device %d reports board ID 0x0", i)
+		require.False(t, seen[boardID], "device %d duplicates board ID %#x", i, boardID)
+		seen[boardID] = true
+	}
+	require.Len(t, seen, 4, "expected 4 distinct board IDs, got %v", seen)
+}

--- a/tests/e2e/go/assertions/nvidiasmi/checks.go
+++ b/tests/e2e/go/assertions/nvidiasmi/checks.go
@@ -3,7 +3,11 @@
 
 package nvidiasmi
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 // The checks over a decoded document. Each is named *Problems because it
 // returns what it found instead of failing: that reports every wrong reading in
@@ -131,6 +135,71 @@ func EncoderFBCProblems(out string, encoder, fbc EncoderFBCStats, accountingBuff
 			gpu.AccountingModeBufferSize, accountingBufferSize, "")...)
 	}
 	return problems
+}
+
+// PCIeIdentityProblems checks the per-GPU PCIe identity elements for values no
+// real GPU can report (#638):
+//
+//   - max_link_gen, max_device_link_gen and max_host_link_gen all equal the
+//     profile's configured pcie.max_link_gen. max_device_link_gen read N/A while
+//     nvmlDeviceGetGpuMaxPcieLinkGeneration was a generated stub, and
+//     max_host_link_gen read 0 while the internal export-table slot behind it
+//     went unserved. Requiring the three to agree encodes the invariant a Gen0
+//     host maximum violated: a link never negotiates higher than either
+//     endpoint supports.
+//   - board_id is non-zero and unique across the node. Every GPU reported 0x0,
+//     leaving the GPUs of a multi-GPU node indistinguishable by board ID.
+//
+// wantGPUs guards against a truncated document silently passing every per-GPU
+// check.
+func PCIeIdentityProblems(out string, wantGPUs, wantMaxLinkGen int) []string {
+	snap, err := ParseSnapshot(out)
+	if err != nil {
+		return []string{err.Error()}
+	}
+
+	var problems []string
+	if snap.Count() != wantGPUs {
+		problems = append(problems, fmt.Sprintf("nvidia-smi XML reported %d GPUs, want %d",
+			snap.Count(), wantGPUs))
+	}
+	boardIDs := make(map[uint64]string, snap.Count())
+	for i, gpu := range snap.doc.GPUs {
+		name := gpu.label(i)
+		gen := gpu.PCI.GPULinkInfo.PCIeGen
+		problems = append(problems,
+			intReadingProblems(name+" max_link_gen", gen.Max, wantMaxLinkGen, "")...)
+		problems = append(problems,
+			intReadingProblems(name+" max_device_link_gen", gen.DeviceMax, wantMaxLinkGen, "")...)
+		problems = append(problems,
+			intReadingProblems(name+" max_host_link_gen", gen.HostMax, wantMaxLinkGen, "")...)
+		problems = append(problems, boardIDProblems(name, gpu.BoardID, boardIDs)...)
+	}
+	return problems
+}
+
+// boardIDProblems validates one GPU's board_id and records it in seen so later
+// GPUs are checked for duplicates. It keys on the parsed value rather than the
+// rendered text, so two renderings of one board (0x700 and 0x0700) still
+// collide.
+func boardIDProblems(name string, got reading, seen map[uint64]string) []string {
+	if !got.present() {
+		return []string{name + " board_id is empty or absent"}
+	}
+	text := strings.TrimSpace(string(got))
+	value, err := strconv.ParseUint(strings.TrimPrefix(strings.ToLower(text), "0x"), 16, 64)
+	if err != nil {
+		return []string{fmt.Sprintf("%s board_id = %q, want a hex value", name, text)}
+	}
+	if value == 0 {
+		return []string{fmt.Sprintf(
+			"%s board_id = %s, want non-zero so the GPUs of a node are distinguishable", name, text)}
+	}
+	if prev, dup := seen[value]; dup {
+		return []string{fmt.Sprintf("%s board_id = %s duplicates %s", name, text, prev)}
+	}
+	seen[value] = name
+	return nil
 }
 
 func statsBlockProblems(name string, got statsBlock, want EncoderFBCStats) []string {

--- a/tests/e2e/go/assertions/nvidiasmi/checks_test.go
+++ b/tests/e2e/go/assertions/nvidiasmi/checks_test.go
@@ -196,6 +196,160 @@ func statsGPU(sessionCount, fps, latency, buffer string) string {
 	</gpu>`
 }
 
+// pcieIdentityGPU renders one <gpu> whose three PCIe maxima agree, the healthy
+// shape: a host and a device of the same generation, and a link negotiated to it.
+func pcieIdentityGPU(id, boardID, gen string) string {
+	return pcieIdentityGPUGens(id, boardID, gen, gen, gen)
+}
+
+// pcieIdentityGPUGens renders one <gpu> with each maximum set independently.
+// Every body is injected verbatim so a test can supply "4", "N/A" or nothing.
+// The captured fixtures cannot drive the passing case here: they predate the
+// host-max fix and carry max_host_link_gen 0.
+func pcieIdentityGPUGens(id, boardID, maxGen, deviceMaxGen, hostMaxGen string) string {
+	return `
+	<gpu id="` + id + `">
+		<product_name>NVIDIA A100-SXM4-40GB</product_name>
+		<board_id>` + boardID + `</board_id>
+		<pci>
+			<pci_bus_id>` + id + `</pci_bus_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>` + maxGen + `</max_link_gen>
+					<current_link_gen>` + maxGen + `</current_link_gen>
+					<device_current_link_gen>` + maxGen + `</device_current_link_gen>
+					<max_device_link_gen>` + deviceMaxGen + `</max_device_link_gen>
+					<max_host_link_gen>` + hostMaxGen + `</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+		</pci>
+	</gpu>`
+}
+
+func TestPCIeIdentityProblems_AcceptsFixedOutput(t *testing.T) {
+	out := xmlDocument(
+		pcieIdentityGPU("0000:07:00.0", "0x700", "4"),
+		pcieIdentityGPU("0000:0F:00.0", "0xf00", "4"),
+	)
+	problems := PCIeIdentityProblems(out, 2, 4)
+	assert.Empty(t, problems, strings.Join(problems, "; "))
+}
+
+// Gen6 pins the expectation to the profile's configured generation rather than a
+// constant: one check must accept 6 on Blackwell and 4 on a100.
+func TestPCIeIdentityProblems_AcceptsGen6Output(t *testing.T) {
+	out := xmlDocument(
+		pcieIdentityGPU("0000:0A:00.0", "0xa00", "6"),
+		pcieIdentityGPU("0000:0B:00.0", "0xb00", "6"),
+	)
+	problems := PCIeIdentityProblems(out, 2, 6)
+	assert.Empty(t, problems, strings.Join(problems, "; "))
+}
+
+// The defect as captured before the fix: board_id 0x0 on every GPU,
+// max_device_link_gen N/A from the generated stub, and a Gen0 host maximum.
+func TestPCIeIdentityProblems_RejectsBuggyOutput(t *testing.T) {
+	out := xmlDocument(
+		pcieIdentityGPUGens("0000:07:00.0", "0x0", "4", "N/A", "0"),
+		pcieIdentityGPUGens("0000:0F:00.0", "0x0", "4", "N/A", "0"),
+	)
+
+	problems := PCIeIdentityProblems(out, 2, 4)
+	require.NotEmpty(t, problems)
+	joined := strings.Join(problems, "; ")
+	assert.Contains(t, joined, "max_device_link_gen")
+	assert.Contains(t, joined, "max_host_link_gen")
+	assert.Contains(t, joined, "board_id")
+}
+
+// The Host Max half of #638 in isolation: nvidia-smi rendered Gen0 for the host
+// side of a link both the GPU and the negotiated maximum put at Gen4.
+func TestPCIeIdentityProblems_RejectsZeroHostMax(t *testing.T) {
+	out := xmlDocument(pcieIdentityGPUGens("0000:07:00.0", "0x700", "4", "4", "0"))
+
+	problems := PCIeIdentityProblems(out, 1, 4)
+	require.Len(t, problems, 1, "only the host maximum is wrong: %s", strings.Join(problems, "; "))
+	assert.Contains(t, problems[0], "max_host_link_gen = 0, want 4")
+}
+
+// A host maximum below the device maximum is equally impossible: the link could
+// not have negotiated Gen4 through a Gen3 host.
+func TestPCIeIdentityProblems_RejectsHostMaxBelowDeviceMax(t *testing.T) {
+	out := xmlDocument(pcieIdentityGPUGens("0000:07:00.0", "0x700", "4", "4", "3"))
+
+	problems := PCIeIdentityProblems(out, 1, 4)
+	require.Len(t, problems, 1, strings.Join(problems, "; "))
+	assert.Contains(t, problems[0], "max_host_link_gen = 3, want 4")
+}
+
+func TestPCIeIdentityProblems_RejectsDuplicateBoardIDs(t *testing.T) {
+	out := xmlDocument(
+		pcieIdentityGPU("0000:07:00.0", "0x700", "4"),
+		pcieIdentityGPU("0000:0F:00.0", "0x700", "4"),
+	)
+
+	problems := PCIeIdentityProblems(out, 2, 4)
+	require.NotEmpty(t, problems, "distinct GPUs sharing a board ID must be reported")
+	assert.Contains(t, strings.Join(problems, "; "), "duplicates")
+}
+
+// Duplicate detection keys on the parsed value, so a leading zero cannot hide a
+// collision.
+func TestPCIeIdentityProblems_RejectsEquivalentBoardIDRenderings(t *testing.T) {
+	out := xmlDocument(
+		pcieIdentityGPU("0000:07:00.0", "0x700", "4"),
+		pcieIdentityGPU("0000:0F:00.0", "0x0700", "4"),
+	)
+
+	problems := PCIeIdentityProblems(out, 2, 4)
+	require.NotEmpty(t, problems, "0x0700 is the same board as 0x700")
+	assert.Contains(t, strings.Join(problems, "; "), "duplicates")
+}
+
+// Absent elements decode as empty strings, which must be reported rather than
+// read as board 0 or Gen0.
+func TestPCIeIdentityProblems_ReportsMissingReadings(t *testing.T) {
+	out := xmlDocument(pcieIdentityGPUGens("0000:07:00.0", "", "4", "", ""))
+
+	problems := PCIeIdentityProblems(out, 1, 4)
+	require.Len(t, problems, 3, "the board ID and both endpoint maxima are absent")
+	joined := strings.Join(problems, "; ")
+	assert.Contains(t, joined, "board_id")
+	assert.Contains(t, joined, "max_device_link_gen")
+	assert.Contains(t, joined, "max_host_link_gen")
+}
+
+func TestPCIeIdentityProblems_RejectsWrongGPUCount(t *testing.T) {
+	out := xmlDocument(pcieIdentityGPU("0000:07:00.0", "0x700", "4"))
+
+	problems := PCIeIdentityProblems(out, 8, 4)
+	require.NotEmpty(t, problems, "a truncated GPU list must be reported")
+	assert.Contains(t, strings.Join(problems, "; "), "reported 1 GPUs, want 8")
+}
+
+func TestPCIeIdentityProblems_RejectsUnparseableOutput(t *testing.T) {
+	require.NotEmpty(t, PCIeIdentityProblems("not xml at all", 2, 4))
+	require.NotEmpty(t, PCIeIdentityProblems(xmlDocument(), 0, 4), "a GPU-less document is an error")
+}
+
+// A real nvidia-smi document, so the element nesting is verified against the
+// driver rather than against the hand-built XML above: the a100 capture carries
+// the derived board IDs (0x700 and 0xf00) and a Gen4 link. It was taken before
+// the host-max fix, so its max_host_link_gen is the one reading still expected
+// to be reported — and nothing else, which is what pins the other paths.
+func TestPCIeIdentityProblems_ReadsCapturedDocument(t *testing.T) {
+	problems := PCIeIdentityProblems(loadFixture(t, "qx-a100-healthy.xml"), 2, 4)
+
+	for _, p := range problems {
+		assert.Contains(t, p, "max_host_link_gen",
+			"the capture predates the host-max fix; every other PCIe reading must already be right")
+	}
+}
+
 func TestEncoderFBCProblems_AcceptsConfiguredStats(t *testing.T) {
 	want := EncoderFBCStats{SessionCount: 2, AverageFPS: 30, AverageLatencyUS: 1500}
 

--- a/tests/e2e/go/assertions/nvidiasmi/exec.go
+++ b/tests/e2e/go/assertions/nvidiasmi/exec.go
@@ -60,6 +60,20 @@ func JpgOfaUtilization(ctx context.Context, k *kube.Client, pod kube.PodRef, wan
 		"JPEG/OFA utilization wrong:\n%s", strings.Join(problems, "\n"))
 }
 
+// PCIeIdentity asserts nvidia-smi -q -x reports per-GPU PCIe identity values a
+// real GPU could produce: the link, device and host maxima all at the profile's
+// configured generation rather than N/A or Gen0, and a non-zero board ID that is
+// unique across the node. See issue #638.
+func PCIeIdentity(ctx context.Context, k *kube.Client, pod kube.PodRef, p profile.Profile) {
+	ginkgo.GinkgoHelper()
+
+	ginkgo.By(fmt.Sprintf("nvidia-smi -q -x PCIe identity on %s (Gen%d, %d GPUs)",
+		p.Name, p.MaxPCIeLinkGen(), p.ExpectedGPUs()))
+	problems := PCIeIdentityProblems(query(ctx, k, pod), p.ExpectedGPUs(), p.MaxPCIeLinkGen())
+	gomega.Expect(problems).To(gomega.BeEmpty(),
+		"PCIe identity wrong for profile %s:\n%s", p.Name, strings.Join(problems, "\n"))
+}
+
 // TemperatureThresholds asserts nvidia-smi -q -x uses the
 // architecture-correct threshold presentation for the profile: absolute
 // elements on pre-Ada, *_tlimit_threshold elements on Ada and later. See issue

--- a/tests/e2e/go/assertions/nvidiasmi/schema.go
+++ b/tests/e2e/go/assertions/nvidiasmi/schema.go
@@ -105,6 +105,8 @@ type gpuElement struct {
 	ProductName              reading       `xml:"product_name"`
 	ProductArchitecture      reading       `xml:"product_architecture"`
 	UUID                     reading       `xml:"uuid"`
+	BoardID                  reading       `xml:"board_id"`
+	PCI                      pciInfo       `xml:"pci"`
 	FanSpeed                 reading       `xml:"fan_speed"`
 	PerformanceState         reading       `xml:"performance_state"`
 	FBMemoryUsage            memoryUsage   `xml:"fb_memory_usage"`
@@ -130,6 +132,29 @@ type memoryUsage struct {
 	Reserved reading `xml:"reserved"`
 	Used     reading `xml:"used"`
 	Free     reading `xml:"free"`
+}
+
+// pciInfo is <pci>. Only the link-generation subtree is decoded; the sibling
+// <pci_bridge_chip> and the flat address elements are not read.
+type pciInfo struct {
+	GPULinkInfo gpuLinkInfo `xml:"pci_gpu_link_info"`
+}
+
+// gpuLinkInfo is <pci_gpu_link_info>. Its other child, <link_widths>, names its
+// readings max_link_width and current_link_width, so the generation and width
+// elements cannot be confused for one another.
+type gpuLinkInfo struct {
+	PCIeGen pcieGen `xml:"pcie_gen"`
+}
+
+// pcieGen is <pcie_gen>. The three maxima reach nvidia-smi by different routes:
+// max_link_gen and max_device_link_gen come from public NVML getters, while
+// max_host_link_gen comes from a slot of the internal export table. The current
+// readings are deliberately not decoded — no assertion reads them yet.
+type pcieGen struct {
+	Max       reading `xml:"max_link_gen"`
+	DeviceMax reading `xml:"max_device_link_gen"`
+	HostMax   reading `xml:"max_host_link_gen"`
 }
 
 type statsBlock struct {

--- a/tests/e2e/go/profile/profile.go
+++ b/tests/e2e/go/profile/profile.go
@@ -60,6 +60,9 @@ type rawProfile struct {
 			JPEG int `json:"jpeg"`
 			OFA  int `json:"ofa"`
 		} `json:"utilization"`
+		PCIe *struct {
+			MaxLinkGen int `json:"max_link_gen"`
+		} `json:"pcie"`
 	} `json:"device_defaults"`
 	Devices []struct {
 		Index int `json:"index"`
@@ -104,6 +107,7 @@ type Profile struct {
 	maxOperatingC      int
 	jpegUtilizationPct int
 	ofaUtilizationPct  int
+	maxPCIeLinkGen     int
 }
 
 // bytesPerMiB is the divisor GPU Feature Discovery uses when it publishes
@@ -178,6 +182,9 @@ func (p *Profile) applyOptionalDeviceDefaults(raw rawProfile) {
 	if u := raw.DeviceDefaults.Utilization; u != nil {
 		p.jpegUtilizationPct = u.JPEG
 		p.ofaUtilizationPct = u.OFA
+	}
+	if pcie := raw.DeviceDefaults.PCIe; pcie != nil {
+		p.maxPCIeLinkGen = pcie.MaxLinkGen
 	}
 	if f := raw.DeviceDefaults.Fabric; f != nil {
 		p.hasFabric = true
@@ -266,6 +273,12 @@ func (p Profile) JPEGUtilizationPct() int { return p.jpegUtilizationPct }
 // OFAUtilizationPct is utilization.ofa from the profile, the percentage
 // nvidia-smi -q -x must report in ofa_util.
 func (p Profile) OFAUtilizationPct() int { return p.ofaUtilizationPct }
+
+// MaxPCIeLinkGen is device_defaults.pcie.max_link_gen from the profile — the
+// PCIe generation nvidia-smi must report for the "Max" and "Device Max" rows.
+// Ranges from 3 (t4) to 6 (Blackwell), so asserting against it pins the value
+// to config rather than a hardcoded constant.
+func (p Profile) MaxPCIeLinkGen() int { return p.maxPCIeLinkGen }
 
 // ReportsTLimitTemp is true when real hardware of this architecture reports the
 // GPU T.Limit temperature field IDs (Ada and later). Pre-Ada profiles keep the

--- a/tests/e2e/go/profile/profile_test.go
+++ b/tests/e2e/go/profile/profile_test.go
@@ -40,14 +40,15 @@ func TestDerivations(t *testing.T) {
 		shutdownC     int
 		slowdownC     int
 		maxOperatingC int
+		maxLinkGen    int
 	}{
-		{"a100", "NVIDIA A100-SXM4-40GB", 8, 8, 12, true, false, true, 2, "ampere", false, 92, 87, 83}, // NVSwitch (FabricMgr) but no ComputeDomain fabric block
-		{"h100", "NVIDIA H100 80GB HBM3", 8, 8, 18, true, true, true, 2, "hopper", true, 92, 87, 83},
-		{"b200", "NVIDIA B200", 8, 8, 0, false, false, true, 2, "blackwell", true, 95, 90, 85}, // NVLink negative control, IB enabled
-		{"gb200", "NVIDIA GB200", 8, 8, 18, true, true, true, 4, "blackwell", true, 95, 90, 85},
-		{"gb300", "NVIDIA GB300 NVL", 8, 8, 18, true, true, true, 4, "blackwell", true, 95, 90, 85},
-		{"l40s", "NVIDIA L40S", 8, 0, 0, false, false, false, 2, "ada_lovelace", true, 96, 93, 89}, // IB + NVLink negative control
-		{"t4", "NVIDIA T4", 4, 0, 0, false, false, false, 1, "turing", false, 96, 93, 89},
+		{"a100", "NVIDIA A100-SXM4-40GB", 8, 8, 12, true, false, true, 2, "ampere", false, 92, 87, 83, 4}, // NVSwitch (FabricMgr) but no ComputeDomain fabric block
+		{"h100", "NVIDIA H100 80GB HBM3", 8, 8, 18, true, true, true, 2, "hopper", true, 92, 87, 83, 5},
+		{"b200", "NVIDIA B200", 8, 8, 0, false, false, true, 2, "blackwell", true, 95, 90, 85, 6}, // NVLink negative control, IB enabled
+		{"gb200", "NVIDIA GB200", 8, 8, 18, true, true, true, 4, "blackwell", true, 95, 90, 85, 6},
+		{"gb300", "NVIDIA GB300 NVL", 8, 8, 18, true, true, true, 4, "blackwell", true, 95, 90, 85, 6},
+		{"l40s", "NVIDIA L40S", 8, 0, 0, false, false, false, 2, "ada_lovelace", true, 96, 93, 89, 4}, // IB + NVLink negative control
+		{"t4", "NVIDIA T4", 4, 0, 0, false, false, false, 1, "turing", false, 96, 93, 89, 3},
 	}
 
 	for _, c := range cases {
@@ -75,6 +76,7 @@ func TestDerivations(t *testing.T) {
 				{"ShutdownThresholdC", p.ShutdownThresholdC(), c.shutdownC},
 				{"SlowdownThresholdC", p.SlowdownThresholdC(), c.slowdownC},
 				{"MaxOperatingC", p.MaxOperatingC(), c.maxOperatingC},
+				{"MaxPCIeLinkGen", p.MaxPCIeLinkGen(), c.maxLinkGen},
 			}
 			for _, ck := range checks {
 				t.Run(ck.name, func(t *testing.T) {

--- a/tests/e2e/go/scenario_standalone_test.go
+++ b/tests/e2e/go/scenario_standalone_test.go
@@ -100,6 +100,14 @@ var _ = Describe("nvml-mock standalone", Ordered, func() {
 				assertJpgOfaUtilizationOverride(ctx, h, pod)
 			})
 
+			It("reports valid per-GPU PCIe identity via nvidia-smi -q -x", Label("nvidia-smi"), func(ctx SpecContext) {
+				// Issue #638: Board ID was 0x0 on every device, Device Max read
+				// N/A from a generated stub, and Host Max read Gen0 because the
+				// internal export-table slot behind it went unserved. Checked on
+				// every selected profile so the generation tracks config.
+				nvidiasmi.PCIeIdentity(ctx, h.Kube, pod, p)
+			})
+
 			It("exposes the NVLink topology (gated on fabricmanager)", Label("nvlink"), func(ctx SpecContext) {
 				assertions.FabricManagerGate(ctx, h.Kube, nvmlMockNamespace, "nvml-mock", pod, config.ReadyTimeout(), config.PollInterval())
 				assertions.NVLink(ctx, h.Kube, pod, p)

--- a/tests/mocknvml/internal_table_tests.go
+++ b/tests/mocknvml/internal_table_tests.go
@@ -78,6 +78,7 @@ const (
 	slotDeviceHandleByIndex = 81
 	slotProcessListFirst    = 213
 	slotProcessListLast     = 215
+	slotHostMaxPcieLinkGen  = 230
 	exportTableSlots        = 256
 )
 
@@ -95,6 +96,7 @@ const (
 	wantProcessPID       = 4242
 	wantProcessName      = "python"
 	wantProcessMemoryMiB = 6000
+	wantMaxPcieLinkGen   = 4
 )
 
 // guardFill is written across a buffer no call is allowed to touch, so a stray
@@ -121,8 +123,50 @@ func testInternalExportTable() []testResult {
 	results = append(results, testResult{"internal/device_handle", true, ""})
 
 	results = append(results, testInternalProcessList(table, handle)...)
+	results = append(results, testInternalHostMaxPcieLinkGen(table, handle)...)
 	results = append(results, testInternalOtherSlotsDoNotWrite(table, handle)...)
 	return results
+}
+
+// testInternalHostMaxPcieLinkGen checks the slot behind nvidia-smi's "Host Max"
+// PCIe generation row. It is a scalar getter rather than a list count, so unlike
+// every other slot outside the process-list range it has to write a real value:
+// leaving the caller's reading at zero is what made every profile report an
+// impossible Gen0 next to a Gen4 device maximum (issue #638). The guard buffer
+// still has to come back untouched, because the fault this surface is prone to is
+// writing through a third argument the caller never passed.
+func testInternalHostMaxPcieLinkGen(table, handle unsafe.Pointer) []testResult {
+	const name = "internal/host_max_pcie_link_gen"
+	var results []testResult
+	if os.Getenv("MOCK_NVML_CONFIG") == "" {
+		return results
+	}
+
+	const guardSize = 2 * procEntrySize
+	guard := C.malloc(guardSize)
+	if guard == nil {
+		return append(results, testResult{name, false, "malloc failed"})
+	}
+	defer C.free(guard)
+	C.memset(guard, guardFill, guardSize)
+	want := bytes.Repeat([]byte{guardFill}, guardSize)
+
+	gen := C.uint(65535)
+	ret := C.mockCallSlot(table, C.uint(slotHostMaxPcieLinkGen), handle, unsafe.Pointer(&gen), guard, nil)
+
+	switch {
+	case ret != 0:
+		return append(results, testResult{name, false,
+			fmt.Sprintf("slot %d returned %d, want NVML_SUCCESS", slotHostMaxPcieLinkGen, ret)})
+	case !bytes.Equal(C.GoBytes(guard, C.int(guardSize)), want):
+		return append(results, testResult{name, false,
+			fmt.Sprintf("slot %d wrote into a buffer it was never given", slotHostMaxPcieLinkGen)})
+	case gen != wantMaxPcieLinkGen:
+		return append(results, testResult{name, false,
+			fmt.Sprintf("slot %d reported Gen%d, want the configured Gen%d: nvidia-smi renders "+
+				"this as the Host Max PCIe generation", slotHostMaxPcieLinkGen, gen, wantMaxPcieLinkGen)})
+	}
+	return append(results, testResult{name, true, ""})
 }
 
 // testInternalProcessList checks that the process-list slots report the
@@ -173,6 +217,11 @@ func testInternalProcessList(table, handle unsafe.Pointer) []testResult {
 // argument shape alone turned those calls into writes through a pointer the
 // caller never passed. Every such slot must leave the buffer alone and report
 // zero entries.
+//
+// The slots with a known meaning are excluded: the process list writes entries,
+// and the host-max PCIe generation writes a scalar reading. Both are covered by
+// their own test above, so anything still in this loop is a slot we have not
+// identified and must therefore keep treating as a list count.
 func testInternalOtherSlotsDoNotWrite(table, handle unsafe.Pointer) []testResult {
 	const name = "internal/other_slots_no_write"
 	var results []testResult
@@ -187,6 +236,9 @@ func testInternalOtherSlotsDoNotWrite(table, handle unsafe.Pointer) []testResult
 
 	for slot := 1; slot < exportTableSlots; slot++ {
 		if slot >= slotProcessListFirst && slot <= slotProcessListLast {
+			continue
+		}
+		if slot == slotHostMaxPcieLinkGen {
 			continue
 		}
 		C.memset(guard, guardFill, guardSize)


### PR DESCRIPTION
## What This PR Does

`nvidia-smi` reported three per-GPU PCIe identity values no real GPU can produce. All three now track the profile:

| Reading | Before | After |
| --- | --- | --- |
| `Board ID` | `0x0` on every GPU | derived from the PCI address (`0000:07:00.0` → `0x700`) |
| `Device Max` PCIe generation | `N/A` | the profile's `pcie.max_link_gen` |
| `Host Max` PCIe generation | `Gen0` | the profile's `pcie.max_link_gen` |

- **Board ID** was hardcoded to 0. It is now derived the way NVML does — `(domain << 16) | (bus << 8) | (device << 3) | function` — so the eight GPUs of a DGX node no longer all claim the same board.
- **Device Max** came from `nvmlDeviceGetGpuMaxPcieLinkGeneration`, a generated stub returning `NVML_ERROR_NOT_SUPPORTED`. It is now hand-written in the bridge and reads config, so the generation tracks the profile: Gen3 on `t4` through Gen6 on Blackwell.
- **Host Max** has no public NVML API behind it — none of the nine `nvmlDeviceGet*Pcie*` functions is host-scoped, which is why implementing the generation getters never moved the row. nvidia-smi reads it through **slot 230 of the internal export table**, where the catch-all C stub wrote a zero count over the caller's reading. That is the same class of bug as the phantom processes fixed in #630: a stub acknowledging a call it does not understand and clobbering the output. The bridge now serves that slot from `pcie.max_link_gen`, modelling a host that keeps up with the GPU, so `Max`, `Device Max` and `Host Max` agree. Profiles with no `pcie` block stay on the existing zero path rather than having a generation invented for them.

The slot was identified by its position in the `-q` call sequence under `MOCK_NVML_DEBUG` — it fires between `nvmlDeviceGetGpuMaxPcieLinkGeneration` (`Device Max`) and `nvmlDeviceGetMaxPcieLinkWidth` (`Link Width`), exactly where `Host Max` prints:

```
[NVML]   nvmlDeviceGetGpuMaxPcieLinkGeneration -> 4  # Device Max
[C-STUB] slot 230 device list query -> 0 entries     # Host Max  <-- clobbered here
[NVML]   nvmlDeviceGetMaxPcieLinkWidth -> 16         # Link Width Max
```

Writing a marker value into the slot moved the `Host Max` row of `-q`, the `<max_host_link_gen>` element of `-q -x` and the `pcie.link.gen.hostmax` query field together, confirming all three surfaces come from it.

### Why a bridge test guard changed

`tests/mocknvml` guarded every internal slot outside the process-list range with a single blanket rule: leave the caller's buffer alone and write a **zero** count. That is correct for a list count and wrong for a scalar getter, so slot 230 now has its own test — returns SUCCESS, reports the fixture's Gen4, guard buffer untouched — and the blanket rule keeps covering every slot whose meaning is still unknown.

That guard exists for a fault that appeared "as soon as a process was configured", so the change was re-checked against `tests/mocknvml/util-test-config.yaml`, which configures a process alongside `max_link_gen: 4`. The only difference in full `nvidia-smi -q` output is the `Host Max` row, `--query-compute-apps` is unchanged with no phantom rows, and `pmon` fails identically before and after.

### E2E coverage

New spec `reports valid per-GPU PCIe identity via nvidia-smi -q -x` in the standalone scenario, backed by the pure `PCIeIdentityProblems` check in the `tests/e2e/go/assertions/nvidiasmi` package (#658). It requires all three maxima to equal the profile's configured `pcie.max_link_gen` and board IDs to be non-zero and unique across the node. `board_id` and the `pci_gpu_link_info/pcie_gen` subtree join `schema.go`, the one place that package names elements, so its tri-state reading keeps an absent element distinguishable from `N/A` and from a genuine `0`.

The captured fixtures in `testdata/` predate the host-max fix and carry `max_host_link_gen` `0`, so the passing case is hand-built — the convention that package already documents for the JPEG/OFA and encoder/FBC checks. The `a100` capture still drives a test, which pins every other element path against a real document; recapturing the fixtures after this merges would let it tighten to "no problems".

## Why

Fixes #638.

A `Board ID` of `0x0` on every device leaves the GPUs of a multi-GPU node indistinguishable to anything keying on it. A `Gen0` host maximum beside a Gen4 device maximum describes a topology that cannot exist, since a link never negotiates higher than either endpoint supports. Both undercut the point of the mock: consumers up the stack should see what they would see on real hardware.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass — `make test` (which runs with `-race`) and `make test-mocknvml-bridge` at 43/43
- [x] Linter passes (`make lint-fix`) — 0 issues, govulncheck clean
- [x] New code has SPDX license headers
- [ ] Documentation updated (if applicable) — n/a
- [x] CHANGELOG.md updated (if user-facing change)

### Verification

- `Host Max` matches each profile's configured generation against built images: `t4` Gen3, `a100`/`l40s` Gen4, `h100` Gen5, `b200`/`gb200` Gen6.
- Diffing full output against a pre-fix image on `a100`: the only structural change is `Host Max` `0` → `4` on all eight GPUs plus the corresponding XML element. `topo -m` is byte-identical, and `-L`, `-q`, `-q -x`, `-q -d MEMORY`, `--list-gpus`, `--query-compute-apps` all still exit 0.
- Running the real `PCIeIdentityProblems` check over live captures from an image built from this branch: clean on `a100` (Gen4) and `gb200` (Gen6), eight GPUs each, and a Gen5 expectation fails on the same document as a negative control.
- The new bridge test was checked for vacuity by pointing the implementation at a neighbouring slot: it reports `slot 230 reported Gen0, want the configured Gen4`, and the blanket guard independently catches the stray non-zero write.
- CI green, including the full e2e matrix across `a100`, `h100`, `b200`, `gb200`, `gb300` and `t4`.

