### PR TITLE
feat(mocknvml): report Platform Info for Grace-Blackwell profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- mocknvml: `nvidia-smi -q` now reports the `Platform Info` block on the
+  `gb200`/`gb300` profiles — chassis serial number, slot number, tray index,
+  host ID, peer type and module ID, where every row previously read `N/A`. These
+  are the fields rack-scale fault correlation reads to turn a GPU fault into a
+  physical location, so a Grace-Blackwell rack was indistinguishable from a PCIe
+  workstation card by location. `nvmlDeviceGetPlatformInfo` (both struct
+  versions) and `nvmlDeviceGetModuleId` are implemented and no longer generated
+  stubs, and a new `device_defaults.platform` block configures the identity —
+  per device, though only `module_id` varies between the GPUs of a node, since
+  NVML scopes the rest to the node, which sits in exactly one tray of one
+  chassis. Profiles that declare no block, and any profile on a driver older
+  than 560, keep reporting `N/A`. The `GPU Fabric GUID` row of the same block is
+  not modelled and now renders `0x0000000000000000` where it used to read `N/A`.
+  (#642)
 - mocknvml: configured `processes:` now surface in nvidia-smi — the default
   table's Processes box, `-q`, and `--query-compute-apps` all report the
   configured PIDs, names and GPU memory instead of always reporting none.

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
@@ -58,6 +58,26 @@ device_defaults:
     health_mask: 0
 
   # ---------------------------------------------------------------------------
+  # Platform identity — where this node sits in the NVL72 rack, which
+  # nvidia-smi -q renders as its "Platform Info" block and rack-scale fault
+  # correlation reads to turn a GPU fault into a physical location.
+  #
+  # Every field but module_id describes the node, so all its GPUs share them:
+  # a node occupies one tray, in one slot, of one chassis. Only module_id
+  # ("ID of this GPU within the node") is set per device below.
+  #
+  # slot_number counts switch trays as well as compute trays while tray_index
+  # counts compute trays only, so slot runs ahead of tray for a tray sitting
+  # above the rack's nine switch trays: compute tray 11 lands in slot 21.
+  # ---------------------------------------------------------------------------
+  platform:
+    chassis_serial_number: "1822725100200"
+    slot_number: 21
+    tray_index: 11
+    host_id: 1                      # first of the tray's two OS domains
+    peer_type: "switch_connected"   # peers reached through the NVSwitch trays
+
+  # ---------------------------------------------------------------------------
   # InfoROM versions
   # ---------------------------------------------------------------------------
   inforom:
@@ -375,6 +395,8 @@ devices:
       bus_id: "0000:0A:00.0"
     minor_number: 0
     grace_cpu_pair: 0               # Paired with Grace CPU 0
+    platform:
+      module_id: 1                  # ID of this GPU within the node
 
   - index: 1
     uuid: "GPU-b200b200-0000-0000-0000-000000000001"
@@ -383,6 +405,8 @@ devices:
       bus_id: "0000:0B:00.0"
     minor_number: 1
     grace_cpu_pair: 0               # Same superchip as GPU 0
+    platform:
+      module_id: 2
 
   - index: 2
     uuid: "GPU-b200b200-0000-0000-0000-000000000002"
@@ -391,6 +415,8 @@ devices:
       bus_id: "0000:4A:00.0"
     minor_number: 2
     grace_cpu_pair: 1
+    platform:
+      module_id: 3
 
   - index: 3
     uuid: "GPU-b200b200-0000-0000-0000-000000000003"
@@ -399,6 +425,8 @@ devices:
       bus_id: "0000:4B:00.0"
     minor_number: 3
     grace_cpu_pair: 1
+    platform:
+      module_id: 4
 
   - index: 4
     uuid: "GPU-b200b200-0000-0000-0000-000000000004"
@@ -407,6 +435,8 @@ devices:
       bus_id: "0000:8A:00.0"
     minor_number: 4
     grace_cpu_pair: 2
+    platform:
+      module_id: 5
 
   - index: 5
     uuid: "GPU-b200b200-0000-0000-0000-000000000005"
@@ -415,6 +445,8 @@ devices:
       bus_id: "0000:8B:00.0"
     minor_number: 5
     grace_cpu_pair: 2
+    platform:
+      module_id: 6
 
   - index: 6
     uuid: "GPU-b200b200-0000-0000-0000-000000000006"
@@ -423,6 +455,8 @@ devices:
       bus_id: "0000:CA:00.0"
     minor_number: 6
     grace_cpu_pair: 3
+    platform:
+      module_id: 7
 
   - index: 7
     uuid: "GPU-b200b200-0000-0000-0000-000000000007"
@@ -431,6 +465,8 @@ devices:
       bus_id: "0000:CB:00.0"
     minor_number: 7
     grace_cpu_pair: 3
+    platform:
+      module_id: 8
 
 # =============================================================================
 # NVLink topology - GB200 uses NVLink 5.0

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/gb300.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/gb300.yaml
@@ -59,6 +59,26 @@ device_defaults:
     health_mask: 0
 
   # ---------------------------------------------------------------------------
+  # Platform identity — where this node sits in the NVL72 rack, which
+  # nvidia-smi -q renders as its "Platform Info" block and rack-scale fault
+  # correlation reads to turn a GPU fault into a physical location.
+  #
+  # Every field but module_id describes the node, so all its GPUs share them:
+  # a node occupies one tray, in one slot, of one chassis. Only module_id
+  # ("ID of this GPU within the node") is set per device below.
+  #
+  # slot_number counts switch trays as well as compute trays while tray_index
+  # counts compute trays only, so slot runs ahead of tray for a tray sitting
+  # above the rack's nine switch trays: compute tray 16 lands in slot 26.
+  # ---------------------------------------------------------------------------
+  platform:
+    chassis_serial_number: "1822725100300"
+    slot_number: 26
+    tray_index: 16
+    host_id: 1                      # first of the tray's two OS domains
+    peer_type: "switch_connected"   # peers reached through the NVSwitch trays
+
+  # ---------------------------------------------------------------------------
   # InfoROM versions
   # ---------------------------------------------------------------------------
   inforom:
@@ -378,6 +398,8 @@ devices:
       bus_id: "0000:0A:00.0"
     minor_number: 0
     grace_cpu_pair: 0               # Paired with Grace CPU 0
+    platform:
+      module_id: 1                  # ID of this GPU within the node
 
   - index: 1
     uuid: "GPU-b300b300-0000-0000-0000-000000000001"
@@ -386,6 +408,8 @@ devices:
       bus_id: "0000:0B:00.0"
     minor_number: 1
     grace_cpu_pair: 0               # Same superchip as GPU 0
+    platform:
+      module_id: 2
 
   - index: 2
     uuid: "GPU-b300b300-0000-0000-0000-000000000002"
@@ -394,6 +418,8 @@ devices:
       bus_id: "0000:4A:00.0"
     minor_number: 2
     grace_cpu_pair: 1
+    platform:
+      module_id: 3
 
   - index: 3
     uuid: "GPU-b300b300-0000-0000-0000-000000000003"
@@ -402,6 +428,8 @@ devices:
       bus_id: "0000:4B:00.0"
     minor_number: 3
     grace_cpu_pair: 1
+    platform:
+      module_id: 4
 
   - index: 4
     uuid: "GPU-b300b300-0000-0000-0000-000000000004"
@@ -410,6 +438,8 @@ devices:
       bus_id: "0000:8A:00.0"
     minor_number: 4
     grace_cpu_pair: 2
+    platform:
+      module_id: 5
 
   - index: 5
     uuid: "GPU-b300b300-0000-0000-0000-000000000005"
@@ -418,6 +448,8 @@ devices:
       bus_id: "0000:8B:00.0"
     minor_number: 5
     grace_cpu_pair: 2
+    platform:
+      module_id: 6
 
   - index: 6
     uuid: "GPU-b300b300-0000-0000-0000-000000000006"
@@ -426,6 +458,8 @@ devices:
       bus_id: "0000:CA:00.0"
     minor_number: 6
     grace_cpu_pair: 3
+    platform:
+      module_id: 7
 
   - index: 7
     uuid: "GPU-b300b300-0000-0000-0000-000000000007"
@@ -434,6 +468,8 @@ devices:
       bus_id: "0000:CB:00.0"
     minor_number: 7
     grace_cpu_pair: 3
+    platform:
+      module_id: 8
 
 # =============================================================================
 # NVLink topology - GB300 uses NVLink 5.0 (same fabric as GB200)

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
@@ -1002,6 +1002,26 @@ should match snapshot with gb200 profile:
             health_mask: 0
 
           # ---------------------------------------------------------------------------
+          # Platform identity — where this node sits in the NVL72 rack, which
+          # nvidia-smi -q renders as its "Platform Info" block and rack-scale fault
+          # correlation reads to turn a GPU fault into a physical location.
+          #
+          # Every field but module_id describes the node, so all its GPUs share them:
+          # a node occupies one tray, in one slot, of one chassis. Only module_id
+          # ("ID of this GPU within the node") is set per device below.
+          #
+          # slot_number counts switch trays as well as compute trays while tray_index
+          # counts compute trays only, so slot runs ahead of tray for a tray sitting
+          # above the rack's nine switch trays: compute tray 11 lands in slot 21.
+          # ---------------------------------------------------------------------------
+          platform:
+            chassis_serial_number: "1822725100200"
+            slot_number: 21
+            tray_index: 11
+            host_id: 1                      # first of the tray's two OS domains
+            peer_type: "switch_connected"   # peers reached through the NVSwitch trays
+
+          # ---------------------------------------------------------------------------
           # InfoROM versions
           # ---------------------------------------------------------------------------
           inforom:
@@ -1319,6 +1339,8 @@ should match snapshot with gb200 profile:
               bus_id: "0000:0A:00.0"
             minor_number: 0
             grace_cpu_pair: 0               # Paired with Grace CPU 0
+            platform:
+              module_id: 1                  # ID of this GPU within the node
 
           - index: 1
             uuid: "GPU-b200b200-0000-0000-0000-000000000001"
@@ -1327,6 +1349,8 @@ should match snapshot with gb200 profile:
               bus_id: "0000:0B:00.0"
             minor_number: 1
             grace_cpu_pair: 0               # Same superchip as GPU 0
+            platform:
+              module_id: 2
 
           - index: 2
             uuid: "GPU-b200b200-0000-0000-0000-000000000002"
@@ -1335,6 +1359,8 @@ should match snapshot with gb200 profile:
               bus_id: "0000:4A:00.0"
             minor_number: 2
             grace_cpu_pair: 1
+            platform:
+              module_id: 3
 
           - index: 3
             uuid: "GPU-b200b200-0000-0000-0000-000000000003"
@@ -1343,6 +1369,8 @@ should match snapshot with gb200 profile:
               bus_id: "0000:4B:00.0"
             minor_number: 3
             grace_cpu_pair: 1
+            platform:
+              module_id: 4
 
           - index: 4
             uuid: "GPU-b200b200-0000-0000-0000-000000000004"
@@ -1351,6 +1379,8 @@ should match snapshot with gb200 profile:
               bus_id: "0000:8A:00.0"
             minor_number: 4
             grace_cpu_pair: 2
+            platform:
+              module_id: 5
 
           - index: 5
             uuid: "GPU-b200b200-0000-0000-0000-000000000005"
@@ -1359,6 +1389,8 @@ should match snapshot with gb200 profile:
               bus_id: "0000:8B:00.0"
             minor_number: 5
             grace_cpu_pair: 2
+            platform:
+              module_id: 6
 
           - index: 6
             uuid: "GPU-b200b200-0000-0000-0000-000000000006"
@@ -1367,6 +1399,8 @@ should match snapshot with gb200 profile:
               bus_id: "0000:CA:00.0"
             minor_number: 6
             grace_cpu_pair: 3
+            platform:
+              module_id: 7
 
           - index: 7
             uuid: "GPU-b200b200-0000-0000-0000-000000000007"
@@ -1375,6 +1409,8 @@ should match snapshot with gb200 profile:
               bus_id: "0000:CB:00.0"
             minor_number: 7
             grace_cpu_pair: 3
+            platform:
+              module_id: 8
 
         # =============================================================================
         # NVLink topology - GB200 uses NVLink 5.0
@@ -1521,6 +1557,26 @@ should match snapshot with gb300 profile:
             clique_id: 0
             state: "auto"                   # couple GPU fabric registration to fake fabricmanager readiness
             health_mask: 0
+
+          # ---------------------------------------------------------------------------
+          # Platform identity — where this node sits in the NVL72 rack, which
+          # nvidia-smi -q renders as its "Platform Info" block and rack-scale fault
+          # correlation reads to turn a GPU fault into a physical location.
+          #
+          # Every field but module_id describes the node, so all its GPUs share them:
+          # a node occupies one tray, in one slot, of one chassis. Only module_id
+          # ("ID of this GPU within the node") is set per device below.
+          #
+          # slot_number counts switch trays as well as compute trays while tray_index
+          # counts compute trays only, so slot runs ahead of tray for a tray sitting
+          # above the rack's nine switch trays: compute tray 16 lands in slot 26.
+          # ---------------------------------------------------------------------------
+          platform:
+            chassis_serial_number: "1822725100300"
+            slot_number: 26
+            tray_index: 16
+            host_id: 1                      # first of the tray's two OS domains
+            peer_type: "switch_connected"   # peers reached through the NVSwitch trays
 
           # ---------------------------------------------------------------------------
           # InfoROM versions
@@ -1842,6 +1898,8 @@ should match snapshot with gb300 profile:
               bus_id: "0000:0A:00.0"
             minor_number: 0
             grace_cpu_pair: 0               # Paired with Grace CPU 0
+            platform:
+              module_id: 1                  # ID of this GPU within the node
 
           - index: 1
             uuid: "GPU-b300b300-0000-0000-0000-000000000001"
@@ -1850,6 +1908,8 @@ should match snapshot with gb300 profile:
               bus_id: "0000:0B:00.0"
             minor_number: 1
             grace_cpu_pair: 0               # Same superchip as GPU 0
+            platform:
+              module_id: 2
 
           - index: 2
             uuid: "GPU-b300b300-0000-0000-0000-000000000002"
@@ -1858,6 +1918,8 @@ should match snapshot with gb300 profile:
               bus_id: "0000:4A:00.0"
             minor_number: 2
             grace_cpu_pair: 1
+            platform:
+              module_id: 3
 
           - index: 3
             uuid: "GPU-b300b300-0000-0000-0000-000000000003"
@@ -1866,6 +1928,8 @@ should match snapshot with gb300 profile:
               bus_id: "0000:4B:00.0"
             minor_number: 3
             grace_cpu_pair: 1
+            platform:
+              module_id: 4
 
           - index: 4
             uuid: "GPU-b300b300-0000-0000-0000-000000000004"
@@ -1874,6 +1938,8 @@ should match snapshot with gb300 profile:
               bus_id: "0000:8A:00.0"
             minor_number: 4
             grace_cpu_pair: 2
+            platform:
+              module_id: 5
 
           - index: 5
             uuid: "GPU-b300b300-0000-0000-0000-000000000005"
@@ -1882,6 +1948,8 @@ should match snapshot with gb300 profile:
               bus_id: "0000:8B:00.0"
             minor_number: 5
             grace_cpu_pair: 2
+            platform:
+              module_id: 6
 
           - index: 6
             uuid: "GPU-b300b300-0000-0000-0000-000000000006"
@@ -1890,6 +1958,8 @@ should match snapshot with gb300 profile:
               bus_id: "0000:CA:00.0"
             minor_number: 6
             grace_cpu_pair: 3
+            platform:
+              module_id: 7
 
           - index: 7
             uuid: "GPU-b300b300-0000-0000-0000-000000000007"
@@ -1898,6 +1968,8 @@ should match snapshot with gb300 profile:
               bus_id: "0000:CB:00.0"
             minor_number: 7
             grace_cpu_pair: 3
+            platform:
+              module_id: 8
 
         # =============================================================================
         # NVLink topology - GB300 uses NVLink 5.0 (same fabric as GB200)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,6 +122,54 @@ device_defaults:
     rx_throughput_kbps: 0
 ```
 
+### Platform identity (rack location)
+
+Where the node's boards sit in a rack, which `nvidia-smi -q` renders as its
+`Platform Info` block. Rack-scale fault correlation reads it to turn a GPU fault
+into a physical location. Only `gb200` and `gb300` ship it; on every other
+profile the whole block reads `N/A`, which is the correct reading for a board
+whose platform reports no location.
+
+```yaml
+device_defaults:
+  platform:
+    chassis_serial_number: "1822725100200"  # serial of the chassis (the rack)
+    slot_number: 21                 # absolute physical slot, switch trays included
+    tray_index: 11                  # position among compute trays only
+    host_id: 1                      # the OS domain within the tray — this node
+    peer_type: "switch_connected"    # or "direct_connected"
+
+devices:
+  - index: 0
+    platform:
+      module_id: 1                  # ID of this GPU within the node
+  - index: 1
+    platform:
+      module_id: 2
+```
+
+Only `module_id` varies between the GPUs of a node: NVML defines it as the ID of
+the GPU within the node, while the other fields describe the node, which occupies
+exactly one tray in one slot of one chassis. All six are settable per device
+anyway, and a device override merges field by field, so a device declares just
+its `module_id`.
+
+`slot_number` counts switch trays and compute trays alike while `tray_index`
+counts compute trays only, so on an NVL72 rack — 18 compute trays, 9 switch
+trays — slot runs ahead of tray for a tray above the switch group.
+
+`peer_type` says how the GPU reaches its NVLink peers: `switch_connected`
+(through an NVSwitch tray) renders as `Switch Connected`, and anything else,
+including an absent key, renders as `Direct Connected`.
+
+As everywhere else in a device override, a zero is indistinguishable from an
+unset key, so `module_id` numbers from 1.
+
+Declaring the block also requires a driver new enough to have the API:
+`nvmlDeviceGetPlatformInfo` arrived in 560, so a profile on an older
+`system.driver_version` reports `N/A` regardless. The `GPU Fabric GUID` row of
+the same block is not modelled and reads `0x0000000000000000`.
+
 ### Power
 
 ```yaml

--- a/pkg/gpu/mocknvml/bridge/nvml_types.h
+++ b/pkg/gpu/mocknvml/bridge/nvml_types.h
@@ -468,7 +468,53 @@ typedef struct nvmlPRMTLV_v1_st                             nvmlPRMTLV_v1_t;
 typedef struct nvmlPSUInfo_st                               nvmlPSUInfo_t;
 typedef struct nvmlPciInfoExt_st                            nvmlPciInfoExt_t;
 typedef struct nvmlPdi_st                                   nvmlPdi_t;
-typedef struct nvmlPlatformInfo_st                          nvmlPlatformInfo_t;
+/**
+ * Platform identity — where the board physically sits in a rack. Full
+ * definition needed so nvmlDeviceGetPlatformInfo can populate the caller's
+ * struct. Layout matches the upstream NVML public header; see
+ * vendor/github.com/NVIDIA/go-nvml/pkg/nvml/nvml.h.
+ *
+ * v1 is deprecated upstream in favour of v2, which renames the same bytes:
+ * rackGuid became chassisSerialNumber (on Blackwell the rack is identified by
+ * the chassis serial), and the three location bytes gained clearer names. The
+ * two layouts are therefore identical in size and offsets, which is what lets
+ * the bridge serve either version from one payload.
+ */
+#define NVML_PLATFORM_CHASSIS_SERIAL_LEN 16
+#define NVML_PLATFORM_IB_GUID_LEN        16
+
+typedef struct nvmlPlatformInfo_v1_st {
+    unsigned int  version;
+    unsigned char ibGuid[NVML_PLATFORM_IB_GUID_LEN];
+    unsigned char rackGuid[NVML_PLATFORM_CHASSIS_SERIAL_LEN];
+    unsigned char chassisPhysicalSlotNumber;
+    unsigned char computeSlotIndex;
+    unsigned char nodeIndex;
+    unsigned char peerType;
+    unsigned char moduleId;
+} nvmlPlatformInfo_v1_t;
+
+typedef struct nvmlPlatformInfo_v2_st {
+    unsigned int  version;
+    unsigned char ibGuid[NVML_PLATFORM_IB_GUID_LEN];
+    unsigned char chassisSerialNumber[NVML_PLATFORM_CHASSIS_SERIAL_LEN];
+    unsigned char slotNumber;
+    unsigned char trayIndex;
+    unsigned char hostId;
+    unsigned char peerType;
+    unsigned char moduleId;
+} nvmlPlatformInfo_v2_t;
+
+typedef nvmlPlatformInfo_v2_t nvmlPlatformInfo_t;
+/* Callers allocate this buffer from go-nvml's PlatformInfo, so a field added
+ * here would make the bridge write past the caller's allocation. The equal
+ * sizes are also what the version dispatch relies on: NVML_STRUCT_VERSION
+ * encodes sizeof in its low bits, so v1 and v2 tags differ only in the version
+ * byte, and a payload written for one fits the other exactly. */
+_Static_assert(sizeof(nvmlPlatformInfo_v1_t) == sizeof(nvmlPlatformInfo_v2_t),
+               "nvmlPlatformInfo v1 and v2 must stay the same size: the bridge serves both from one payload");
+_Static_assert(sizeof(nvmlPlatformInfo_v2_t) == 44,
+               "nvmlPlatformInfo_v2_t must stay 44 bytes to match the go-nvml ABI");
 typedef struct nvmlPowerSmoothingProfile_st                 nvmlPowerSmoothingProfile_t;
 typedef struct nvmlPowerSmoothingState_st                   nvmlPowerSmoothingState_t;
 typedef struct nvmlPowerSource_st                           nvmlPowerSource_t;

--- a/pkg/gpu/mocknvml/bridge/platform.go
+++ b/pkg/gpu/mocknvml/bridge/platform.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main provides the NVML platform-identity functions:
+//   - nvmlDeviceGetPlatformInfo (versioned, dispatches on the version field)
+//   - nvmlDeviceGetModuleId
+//
+// These answer where a board physically sits in a rack, which `nvidia-smi -q`
+// renders as its "Platform Info" block. On NVL72 that is what turns a GPU
+// fault into an actionable location — module 2 of the tray in slot 9 of a given
+// chassis — so rack-scale fault correlation cannot be tested against the mock
+// without them. See issue NVIDIA/k8s-test-infra#642.
+package main
+
+/*
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "nvml_types.h"
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
+)
+
+//export nvmlDeviceGetPlatformInfo
+func nvmlDeviceGetPlatformInfo(device C.nvmlDevice_t, platformInfo *C.nvmlPlatformInfo_t) C.nvmlReturn_t {
+	if platformInfo == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetPlatformInfo"); !ok {
+		return ret
+	}
+	dev, ok := lookupPlatformDevice(device)
+	if !ok {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	info, ret := dev.GetMockPlatformInfo()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+
+	// The caller selects the struct version by writing into the `version`
+	// field before calling. v1 and v2 cover the same 44 bytes under different
+	// names, so both are served from one payload; anything else — including a
+	// zero/unset version — gets ARGUMENT_VERSION_MISMATCH, as the upstream
+	// header documents.
+	requested := uint32(platformInfo.version)
+	v1Tag := FabricStructVersion(unsafe.Sizeof(C.nvmlPlatformInfo_v1_t{}), 1)
+	v2Tag := FabricStructVersion(unsafe.Sizeof(C.nvmlPlatformInfo_v2_t{}), 2)
+
+	switch ClassifyPlatformVersion(requested, v1Tag, v2Tag) {
+	case PlatformVersionV1:
+		// Reinterpret as v1, whose rackGuid occupies the bytes v2 calls
+		// chassisSerialNumber: on Blackwell the rack is identified by that
+		// same serial, which is why the rename was ABI-compatible.
+		v1info := (*C.nvmlPlatformInfo_v1_t)(unsafe.Pointer(platformInfo))
+		v1info.version = C.uint(v1Tag)
+		fillUchars(v1info.rackGuid[:], info.ChassisSerialNumber[:])
+		fillUchars(v1info.ibGuid[:], nil)
+		v1info.chassisPhysicalSlotNumber = C.uchar(info.SlotNumber)
+		v1info.computeSlotIndex = C.uchar(info.TrayIndex)
+		v1info.nodeIndex = C.uchar(info.HostID)
+		v1info.peerType = C.uchar(info.PeerType)
+		v1info.moduleId = C.uchar(info.ModuleID)
+		return C.NVML_SUCCESS
+	case PlatformVersionV2:
+		platformInfo.version = C.uint(v2Tag)
+		fillUchars(platformInfo.chassisSerialNumber[:], info.ChassisSerialNumber[:])
+		fillUchars(platformInfo.ibGuid[:], nil)
+		platformInfo.slotNumber = C.uchar(info.SlotNumber)
+		platformInfo.trayIndex = C.uchar(info.TrayIndex)
+		platformInfo.hostId = C.uchar(info.HostID)
+		platformInfo.peerType = C.uchar(info.PeerType)
+		platformInfo.moduleId = C.uchar(info.ModuleID)
+		return C.NVML_SUCCESS
+	default:
+		debugLog("[NVML] nvmlDeviceGetPlatformInfo rejected version 0x%x (v1=0x%x v2=0x%x)\n",
+			requested, v1Tag, v2Tag)
+		return C.NVML_ERROR_ARGUMENT_VERSION_MISMATCH
+	}
+}
+
+//export nvmlDeviceGetModuleId
+func nvmlDeviceGetModuleId(device C.nvmlDevice_t, moduleId *C.uint) C.nvmlReturn_t {
+	if moduleId == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	dev, ok := lookupPlatformDevice(device)
+	if !ok {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	id, ret := dev.GetMockModuleID()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	*moduleId = C.uint(id)
+	return C.NVML_SUCCESS
+}
+
+// fillUchars writes src over the whole of the caller's buffer, zeroing whatever
+// src does not reach. Every byte is written on purpose: the struct arrives
+// uninitialised, so a partial write would render caller garbage — and for the
+// ibGuid, which the mock does not model, zero is the whole payload. copy() is
+// not usable here because cgo's C.uchar is a distinct type from byte.
+func fillUchars(dst []C.uchar, src []byte) {
+	for i := range dst {
+		var b byte
+		if i < len(src) {
+			b = src[i]
+		}
+		dst[i] = C.uchar(b)
+	}
+}
+
+func lookupPlatformDevice(device C.nvmlDevice_t) (*engine.ConfigurableDevice, bool) {
+	handle := unsafe.Pointer(device.handle)
+	dev, ok := engine.GetEngine().LookupDevice(handle).(*engine.ConfigurableDevice)
+	return dev, ok
+}

--- a/pkg/gpu/mocknvml/bridge/platform_dispatch.go
+++ b/pkg/gpu/mocknvml/bridge/platform_dispatch.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pure-Go helper for classifying caller-supplied platform-info struct version
+// tags. Lives in a non-cgo file so a Go test (which cannot use cgo in packages
+// that contain //export directives) can exercise the dispatch decision without
+// going through the .so entry point, following fabric_dispatch.go.
+
+package main
+
+// PlatformVersionKind classifies which nvmlPlatformInfo_t struct version a
+// caller is asking for.
+type PlatformVersionKind int
+
+const (
+	// PlatformVersionInvalid means the version tag matches no supported
+	// layout. nvmlDeviceGetPlatformInfo must then return
+	// NVML_ERROR_ARGUMENT_VERSION_MISMATCH, as the upstream header documents.
+	PlatformVersionInvalid PlatformVersionKind = iota
+	// PlatformVersionV1 selects nvmlPlatformInfo_v1_t, deprecated upstream.
+	PlatformVersionV1
+	// PlatformVersionV2 selects nvmlPlatformInfo_v2_t (also exposed as
+	// nvmlPlatformInfo_t).
+	PlatformVersionV2
+)
+
+// ClassifyPlatformVersion returns the layout selected by a caller-supplied
+// version tag. v1Tag and v2Tag must be the encoded forms produced by
+// FabricStructVersion(size, N) for the corresponding struct. Any other value —
+// including zero — is rejected as Invalid, so a caller that forgot to set
+// Version gets an error rather than a payload written to a layout it did not
+// ask for.
+//
+// The two versions describe the same 44 bytes under different field names, so
+// unlike the fabric dispatch this classification does not change what the
+// bridge writes; it only decides whether to write at all and which tag to echo
+// back. It stays strict anyway: a caller passing a garbage tag is confused
+// about the ABI, and silently answering it would hide that.
+func ClassifyPlatformVersion(requested, v1Tag, v2Tag uint32) PlatformVersionKind {
+	switch requested {
+	case v1Tag:
+		return PlatformVersionV1
+	case v2Tag:
+		return PlatformVersionV2
+	default:
+		return PlatformVersionInvalid
+	}
+}

--- a/pkg/gpu/mocknvml/bridge/platform_dispatch_test.go
+++ b/pkg/gpu/mocknvml/bridge/platform_dispatch_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
+)
+
+// platformStructSize is the size nvml_types.h asserts for both
+// nvmlPlatformInfo_v1_t and nvmlPlatformInfo_v2_t. The _Static_assert there
+// guards the C side; this constant carries the same number into the Go tests,
+// which cannot use cgo in this package.
+const platformStructSize = 44
+
+// The version tags the bridge accepts are computed from the struct size, so a
+// go-nvml bump that grew or shrank the struct would silently move every tag
+// and make nvidia-smi's request classify as Invalid — the whole Platform Info
+// block would go back to N/A with nothing failing. Pin the size against the
+// vendored structs the callers actually allocate.
+func TestPlatformInfoStructSizeIsPinned(t *testing.T) {
+	require.Equal(t, uintptr(platformStructSize), unsafe.Sizeof(nvml.PlatformInfo_v1{}),
+		"nvml.PlatformInfo_v1 size; update nvml_types.h and this constant together")
+	require.Equal(t, uintptr(platformStructSize), unsafe.Sizeof(nvml.PlatformInfo_v2{}),
+		"nvml.PlatformInfo_v2 size; update nvml_types.h and this constant together")
+	require.Equal(t, unsafe.Sizeof(nvml.PlatformInfo_v2{}), unsafe.Sizeof(nvml.PlatformInfo{}),
+		"nvml.PlatformInfo must alias the v2 layout")
+}
+
+// TestClassifyPlatformVersion locks in the strict dispatch contract used by
+// nvmlDeviceGetPlatformInfo: only the two known tags select a layout, and
+// everything else — including a caller that never set Version — must result in
+// NVML_ERROR_ARGUMENT_VERSION_MISMATCH.
+func TestClassifyPlatformVersion(t *testing.T) {
+	v1Tag := FabricStructVersion(platformStructSize, 1)
+	v2Tag := FabricStructVersion(platformStructSize, 2)
+	require.NotEqual(t, v1Tag, v2Tag, "equal-sized structs must still get distinct tags")
+
+	for name, tc := range map[string]struct {
+		requested uint32
+		want      PlatformVersionKind
+	}{
+		"v1 tag":                     {v1Tag, PlatformVersionV1},
+		"v2 tag":                     {v2Tag, PlatformVersionV2},
+		"zero (unset version field)": {0, PlatformVersionInvalid},
+		"garbage 0xdeadbeef":         {0xdeadbeef, PlatformVersionInvalid},
+		// STRUCT_VERSION encodes size and version together, so a right
+		// version byte over a wrong size means the caller is compiled
+		// against a struct the bridge cannot safely fill.
+		"v2 version with wrong size": {FabricStructVersion(platformStructSize+8, 2), PlatformVersionInvalid},
+		"unsupported v3 tag":         {FabricStructVersion(platformStructSize, 3), PlatformVersionInvalid},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := ClassifyPlatformVersion(tc.requested, v1Tag, v2Tag)
+			require.Equal(t, tc.want, got,
+				"ClassifyPlatformVersion(0x%x, v1=0x%x, v2=0x%x)", tc.requested, v1Tag, v2Tag)
+		})
+	}
+}

--- a/pkg/gpu/mocknvml/bridge/stubs_generated.go
+++ b/pkg/gpu/mocknvml/bridge/stubs_generated.go
@@ -21,7 +21,7 @@ package main
 */
 import "C"
 
-// 268 stub functions for unimplemented NVML functions.
+// 266 stub functions for unimplemented NVML functions.
 // These return NVML_ERROR_NOT_SUPPORTED (3).
 
 //export nvmlComputeInstanceDestroy
@@ -394,11 +394,6 @@ func nvmlDeviceGetMinMaxFanSpeed(device C.nvmlDevice_t, minSpeed *C.uint, maxSpe
 	return stubReturn("nvmlDeviceGetMinMaxFanSpeed")
 }
 
-//export nvmlDeviceGetModuleId
-func nvmlDeviceGetModuleId(device C.nvmlDevice_t, moduleId *C.uint) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetModuleId")
-}
-
 //export nvmlDeviceGetNumGpuCores
 func nvmlDeviceGetNumGpuCores(device C.nvmlDevice_t, numCores *C.uint) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetNumGpuCores")
