### PR TITLE
fix(mocknvml): report bare-metal virtualization mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reading — the same class of bug as the phantom processes above. All three
   maxima now agree in `nvidia-smi -q`, `-q -x` (`<max_host_link_gen>`) and
   `--query-gpu=pcie.link.gen.hostmax`. (#638)
+- mocknvml: `nvidia-smi -q` reports `Virtualization Mode : None` instead of
+  `N/A`. `nvmlDeviceGetVirtualizationMode` was a generated stub — the most
+  frequently called one in a single `-q` run — so the mock claimed it could not
+  tell whether it was virtualized, where bare-metal hardware always answers
+  `None`. The export is now hand-written and resolves the `virtualization.mode`
+  the profiles already carried (`none`, `passthrough`, `vgpu`; anything
+  unrecognised reads as bare metal). vGPU stays out of scope: `Host VGPU Mode`
+  and `vGPU Heterogeneous Mode` still read `N/A`, matching bare metal. An
+  earlier attempt at this fix was reverted during PR #630 because it moved
+  `nvidia-smi pmon` onto a different code path and segfaulted it, so an e2e spec
+  now pins `pmon -c 1` to a graceful refusal or success and requires `topo -m`
+  to succeed, guarding the neighbouring internal-export-table path. (#640)
 - Wire eight NVML device exports that already had engine implementations but
   were still generated stubs (`GetEncoderStats`, `GetFBCStats`,
   `GetAccountingBufferSize`, `GetEncoderCapacity`, `GetEncoderSessions`,

--- a/pkg/gpu/mocknvml/bridge/device.go
+++ b/pkg/gpu/mocknvml/bridge/device.go
@@ -54,6 +54,7 @@
 // - nvmlDeviceGetCurrentClocksThrottleReasons
 // - nvmlDeviceGetUtilizationRates
 // - nvmlDeviceGetComputeMode
+// - nvmlDeviceGetVirtualizationMode
 // - nvmlDeviceGetEccMode
 // - nvmlDeviceGetDisplayMode
 // - nvmlDeviceGetAccountingMode
@@ -1384,6 +1385,27 @@ func nvmlDeviceGetComputeMode(device C.nvmlDevice_t, mode *C.nvmlComputeMode_t) 
 		return toReturn(ret)
 	}
 	*mode = C.nvmlComputeMode_t(val)
+	return C.NVML_SUCCESS
+}
+
+//export nvmlDeviceGetVirtualizationMode
+func nvmlDeviceGetVirtualizationMode(device C.nvmlDevice_t, pVirtualMode *C.nvmlGpuVirtualizationMode_t) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetVirtualizationMode"); !ok {
+		return ret
+	}
+	if pVirtualMode == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := unsafe.Pointer(device.handle)
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	val, ret := dev.GetVirtualizationMode()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	*pVirtualMode = C.nvmlGpuVirtualizationMode_t(val)
 	return C.NVML_SUCCESS
 }
 

--- a/pkg/gpu/mocknvml/bridge/stubs_generated.go
+++ b/pkg/gpu/mocknvml/bridge/stubs_generated.go
@@ -604,11 +604,6 @@ func nvmlDeviceGetVgpuUtilization(device C.nvmlDevice_t, lastSeenTimeStamp C.ulo
 	return stubReturn("nvmlDeviceGetVgpuUtilization")
 }
 
-//export nvmlDeviceGetVirtualizationMode
-func nvmlDeviceGetVirtualizationMode(device C.nvmlDevice_t, pVirtualMode *C.nvmlGpuVirtualizationMode_t) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetVirtualizationMode")
-}
-
 //export nvmlDeviceModifyDrainState
 func nvmlDeviceModifyDrainState(pciInfo *C.nvmlPciInfo_t, newState C.nvmlEnableState_t) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceModifyDrainState")

--- a/pkg/gpu/mocknvml/bridge/stubs_generated.go
+++ b/pkg/gpu/mocknvml/bridge/stubs_generated.go
@@ -21,7 +21,7 @@ package main
 */
 import "C"
 
