### PR TITLE
fix(mocknvml): report the 8-digit PCI domain in nvmlPciInfo_t.busId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `FORCE_RECREATE=true`.
 
 ### Fixed
+- mocknvml: `nvmlPciInfo_t.busId` now reports the 8-digit PCI domain real NVML
+  uses (`00000000:07:00.0`, `NVML_DEVICE_PCI_BUS_ID_FMT`) while `busIdLegacy`
+  keeps the 4-digit one (`0000:07:00.0`). Both were filled with the profile's
+  4-digit `bus_id` verbatim, and consumers recover a sysfs BDF by stripping a
+  leading `0000` from `busId` — so go-nvlib derived the malformed `:07:00.0` and
+  every `/sys/bus/pci` lookup built from it failed. GPU Operator's
+  gpu-feature-discovery logged `unable to read PCI device vendor id for
+  :07:00.0` and labelled `nvidia.com/gpu.mode=unknown`. NVLink remote PCI info
+  follows the same split, `nvidia-smi` reports the address hardware shows, and
+  bus-ID handle lookups now accept either domain width and either case, so a
+  consumer that hands back the `busId` it just read (DCGM) still resolves the
+  device. (#671)
 - mocknvml: `nvidia-smi` no longer reports impossible per-GPU PCIe identity
   values. `Board ID` is derived from the device's PCI address the way NVML does
   — `(domain << 16) | (bus << 8) | (device << 3)`, so a GPU at `0000:07:00.0`

--- a/pkg/gpu/mocknvml/README.md
+++ b/pkg/gpu/mocknvml/README.md
@@ -157,10 +157,12 @@ devices:
 ```
 
 > **Note:** `bus_id` uses the canonical Linux sysfs form `DDDD:BB:DD.F`
-> (4-digit PCI domain). The 8-digit NVML `busIdLegacy` form
-> (`00000000:07:00.0`) is **not accepted** — the PCI sysfs renderer
-> rejects it at validation time so half-migrated profiles don't silently
-> produce trees the DRA driver can't resolve.
+> (4-digit PCI domain). The 8-digit form (`00000000:07:00.0`) is **not
+> accepted** — the PCI sysfs renderer rejects it at validation time so
+> half-migrated profiles don't silently produce trees the DRA driver
+> can't resolve. NVML reports both widths from the one declaration:
+> `nvmlPciInfo_t.busId` carries the 8-digit domain, `busIdLegacy` the
+> 4-digit one, matching real hardware.
 
 #### PCIe Topology (optional)
 

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -307,8 +308,43 @@ func ParsePCIBusID(busID string) (domain, bus, device, function uint32, err erro
 	return 0, 0, 0, 0, fmt.Errorf("invalid PCI bus ID format: %q (expected DDDD:BB:DD.F or BB:DD.F)", busID)
 }
 
+// formatPCIBusID renders a parsed PCI address in NVML's busId format
+// (NVML_DEVICE_PCI_BUS_ID_FMT, "%08X:%02X:%02X.0"). The 8-digit domain is not
+// cosmetic: consumers recover a Linux sysfs BDF from busId by stripping its
+// leading "0000" (go-nvlib's device.GetPCIBusID), so a narrower domain here
+// yields a malformed address such as ":07:00.0" and every /sys/bus/pci lookup
+// the consumer builds from it misses. Unlike NVML we carry the function digit
+// through rather than hard-coding .0, so a multi-function BDF survives.
+func formatPCIBusID(domain, bus, device, function uint32) string {
+	return fmt.Sprintf("%08X:%02X:%02X.%X", domain, bus, device, function)
+}
+
+// formatPCIBusIDLegacy renders the same address in the narrower form NVML puts
+// in busIdLegacy (NVML_DEVICE_PCI_BUS_ID_LEGACY_FMT, "%04X:%02X:%02X.0"), which
+// is also the canonical Linux sysfs BDF that profiles declare.
+func formatPCIBusIDLegacy(domain, bus, device, function uint32) string {
+	return fmt.Sprintf("%04X:%02X:%02X.%X", domain, bus, device, function)
+}
+
+// canonicalPCIBusID reduces every accepted spelling of one PCI address to a
+// single comparable string, so a lookup is insensitive to domain width and case
+// the way real NVML is. An unparseable address is upper-cased and handed back
+// unchanged: it still matches a device configured with the same unparseable
+// value, and can never collide with a well-formed one.
+func canonicalPCIBusID(busID string) string {
+	domain, bus, device, function, err := ParsePCIBusID(busID)
+	if err != nil {
+		return strings.ToUpper(busID)
+	}
+	return formatPCIBusID(domain, bus, device, function)
+}
+
 func (d *ConfigurableDevice) initPciInfo(config *DeviceConfig) {
 	var domain, bus, device, function uint32
+	// An unparseable bus ID is reported back verbatim: rendering the zeroed
+	// tuple instead would present a plausible 00000000:00:00.0 and hide the
+	// misconfiguration from whoever wrote the profile.
+	busID, legacyBusID := d.PciBusID, d.PciBusID
 
 	if d.PciBusID != "" {
 		var err error
@@ -316,6 +352,9 @@ func (d *ConfigurableDevice) initPciInfo(config *DeviceConfig) {
 		if err != nil {
 			debugLog("[DEVICE %d] Warning: %v, using defaults\n", d.index, err)
 			// Use default values (zeros) on parse failure
+		} else {
+			busID = formatPCIBusID(domain, bus, device, function)
+			legacyBusID = formatPCIBusIDLegacy(domain, bus, device, function)
 		}
 	}
 
@@ -341,11 +380,12 @@ func (d *ConfigurableDevice) initPciInfo(config *DeviceConfig) {
 	}
 
 	// Populate both the modern busId ([32]) and the legacy busIdLegacy ([16])
-	// strings. Real NVML fills both; consumers that read busIdLegacy — e.g.
-	// NVSentinel's metadata-collector, which derives each GPU's pci_address
-	// from nvmlPciInfo_t.busIdLegacy — get an empty string otherwise.
-	writeBusID(d.pciInfo.BusId[:], d.PciBusID)
-	writeBusID(d.pciInfo.BusIdLegacy[:], d.PciBusID)
+	// strings, each in its own NVML format. Real NVML fills both; consumers that
+	// read busIdLegacy — e.g. NVSentinel's metadata-collector, which derives each
+	// GPU's pci_address from nvmlPciInfo_t.busIdLegacy — get an empty string
+	// otherwise.
+	writeBusID(d.pciInfo.BusId[:], busID)
+	writeBusID(d.pciInfo.BusIdLegacy[:], legacyBusID)
 }
 
 // deriveBoardID encodes a PCI address the way NVML derives nvmlDeviceGetBoardId:
@@ -1596,12 +1636,12 @@ func (d *ConfigurableDevice) GetNvLinkRemotePciInfo(link int) (nvml.PciInfo, nvm
 		debugLog("[NVML] nvmlDeviceGetNvLinkRemotePciInfo(link=%d) -> switch sentinel\n", link)
 		return pci, nvml.SUCCESS
 	}
-	if domain, bus, device, _, err := ParsePCIBusID(l.RemoteBDF); err == nil {
+	if domain, bus, device, function, err := ParsePCIBusID(l.RemoteBDF); err == nil {
 		pci.Domain = domain
 		pci.Bus = bus
 		pci.Device = device
-		writeBusID(pci.BusId[:], l.RemoteBDF)
-		writeBusID(pci.BusIdLegacy[:], l.RemoteBDF)
+		writeBusID(pci.BusId[:], formatPCIBusID(domain, bus, device, function))
+		writeBusID(pci.BusIdLegacy[:], formatPCIBusIDLegacy(domain, bus, device, function))
 	}
 	debugLog("[NVML] nvmlDeviceGetNvLinkRemotePciInfo(link=%d) -> %s\n", link, l.RemoteBDF)
 	return pci, nvml.SUCCESS
@@ -2167,10 +2207,16 @@ func (s *MockServer) DeviceGetHandleByUUID(uuid string) (nvml.Device, nvml.Retur
 // DeviceGetHandleByPciBusId returns a configurable device by PCI bus ID.
 // When device visibility filtering is active, only visible devices are returned.
 // Lost devices behave the same as in DeviceGetHandleByIndex.
+//
+// Both sides of the comparison are normalized so any spelling of an address
+// resolves, as it does on real NVML: callers arrive with the 8-digit busId they
+// read back from nvmlDeviceGetPciInfo (DCGM), with the 4-digit sysfs BDF, or
+// with either in lower case.
 func (s *MockServer) DeviceGetHandleByPciBusId(pciBusId string) (nvml.Device, nvml.Return) {
 	debugLog("[NVML] nvmlDeviceGetHandleByPciBusId(%s)\n", pciBusId)
+	want := canonicalPCIBusID(pciBusId)
 	for i, dev := range s.configurableDevices {
-		if dev != nil && dev.PciBusID == pciBusId {
+		if dev != nil && canonicalPCIBusID(dev.PciBusID) == want {
 			if !s.isDeviceVisible(i) {
 				return nil, nvml.ERROR_NOT_FOUND
 			}

--- a/pkg/gpu/mocknvml/engine/device_test.go
+++ b/pkg/gpu/mocknvml/engine/device_test.go
@@ -93,11 +93,20 @@ func TestConfigurableDevice_GetPciInfo(t *testing.T) {
 	require.Equal(t, uint32(0x20B010DE), pciInfo.PciDeviceId, "Expected A100 PCI device ID")
 }
 
-// TestConfigurableDevice_GetPciInfo_BusIdLegacy verifies that GetPciInfo
-// populates BOTH the modern busId and the legacy busIdLegacy strings. Real NVML
-// fills both; NVSentinel's metadata-collector derives each GPU's pci_address
-// from busIdLegacy, so leaving it empty produces blank PCI addresses.
-func TestConfigurableDevice_GetPciInfo_BusIdLegacy(t *testing.T) {
+// TestConfigurableDevice_GetPciInfo_BusIDDomainWidths verifies that GetPciInfo
+// populates BOTH bus-ID strings, each in the format nvml.h defines for it:
+// busId uses an 8-digit domain (NVML_DEVICE_PCI_BUS_ID_FMT, "%08X:%02X:%02X.0")
+// and busIdLegacy a 4-digit one (NVML_DEVICE_PCI_BUS_ID_LEGACY_FMT).
+//
+// Both fields matter to real consumers. NVSentinel's metadata-collector derives
+// each GPU's pci_address from busIdLegacy, so leaving it empty produces blank
+// PCI addresses. And the domain width of busId is load-bearing rather than
+// cosmetic: go-nvlib recovers a sysfs BDF by stripping a leading "0000" from
+// busId, so a 4-digit domain there leaves the malformed ":3b:00.0" and every
+// /sys/bus/pci lookup built from it fails — which is how GPU Operator's GFD
+// ends up labelling nvidia.com/gpu.mode=unknown.
+func TestConfigurableDevice_GetPciInfo_BusIDDomainWidths(t *testing.T) {
+	// Profiles declare the canonical Linux sysfs BDF; only busId widens.
 	const busID = "0000:3b:00.0"
 	yaml := &YAMLConfig{
 		System: SystemConfig{DriverVersion: "550.0", NumDevices: 1},
@@ -116,8 +125,10 @@ func TestConfigurableDevice_GetPciInfo_BusIdLegacy(t *testing.T) {
 
 	pci, ret := cd.GetPciInfo()
 	require.Equal(t, nvml.SUCCESS, ret, "GetPciInfo failed")
-	require.Equal(t, busID, busIDString(pci.BusId[:]), "BusId not populated")
-	require.Equal(t, busID, busIDString(pci.BusIdLegacy[:]), "BusIdLegacy not populated")
+	require.Equal(t, "00000000:3B:00.0", busIDString(pci.BusId[:]),
+		"busId must use the 8-digit NVML domain form")
+	require.Equal(t, "0000:3B:00.0", busIDString(pci.BusIdLegacy[:]),
+		"busIdLegacy must use the 4-digit domain form")
 }
 
 // =============================================================================
@@ -273,9 +284,10 @@ func TestConfigurableDevice_GetNvLinkRemotePciInfo(t *testing.T) {
 	pci, ret := cd.GetNvLinkRemotePciInfo(0)
 	require.Equal(t, nvml.SUCCESS, ret, "GetNvLinkRemotePciInfo failed")
 	require.Equal(t, uint32(0x3B), pci.Bus, "Expected bus 0x3B")
-	// busIdLegacy must carry the remote BDF too — the metadata-collector reads
-	// it to build each NVLink's remote_pci_address.
-	require.Equal(t, "0000:3B:00.0", busIDString(pci.BusId[:]), "remote BusId not populated")
+	// Each field carries the remote BDF in its own NVML format, as the local
+	// address does. busIdLegacy must be populated too — the metadata-collector
+	// reads it to build each NVLink's remote_pci_address.
+	require.Equal(t, "00000000:3B:00.0", busIDString(pci.BusId[:]), "remote BusId not populated")
 	require.Equal(t, "0000:3B:00.0", busIDString(pci.BusIdLegacy[:]), "remote BusIdLegacy not populated")
 }
 
@@ -1135,8 +1147,8 @@ func TestConfigurableDevice_NvLinkGetters_PerDevice(t *testing.T) {
 	pci, ret := d0.GetNvLinkRemotePciInfo(2)
 	require.Equal(t, nvml.SUCCESS, ret, "d0.GetNvLinkRemotePciInfo(2)")
 	busID := busIDString(pci.BusId[:])
-	require.True(t, containsPrefix(busID, "0000:0B") || containsPrefix(busID, "0000:0b"),
-		"d0 link2 remote BusId: got %q, want 0000:0B prefix", busID)
+	require.True(t, containsPrefix(busID, "00000000:0B") || containsPrefix(busID, "00000000:0b"),
+		"d0 link2 remote BusId: got %q, want 00000000:0B prefix", busID)
 }
 
 func TestConfigurableDevice_TopologyCommonAncestor_Pairwise(t *testing.T) {

--- a/pkg/gpu/mocknvml/engine/engine_test.go
+++ b/pkg/gpu/mocknvml/engine/engine_test.go
@@ -397,6 +397,33 @@ func TestEngine_DeviceGetHandleByPciBusId(t *testing.T) {
 	require.Equal(t, handle, handleByPCI, "Expected same handle for same device")
 }
 
+// TestEngine_DeviceGetHandleByPciBusIdDomainWidths pins that a lookup resolves
+// the same device whichever domain width the caller passes. Real NVML accepts
+// both, and it has to: a consumer that reads busId (8-digit) and hands the
+// string straight back — DCGM does exactly this — would otherwise fail to
+// resolve a device the mock had just described to it.
+func TestEngine_DeviceGetHandleByPciBusIdDomainWidths(t *testing.T) {
+	const busID = "0000:3b:00.0"
+	yaml := &YAMLConfig{
+		System: SystemConfig{DriverVersion: "550.0", NumDevices: 1},
+		Devices: []DeviceOverride{
+			{Index: 0, DeviceConfig: DeviceConfig{PCI: &PCIConfig{BusID: busID}}},
+		},
+	}
+	e := NewEngine(&Config{NumDevices: 1, DriverVersion: "550.0", YAMLConfig: yaml})
+	_ = e.Init()
+	defer func() { _ = e.Shutdown() }()
+
+	want, ret := e.DeviceGetHandleByIndex(0)
+	require.Equal(t, nvml.SUCCESS, ret, "DeviceGetHandleByIndex failed")
+
+	for _, form := range []string{"0000:3b:00.0", "00000000:3B:00.0", "0000:3B:00.0"} {
+		got, ret := e.DeviceGetHandleByPciBusId(form)
+		require.Equal(t, nvml.SUCCESS, ret, "DeviceGetHandleByPciBusId(%q) failed", form)
+		require.Equal(t, want, got, "DeviceGetHandleByPciBusId(%q) resolved a different device", form)
+	}
+}
+
 func TestEngine_DeviceGetHandleByPciBusIdInvalid(t *testing.T) {
 	e := NewEngine(nil)
 	_ = e.Init()

--- a/pkg/system/mockpcisysfs/config/types.go
+++ b/pkg/system/mockpcisysfs/config/types.go
@@ -79,8 +79,8 @@ type RootComplex struct {
 	Devices []string `json:"devices" yaml:"devices"`
 }
 
-// bdfRE matches a canonical Linux sysfs BDF ("0000:07:00.0"). NVML's
-// `busIdLegacy` 8-digit form is intentionally rejected here so the
+// bdfRE matches a canonical Linux sysfs BDF ("0000:07:00.0"). The 8-digit
+// domain form NVML reports in `busId` is intentionally rejected here so the
 // renderer fails loudly if a profile still carries it.
 var bdfRE = regexp.MustCompile(`^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F]$`)
 
@@ -126,7 +126,7 @@ func (p *Profile) Validate() error {
 
 		for _, bdf := range rc.Devices {
 			if !bdfRE.MatchString(bdf) {
-				return fmt.Errorf("pcie_topology: invalid device BDF %q under %q (want DDDD:BB:DD.F; the 8-digit busIdLegacy form is not accepted)", bdf, rc.ID)
+				return fmt.Errorf("pcie_topology: invalid device BDF %q under %q (want DDDD:BB:DD.F; the 8-digit busId form is not accepted)", bdf, rc.ID)
 			}
 			lb := strings.ToLower(bdf)
 			if _, dup := seenBDF[lb]; dup {

--- a/pkg/system/mockpcisysfs/render/render_test.go
+++ b/pkg/system/mockpcisysfs/render/render_test.go
@@ -240,8 +240,8 @@ pcie_topology:
 }
 
 func TestValidate_RejectsLegacy8DigitBDF(t *testing.T) {
-	// The whole point of the BDF migration is to stop using busIdLegacy
-	// form in profile YAMLs. Validation must catch it explicitly so a
+	// The whole point of the BDF migration is to stop using the 8-digit
+	// busId form in profile YAMLs. Validation must catch it explicitly so a
 	// half-migrated profile doesn't silently render a tree the DRA
 	// driver can't resolve.
 	p := config.Profile{


### PR DESCRIPTION
## Summary

`nvml.h` gives the two bus-ID strings in `nvmlPciInfo_t` different formats — `busId` an 8-digit domain (`NVML_DEVICE_PCI_BUS_ID_FMT`, `00000000:07:00.0`) and `busIdLegacy` a 4-digit one (`0000:07:00.0`) — but `initPciInfo` filled both with the profile's `bus_id` verbatim. Consumers recover a sysfs BDF by stripping a leading `0000` from `busId` (go-nvlib's `device.GetPCIBusID`), so our 4-digit value degraded to `:07:00.0` and every `/sys/bus/pci` lookup built from it missed. GPU Operator's gpu-feature-discovery logged

```
Failed to create GPU mode labeler: failed to get device classes: unable to read PCI device vendor id
for :07:00.0: open /sys/bus/pci/devices/:07:00.0/vendor: no such file or directory
```

and labelled the node `nvidia.com/gpu.mode=unknown`. `nvidia-smi` was equally off: it printed `0000:07:00.0` where hardware prints `00000000:07:00.0`.

- Each field is now rendered from the parsed address in its own NVML format, for the device's own address and for NVLink remote endpoints. Profiles, the PCI sysfs renderer and its validation stay on the canonical 4-digit sysfs BDF — nothing in the profile surface changes.
- Bus-ID handle lookups compare normalized addresses, so a consumer that hands back the `busId` it just read (DCGM does exactly this) still resolves the device whichever domain width or letter case it uses. Without this, widening `busId` alone would have broken that round trip — `TestEngine_DeviceGetHandleByPciBusId` catches it.
- Corrected the inverted "8-digit `busIdLegacy`" wording in the sysfs renderer's validation error and docs; the 8-digit form is `busId`.

Fixes #671. The issue also records two gaps this PR deliberately leaves alone, because neither is a mock-fidelity defect: the rendered PCI tree does not reach GPU Operator pods (the `LD_PRELOAD` shim cannot intercept Go's direct `openat` syscalls, so it needs a bind mount), and nothing mocks `/sys/class/dmi`. `nvidia.com/gpu.mode` stays `unknown` until the first of those lands.

## Test plan

- [x] `TestConfigurableDevice_GetPciInfo_BusIDDomainWidths` — pins both formats off one profile declaration. Written first; failed with `expected "00000000:3B:00.0", actual "0000:3b:00.0"`.
- [x] `TestEngine_DeviceGetHandleByPciBusIdDomainWidths` — 8-digit, 4-digit and lower-case spellings all resolve to the same handle. Failed first with `ERROR_NOT_FOUND` for the 8-digit form.
- [x] Updated the NVLink remote-PCI expectations, which asserted the old 4-digit `busId`.
- [x] `make test` — all 32 packages pass.
- [x] `make lint-fix` — 0 issues, `go vet` clean, no generated-code drift. (`govulncheck` reports pre-existing Go 1.26.5 stdlib advisories, unrelated to this diff.)
- [ ] e2e on a kind cluster: `nvidia-smi --query-gpu=pci.bus_id` reports `00000000:07:00.0`, and GFD's warning names the well-formed `0000:07:00.0`.