@@ -447,11 +442,6 @@ func nvmlDeviceGetPerformanceModes(device C.nvmlDevice_t, perfModes *C.nvmlDevic
 //export nvmlDeviceGetPgpuMetadataString
 func nvmlDeviceGetPgpuMetadataString(device C.nvmlDevice_t, pgpuMetadata *C.char, bufferSize *C.uint) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetPgpuMetadataString")
-}
-
-//export nvmlDeviceGetPlatformInfo
-func nvmlDeviceGetPlatformInfo(device C.nvmlDevice_t, platformInfo *C.nvmlPlatformInfo_t) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetPlatformInfo")
 }
 
 //export nvmlDeviceGetPowerMizerMode_v1

--- a/pkg/gpu/mocknvml/engine/config.go
+++ b/pkg/gpu/mocknvml/engine/config.go
@@ -396,7 +396,46 @@ func mergeDeviceOverride(base *DeviceConfig, override *DeviceOverride) {
 	if override.Processes != nil {
 		base.Processes = override.Processes // nil = not overridden; [] = explicit clear
 	}
+	if override.Platform != nil {
+		mergePlatformOverride(base, override.Platform)
+	}
 	// Add more fields as needed
+}
+
+// mergePlatformOverride merges per-field rather than replacing the block, so a
+// device can set its own module_id — the one field that varies between the GPUs
+// of a node — without restating the chassis, slot, tray, and host id it shares
+// with them.
+//
+// The block is copied before it is written to: GetDeviceConfig copies
+// DeviceDefaults shallowly, so every device's merge starts out pointing at the
+// same PlatformConfig. Editing that in place would give all of them whichever
+// module id was merged last.
+func mergePlatformOverride(base *DeviceConfig, override *PlatformConfig) {
+	if base.Platform == nil {
+		base.Platform = &PlatformConfig{}
+	} else {
+		clone := *base.Platform
+		base.Platform = &clone
+	}
+	if override.ChassisSerialNumber != "" {
+		base.Platform.ChassisSerialNumber = override.ChassisSerialNumber
+	}
+	if override.SlotNumber != 0 {
+		base.Platform.SlotNumber = override.SlotNumber
+	}
+	if override.TrayIndex != 0 {
+		base.Platform.TrayIndex = override.TrayIndex
+	}
+	if override.HostID != 0 {
+		base.Platform.HostID = override.HostID
+	}
+	if override.PeerType != "" {
+		base.Platform.PeerType = override.PeerType
+	}
+	if override.ModuleID != 0 {
+		base.Platform.ModuleID = override.ModuleID
+	}
 }
 
 // applyTopologyOverlay rewrites yamlConfig.DeviceDefaults.Fabric (and any