-// 269 stub functions for unimplemented NVML functions.
+// 268 stub functions for unimplemented NVML functions.
 // These return NVML_ERROR_NOT_SUPPORTED (3).
 
 //export nvmlComputeInstanceDestroy

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -957,6 +957,18 @@ func (d *ConfigurableDevice) GetComputeMode() (nvml.ComputeMode, nvml.Return) {
 	return mode, nvml.SUCCESS
 }
 
+// GetVirtualizationMode reports whether the device is virtualized. Answering
+// NOT_SUPPORTED here makes nvidia-smi print "N/A", which claims the driver
+// cannot tell — real hardware always knows, and bare metal answers NONE.
+func (d *ConfigurableDevice) GetVirtualizationMode() (nvml.GpuVirtualizationMode, nvml.Return) {
+	mode := nvml.GPU_VIRTUALIZATION_MODE_NONE
+	if c := d.cfg(); c.Virtualization != nil {
+		mode = parseVirtualizationMode(c.Virtualization.Mode)
+	}
+	debugLog("[NVML] nvmlDeviceGetVirtualizationMode -> %d\n", mode)
+	return mode, nvml.SUCCESS
+}
+
 // GetEccMode returns ECC mode status
 func (d *ConfigurableDevice) GetEccMode() (nvml.EnableState, nvml.EnableState, nvml.Return) {
 	current := nvml.FEATURE_DISABLED
@@ -2023,6 +2035,19 @@ func parseTopologyLevel(level string) nvml.GpuTopologyLevel {
 		return nvml.TOPOLOGY_SYSTEM
 	default:
 		return nvml.TOPOLOGY_SINGLE
+	}
+}
+
+func parseVirtualizationMode(mode string) nvml.GpuVirtualizationMode {
+	switch mode {
+	case "none":
+		return nvml.GPU_VIRTUALIZATION_MODE_NONE
+	case "passthrough":
+		return nvml.GPU_VIRTUALIZATION_MODE_PASSTHROUGH
+	case "vgpu":
+		return nvml.GPU_VIRTUALIZATION_MODE_VGPU
+	default:
+		return nvml.GPU_VIRTUALIZATION_MODE_NONE
 	}
 }
 

--- a/pkg/gpu/mocknvml/engine/device_virtualization_test.go
+++ b/pkg/gpu/mocknvml/engine/device_virtualization_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/go-nvml/pkg/nvml/mock/dgxa100"
+	mockserver "github.com/NVIDIA/go-nvml/pkg/nvml/mock/server"
+	"github.com/stretchr/testify/require"
+)
+
+func makeVirtualizationDevice(t *testing.T, virt *VirtualizationConfig) *ConfigurableDevice {
+	t.Helper()
+	base := dgxa100.New()
+	bd, _ := base.Devices[0].(*mockserver.Device)
+	return NewConfigurableDevice(0, bd, &DeviceConfig{Virtualization: virt},
+		"GPU-00000000-0000-0000-0000-000000000000", "0000:01:00.0", 0, (*NodeFabric)(nil))
+}
+
+// Issue #640: every profile ships virtualization.mode but nothing read it, so
+// nvidia-smi reported "Virtualization Mode : N/A". N/A is the wrong claim for
+// bare metal — real hardware always knows whether it is virtualized, and NONE
+// is that answer.
+func TestConfigurableDevice_GetVirtualizationModeReportsConfiguredMode(t *testing.T) {
+	for _, tc := range []struct {
+		mode string
+		want nvml.GpuVirtualizationMode
+	}{
+		{"none", nvml.GPU_VIRTUALIZATION_MODE_NONE},
+		{"passthrough", nvml.GPU_VIRTUALIZATION_MODE_PASSTHROUGH},
+		{"vgpu", nvml.GPU_VIRTUALIZATION_MODE_VGPU},
+	} {
+		t.Run(tc.mode, func(t *testing.T) {
+			dev := makeVirtualizationDevice(t, &VirtualizationConfig{Mode: tc.mode})
+
+			mode, ret := dev.GetVirtualizationMode()
+			require.Equal(t, nvml.SUCCESS, ret, "GetVirtualizationMode")
+			require.Equal(t, tc.want, mode, "virtualization.mode %q", tc.mode)
+		})
+	}
+}
+
+// A profile with no virtualization block, or a mode nobody recognises, must
+// still answer SUCCESS with NONE. The mock only ever simulates bare-metal
+// hardware, so bare metal is the safe default rather than an error.
+func TestConfigurableDevice_GetVirtualizationModeDefaultsToBareMetal(t *testing.T) {
+	for name, virt := range map[string]*VirtualizationConfig{
+		"no virtualization block": nil,
+		"empty mode":              {},
+		"unrecognised mode":       {Mode: "not-a-mode"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dev := makeVirtualizationDevice(t, virt)
+
+			mode, ret := dev.GetVirtualizationMode()
+			require.Equal(t, nvml.SUCCESS, ret, "GetVirtualizationMode")
+			require.Equal(t, nvml.GPU_VIRTUALIZATION_MODE_NONE, mode, name)
+		})
+	}
+}

