### PR TITLE
chore(deps): bump all codeql-action pins to 4.37.7

### DIFF
--- a/.github/workflows/code_scanning.yaml
+++ b/.github/workflows/code_scanning.yaml
@@ -48,6 +48,6 @@ jobs:
         run: go mod download
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: "/language:go"

--- a/.github/workflows/code_scanning.yaml
+++ b/.github/workflows/code_scanning.yaml
@@ -40,7 +40,7 @@ jobs:
           go-version: ${{ inputs.golang_version }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: go
 

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -33,6 +33,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Problem

Dependabot keeps reopening one PR per `github/codeql-action` sub-action as it
walks the repo. Merging them individually costs a CI run each, and every one
that lands forces a rebase of the rest — they all pin the same action to the
same SHA.

## Approach

Cherry-picked each bump onto one branch cut from current `main` (38b39a80),
preserving `dependabot[bot]` authorship, the original messages and the
`updated-dependencies` trailers. All commits are GPG-signed and carry a DCO
sign-off.

After this, **every** `github/codeql-action` reference in the repo is at
v4.37.7 (`ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd`) — there are exactly three,
and all three are covered:

```
.github/workflows/code_scanning.yaml:43  init@ff2f1c62         # v4.37.7
.github/workflows/code_scanning.yaml:51  analyze@ff2f1c62      # v4.37.7
.github/workflows/scorecard.yaml:36      upload-sarif@ff2f1c62 # v4.37.7
```

## Included

| PR | Bump | File |
|----|------|------|
| #631 / #666 | `codeql-action/init` 4.37.6 → 4.37.7 | `code_scanning.yaml` |
| #632 / #668 | `codeql-action/analyze` 4.37.6 → 4.37.7 | `code_scanning.yaml` |
| #667 | `codeql-action/upload-sarif` 4.37.6 → 4.37.7 | `scorecard.yaml` |

#666 and #668 are Dependabot's recreations of #631 and #632 (which it closed);
each bumps one of the two lines this branch already carries, so they are
redundant with it rather than additional to it.

## Conflict resolutions

None. All cherry-picks applied clean.

## Testing done

The change is three pinned-SHA lines across two workflow files.

- `git diff --name-only` against `main` returns two files and **zero**
  non-workflow files — no Go source, `go.mod`, `go.sum` or `vendor/` content is
  touched, so the Go build/test/lint/vuln gates are unaffected by construction.
- Both changed workflows parse as valid YAML.
- `actionlint` clean on both.
- `grep -rn codeql-action .github/workflows/` shows no remaining 4.37.6 pin.

The real verification is this PR's own CodeQL run executing on the bumped action.

## Breaking changes

None. Patch bump of a pinned action.

## Supersedes

#667 — and supersedes the content of #666 / #668 (and the already-closed
#631 / #632). To be closed once this merges.