--- a/pkg/gpu/mocknvml/engine/config_profiles_platform_test.go
+++ b/pkg/gpu/mocknvml/engine/config_profiles_platform_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// gracePlatformProfiles are the rack-scale profiles expected to describe a
+// physical location. Every other shipped profile models a board whose platform
+// cannot report one, so it must leave the whole block absent — a new profile
+// has to choose a side here rather than defaulting into the untested one.
+var gracePlatformProfiles = map[string]bool{
+	"gb200.yaml": true,
+	"gb300.yaml": true,
+	"a100.yaml":  false,
+	"b200.yaml":  false,
+	"h100.yaml":  false,
+	"l40s.yaml":  false,
+	"t4.yaml":    false,
+}
+
+// TestProfilePlatformIdentity pins the layout the NVL72 profiles ship: the
+// node-level fields shared across the node's GPUs, and a module id that is
+// distinct per GPU so a physical location can be derived per device. Loading
+// through Config.GetDeviceConfig is what makes the distinctness meaningful —
+// that is the merge path a device's getters read, and a shared PlatformConfig
+// pointer would collapse all eight module ids onto whichever merged last.
+func TestProfilePlatformIdentity(t *testing.T) {
+	for file, grace := range gracePlatformProfiles {
+		t.Run(file, func(t *testing.T) {
+			yamlCfg, err := LoadYAMLConfig(filepath.Join(testdataDir(), file))
+			require.NoError(t, err, "loading profile")
+			cfg := &Config{YAMLConfig: yamlCfg, NumDevices: len(yamlCfg.Devices)}
+
+			if !grace {
+				require.Nil(t, yamlCfg.DeviceDefaults.Platform, "device_defaults.platform")
+				for i := range yamlCfg.Devices {
+					require.Nil(t, cfg.GetDeviceConfig(i).Platform, "device %d platform", i)
+				}
+				return
+			}
+
+			defaults := yamlCfg.DeviceDefaults.Platform
+			require.NotNil(t, defaults, "device_defaults.platform")
+			require.NotEmpty(t, defaults.ChassisSerialNumber, "chassis_serial_number")
+			require.NotZero(t, defaults.SlotNumber, "slot_number")
+			require.NotZero(t, defaults.TrayIndex, "tray_index")
+			require.NotZero(t, defaults.HostID, "host_id")
+			require.Equal(t, PeerTypeSwitchConnected, parsePeerType(defaults.PeerType),
+				"peer_type: an NVL72 GPU reaches its peers through a switch tray")
+			// A compute tray sits above the rack's switch trays, which the
+			// slot numbering counts and the tray index does not.
+			require.Greater(t, defaults.SlotNumber, defaults.TrayIndex,
+				"slot_number must lead tray_index: slots count switch trays too")
+
+			seen := map[uint8]int{}
+			for i := range yamlCfg.Devices {
+				platform := cfg.GetDeviceConfig(i).Platform
+				require.NotNil(t, platform, "device %d platform", i)
+				require.NotZero(t, platform.ModuleID, "device %d module_id", i)
+				if prev, dup := seen[platform.ModuleID]; dup {
+					t.Fatalf("device %d shares module_id %d with device %d: a GPU's "+
+						"physical location must identify it", i, platform.ModuleID, prev)
+				}
+				seen[platform.ModuleID] = i
+
+				// The rest of the identity describes the node, so every GPU
+				// must agree on it.
+				require.Equal(t, defaults.ChassisSerialNumber, platform.ChassisSerialNumber, "device %d chassis", i)
+				require.Equal(t, defaults.SlotNumber, platform.SlotNumber, "device %d slot", i)
+				require.Equal(t, defaults.TrayIndex, platform.TrayIndex, "device %d tray", i)
+				require.Equal(t, defaults.HostID, platform.HostID, "device %d host", i)
+				require.Equal(t, defaults.PeerType, platform.PeerType, "device %d peer type", i)
+			}
+			require.Len(t, seen, len(yamlCfg.Devices), "distinct module ids")
+		})
+	}
+}
+
+// A per-device block must not leak into the defaults every other device merges
+// from, which is the mechanism that made all eight GPUs report one module id.
+func TestMergePlatformOverride_LeavesDefaultsIntact(t *testing.T) {
+	defaults := DeviceConfig{Platform: &PlatformConfig{
+		ChassisSerialNumber: "1822725100200",
+		SlotNumber:          21,
+		ModuleID:            1,
+	}}
+	cfg := &Config{YAMLConfig: &YAMLConfig{
+		DeviceDefaults: defaults,
+		Devices: []DeviceOverride{
+			{Index: 0, DeviceConfig: DeviceConfig{Platform: &PlatformConfig{ModuleID: 7}}},
+			{Index: 1},
+		},
+	}}
+
+	require.Equal(t, uint8(7), cfg.GetDeviceConfig(0).Platform.ModuleID, "overridden device")
+	require.Equal(t, uint8(1), cfg.GetDeviceConfig(1).Platform.ModuleID, "device without an override")
+	require.Equal(t, uint8(1), defaults.Platform.ModuleID, "device_defaults after merging")
+	// The fields the override stayed silent about still come from the defaults.
+	require.Equal(t, "1822725100200", cfg.GetDeviceConfig(0).Platform.ChassisSerialNumber, "chassis serial")
+	require.Equal(t, uint8(21), cfg.GetDeviceConfig(0).Platform.SlotNumber, "slot number")
+}