--- a/tests/e2e/go/assertions/nvidiasmi/checks.go
+++ b/tests/e2e/go/assertions/nvidiasmi/checks.go
@@ -157,6 +157,66 @@ func C2CModeProblems(out string, wantEnabled bool) []string {
 	return problems
 }
 
+// bareMetalVirtualizationMode is what nvidia-smi renders for
+// NVML_GPU_VIRTUALIZATION_MODE_NONE.
+const bareMetalVirtualizationMode = "None"
+
+// VirtualizationModeProblems checks every GPU reports the bare-metal
+// virtualization mode the profiles configure, with no vGPU state alongside it.
+// "N/A" is the defect this exists to catch (#640): it says the driver cannot
+// tell whether the GPU is virtualized, where real hardware always answers.
+func VirtualizationModeProblems(out string) []string {
+	snap, err := ParseSnapshot(out)
+	if err != nil {
+		return []string{err.Error()}
+	}
+
+	var problems []string
+	for i, gpu := range snap.doc.GPUs {
+		name := gpu.label(i)
+		if mode := strings.TrimSpace(string(gpu.Virtualization.Mode)); mode != bareMetalVirtualizationMode {
+			problems = append(problems, fmt.Sprintf("%s virtualization_mode = %q, want %q",
+				name, mode, bareMetalVirtualizationMode))
+		}
+		problems = append(problems, unsupportedReadingProblems(
+			name+" host_vgpu_mode", gpu.Virtualization.HostVGPUMode)...)
+		problems = append(problems, unsupportedReadingProblems(
+			name+" vgpu_heterogeneous_mode", gpu.Virtualization.HeterogeneousMode)...)
+	}
+	return problems
+}
+
+// unsupportedReadingProblems checks an element the mock must leave unsupported.
+// An absent element passes: nvidia-smi omits elements the driver never reports,
+// which is a stronger form of the same claim.
+func unsupportedReadingProblems(name string, got reading) []string {
+	if got.present() && !got.unsupported() {
+		return []string{fmt.Sprintf("%s = %q, want \"N/A\"", name, strings.TrimSpace(string(got)))}
+	}
+	return nil
+}
+
+// pmonAcceptableExitCodes are the outcomes of `nvidia-smi pmon` that are not a
+// regression: 0 if the process-monitor path ever becomes supported, and the 255
+// it exits with today after printing "Not supported on the device(s)". Anything
+// else is abnormal — above all the 139 kubectl reports for a SIGSEGV, which is
+// how the reverted attempt behind PR #630 failed.
+var pmonAcceptableExitCodes = []int{0, 255}
+
+// ProcessMonitorProblems judges an `nvidia-smi pmon` exit code. pmon refuses to
+// run against the mock, so a non-zero exit is the baseline rather than the
+// defect; the check exists to catch it dying instead of refusing.
+func ProcessMonitorProblems(exitCode int, output string) []string {
+	for _, ok := range pmonAcceptableExitCodes {
+		if exitCode == ok {
+			return nil
+		}
+	}
+	return []string{fmt.Sprintf(
+		"nvidia-smi pmon -c 1 exited %d, want one of %v (139 is a SIGSEGV through kubectl): %s",
+		exitCode, pmonAcceptableExitCodes, output)}
+}
+
 // EncoderFBCStats are the non-default values issue #636 expects nvidia-smi to
 // surface.
 type EncoderFBCStats struct {

--- a/tests/e2e/go/assertions/nvidiasmi/checks_test.go
+++ b/tests/e2e/go/assertions/nvidiasmi/checks_test.go
@@ -488,3 +488,97 @@ func TestEncoderFBCProblems_ChecksBothBlocksAgainstTheirOwnExpectation(t *testin
 	require.Len(t, problems, 3, "the fbc_stats block matches the encoder expectation")
 	assert.Contains(t, strings.Join(problems, "; "), "fbc_stats session_count = 2, want 4")
 }
+
+// virtualizationGPU renders one <gpu> whose gpu_virtualization_mode block
+// carries the given bodies verbatim, so a test can inject the "None" of bare
+// metal, the "N/A" of a missing getter, or a vGPU mode.
+func virtualizationGPU(id, mode, hostVGPU, heterogeneous string) string {
+	return `
+	<gpu id="` + id + `">
+		<product_name>NVIDIA A100-SXM4-40GB</product_name>
+		<gpu_virtualization_mode>
+			<virtualization_mode>` + mode + `</virtualization_mode>
+			<host_vgpu_mode>` + hostVGPU + `</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>` + heterogeneous + `</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+	</gpu>`
+}
+
+func TestVirtualizationModeProblems_AcceptsBareMetalDocument(t *testing.T) {
+	out := xmlDocument(
+		virtualizationGPU("0000:07:00.0", "None", "N/A", "N/A"),
+		virtualizationGPU("0000:0F:00.0", "None", "N/A", "N/A"),
+	)
+
+	problems := VirtualizationModeProblems(out)
+	assert.Empty(t, problems, strings.Join(problems, "; "))
+}
+
+// The #640 defect, asserted against real pre-fix captures: while
+// nvmlDeviceGetVirtualizationMode was a generated stub nvidia-smi rendered
+// "N/A", claiming the driver could not tell whether the GPU was virtualized.
+func TestVirtualizationModeProblems_RejectsCapturedStubbedDocuments(t *testing.T) {
+	for _, fixture := range []string{"qx-a100-healthy.xml", "qx-gb200-healthy.xml"} {
+		t.Run(fixture, func(t *testing.T) {
+			problems := VirtualizationModeProblems(loadFixture(t, fixture))
+			require.Len(t, problems, 2, "both GPUs report a stubbed virtualization_mode")
+			assert.Contains(t, strings.Join(problems, "; "), `virtualization_mode = "N/A", want "None"`)
+		})
+	}
+}
+
+// vGPU is out of scope for the mock, so host_vgpu_mode and
+// vgpu_heterogeneous_mode must keep reading N/A the way bare-metal hardware
+// reports them. A value in either means vGPU state leaked into the answer.
+func TestVirtualizationModeProblems_RejectsReportedVGPUState(t *testing.T) {
+	out := xmlDocument(
+		virtualizationGPU("0000:07:00.0", "None", "Non SR-IOV", "N/A"),
+		virtualizationGPU("0000:0F:00.0", "None", "N/A", "Enabled"),
+	)
+
+	problems := VirtualizationModeProblems(out)
+	require.Len(t, problems, 2)
+	joined := strings.Join(problems, "; ")
+	assert.Contains(t, joined, "host_vgpu_mode")
+	assert.Contains(t, joined, "vgpu_heterogeneous_mode")
+}
+
+// A GPU-scoped getter that answers for only the first device must be caught.
+func TestVirtualizationModeProblems_ChecksEveryGPU(t *testing.T) {
+	out := xmlDocument(
+		virtualizationGPU("0000:07:00.0", "None", "N/A", "N/A"),
+		virtualizationGPU("0000:0F:00.0", "N/A", "N/A", "N/A"),
+	)
+
+	problems := VirtualizationModeProblems(out)
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "0000:0F:00.0")
+}
+
+func TestVirtualizationModeProblems_ReportsUnparseableDocument(t *testing.T) {
+	problems := VirtualizationModeProblems("not xml")
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "parse nvidia-smi XML")
+}
+
+// pmon reaches the mock through the reverse-engineered internal export table
+// and refuses to run there, so its non-zero exit is the baseline rather than a
+// failure. Only a crash is (#640, PR #630).
+func TestProcessMonitorProblems_AcceptsGracefulRefusalAndSuccess(t *testing.T) {
+	assert.Empty(t, ProcessMonitorProblems(255, "Not supported on the device(s)"))
+	assert.Empty(t, ProcessMonitorProblems(0, "# gpu        pid  type"))
+}
+
+func TestProcessMonitorProblems_RejectsSegfault(t *testing.T) {
+	problems := ProcessMonitorProblems(139, "command terminated with exit code 139")
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "139")
+}
+
+// A signal death surfaces as 128+N through kubectl, or as a negative code when
+// the local kubectl process is itself signalled.
+func TestProcessMonitorProblems_RejectsOtherAbnormalExits(t *testing.T) {
+	for _, code := range []int{-1, 134, 2} {
+		assert.NotEmpty(t, ProcessMonitorProblems(code, "output"), "exit %d", code)
+	}
+}