--- a/pkg/gpu/mocknvml/engine/config_types.go
+++ b/pkg/gpu/mocknvml/engine/config_types.go
@@ -159,6 +159,44 @@ type DeviceConfig struct {
 	// links to its NVSwitch. When nil (default) the links report the healthy
 	// baseline. See NVLinkErrorInjectionConfig.
 	NVLinkError *NVLinkErrorInjectionConfig `json:"nvlink_error,omitempty"`
+
+	// Platform describes where the board physically sits in a rack. When nil
+	// (default) nvmlDeviceGetPlatformInfo and nvmlDeviceGetModuleId report
+	// ERROR_NOT_SUPPORTED — matching every board outside a Grace-Blackwell
+	// rack, whose platform cannot report a location.
+	Platform *PlatformConfig `json:"platform,omitempty"`
+}
+
+// PlatformConfig models the platform identity nvmlDeviceGetPlatformInfo
+// exposes, which `nvidia-smi -q` renders as its "Platform Info" block. It is
+// what turns a GPU fault into an actionable physical location on NVL72: module
+// 2 of the tray in slot 9 of a given chassis.
+//
+// The fields live on DeviceConfig so a profile can set any of them per device,
+// but only ModuleID varies between the GPUs of a shipped profile. NVML defines
+// the rest as properties of the node — see PlatformInfo — and a node occupies
+// exactly one tray in one slot of one chassis.
+type PlatformConfig struct {
+	// ChassisSerialNumber identifies the chassis (the rack). Rendered as a
+	// string, so real values are the 13-digit serial read from the backplane
+	// EEPROM. Truncated to 15 characters plus a terminator.
+	ChassisSerialNumber string `json:"chassis_serial_number,omitempty"`
+	// SlotNumber is the absolute physical slot in the chassis, counting
+	// switch trays as well as compute trays (1-27 on NVL72).
+	SlotNumber uint8 `json:"slot_number,omitempty"`
+	// TrayIndex is the position of this tray among compute trays only, so it
+	// runs below SlotNumber on a rack whose switch trays sit in between
+	// (1-18 on NVL72).
+	TrayIndex uint8 `json:"tray_index,omitempty"`
+	// HostID identifies the OS domain within the tray — this node.
+	HostID uint8 `json:"host_id,omitempty"`
+	// PeerType is how this GPU reaches its NVLink peers:
+	// "switch_connected" through an NVSwitch tray, or "direct_connected".
+	// Empty defaults to direct. See PeerType* constants.
+	PeerType string `json:"peer_type,omitempty"`
+	// ModuleID is the id of this GPU within the node, and the one field a
+	// profile is expected to vary per device.
+	ModuleID uint8 `json:"module_id,omitempty"`
 }
 
 // NVLinkErrorInjectionConfig injects NVLink data-link error accrual on a

--- a/pkg/gpu/mocknvml/engine/platform.go
+++ b/pkg/gpu/mocknvml/engine/platform.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"strings"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+// PeerType* are the platform-indicated NVLink peer types NVML reports in
+// nvmlPlatformInfo_t.peerType ("switch present or not"), which `nvidia-smi -q`
+// renders as "Direct Connected" / "Switch Connected". The numeric encoding is
+// not published in nvml.h; it is pinned here by the rendering an NVL72 profile
+// produces, where a GPU reaching its peers through an NVSwitch tray is
+// "Switch Connected".
+const (
+	PeerTypeDirectConnected uint8 = 0
+	PeerTypeSwitchConnected uint8 = 1
+)
+
+// chassisSerialLen is the width of nvmlPlatformInfo_t.chassisSerialNumber.
+// NVML documents Blackwell as filling only the first 13 bytes, so the buffer
+// always carries a NUL terminator.
+const chassisSerialLen = 16
+
+// PlatformInfo is the engine-internal shape of a GPU's platform identity —
+// where the board physically sits in a rack. The CGo bridge converts it to
+// whichever nvmlPlatformInfo_t struct version the caller selected.
+//
+// Only ModuleID is per-GPU: NVML defines it as "ID of this GPU within the
+// node", while the chassis serial, slot, tray, and host id describe the one
+// node this process runs on and are therefore shared by all of its GPUs.
+// No IbGuid: nvidia-smi sources "GPU Fabric GUID" from nvmlDeviceGetPdi, so
+// carrying an unread GUID through the engine would only be dead weight.
+type PlatformInfo struct {
+	ChassisSerialNumber [chassisSerialLen]byte
+	SlotNumber          uint8
+	TrayIndex           uint8
+	HostID              uint8
+	PeerType            uint8
+	ModuleID            uint8
+}
+
+// chassisSerial reads the serial back as the string nvidia-smi renders.
+func (p PlatformInfo) chassisSerial() string {
+	if i := strings.IndexByte(string(p.ChassisSerialNumber[:]), 0); i >= 0 {
+		return string(p.ChassisSerialNumber[:i])
+	}
+	return string(p.ChassisSerialNumber[:])
+}
+
+// GetMockPlatformInfo returns this GPU's platform identity, backing
+// nvmlDeviceGetPlatformInfo and the "Platform Info" block of `nvidia-smi -q`.
+//
+// A device with no platform block yields ERROR_NOT_SUPPORTED, which
+// nvidia-smi renders as N/A — the correct reading on any board whose platform
+// cannot report a physical location, i.e. everything outside a Grace-Blackwell
+// rack. Only the NVL72 profiles declare one.
+//
+// Named GetMockPlatformInfo to avoid shadowing the embedded dgxa100.Device's
+// GetPlatformInfo method, following GetMockFabricInfo.
+func (d *ConfigurableDevice) GetMockPlatformInfo() (PlatformInfo, nvml.Return) {
+	if ret := d.handleLookupReturn(); ret != nvml.SUCCESS {
+		return PlatformInfo{}, ret
+	}
+	cfg := d.cfg()
+	if cfg.Platform == nil {
+		return PlatformInfo{}, nvml.ERROR_NOT_SUPPORTED
+	}
+	info := buildPlatformInfo(cfg.Platform)
+	debugLog("[NVML] nvmlDeviceGetPlatformInfo -> slot=%d tray=%d host=%d module=%d\n",
+		info.SlotNumber, info.TrayIndex, info.HostID, info.ModuleID)
+	return info, nvml.SUCCESS
+}
+
+// GetMockModuleID returns the GPU's module id within its node, backing
+// nvmlDeviceGetModuleId. It answers from the same platform block as
+// GetMockPlatformInfo so the two APIs cannot disagree about one GPU.
+func (d *ConfigurableDevice) GetMockModuleID() (uint32, nvml.Return) {
+	info, ret := d.GetMockPlatformInfo()
+	if ret != nvml.SUCCESS {
+		return 0, ret
+	}
+	return uint32(info.ModuleID), nvml.SUCCESS
+}
+
+func buildPlatformInfo(cfg *PlatformConfig) PlatformInfo {
+	info := PlatformInfo{
+		SlotNumber: cfg.SlotNumber,
+		TrayIndex:  cfg.TrayIndex,
+		HostID:     cfg.HostID,
+		PeerType:   parsePeerType(cfg.PeerType),
+		ModuleID:   cfg.ModuleID,
+	}
+	// One byte short of the buffer: the last byte stays zero so the copy is
+	// always NUL-terminated, however long the configured serial is.
+	copy(info.ChassisSerialNumber[:chassisSerialLen-1], cfg.ChassisSerialNumber)
+	return info
+}
+
+// parsePeerType maps the configured peer type onto NVML's encoding. Anything
+// unrecognised — including the empty string — is "direct connected", the
+// reading of a GPU with no NVSwitch between it and its peers.
+func parsePeerType(s string) uint8 {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "switch_connected", "switchconnected", "switch":
+		return PeerTypeSwitchConnected
+	default:
+		return PeerTypeDirectConnected
+	}
+}

--- a/pkg/gpu/mocknvml/engine/platform_test.go
+++ b/pkg/gpu/mocknvml/engine/platform_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/go-nvml/pkg/nvml/mock/dgxa100"
+	mockserver "github.com/NVIDIA/go-nvml/pkg/nvml/mock/server"
+	"github.com/stretchr/testify/require"
+)
+
+func makePlatformDevice(t *testing.T, cfg *DeviceConfig) *ConfigurableDevice {
+	t.Helper()
+	base := dgxa100.New()
+	bd, _ := base.Devices[0].(*mockserver.Device)
+	return NewConfigurableDevice(0, bd, cfg,
+		"GPU-00000000-0000-0000-0000-000000000000", "0000:01:00.0", 0, nil)
+}
+
+func TestGetMockPlatformInfo_ReportsConfiguredIdentity(t *testing.T) {
+	dev := makePlatformDevice(t, &DeviceConfig{Platform: &PlatformConfig{
+		ChassisSerialNumber: "1822725187334",
+		SlotNumber:          26,
+		TrayIndex:           16,
+		HostID:              1,
+		PeerType:            "switch_connected",
+		ModuleID:            3,
+	}})
+
+	info, ret := dev.GetMockPlatformInfo()
+	require.Equal(t, nvml.SUCCESS, ret, "return code")
+	require.Equal(t, "1822725187334", info.chassisSerial(), "chassis serial number")
+	require.Equal(t, uint8(26), info.SlotNumber, "slot number")
+	require.Equal(t, uint8(16), info.TrayIndex, "tray index")
+	require.Equal(t, uint8(1), info.HostID, "host id")
+	require.Equal(t, PeerTypeSwitchConnected, info.PeerType, "peer type")
+	require.Equal(t, uint8(3), info.ModuleID, "module id")
+}
+
+// The chassis serial travels as a fixed 16-byte buffer whose trailing bytes
+// must be zero: nvidia-smi renders it as a NUL-terminated string, and NVML
+// documents Blackwell as filling only the first 13 bytes.
+func TestGetMockPlatformInfo_ChassisSerialIsZeroPadded(t *testing.T) {
+	dev := makePlatformDevice(t, &DeviceConfig{Platform: &PlatformConfig{
+		ChassisSerialNumber: "1822725187334",
+	}})
+
+	info, ret := dev.GetMockPlatformInfo()
+	require.Equal(t, nvml.SUCCESS, ret, "return code")
+	require.Equal(t, byte(0), info.ChassisSerialNumber[13], "byte after the 13-byte serial")
+	require.Equal(t, [16]byte{}, PlatformInfo{}.ChassisSerialNumber, "zero value")
+}
+
+// A serial longer than the buffer is truncated with room kept for the
+// terminator, so a misconfigured profile cannot hand nvidia-smi an
+// unterminated string.
+func TestGetMockPlatformInfo_ChassisSerialTruncatedToBuffer(t *testing.T) {
+	dev := makePlatformDevice(t, &DeviceConfig{Platform: &PlatformConfig{
+		ChassisSerialNumber: "12345678901234567890",
+	}})
+
+	info, ret := dev.GetMockPlatformInfo()
+	require.Equal(t, nvml.SUCCESS, ret, "return code")
+	require.Equal(t, "123456789012345", info.chassisSerial(), "truncated serial")
+	require.Equal(t, byte(0), info.ChassisSerialNumber[15], "terminator")
+}
+
+// The negative direction is what keeps the fix from degenerating into
+// hardcoded constants on every board: a profile with no platform block is a
+// GPU whose platform cannot report a physical location, which nvidia-smi
+// renders as N/A across the whole block.
+func TestGetMockPlatformInfo_NotSupportedWithoutPlatformBlock(t *testing.T) {
+	for name, cfg := range map[string]*DeviceConfig{
+		"no platform block": {},
+		"empty config":      nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			dev := makePlatformDevice(t, cfg)
+			info, ret := dev.GetMockPlatformInfo()
+			require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret, "return code")
+			require.Equal(t, PlatformInfo{}, info, "platform info")
+		})
+	}
+}
+
+func TestParsePeerType(t *testing.T) {
+	for name, tc := range map[string]struct {
+		in   string
+		want uint8
+	}{
+		"switch connected":       {"switch_connected", PeerTypeSwitchConnected},
+		"direct connected":       {"direct_connected", PeerTypeDirectConnected},
+		"mixed case and spacing": {" Switch_Connected ", PeerTypeSwitchConnected},
+		"switch shorthand":       {"switch", PeerTypeSwitchConnected},
+		"direct shorthand":       {"direct", PeerTypeDirectConnected},
+		"empty defaults direct":  {"", PeerTypeDirectConnected},
+		"unknown means direct":   {"nonsense", PeerTypeDirectConnected},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, parsePeerType(tc.in))
+		})
+	}
+}
+
+// GetMockModuleID answers from the same configured identity as the
+// PlatformInfo block, so a consumer reading either API sees one GPU.
+func TestGetMockModuleID(t *testing.T) {
+	dev := makePlatformDevice(t, &DeviceConfig{Platform: &PlatformConfig{ModuleID: 5}})
+	id, ret := dev.GetMockModuleID()
+	require.Equal(t, nvml.SUCCESS, ret, "return code")
+	require.Equal(t, uint32(5), id, "module id")
+
+	bare := makePlatformDevice(t, &DeviceConfig{})
+	id, ret = bare.GetMockModuleID()
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret, "return code without a platform block")
+	require.Zero(t, id, "module id without a platform block")
+}

--- a/tests/e2e/go/assertions/nvidiasmi/exec.go
+++ b/tests/e2e/go/assertions/nvidiasmi/exec.go
@@ -139,6 +139,33 @@ func C2CMode(ctx context.Context, k *kube.Client, pod kube.PodRef, p profile.Pro
 		p.Name, strings.Join(problems, "\n"))
 }
 