--- a/tests/e2e/go/assertions/nvidiasmi/exec.go
+++ b/tests/e2e/go/assertions/nvidiasmi/exec.go
@@ -74,6 +74,42 @@ func PCIeIdentity(ctx context.Context, k *kube.Client, pod kube.PodRef, p profil
 		"PCIe identity wrong for profile %s:\n%s", p.Name, strings.Join(problems, "\n"))
 }
 
+// VirtualizationMode asserts nvidia-smi -q -x reports the bare-metal
+// virtualization mode on every GPU. The element read N/A while
+// nvmlDeviceGetVirtualizationMode was a generated stub, which claims the driver
+// cannot tell whether the GPU is virtualized. See issue #640.
+func VirtualizationMode(ctx context.Context, k *kube.Client, pod kube.PodRef) {
+	ginkgo.GinkgoHelper()
+
+	ginkgo.By("nvidia-smi -q -x reports virtualization_mode None")
+	problems := VirtualizationModeProblems(query(ctx, k, pod))
+	gomega.Expect(problems).To(gomega.BeEmpty(),
+		"virtualization mode wrong:\n%s", strings.Join(problems, "\n"))
+}
+
+// ProcessMonitorAndTopology asserts the two nvidia-smi subcommands that reach
+// the mock through the reverse-engineered internal export table still behave.
+// They are checked together because they share that path and are unusually
+// sensitive to what neighbouring NVML calls return: implementing
+// nvmlDeviceGetVirtualizationMode during the investigation behind PR #630 moved
+// pmon onto a different branch and segfaulted it. See issue #640.
+func ProcessMonitorAndTopology(ctx context.Context, k *kube.Client, pod kube.PodRef) {
+	ginkgo.GinkgoHelper()
+
+	// pmon's own failure is expected, so the error is deliberately not
+	// asserted on — only the exit code, which is what tells a graceful refusal
+	// from a crash.
+	ginkgo.By("nvidia-smi pmon -c 1 does not crash")
+	res, _ := k.Exec(ctx, pod, "nvidia-smi", "pmon", "-c", "1")
+	problems := ProcessMonitorProblems(res.ExitCode, res.Combined())
+	gomega.Expect(problems).To(gomega.BeEmpty(), strings.Join(problems, "\n"))
+
+	ginkgo.By("nvidia-smi topo -m succeeds")
+	res, err := k.ExecQuiet(ctx, pod, "nvidia-smi", "topo", "-m")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+		"nvidia-smi topo -m exited %d: %s", res.ExitCode, res.Combined())
+}
+
 // TemperatureThresholds asserts nvidia-smi -q -x uses the
 // architecture-correct threshold presentation for the profile: absolute
 // elements on pre-Ada, *_tlimit_threshold elements on Ada and later. See issue