+// PlatformIdentity asserts nvidia-smi -q -x reports the platform identity the
+// profile declares: on a rack-scale profile the configured chassis, slot, tray,
+// host and peer type with a module id that is distinct per GPU, and N/A across
+// the whole block on every other profile. Both directions come from the profile,
+// so one spec covers them as the CI matrix moves across profiles. See issue #642.
+func PlatformIdentity(ctx context.Context, k *kube.Client, pod kube.PodRef, p profile.Profile) {
+	ginkgo.GinkgoHelper()
+
+	identity, declared := p.PlatformIdentity()
+	var want *PlatformExpectation
+	if declared {
+		want = &PlatformExpectation{
+			ChassisSerialNumber: identity.ChassisSerialNumber,
+			SlotNumber:          identity.SlotNumber,
+			TrayIndex:           identity.TrayIndex,
+			HostID:              identity.HostID,
+			PeerType:            identity.PeerType,
+			ModuleIDs:           identity.ModuleIDs,
+		}
+	}
+
+	ginkgo.By(fmt.Sprintf("nvidia-smi -q -x platformInfo on %s (declares a location=%v)", p.Name, declared))
+	problems := PlatformIdentityProblems(query(ctx, k, pod), want)
+	gomega.Expect(problems).To(gomega.BeEmpty(), "platform identity wrong for profile %s:\n%s",
+		p.Name, strings.Join(problems, "\n"))
+}
+
 // query execs `nvidia-smi -q -x` and asserts it succeeded, returning stdout.
 func query(ctx context.Context, k *kube.Client, pod kube.PodRef) string {
 	ginkgo.GinkgoHelper()

--- a/tests/e2e/go/assertions/nvidiasmi/platform.go
+++ b/tests/e2e/go/assertions/nvidiasmi/platform.go
@@ -1,0 +1,198 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidiasmi
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// The platformInfo check, large enough to live beside checks.go rather than in
+// it, following temperature.go.
+
+// Rendered peer types. nvidia-smi turns the NVML peerType byte into prose, so
+// the expectation is compared against these strings rather than a number.
+const (
+	peerTypeSwitchConnected = "Switch Connected"
+	peerTypeDirectConnected = "Direct Connected"
+)
+
+// unsupportedReading is the body nvidia-smi renders for a query the platform
+// cannot answer.
+const unsupportedReading = "N/A"
+
+// PlatformExpectation is the platform identity a profile configures, in profile
+// spelling: PeerType is the YAML value ("switch_connected"), which the check
+// translates into what nvidia-smi renders.
+//
+// ModuleIDs is indexed by device, and every other field is shared by all of the
+// node's GPUs — a node occupies one tray, in one slot, of one chassis, so NVML
+// reports those as properties of the node and only the module id identifies the
+// GPU inside it.
+type PlatformExpectation struct {
+	ChassisSerialNumber string
+	SlotNumber          int
+	TrayIndex           int
+	HostID              int
+	PeerType            string
+	ModuleIDs           []int
+}
+
+// PlatformIdentityProblems checks the platformInfo block of every GPU. A nil
+// want expects the whole block to read N/A, which is correct for every board
+// outside a Grace-Blackwell rack and is what keeps this check from being
+// satisfiable by hardcoded constants in the mock.
+//
+// With an expectation it asserts three things: each field carries the
+// configured value rather than N/A, the module ids are distinct across the node
+// so a physical location identifies one GPU, and the node-level fields agree
+// across GPUs. Every field read N/A while nvmlDeviceGetPlatformInfo was a
+// generated stub (#642).
+//
+// A failed GPU is skipped instead of compared, for the reason C2CModeProblems
+// documents: platform identity is answered from a handle-lookup path that does
+// not tick the failure injector. Skipping every GPU is itself reported.
+func PlatformIdentityProblems(out string, want *PlatformExpectation) []string {
+	snap, err := ParseSnapshot(out)
+	if err != nil {
+		return []string{err.Error()}
+	}
+
+	var problems []string
+	compared := 0
+	// Keyed on the parsed number, so only GPUs that actually reported a module
+	// id are compared for collisions; a missing or N/A reading is already
+	// reported as such by the field comparison.
+	moduleOwner := map[int]string{}
+	for i := range snap.doc.GPUs {
+		gpu := snap.gpu(i)
+		if gpu.Failed() {
+			continue
+		}
+		compared++
+		got := gpu.PlatformInfo()
+		if want == nil {
+			problems = append(problems, unsupportedPlatformProblems(gpu.Label(), got)...)
+			continue
+		}
+		problems = append(problems, platformFieldProblems(gpu.Label(), got, *want, i)...)
+		moduleID, ok := gpu.ModuleID()
+		if !ok {
+			continue
+		}
+		if prev, dup := moduleOwner[moduleID]; dup {
+			problems = append(problems, fmt.Sprintf(
+				"%s reports module_id %d, already reported by %s; a GPU's physical location must identify it",
+				gpu.Label(), moduleID, prev))
+		}
+		moduleOwner[moduleID] = gpu.Label()
+	}
+	if compared == 0 {
+		return []string{"no GPU had a comparable platformInfo block: every device in the document failed"}
+	}
+	return problems
+}
+
+// unsupportedPlatformProblems reports any field that carries a value on a board
+// whose platform cannot report a location. An absent element is a problem too:
+// nvidia-smi emits the block on every board, so silence means the driver
+// renamed it and the populated case is no longer being checked either.
+func unsupportedPlatformProblems(label string, got PlatformInfo) []string {
+	var problems []string
+	for _, f := range platformFields(got) {
+		switch {
+		case f.got == "":
+			problems = append(problems, fmt.Sprintf(
+				"%s emits no %s element, want %q; the driver may have renamed it",
+				label, f.name, unsupportedReading))
+		case f.got != unsupportedReading:
+			problems = append(problems, fmt.Sprintf("%s %s = %q, want %q",
+				label, f.name, f.got, unsupportedReading))
+		}
+	}
+	return problems
+}
+
+// platformFieldProblems compares one GPU's block against the configured
+// identity. The module id is expected per device index, which is the order
+// nvidia-smi emits GPUs in; the rest must match the node-level values, so a
+// mock that answered per-GPU where the hardware answers per-node fails here.
+func platformFieldProblems(label string, got PlatformInfo, want PlatformExpectation, index int) []string {
+	wantFields := []struct {
+		name string
+		want string
+	}{
+		{"chassis_serial_number", want.ChassisSerialNumber},
+		{"slot_number", strconv.Itoa(want.SlotNumber)},
+		{"tray_index", strconv.Itoa(want.TrayIndex)},
+		{"host_id", strconv.Itoa(want.HostID)},
+		{"peer_type", renderedPeerType(want.PeerType)},
+		{"module_id", wantModuleID(want.ModuleIDs, index)},
+	}
+
+	var problems []string
+	for i, f := range platformFields(got) {
+		expected := wantFields[i].want
+		switch {
+		case f.got == "":
+			problems = append(problems, fmt.Sprintf(
+				"%s emits no %s element, want %q; the driver may have renamed it",
+				label, f.name, expected))
+		case f.got == unsupportedReading:
+			problems = append(problems, fmt.Sprintf(
+				"%s %s = %q, want %q; the platform reports no physical location for a GPU that has one",
+				label, f.name, unsupportedReading, expected))
+		case expected == "":
+			problems = append(problems, fmt.Sprintf(
+				"%s %s = %q, but the expectation names no module id for device %d",
+				label, f.name, f.got, index))
+		case f.got != expected:
+			problems = append(problems, fmt.Sprintf("%s %s = %q, want %q", label, f.name, f.got, expected))
+		}
+	}
+	return problems
+}
+
+// platformFields pairs each element name with its body, in one order both
+// comparisons walk.
+func platformFields(got PlatformInfo) []struct {
+	name string
+	got  string
+} {
+	return []struct {
+		name string
+		got  string
+	}{
+		{"chassis_serial_number", got.ChassisSerialNumber},
+		{"slot_number", got.SlotNumber},
+		{"tray_index", got.TrayIndex},
+		{"host_id", got.HostID},
+		{"peer_type", got.PeerType},
+		{"module_id", got.ModuleID},
+	}
+}
+
+// wantModuleID is the module id configured for a device index, or "" when the
+// expectation names none — which platformFieldProblems reports rather than
+// silently passing, since a document with more GPUs than the profile describes
+// would otherwise go unchecked.
+func wantModuleID(moduleIDs []int, index int) string {
+	if index < 0 || index >= len(moduleIDs) {
+		return ""
+	}
+	return strconv.Itoa(moduleIDs[index])
+}
+
+// renderedPeerType translates a profile's peer_type into what nvidia-smi prints.
+// Anything the engine does not recognise as switch-connected resolves to direct,
+// so the two sides agree on the default.
+func renderedPeerType(configured string) string {
+	switch strings.ToLower(strings.TrimSpace(configured)) {
+	case "switch_connected", "switchconnected", "switch":
+		return peerTypeSwitchConnected
+	default:
+		return peerTypeDirectConnected
+	}
+}

--- a/tests/e2e/go/assertions/nvidiasmi/platform_test.go
+++ b/tests/e2e/go/assertions/nvidiasmi/platform_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidiasmi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gb200Platform is what the gb200 chart profile configures, and what the
+// captured fixtures carry: one node in one tray of one chassis, with a module
+// id per GPU.
+func gb200Platform() *PlatformExpectation {
+	return &PlatformExpectation{
+		ChassisSerialNumber: "1822725100200",
+		SlotNumber:          21,
+		TrayIndex:           11,
+		HostID:              1,
+		PeerType:            "switch_connected",
+		ModuleIDs:           []int{1, 2},
+	}
+}
+
+// platformGPU builds a <gpu> whose platformInfo carries the given bodies. The
+// temperature body drives Failed(), so a caller can build a lost device.
+func platformGPU(id string, p PlatformInfo, gpuTemp string) string {
+	return `	<gpu id="` + id + `">
+		<platformInfo>
+			<chassis_serial_number>` + p.ChassisSerialNumber + `</chassis_serial_number>
+			<slot_number>` + p.SlotNumber + `</slot_number>
+			<tray_index>` + p.TrayIndex + `</tray_index>
+			<host_id>` + p.HostID + `</host_id>
+			<peer_type>` + p.PeerType + `</peer_type>
+			<module_id>` + p.ModuleID + `</module_id>
+		</platformInfo>
+		<temperature>
+			<gpu_temp>` + gpuTemp + `</gpu_temp>
+		</temperature>
+	</gpu>`
+}
+
+// populatedPlatform is the block a GPU on the gb200 profile renders.
+func populatedPlatform(moduleID string) PlatformInfo {
+	return PlatformInfo{
+		ChassisSerialNumber: "1822725100200",
+		SlotNumber:          "21",
+		TrayIndex:           "11",
+		HostID:              "1",
+		PeerType:            "Switch Connected",
+		ModuleID:            moduleID,
+	}
+}
+
+func unsupportedPlatform() PlatformInfo {
+	return PlatformInfo{
+		ChassisSerialNumber: "N/A", SlotNumber: "N/A", TrayIndex: "N/A",
+		HostID: "N/A", PeerType: "N/A", ModuleID: "N/A",
+	}
+}
+
+func TestPlatformIdentityProblems_AcceptsCapturedGraceProfile(t *testing.T) {
+	problems := PlatformIdentityProblems(loadFixture(t, "qx-gb200-healthy.xml"), gb200Platform())
+	assert.Empty(t, problems, strings.Join(problems, "; "))
+}
+
+func TestPlatformIdentityProblems_AcceptsNotAvailableOnNonGraceProfile(t *testing.T) {
+	problems := PlatformIdentityProblems(loadFixture(t, "qx-a100-healthy.xml"), nil)
+	assert.Empty(t, problems, strings.Join(problems, "; "))
+}
+
+// The #642 regression itself: the stubbed entry point made every board read N/A,
+// including the NVL72 ones whose whole point is a physical location.
+func TestPlatformIdentityProblems_RejectsNotAvailableWhenLocationExpected(t *testing.T) {
+	problems := PlatformIdentityProblems(loadFixture(t, "qx-a100-healthy.xml"), gb200Platform())
+	require.Len(t, problems, 12, "six fields on each of two GPUs")
+	assert.Contains(t, strings.Join(problems, "; "), "the platform reports no physical location")
+}
+
+// The other direction, which keeps the fix from being "always report a
+// location": a board that cannot report one must not satisfy the check.
+func TestPlatformIdentityProblems_RejectsLocationWhenNotAvailableExpected(t *testing.T) {
+	problems := PlatformIdentityProblems(loadFixture(t, "qx-gb200-healthy.xml"), nil)
+	require.Len(t, problems, 12, "six fields on each of two GPUs")
+	assert.Contains(t, strings.Join(problems, "; "), `chassis_serial_number = "1822725100200", want "N/A"`)
+}
+
+// A shared module id is the failure mode the whole check exists for: a fix that
+// answered one constant for every GPU would render a location that cannot say
+// which board failed.
+func TestPlatformIdentityProblems_RejectsSharedModuleID(t *testing.T) {
+	out := xmlDocument(
+		platformGPU("0000:0A:00.0", populatedPlatform("1"), "36 C"),
+		platformGPU("0000:0B:00.0", populatedPlatform("1"), "36 C"),
+	)
+	problems := PlatformIdentityProblems(out, gb200Platform())
+	joined := strings.Join(problems, "; ")
+	assert.Contains(t, joined, "already reported by")
+	assert.Contains(t, joined, `module_id = "1", want "2"`)
+}
+
+// Each field is compared against the profile, not merely checked for presence,
+// so a plausible-looking wrong value fails.
+func TestPlatformIdentityProblems_RejectsWrongFieldValues(t *testing.T) {
+	for name, mutate := range map[string]func(p *PlatformInfo){
+		"chassis": func(p *PlatformInfo) { p.ChassisSerialNumber = "1822725100999" },
+		"slot":    func(p *PlatformInfo) { p.SlotNumber = "22" },
+		"tray":    func(p *PlatformInfo) { p.TrayIndex = "12" },
+		"host":    func(p *PlatformInfo) { p.HostID = "2" },
+		"peer":    func(p *PlatformInfo) { p.PeerType = "Direct Connected" },
+		"module":  func(p *PlatformInfo) { p.ModuleID = "5" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := populatedPlatform("1")
+			mutate(&got)
+			problems := PlatformIdentityProblems(
+				xmlDocument(platformGPU("0000:0A:00.0", got, "36 C")),
+				&PlatformExpectation{
+					ChassisSerialNumber: "1822725100200", SlotNumber: 21, TrayIndex: 11,
+					HostID: 1, PeerType: "switch_connected", ModuleIDs: []int{1},
+				})
+			require.Len(t, problems, 1)
+			assert.Contains(t, problems[0], "want")
+		})
+	}
+}
+
+// The node-level fields must agree across GPUs, since a node sits in exactly one
+// tray of one chassis. A mock answering them per GPU fails here.
+func TestPlatformIdentityProblems_RejectsPerGPUNodeFields(t *testing.T) {
+	second := populatedPlatform("2")
+	second.TrayIndex = "12"
+	out := xmlDocument(
+		platformGPU("0000:0A:00.0", populatedPlatform("1"), "36 C"),
+		platformGPU("0000:0B:00.0", second, "36 C"),
+	)
+	problems := PlatformIdentityProblems(out, gb200Platform())
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], `tray_index = "12", want "11"`)
+}
+
+// An absent element is reported as such rather than compared as an empty body,
+// because that is what a driver renaming the element looks like. Both directions
+// report it: on a non-Grace profile the check would otherwise pass vacuously.
+func TestPlatformIdentityProblems_ReportsMissingElement(t *testing.T) {
+	got := populatedPlatform("1")
+	got.ModuleID = ""
+	out := xmlDocument(platformGPU("0000:0A:00.0", got, "36 C"))
+
+	problems := PlatformIdentityProblems(out, &PlatformExpectation{
+		ChassisSerialNumber: "1822725100200", SlotNumber: 21, TrayIndex: 11,
+		HostID: 1, PeerType: "switch_connected", ModuleIDs: []int{1},
+	})
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "emits no module_id element")
+
+	blank := xmlDocument(platformGPU("0000:0A:00.0", PlatformInfo{}, "36 C"))
+	problems = PlatformIdentityProblems(blank, nil)
+	require.Len(t, problems, 6, "every absent element is reported")
+	assert.Contains(t, problems[0], "emits no chassis_serial_number element")
+}
+
+// A document with more GPUs than the profile describes must not pass for want of
+// an expected module id.
+func TestPlatformIdentityProblems_ReportsUnexpectedExtraGPU(t *testing.T) {
+	out := xmlDocument(
+		platformGPU("0000:0A:00.0", populatedPlatform("1"), "36 C"),
+		platformGPU("0000:0B:00.0", populatedPlatform("2"), "36 C"),
+	)
+	problems := PlatformIdentityProblems(out, &PlatformExpectation{
+		ChassisSerialNumber: "1822725100200", SlotNumber: 21, TrayIndex: 11,
+		HostID: 1, PeerType: "switch_connected", ModuleIDs: []int{1},
+	})
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "names no module id for device 1")
+}
+
+// A lost GPU is not evidence either way, for the reason C2CModeProblems
+// documents. The healthy siblings are still checked.
+func TestPlatformIdentityProblems_SkipsFailedGPU(t *testing.T) {
+	out := xmlDocument(
+		platformGPU("0000:0A:00.0", populatedPlatform("1"), "36 C"),
+		platformGPU("0000:0B:00.0", unsupportedPlatform(), "GPU is lost"),
+	)
+	assert.Empty(t, PlatformIdentityProblems(out, gb200Platform()))
+
+	wrongHealthy := xmlDocument(
+		platformGPU("0000:0A:00.0", unsupportedPlatform(), "36 C"),
+		platformGPU("0000:0B:00.0", unsupportedPlatform(), "GPU is lost"),
+	)
+	problems := PlatformIdentityProblems(wrongHealthy, gb200Platform())
+	require.Len(t, problems, 6, "the healthy GPU is still compared")
+	assert.Contains(t, problems[0], "0000:0A:00.0")
+}
+
+// The captured lost document must pass as-is: GPU 0 is healthy and GPU 1 is
+// skipped, so the failure-injection scenario needs no separate expectation.
+func TestPlatformIdentityProblems_AcceptsCapturedLostDocument(t *testing.T) {
+	problems := PlatformIdentityProblems(loadFixture(t, "qx-gb200-lost.xml"), gb200Platform())
+	assert.Empty(t, problems, strings.Join(problems, "; "))
+}
+
+// Skipping failed GPUs must not let a document where every device failed pass
+// for want of anything to compare.
+func TestPlatformIdentityProblems_RejectsDocumentWhereEveryGPUFailed(t *testing.T) {
+	out := xmlDocument(
+		platformGPU("0000:0A:00.0", unsupportedPlatform(), "GPU is lost"),
+		platformGPU("0000:0B:00.0", unsupportedPlatform(), "GPU is lost"),
+	)
+	problems := PlatformIdentityProblems(out, gb200Platform())
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "every device in the document failed")
+}
+
+func TestPlatformIdentityProblems_ReportsUnparseableDocument(t *testing.T) {
+	problems := PlatformIdentityProblems("not xml", gb200Platform())
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "parse nvidia-smi XML")
+}
+
+// The rendering must match nvidia-smi's own vocabulary, which is prose rather
+// than the NVML byte or the profile spelling.
+func TestRenderedPeerType(t *testing.T) {
+	for in, want := range map[string]string{
+		"switch_connected":   peerTypeSwitchConnected,
+		" Switch_Connected ": peerTypeSwitchConnected,
+		"switch":             peerTypeSwitchConnected,
+		"direct_connected":   peerTypeDirectConnected,
+		"":                   peerTypeDirectConnected,
+		"nonsense":           peerTypeDirectConnected,
+	} {
+		assert.Equal(t, want, renderedPeerType(in), "peer_type %q", in)
+	}
+}
+
+// ModuleID is the accessor a consumer deriving a physical position uses, so an
+// unsupported board must not read as module 0.
+func TestGPUModuleID(t *testing.T) {
+	snap, err := ParseSnapshot(loadFixture(t, "qx-gb200-healthy.xml"))
+	require.NoError(t, err)
+	gpu, err := snap.GPU(1)
+	require.NoError(t, err)
+	id, ok := gpu.ModuleID()
+	require.True(t, ok, "gb200 GPU 1 reports a module id")
+	assert.Equal(t, 2, id)
+
+	snap, err = ParseSnapshot(loadFixture(t, "qx-a100-healthy.xml"))
+	require.NoError(t, err)
+	gpu, err = snap.GPU(0)
+	require.NoError(t, err)
+	_, ok = gpu.ModuleID()
+	assert.False(t, ok, "a100 reports no module id")
+}

--- a/tests/e2e/go/assertions/nvidiasmi/schema.go
+++ b/tests/e2e/go/assertions/nvidiasmi/schema.go
@@ -107,6 +107,7 @@ type gpuElement struct {
 	UUID                     reading           `xml:"uuid"`
 	BoardID                  reading           `xml:"board_id"`
 	C2CMode                  reading           `xml:"c2c_mode"`
+	PlatformInfo             platformInfo      `xml:"platformInfo"`
 	PCI                      pciInfo           `xml:"pci"`
 	FanSpeed                 reading           `xml:"fan_speed"`
 	PerformanceState         reading           `xml:"performance_state"`
@@ -134,6 +135,20 @@ type memoryUsage struct {
 	Reserved reading `xml:"reserved"`
 	Used     reading `xml:"used"`
 	Free     reading `xml:"free"`
+}
+
+// platformInfo is <platformInfo> — the one camelCase container in the document.
+// It answers where the board sits in a rack: the chassis, the slot and tray
+// within it, the node inside that tray, and the GPU's module within the node.
+// gpu_fabric_guid shares the block but comes from a field of the same NVML
+// struct that the mock does not model, so it is deliberately not decoded.
+type platformInfo struct {
+	ChassisSerialNumber reading `xml:"chassis_serial_number"`
+	SlotNumber          reading `xml:"slot_number"`
+	TrayIndex           reading `xml:"tray_index"`
+	HostID              reading `xml:"host_id"`
+	PeerType            reading `xml:"peer_type"`
+	ModuleID            reading `xml:"module_id"`
 }
 
 // pciInfo is <pci>. Only the link-generation subtree is decoded; the sibling

--- a/tests/e2e/go/assertions/nvidiasmi/snapshot.go
+++ b/tests/e2e/go/assertions/nvidiasmi/snapshot.go
@@ -255,6 +255,36 @@ func (g GPU) ThermalSlowdownState() string {
 // mock never reports.
 func (g GPU) C2CMode() string { return strings.TrimSpace(string(g.element.C2CMode)) }
 
+// PlatformInfo is the <platformInfo> block as rendered, each field kept as its
+// body rather than a number: "N/A" is the correct reading on every board whose
+// platform cannot report a location, and the assertions must round-trip it.
+type PlatformInfo struct {
+	ChassisSerialNumber string
+	SlotNumber          string
+	TrayIndex           string
+	HostID              string
+	PeerType            string
+	ModuleID            string
+}
+
+// PlatformInfo decodes this GPU's <platformInfo> block.
+func (g GPU) PlatformInfo() PlatformInfo {
+	p := g.element.PlatformInfo
+	return PlatformInfo{
+		ChassisSerialNumber: strings.TrimSpace(string(p.ChassisSerialNumber)),
+		SlotNumber:          strings.TrimSpace(string(p.SlotNumber)),
+		TrayIndex:           strings.TrimSpace(string(p.TrayIndex)),
+		HostID:              strings.TrimSpace(string(p.HostID)),
+		PeerType:            strings.TrimSpace(string(p.PeerType)),
+		ModuleID:            strings.TrimSpace(string(p.ModuleID)),
+	}
+}
+
+// ModuleID is <module_id> inside <platformInfo>: which GPU this is within its
+// node. false when the platform reports no location, so a caller deriving a
+// physical position cannot mistake an unsupported board for module 0.
+func (g GPU) ModuleID() (int, bool) { return g.element.PlatformInfo.ModuleID.intValue() }
+
 // Process is one decoded <process_info> entry.
 type Process struct {
 	PID       int

--- a/tests/e2e/go/assertions/nvidiasmi/testdata/qx-gb200-ecc-injected.xml
+++ b/tests/e2e/go/assertions/nvidiasmi/testdata/qx-gb200-ecc-injected.xml
@@ -38,13 +38,13 @@
 		<gpu_part_number>N/A</gpu_part_number>
 		<gpu_fru_part_number>N/A</gpu_fru_part_number>
 		<platformInfo>
-			<chassis_serial_number>N/A</chassis_serial_number>
-			<slot_number>N/A</slot_number>
-			<tray_index>N/A</tray_index>
-			<host_id>N/A</host_id>
-			<peer_type>N/A</peer_type>
-			<module_id>N/A</module_id>
-			<gpu_fabric_guid>N/A</gpu_fabric_guid>
+			<chassis_serial_number>1822725100200</chassis_serial_number>
+			<slot_number>21</slot_number>
+			<tray_index>11</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>1</module_id>
+			<gpu_fabric_guid>0x0000000000000000</gpu_fabric_guid>
 		</platformInfo>
 		<inforom_version>
 			<img_version>G530.0200.00.01</img_version>
@@ -343,13 +343,13 @@
 		<gpu_part_number>N/A</gpu_part_number>
 		<gpu_fru_part_number>N/A</gpu_fru_part_number>
 		<platformInfo>
-			<chassis_serial_number>N/A</chassis_serial_number>
-			<slot_number>N/A</slot_number>
-			<tray_index>N/A</tray_index>
-			<host_id>N/A</host_id>
-			<peer_type>N/A</peer_type>
-			<module_id>N/A</module_id>
-			<gpu_fabric_guid>N/A</gpu_fabric_guid>
+			<chassis_serial_number>1822725100200</chassis_serial_number>
+			<slot_number>21</slot_number>
+			<tray_index>11</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>2</module_id>
+			<gpu_fabric_guid>0x0000000000000000</gpu_fabric_guid>
 		</platformInfo>
 		<inforom_version>
 			<img_version>G530.0200.00.01</img_version>

--- a/tests/e2e/go/assertions/nvidiasmi/testdata/qx-gb200-healthy.xml
+++ b/tests/e2e/go/assertions/nvidiasmi/testdata/qx-gb200-healthy.xml
@@ -38,13 +38,13 @@
 		<gpu_part_number>N/A</gpu_part_number>
 		<gpu_fru_part_number>N/A</gpu_fru_part_number>
 		<platformInfo>
-			<chassis_serial_number>N/A</chassis_serial_number>
-			<slot_number>N/A</slot_number>
-			<tray_index>N/A</tray_index>
-			<host_id>N/A</host_id>
-			<peer_type>N/A</peer_type>
-			<module_id>N/A</module_id>
-			<gpu_fabric_guid>N/A</gpu_fabric_guid>
+			<chassis_serial_number>1822725100200</chassis_serial_number>
+			<slot_number>21</slot_number>
+			<tray_index>11</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>1</module_id>
+			<gpu_fabric_guid>0x0000000000000000</gpu_fabric_guid>
 		</platformInfo>
 		<inforom_version>
 			<img_version>G530.0200.00.01</img_version>
@@ -343,13 +343,13 @@
 		<gpu_part_number>N/A</gpu_part_number>
 		<gpu_fru_part_number>N/A</gpu_fru_part_number>
 		<platformInfo>
-			<chassis_serial_number>N/A</chassis_serial_number>
-			<slot_number>N/A</slot_number>
-			<tray_index>N/A</tray_index>
-			<host_id>N/A</host_id>
-			<peer_type>N/A</peer_type>
-			<module_id>N/A</module_id>
-			<gpu_fabric_guid>N/A</gpu_fabric_guid>
+			<chassis_serial_number>1822725100200</chassis_serial_number>
+			<slot_number>21</slot_number>
+			<tray_index>11</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>2</module_id>
+			<gpu_fabric_guid>0x0000000000000000</gpu_fabric_guid>
 		</platformInfo>
 		<inforom_version>
 			<img_version>G530.0200.00.01</img_version>

--- a/tests/e2e/go/assertions/nvidiasmi/testdata/qx-gb200-lost.xml
+++ b/tests/e2e/go/assertions/nvidiasmi/testdata/qx-gb200-lost.xml
@@ -38,13 +38,13 @@
 		<gpu_part_number>N/A</gpu_part_number>
 		<gpu_fru_part_number>N/A</gpu_fru_part_number>
 		<platformInfo>
-			<chassis_serial_number>N/A</chassis_serial_number>
-			<slot_number>N/A</slot_number>
-			<tray_index>N/A</tray_index>
-			<host_id>N/A</host_id>
-			<peer_type>N/A</peer_type>
-			<module_id>N/A</module_id>
-			<gpu_fabric_guid>N/A</gpu_fabric_guid>
+			<chassis_serial_number>1822725100200</chassis_serial_number>
+			<slot_number>21</slot_number>
+			<tray_index>11</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>1</module_id>
+			<gpu_fabric_guid>0x0000000000000000</gpu_fabric_guid>
 		</platformInfo>
 		<inforom_version>
 			<img_version>G530.0200.00.01</img_version>
@@ -343,13 +343,13 @@
 		<gpu_part_number>N/A</gpu_part_number>
 		<gpu_fru_part_number>N/A</gpu_fru_part_number>
 		<platformInfo>
-			<chassis_serial_number>N/A</chassis_serial_number>
-			<slot_number>N/A</slot_number>
-			<tray_index>N/A</tray_index>
-			<host_id>N/A</host_id>
-			<peer_type>N/A</peer_type>
-			<module_id>N/A</module_id>
-			<gpu_fabric_guid>N/A</gpu_fabric_guid>
+			<chassis_serial_number>1822725100200</chassis_serial_number>
+			<slot_number>21</slot_number>
+			<tray_index>11</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>2</module_id>
+			<gpu_fabric_guid>0x0000000000000000</gpu_fabric_guid>
 		</platformInfo>
 		<inforom_version>
 			<img_version>G530.0200.00.01</img_version>

--- a/tests/e2e/go/profile/profile.go
+++ b/tests/e2e/go/profile/profile.go
@@ -63,9 +63,11 @@ type rawProfile struct {
 		PCIe *struct {
 			MaxLinkGen int `json:"max_link_gen"`
 		} `json:"pcie"`
+		Platform *rawPlatform `json:"platform"`
 	} `json:"device_defaults"`
 	Devices []struct {
-		Index int `json:"index"`
+		Index    int          `json:"index"`
+		Platform *rawPlatform `json:"platform"`
 	} `json:"devices"`
 	NVLink struct {
 		LinksPerGPU int  `json:"links_per_gpu"`
@@ -83,6 +85,30 @@ type rawProfile struct {
 			ID string `json:"id"`
 		} `json:"root_complexes"`
 	} `json:"pcie_topology"`
+}
+
+// rawPlatform decodes a platform block, which appears both under
+// device_defaults (the node's location) and per device (its module id).
+type rawPlatform struct {
+	ChassisSerialNumber string `json:"chassis_serial_number"`
+	SlotNumber          int    `json:"slot_number"`
+	TrayIndex           int    `json:"tray_index"`
+	HostID              int    `json:"host_id"`
+	PeerType            string `json:"peer_type"`
+	ModuleID            int    `json:"module_id"`
+}
+
+// PlatformIdentity is the platform identity a profile configures — where its
+// node sits in a rack. ModuleIDs is indexed by device; the rest describe the
+// node and are shared by all its GPUs. PeerType keeps the profile spelling
+// ("switch_connected"), leaving the rendering nvidia-smi uses to the assertion.
+type PlatformIdentity struct {
+	ChassisSerialNumber string
+	SlotNumber          int
+	TrayIndex           int
+	HostID              int
+	PeerType            string
+	ModuleIDs           []int
 }
 
 // Profile is the typed, validated view of a chart GPU profile.
@@ -110,6 +136,9 @@ type Profile struct {
 	jpegUtilizationPct int
 	ofaUtilizationPct  int
 	maxPCIeLinkGen     int
+
+	platform    PlatformIdentity
+	hasPlatform bool
 }
 
 // bytesPerMiB is the divisor GPU Feature Discovery uses when it publishes
@@ -193,6 +222,38 @@ func (p *Profile) applyOptionalDeviceDefaults(raw rawProfile) {
 		p.hasFabric = true
 		p.fabricAuto = strings.EqualFold(strings.TrimSpace(f.State), "auto")
 	}
+	if pl := raw.DeviceDefaults.Platform; pl != nil {
+		p.hasPlatform = true
+		p.platform = PlatformIdentity{
+			ChassisSerialNumber: pl.ChassisSerialNumber,
+			SlotNumber:          pl.SlotNumber,
+			TrayIndex:           pl.TrayIndex,
+			HostID:              pl.HostID,
+			PeerType:            pl.PeerType,
+			ModuleIDs:           deviceModuleIDs(raw, pl.ModuleID),
+		}
+	}
+}
+
+// deviceModuleIDs collects each device's module id, keyed by the declared
+// device index so the result lines up with NVML's device order however the YAML
+// lists them. A device that declares no module id falls back to the default,
+// mirroring the mock's per-device merge, which treats zero as unset.
+func deviceModuleIDs(raw rawProfile, defaultModuleID int) []int {
+	ids := make([]int, len(raw.Devices))
+	for i := range ids {
+		ids[i] = defaultModuleID
+	}
+	for i, dev := range raw.Devices {
+		at := dev.Index
+		if at < 0 || at >= len(ids) {
+			at = i
+		}
+		if dev.Platform != nil && dev.Platform.ModuleID != 0 {
+			ids[at] = dev.Platform.ModuleID
+		}
+	}
+	return ids
 }
 
 // All loads every KnownProfiles entry from profilesDir.
@@ -262,6 +323,14 @@ func (p Profile) HasFabric() bool { return p.hasFabric }
 // nvidia-smi -q renders it as "GPU C2C Mode : Enabled" there and N/A
 // elsewhere. Absent key means false, i.e. N/A.
 func (p Profile) C2CEnabled() bool { return p.c2cEnabled }
+
+// PlatformIdentity returns the platform identity the profile configures and
+// whether it declares one at all. Only the rack-scale profiles (gb200, gb300)
+// do: NVML answers nvmlDeviceGetPlatformInfo for a board whose platform can
+// report a physical location, and nvidia-smi renders N/A for every other one, so
+// the absent case is the negative control that keeps the populated case from
+// being satisfiable by constants.
+func (p Profile) PlatformIdentity() (PlatformIdentity, bool) { return p.platform, p.hasPlatform }
 
 // Architecture is device_defaults.architecture (lowercased), e.g. "ampere".
 func (p Profile) Architecture() string { return p.architecture }

--- a/tests/e2e/go/profile/profile_test.go
+++ b/tests/e2e/go/profile/profile_test.go
@@ -171,3 +171,47 @@ func TestC2CIsGraceOnly(t *testing.T) {
 			"%s: nvlink.c2c_enabled should be %v", name, graceProfiles[name])
 	}
 }