--- a/tests/e2e/go/assertions/nvidiasmi/schema.go
+++ b/tests/e2e/go/assertions/nvidiasmi/schema.go
@@ -101,25 +101,26 @@ type document struct {
 // gpuElement holds the elements assertions read; add fields as more are needed.
 // Every body is a reading rather than a number for the reasons on that type.
 type gpuElement struct {
-	ID                       string        `xml:"id,attr"`
-	ProductName              reading       `xml:"product_name"`
-	ProductArchitecture      reading       `xml:"product_architecture"`
-	UUID                     reading       `xml:"uuid"`
-	BoardID                  reading       `xml:"board_id"`
-	C2CMode                  reading       `xml:"c2c_mode"`
-	PCI                      pciInfo       `xml:"pci"`
-	FanSpeed                 reading       `xml:"fan_speed"`
-	PerformanceState         reading       `xml:"performance_state"`
-	FBMemoryUsage            memoryUsage   `xml:"fb_memory_usage"`
-	AccountingModeBufferSize reading       `xml:"accounting_mode_buffer_size"`
-	EncoderStats             statsBlock    `xml:"encoder_stats"`
-	FBCStats                 statsBlock    `xml:"fbc_stats"`
-	Utilization              utilization   `xml:"utilization"`
-	Temperature              temperature   `xml:"temperature"`
-	PowerReadings            powerReadings `xml:"gpu_power_readings"`
-	Clocks                   clocks        `xml:"clocks"`
-	ECCErrors                eccErrors     `xml:"ecc_errors"`
-	ClocksEventReasons       eventReasons  `xml:"clocks_event_reasons"`
+	ID                       string            `xml:"id,attr"`
+	ProductName              reading           `xml:"product_name"`
+	ProductArchitecture      reading           `xml:"product_architecture"`
+	UUID                     reading           `xml:"uuid"`
+	BoardID                  reading           `xml:"board_id"`
+	C2CMode                  reading           `xml:"c2c_mode"`
+	PCI                      pciInfo           `xml:"pci"`
+	FanSpeed                 reading           `xml:"fan_speed"`
+	PerformanceState         reading           `xml:"performance_state"`
+	FBMemoryUsage            memoryUsage       `xml:"fb_memory_usage"`
+	AccountingModeBufferSize reading           `xml:"accounting_mode_buffer_size"`
+	EncoderStats             statsBlock        `xml:"encoder_stats"`
+	FBCStats                 statsBlock        `xml:"fbc_stats"`
+	Utilization              utilization       `xml:"utilization"`
+	Virtualization           gpuVirtualization `xml:"gpu_virtualization_mode"`
+	Temperature              temperature       `xml:"temperature"`
+	PowerReadings            powerReadings     `xml:"gpu_power_readings"`
+	Clocks                   clocks            `xml:"clocks"`
+	ECCErrors                eccErrors         `xml:"ecc_errors"`
+	ClocksEventReasons       eventReasons      `xml:"clocks_event_reasons"`
 	Processes                struct {
 		Infos []processInfo `xml:"process_info"`
 	} `xml:"processes"`
@@ -171,6 +172,15 @@ type utilization struct {
 	Decoder reading `xml:"decoder_util"`
 	JPEG    reading `xml:"jpeg_util"`
 	OFA     reading `xml:"ofa_util"`
+}
+
+// gpuVirtualization is <gpu_virtualization_mode>. Only the first element is a
+// bare-metal answer the mock can give; the vGPU pair is unsupported hardware
+// state, so N/A is correct for them and asserted as such.
+type gpuVirtualization struct {
+	Mode              reading `xml:"virtualization_mode"`
+	HostVGPUMode      reading `xml:"host_vgpu_mode"`
+	HeterogeneousMode reading `xml:"vgpu_heterogeneous_mode"`
 }
 
 // temperature carries both threshold presentations. nvidia-smi emits the

--- a/tests/e2e/go/scenario_standalone_test.go
+++ b/tests/e2e/go/scenario_standalone_test.go
@@ -117,6 +117,17 @@ var _ = Describe("nvml-mock standalone", Ordered, func() {
 				nvidiasmi.C2CMode(ctx, h.Kube, pod, p)
 			})
 
+			It("reports the bare-metal virtualization mode via nvidia-smi -q -x", Label("nvidia-smi"), func(ctx SpecContext) {
+				// Issue #640: the reading was N/A because
+				// nvmlDeviceGetVirtualizationMode was a generated stub, so the
+				// mock claimed it could not tell whether it was virtualized
+				// where bare metal answers None. pmon and topo -m are checked
+				// alongside it because an earlier attempt at this fix moved pmon
+				// onto a different code path and segfaulted it (PR #630).
+				nvidiasmi.VirtualizationMode(ctx, h.Kube, pod)
+				nvidiasmi.ProcessMonitorAndTopology(ctx, h.Kube, pod)
+			})
+
 			It("exposes the NVLink topology (gated on fabricmanager)", Label("nvlink"), func(ctx SpecContext) {
 				assertions.FabricManagerGate(ctx, h.Kube, nvmlMockNamespace, "nvml-mock", pod, config.ReadyTimeout(), config.PollInterval())
 				assertions.NVLink(ctx, h.Kube, pod, p)


### PR DESCRIPTION
## What This PR Does

`nvmlDeviceGetVirtualizationMode` was a generated stub, so `nvidia-smi -q` printed `Virtualization Mode : N/A`. It is now hand-written and resolves the `virtualization.mode` every profile already carried, so `-q` reports `None`:

```
    GPU Virtualization Mode
        Virtualization Mode               : None      # was N/A
        Host VGPU Mode                    : N/A
        vGPU Heterogeneous Mode           : N/A
```

vGPU stays out of scope. `Host VGPU Mode` and `vGPU Heterogeneous Mode` keep reading `N/A` the way bare-metal hardware reports them, and `nvmlDeviceGetVgpuHeterogeneousMode` remains a stub.

A new Ginkgo spec under `Label("nvidia-smi")` asserts the reading from `-q -x`, and — the point of the second commit — pins `pmon -c 1` and `topo -m` alongside it.

## Why

Closes #640.

`N/A` claims the driver cannot tell whether the GPU is virtualized. No real device answers that: bare metal reports `None`. It was also the most frequently called unimplemented export in a single `-q` run, at 25 calls across 8 GPUs.

**The reason this was filed separately from the other stub-wiring gaps:** an implementation was written and reverted during the investigation behind #630, because returning a mode moved `nvidia-smi pmon` onto a different code path and crashed it. `pmon` reaches the mock through the reverse-engineered internal export table, which is unusually sensitive to what neighbouring calls return, so that regression was only ever caught by hand. This PR turns it into something CI catches.

### Verification against `main`

Baseline captured from the pre-fix image before anything was touched, then compared:

| | `main` | this PR |
| --- | --- | --- |
| `-q` virtualization mode | `N/A` | `None` |
| `-q` host vGPU / heterogeneous | `N/A` | `N/A` |
| `pmon -c 1` | 255, `Not supported on the device(s)` | 255, identical |
| `topo -m` | 0 | 0 |
| default table, `-q`, `-q -x` | 0 | 0 |

Checked across the `a100`, `gb200`, `t4` and `h100` profiles. No segfault, no exit-code regression. A full diff of `nvidia-smi -q` between the two images moves only three things: the timestamp, the virtualization mode itself, and the deliberately dynamic utilization percentages.

Note the issue text says `pmon` exits 0 with no output on `main`. That is no longer accurate — #630 changed it to refuse gracefully with 255, as the current `[Unreleased]` changelog records — so the spec accepts 0 or 255 and fails on a signal death instead of pinning today's number as correct.

The document check is proved against the committed `-q -x` fixtures, which are verbatim captures of `main`, so it fails against `main` as the issue requires. The e2e spec was run against a real Kind cluster: 5 specs passed, and the log confirms `kubectl exec` surfaces pmon's 255 the way the assertion reads it.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`make test`, plus `make e2e E2E_PROFILES=a100 E2E_GINKGO_FLAGS='--label-filter="nvidia-smi && !nri"'`)
- [x] Linter passes (`make lint-fix`) — `golangci-lint` and `gen-check` are clean. `govulncheck` fails locally on seven Go standard-library CVEs fixed in go1.26.6; my toolchain is 1.26.5 and the repo pins 1.26.6 since #654, so this is a local-toolchain artefact rather than anything in the diff.
- [x] New code has SPDX license headers — the new e2e code follows the SPDX form used in `tests/e2e/go`; the new engine test uses the full Apache header that every other file in `pkg/gpu/mocknvml/engine` carries.
- [ ] Documentation updated (if applicable) — no doc change needed; the profile field was already documented.
- [x] CHANGELOG.md updated (if user-facing change)