+
+// TestPlatformIdentityIsRackScaleOnly pins platform identity as a rack-scale
+// axis, for the same reason as the C2C one: an e2e expectation derived from the
+// profiles must keep a negative control, or "reports a location" could quietly
+// become "always reports one". b200 is the interesting case — Blackwell, but a
+// board in no rack. See issue #642.
+func TestPlatformIdentityIsRackScaleOnly(t *testing.T) {
+	rackProfiles := map[string]bool{"gb200": true, "gb300": true}
+	for _, name := range KnownProfiles {
+		p, err := Load(profilesDir, name)
+		require.NoError(t, err, "Load(%q)", name)
+		identity, declared := p.PlatformIdentity()
+		require.Equal(t, rackProfiles[name], declared,
+			"%s: device_defaults.platform should be declared=%v", name, rackProfiles[name])
+		if !declared {
+			require.Empty(t, identity.ModuleIDs, "%s: module ids without a platform block", name)
+			continue
+		}
+		require.Len(t, identity.ModuleIDs, p.ExpectedGPUs(), "%s: a module id per GPU", name)
+		require.NotEmpty(t, identity.ChassisSerialNumber, "%s: chassis_serial_number", name)
+	}
+}
+
+// The per-device module ids must survive the profile decode distinctly: they are
+// the only field that tells one of a node's GPUs from another, and a decode that
+// read them from device_defaults alone would hand every GPU the same one.
+func TestPlatformIdentityModuleIDsAreDistinct(t *testing.T) {
+	for _, name := range []string{"gb200", "gb300"} {
+		t.Run(name, func(t *testing.T) {
+			p, err := Load(profilesDir, name)
+			require.NoError(t, err, "Load(%q)", name)
+			identity, declared := p.PlatformIdentity()
+			require.True(t, declared, "declares a platform block")
+
+			seen := map[int]int{}
+			for i, id := range identity.ModuleIDs {
+				require.NotZero(t, id, "device %d module id", i)
+				prev, dup := seen[id]
+				require.False(t, dup, "device %d shares module id %d with device %d", i, id, prev)
+				seen[id] = i
+			}
+		})
+	}
+}

--- a/tests/e2e/go/scenario_standalone_test.go
+++ b/tests/e2e/go/scenario_standalone_test.go
@@ -128,6 +128,17 @@ var _ = Describe("nvml-mock standalone", Ordered, func() {
 				nvidiasmi.ProcessMonitorAndTopology(ctx, h.Kube, pod)
 			})
 
+			It("reports the profile's platform identity via nvidia-smi", Label("nvidia-smi"), func(ctx SpecContext) {
+				// Issue #642: nvmlDeviceGetPlatformInfo was a generated stub, so
+				// the whole Platform Info block read N/A even on gb200/gb300,
+				// leaving a Grace-Blackwell rack indistinguishable from a PCIe
+				// workstation card by physical location. The expectation comes
+				// from the profile, so this same spec pins the configured
+				// chassis/slot/tray/host and a per-GPU module id on the NVL72
+				// profiles and N/A on every other selected profile.
+				nvidiasmi.PlatformIdentity(ctx, h.Kube, pod, p)
+			})
+
 			It("exposes the NVLink topology (gated on fabricmanager)", Label("nvlink"), func(ctx SpecContext) {
 				assertions.FabricManagerGate(ctx, h.Kube, nvmlMockNamespace, "nvml-mock", pod, config.ReadyTimeout(), config.PollInterval())
 				assertions.NVLink(ctx, h.Kube, pod, p)


### PR DESCRIPTION
Fixes #642

## Summary

`nvidia-smi -q` read `N/A` for every row of the `Platform Info` block on `gb200` and `gb300`, so an NVL72 rack was indistinguishable from a PCIe workstation card by physical location — the fields rack-scale fault correlation reads to turn a GPU fault into "module 2 of the tray in slot 9 of this chassis".

- `nvmlDeviceGetPlatformInfo` and `nvmlDeviceGetModuleId` are implemented and removed from `stubs_generated.go`. The former dispatches on the caller's struct version tag and serves both v1 and v2 from one payload, since the rename (`rackGuid` -> `chassisSerialNumber`) kept the same 44 bytes. The layout is pinned by `_Static_assert` in `nvml_types.h` and by a unit test, so a wrong layout cannot fail silently.
- A `device_defaults.platform` block configures the identity. Only `module_id` is set per device: NVML scopes the other five fields to the node, which occupies exactly one tray of one chassis, so the shipped profiles vary GPUs by module while sharing the node's location. Per-device merging is copy-on-write, or every GPU would inherit the last override's module id.
- `gb200` and `gb300` describe a coherent NVL72 layout. `slot_number` counts switch trays as well as compute trays while `tray_index` counts compute trays only, so slot runs ahead of tray for a tray above the rack's nine switch trays: compute tray 11 lands in slot 21.
- Profiles declaring no block keep reporting `N/A`, which stays correct for every board outside such a rack.

`gb200`, GPU 0 and 1:

```
    Platform Info
        Chassis Serial Number             : 1822725100200
        Slot Number                       : 21
        Tray Index                        : 11
        Host ID                           : 1
        Peer Type                         : Switch Connected
        Module Id                         : 1
        GPU Fabric GUID                   : 0x0000000000000000
    Platform Info
        ...
        Module Id                         : 2
```

## Notes for review

`GPU Fabric GUID` is a non-goal of the issue and is not modelled, but it sits in the same struct and now renders `0x0000000000000000` where it used to read `N/A`. The bridge zeroes that buffer deliberately, so the row cannot render the caller's uninitialised memory; the changelog records it as unmodelled.

`b200` turned out to be the negative control the acceptance criteria were really after — Blackwell, driver past the 560 version gate, but in no rack — so its `N/A` proves the reading is driven by configuration rather than by the version gate. It is covered alongside `a100`.

## Test plan

- [x] New Ginkgo spec `reports the profile's platform identity via nvidia-smi` under `Label("nvidia-smi")`, deriving its expectation from the profile so it asserts both directions: populated, node-consistent and module-distinct on `gb200`; `N/A` on `a100` and `b200`. Passes against a freshly built image on all three.
- [x] Red against `main`: the profile guard fails on `main`'s profiles, which declare no platform block, and the assertion rejects an all-`N/A` document against the `gb200` expectation with 12 problems — `main`'s exact output.
- [x] `make test`, `make helm-tests` (snapshots updated for the two profiles), `make gen-check`, `go vet`, `golangci-lint`.
- [x] `docs/configuration.md` documents the configuration surface; `CHANGELOG.md` entry under `[Unreleased]`.