### PR TITLE
fix(local): pin kind worker node names and select the fleet by hostname

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -50,7 +50,7 @@ config.define_string('k8s-context', args=False,
 # --dra` parses as three separate flags without positional-value
 # ambiguity that Tilt's string-flag parser can exhibit for `=X` forms.
 config.define_bool('multi-gpu-profile', args=False,
-    usage='Install one nvml-mock release per GPU profile, node-pinned via nodeSelector.nvml-mock/profile=<profile>. Simulates a heterogeneous fleet on the default cluster (a100 + t4 workers). Without this flag, a single nvml-mock release covers all nodes with the profile from --gpu-profile.')
+    usage='Install one nvml-mock release per GPU profile, node-pinned via nodeSelector.kubernetes.io/hostname=<worker>. Simulates a heterogeneous fleet on the default cluster (a100 on worker-0 + t4 on worker-1). Without this flag, a single nvml-mock release covers all nodes with the profile from --gpu-profile.')
 config.define_bool('compute-domain', args=False,
     usage='ComputeDomain scenario: 4-worker cluster with GB200 profile + NVLink topology overlay (requires PROFILE=compute-domain cluster)')
 config.define_bool('gpu-operator', args=False,

--- a/local/README.md
+++ b/local/README.md
@@ -54,7 +54,7 @@ Supported `--gpu-profile` values: `a100`, `h100`, `b200`, `gb200`, `gb300`, `l40
 
 ### Heterogeneous fleet (per-GPU-profile releases)
 
-Installs one nvml-mock release per worker, pinned by node selector `nvml-mock/profile=<profile>`. Profiles are fixed to `a100` and `t4` (matching the worker labels in `local/kind/default.kind.yaml`). `--gpu-profile` is ignored in this mode.
+Installs one nvml-mock release per worker, pinned by node selector `kubernetes.io/hostname=<worker>`. Profiles are fixed to `a100` on `worker-0` and `t4` on `worker-1` (the worker names come from `local/kind/default.kind.yaml`). `--gpu-profile` is ignored in this mode.
 
 ```bash
 tilt up -- --multi-gpu-profile

--- a/local/kind/default.kind.yaml
+++ b/local/kind/default.kind.yaml
@@ -68,6 +68,10 @@ nodes:
         apiServer:
           extraArgs:
             runtime-config: "resource.k8s.io/v1beta1=true"
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          name: control-0
   - role: worker
     labels:
       nvml-mock/profile: a100

--- a/local/kind/default.kind.yaml
+++ b/local/kind/default.kind.yaml
@@ -74,9 +74,17 @@ nodes:
           name: control-0
   - role: worker
     labels:
-      nvml-mock/profile: a100
       run.ai/simulated-gpu-node-pool: integration
+    kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          name: worker-0
   - role: worker
     labels:
-      nvml-mock/profile: t4
       run.ai/simulated-gpu-node-pool: scale
+    kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          name: worker-1

--- a/local/kind/default.kind.yaml
+++ b/local/kind/default.kind.yaml
@@ -42,10 +42,13 @@
 #      overlay at container-creation time. Inert until a workload registers
 #      as an NRI plugin, so the node-wide-NRI scenario is the only consumer.
 #
-# Worker labels drive two orthogonal consumer paths without conflict:
-#   - nvml-mock/profile=<a100|t4>            — targeted by install_fleet() in
-#     local/nvml_mock.tiltfile under --multi-gpu-profile, so each worker runs
-#     its own nvml-mock release simulating the labelled GPU.
+# Node names are pinned via JoinConfiguration instead of being derived from the
+# cluster name, so they stay stable across recreations and can be selected
+# directly: install_fleet() in local/nvml_mock.tiltfile pins each per-profile
+# nvml-mock release with kubernetes.io/hostname=<worker> under
+# --multi-gpu-profile (a100 on worker-0, t4 on worker-1).
+#
+# Worker labels drive the remaining consumer path:
 #   - run.ai/simulated-gpu-node-pool=<integration|scale> — FGO node-pool split.
 #     integration (a100) runs nvml-mock as the NVML shim; scale (t4) is managed
 #     entirely by FGO's fake backend. Consumers that ignore these labels see

--- a/local/kind/default.kind.yaml
+++ b/local/kind/default.kind.yaml
@@ -42,11 +42,13 @@
 #      overlay at container-creation time. Inert until a workload registers
 #      as an NRI plugin, so the node-wide-NRI scenario is the only consumer.
 #
-# Node names are pinned via JoinConfiguration instead of being derived from the
-# cluster name, so they stay stable across recreations and can be selected
+# Worker names are pinned via JoinConfiguration instead of being derived from
+# the cluster name, so they stay stable across recreations and can be selected
 # directly: install_fleet() in local/nvml_mock.tiltfile pins each per-profile
 # nvml-mock release with kubernetes.io/hostname=<worker> under
-# --multi-gpu-profile (a100 on worker-0, t4 on worker-1).
+# --multi-gpu-profile (a100 on worker-0, t4 on worker-1). The control-plane
+# node keeps its kind-derived name: kubeadm names the bootstrap node from
+# InitConfiguration, which JoinConfiguration cannot override.
 #
 # Worker labels drive the remaining consumer path:
 #   - run.ai/simulated-gpu-node-pool=<integration|scale> — FGO node-pool split.
@@ -71,10 +73,6 @@ nodes:
         apiServer:
           extraArgs:
             runtime-config: "resource.k8s.io/v1beta1=true"
-      - |
-        kind: JoinConfiguration
-        nodeRegistration:
-          name: control-0
   - role: worker
     labels:
       run.ai/simulated-gpu-node-pool: integration

--- a/local/nvml_mock.tiltfile
+++ b/local/nvml_mock.tiltfile
@@ -8,7 +8,7 @@
 #   build_nvml_mock_image()       — build the ghcr.io/nvidia/nvml-mock image.
 #   install_single()              — install one nvml-mock Helm release. Returns list[str] of Tilt resource names.
 #   install_fleet()               — install one nvml-mock release per profile, node-pinned via
-#                                   nodeSelector.nvml-mock/profile=<p>. Returns list[str].
+#                                   nodeSelector.kubernetes.io/hostname=<worker>. Returns list[str].
 #
 # All side effects (docker_build / helm_resource) are inside functions so
 # `load()`ing this file is a pure import; the orchestrator controls order.
@@ -20,8 +20,12 @@
 
 load('ext://helm_resource', 'helm_resource')
 
-# Must match the worker labels in local/kind/default.kind.yaml. Keep in sync.
 FLEET_PROFILES = ['a100', 't4']
+
+# Worker hostnames pinned by the JoinConfiguration patches in
+# local/kind/default.kind.yaml. Positional: the Nth fleet profile lands on the
+# Nth worker, so reordering either list re-assigns profiles to nodes.
+_FLEET_NODES = ['worker-0', 'worker-1']
 
 _IMAGE = 'ghcr.io/nvidia/nvml-mock'
 _CONTROL_PLANE_IMAGE = 'ghcr.io/nvidia/mokka-control-plane'
@@ -204,12 +208,18 @@ def install_fleet(active_consumers, profiles = FLEET_PROFILES, nvmlmock_image=''
     (health probes only), and future MEPs that give the CP real state will
     revisit the placement story.
     """
-    for p in profiles:
+    if len(profiles) > len(_FLEET_NODES):
+        fail('install_fleet: %d profiles (%s) but only %d worker nodes (%s)' % (
+            len(profiles), ', '.join(profiles), len(_FLEET_NODES), ', '.join(_FLEET_NODES)))
+
+    for i in range(len(profiles)):
         _install(
-            'nvml-mock-' + p,
-            p,
+            'nvml-mock-' + profiles[i],
+            profiles[i],
             active_consumers,
-            extra_set=['nodeSelector.nvml-mock/profile=' + p],
+            # helm --set reads '.' as a path separator, so the dot in
+            # kubernetes.io is escaped to keep the label key in one piece.
+            extra_set=['nodeSelector.kubernetes\\.io/hostname=' + _FLEET_NODES[i]],
             nvmlmock_image=nvmlmock_image,
             control_plane=control_plane,
         )

--- a/local/nvml_mock.tiltfile
+++ b/local/nvml_mock.tiltfile
@@ -20,12 +20,9 @@
 
 load('ext://helm_resource', 'helm_resource')
 
+# Order matters: the Nth profile is pinned to worker-N, whose name comes from
+# the JoinConfiguration patches in local/kind/default.kind.yaml.
 FLEET_PROFILES = ['a100', 't4']
-
-# Worker hostnames pinned by the JoinConfiguration patches in
-# local/kind/default.kind.yaml. Positional: the Nth fleet profile lands on the
-# Nth worker, so reordering either list re-assigns profiles to nodes.
-_FLEET_NODES = ['worker-0', 'worker-1']
 
 _IMAGE = 'ghcr.io/nvidia/nvml-mock'
 _CONTROL_PLANE_IMAGE = 'ghcr.io/nvidia/mokka-control-plane'
@@ -197,7 +194,7 @@ def install_single(profile, active_consumers, nvmlmock_image='', control_plane=F
     return ['nvml-mock']
 
 def install_fleet(active_consumers, profiles = FLEET_PROFILES, nvmlmock_image='', control_plane=False):
-    """Install one nvml-mock release per profile, node-pinned to workers.
+    """Install one nvml-mock release per profile, the Nth pinned to worker-N.
 
     The chart's fullname template collapses to the release name when it already
     contains the chart name ('nvml-mock'), so 'nvml-mock-a100' / 'nvml-mock-t4'
@@ -208,10 +205,6 @@ def install_fleet(active_consumers, profiles = FLEET_PROFILES, nvmlmock_image=''
     (health probes only), and future MEPs that give the CP real state will
     revisit the placement story.
     """
-    if len(profiles) > len(_FLEET_NODES):
-        fail('install_fleet: %d profiles (%s) but only %d worker nodes (%s)' % (
-            len(profiles), ', '.join(profiles), len(_FLEET_NODES), ', '.join(_FLEET_NODES)))
-
     for i in range(len(profiles)):
         _install(
             'nvml-mock-' + profiles[i],
@@ -219,7 +212,7 @@ def install_fleet(active_consumers, profiles = FLEET_PROFILES, nvmlmock_image=''
             active_consumers,
             # helm --set reads '.' as a path separator, so the dot in
             # kubernetes.io is escaped to keep the label key in one piece.
-            extra_set=['nodeSelector.kubernetes\\.io/hostname=' + _FLEET_NODES[i]],
+            extra_set=['nodeSelector.kubernetes\\.io/hostname=worker-%d' % i],
             nvmlmock_image=nvmlmock_image,
             control_plane=control_plane,
         )

--- a/tests/e2e/go/framework/cluster/cluster.go
+++ b/tests/e2e/go/framework/cluster/cluster.go
@@ -3,13 +3,14 @@
 // Copyright 2026 NVIDIA CORPORATION
 // SPDX-License-Identifier: Apache-2.0
 
-// Package cluster reads Kind cluster node topology via the `kind` CLI, using
-// Kind/kubectl's default kubeconfig. Cluster provisioning itself lives outside
-// this package (Tilt / `make cluster-create`); the suite only observes.
+// Package cluster reads Kind cluster node topology from the Kubernetes API,
+// using Kind/kubectl's default kubeconfig. Cluster provisioning itself lives
+// outside this package (Tilt / `make cluster-create`); the suite only observes.
 package cluster
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
@@ -27,10 +28,14 @@ const (
 	RoleWorker       Role = "worker"
 )
 
-// Node is a Kind node; Name is also the docker container name.
+// Node is a Kind node. Name is the Kubernetes node name; Container is the
+// docker container hosting it. They diverge whenever the cluster config pins
+// nodeRegistration.name (see local/kind/default.kind.yaml), so callers must
+// choose deliberately: kubectl takes Name, `docker exec` takes Container.
 type Node struct {
-	Name string
-	Role Role
+	Name      string
+	Container string
+	Role      Role
 }
 
 // Cluster is an existing Kind cluster the suite attaches to.
@@ -54,31 +59,76 @@ func ValidateName(name string) error {
 	return nil
 }
 
-// Nodes returns all nodes (cached), parsed once from `kind get nodes`.
+// controlPlaneLabel is kubeadm's control-plane marker. Roles are read from it
+// rather than from the node name: a config that pins nodeRegistration.name is
+// free to choose names that say nothing about the role.
+const controlPlaneLabel = "node-role.kubernetes.io/control-plane"
+
+// nodeList is the subset of `kubectl get nodes -o json` the suite reads.
+type nodeList struct {
+	Items []struct {
+		Metadata struct {
+			Name   string            `json:"name"`
+			Labels map[string]string `json:"labels"`
+		} `json:"metadata"`
+		Spec struct {
+			ProviderID string `json:"providerID"`
+		} `json:"spec"`
+	} `json:"items"`
+}
+
+// Nodes returns all nodes (cached), discovered from the Kubernetes API rather
+// than from `kind get nodes`: the latter reports container names, which are not
+// the node names once the cluster config pins nodeRegistration.name.
 func (c *Cluster) Nodes(ctx context.Context) ([]Node, error) {
 	if c.nodes != nil {
 		return c.nodes, nil
 	}
-	res, err := runner.Run(ctx, "kind", "get", "nodes", "--name", c.Name)
+	res, err := runner.Run(ctx, "kubectl", "--context", c.Context, "get", "nodes", "-o", "json")
 	if err != nil {
-		return nil, fmt.Errorf("kind get nodes %q: %w", c.Name, err)
+		return nil, fmt.Errorf("kubectl get nodes (context %q): %w", c.Context, err)
 	}
-	var ns []Node
-	for _, line := range strings.Split(res.Stdout, "\n") {
-		name := strings.TrimSpace(line)
-		if name == "" {
-			continue
-		}
-		role := RoleControlPlane
-		if strings.Contains(name, "worker") {
-			role = RoleWorker
-		}
-		ns = append(ns, Node{Name: name, Role: role})
+	ns, err := parseNodes([]byte(res.Stdout))
+	if err != nil {
+		return nil, err
 	}
-	// Deterministic ordering: workers sorted by name so worker1<worker2.
-	sort.Slice(ns, func(i, j int) bool { return ns[i].Name < ns[j].Name })
 	c.nodes = ns
 	return ns, nil
+}
+
+func parseNodes(stdout []byte) ([]Node, error) {
+	var nl nodeList
+	if err := json.Unmarshal(stdout, &nl); err != nil {
+		return nil, fmt.Errorf("parse kubectl get nodes output: %w", err)
+	}
+	ns := make([]Node, 0, len(nl.Items))
+	for _, item := range nl.Items {
+		role := RoleWorker
+		if _, ok := item.Metadata.Labels[controlPlaneLabel]; ok {
+			role = RoleControlPlane
+		}
+		ns = append(ns, Node{
+			Name:      item.Metadata.Name,
+			Container: containerName(item.Spec.ProviderID, item.Metadata.Name),
+			Role:      role,
+		})
+	}
+	// Deterministic ordering: scenarios pair workers[i] with a GPU profile.
+	sort.Slice(ns, func(i, j int) bool { return ns[i].Name < ns[j].Name })
+	return ns, nil
+}
+
+// containerName reads the container out of Kind's provider ID, which has the
+// form kind://docker/<cluster>/<container>. Anything else means the node was
+// not provisioned by Kind, and the node name is the best guess available.
+func containerName(providerID, nodeName string) string {
+	if !strings.HasPrefix(providerID, "kind://") {
+		return nodeName
+	}
+	if i := strings.LastIndex(providerID, "/"); i >= 0 && i+1 < len(providerID) {
+		return providerID[i+1:]
+	}
+	return nodeName
 }
 
 // ControlPlane returns the (first) control-plane node.

--- a/tests/e2e/go/framework/cluster/cluster.go
+++ b/tests/e2e/go/framework/cluster/cluster.go
@@ -84,7 +84,7 @@ func (c *Cluster) Nodes(ctx context.Context) ([]Node, error) {
 	if c.nodes != nil {
 		return c.nodes, nil
 	}
-	res, err := runner.Run(ctx, "kubectl", "--context", c.Context, "get", "nodes", "-o", "json")
+	res, err := runner.RunQuiet(ctx, "kubectl", "--context", c.Context, "get", "nodes", "-o", "json")
 	if err != nil {
 		return nil, fmt.Errorf("kubectl get nodes (context %q): %w", c.Context, err)
 	}

--- a/tests/e2e/go/framework/cluster/cluster_test.go
+++ b/tests/e2e/go/framework/cluster/cluster_test.go
@@ -100,4 +100,10 @@ func TestValidateName(t *testing.T) {
 	require.NoError(t, ValidateName("mokka"))
 	require.Error(t, ValidateName(""))
 	require.Error(t, ValidateName("Mokka"))
+
+	// The length bound is a docker name-length guard the regex does not
+	// enforce, so it needs cases either side of it: every other input here
+	// fails on the pattern alone.
+	require.NoError(t, ValidateName(strings.Repeat("a", 40)))
+	require.Error(t, ValidateName(strings.Repeat("a", 41)))
 }

--- a/tests/e2e/go/framework/cluster/cluster_test.go
+++ b/tests/e2e/go/framework/cluster/cluster_test.go
@@ -4,3 +4,100 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package cluster
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// nodesJSON builds a `kubectl get nodes -o json` payload.
+func nodesJSON(items ...string) string {
+	return `{"items":[` + strings.Join(items, ",") + `]}`
+}
+
+// nodeJSON renders one node. providerID is omitted when empty, which is how a
+// non-Kind cluster looks.
+
+func nodeJSON(name, providerID string, controlPlane bool) string {
+	labels := `"kubernetes.io/hostname":"` + name + `"`
+	if controlPlane {
+		labels += `,"node-role.kubernetes.io/control-plane":""`
+	}
+	spec := `{}`
+	if providerID != "" {
+		spec = `{"providerID":"` + providerID + `"}`
+	}
+	return `{"metadata":{"name":"` + name + `","labels":{` + labels + `}},"spec":` + spec + `}`
+}
+
+// The renamed case is the whole point: nodeRegistration.name decouples the
+// Kubernetes node name from the container name, and kubectl-vs-docker call
+// sites need different ones.
+func TestParseNodesResolvesRenamedNodesToTheirContainers(t *testing.T) {
+	in := nodesJSON(
+		nodeJSON("mokka-control-plane", "kind://docker/mokka/mokka-control-plane", true),
+		nodeJSON("worker-0", "kind://docker/mokka/mokka-worker", false),
+		nodeJSON("worker-1", "kind://docker/mokka/mokka-worker2", false),
+	)
+
+	got, err := parseNodes([]byte(in))
+	require.NoError(t, err)
+	require.Equal(t, []Node{
+		{Name: "mokka-control-plane", Container: "mokka-control-plane", Role: RoleControlPlane},
+		{Name: "worker-0", Container: "mokka-worker", Role: RoleWorker},
+		{Name: "worker-1", Container: "mokka-worker2", Role: RoleWorker},
+	}, got)
+}
+
+// Roles come from the control-plane label, not from a substring of the name:
+// a pinned name need not contain "worker", and "worker" could appear in a
+// control-plane name.
+func TestParseNodesReadsRoleFromLabelNotName(t *testing.T) {
+	in := nodesJSON(
+		nodeJSON("cp-worker-host", "kind://docker/mokka/mokka-control-plane", true),
+		nodeJSON("gpu-a", "kind://docker/mokka/mokka-worker", false),
+	)
+
+	got, err := parseNodes([]byte(in))
+	require.NoError(t, err)
+	require.Equal(t, RoleControlPlane, got[0].Role)
+	require.Equal(t, RoleWorker, got[1].Role)
+}
+
+func TestParseNodesFallsBackToNodeNameWithoutKindProviderID(t *testing.T) {
+	in := nodesJSON(
+		nodeJSON("node-a", "", false),
+		nodeJSON("node-b", "aws:///us-east-1a/i-0abc", false),
+	)
+
+	got, err := parseNodes([]byte(in))
+	require.NoError(t, err)
+	require.Equal(t, "node-a", got[0].Container)
+	require.Equal(t, "node-b", got[1].Container)
+}
+
+// Scenarios index into Workers() (workers[0], workers[1]) to pair a node with
+// a GPU profile, so ordering has to be stable regardless of API return order.
+func TestParseNodesSortsByName(t *testing.T) {
+	in := nodesJSON(
+		nodeJSON("worker-1", "kind://docker/mokka/mokka-worker2", false),
+		nodeJSON("worker-0", "kind://docker/mokka/mokka-worker", false),
+	)
+
+	got, err := parseNodes([]byte(in))
+	require.NoError(t, err)
+	require.Equal(t, []string{"worker-0", "worker-1"}, []string{got[0].Name, got[1].Name})
+}
+
+func TestParseNodesRejectsMalformedOutput(t *testing.T) {
+	_, err := parseNodes([]byte("not json"))
+	require.Error(t, err)
+}
+
+func TestValidateName(t *testing.T) {
+	require.NoError(t, ValidateName("mokka"))
+	require.Error(t, ValidateName(""))
+	require.Error(t, ValidateName("Mokka"))
+}

--- a/tests/e2e/go/framework/config/config.go
+++ b/tests/e2e/go/framework/config/config.go
@@ -94,8 +94,9 @@ func Image() string { return env("E2E_IMAGE", defaultImage) }
 // produces from local/kind/default.kind.yaml.
 func KubeContext() string { return env("E2E_KUBE_CONTEXT", defaultKubeContext) }
 
-// ClusterName is the Kind cluster name of the externally-owned cluster. Used
-// by `kind get nodes --name` for node-role assertions. Defaults to `mokka` —
+// ClusterName is the Kind cluster name of the externally-owned cluster. It
+// identifies the cluster in harness attach errors and diagnostics; node
+// discovery goes through the kubeconfig context instead. Defaults to `mokka` —
 // the cluster name `make cluster-create` produces.
 func ClusterName() string { return env("E2E_CLUSTER_NAME", defaultClusterName) }
 

--- a/tests/e2e/go/scenario_gpu_operator_test.go
+++ b/tests/e2e/go/scenario_gpu_operator_test.go
@@ -41,7 +41,6 @@ var _ = Describe("nvml-mock GPU Operator", Label("gpu-operator"), Ordered, func(
 			)
 
 			BeforeAll(func(ctx SpecContext) {
-				var podName string
 				p, _, _ = setupStandaloneProfile(ctx, h, name)
 				// Not the node setupStandaloneProfile returns: that comes from
 				// FirstPodName over the nvml-mock DaemonSet, which can land on
@@ -51,8 +50,7 @@ var _ = Describe("nvml-mock GPU Operator", Label("gpu-operator"), Ordered, func(
 				node = gpuOperatorTargetNode(ctx, h)
 				cp, err := h.Cluster.ControlPlane(ctx)
 				Expect(err).NotTo(HaveOccurred())
-				podName = cp.Name
-				verifyGPUOperatorNodeSetup(ctx, podName)
+				verifyGPUOperatorNodeSetup(ctx, cp.Container)
 
 				// Wait belongs here, not in a spec: every spec below reads state
 				// that only the operator publishes, and `helm --wait` covers only
@@ -243,10 +241,10 @@ func rolloutRestart(ctx context.Context, h *harness.Harness, ns, ds string) {
 	Expect(err).NotTo(HaveOccurred(), "rollout status %s/%s", ns, ds)
 }
 
-func verifyGPUOperatorNodeSetup(ctx context.Context, node string) {
+func verifyGPUOperatorNodeSetup(ctx context.Context, container string) {
 	GinkgoHelper()
-	Expect(dockerExec(ctx, node, "test", "-f", "/var/run/cdi/nvidia.yaml")).To(Succeed(), "CDI spec exists")
-	Expect(dockerExec(ctx, node, "bash", "-c", "LD_LIBRARY_PATH=/run/nvidia/driver/usr/lib64 /run/nvidia/driver/usr/bin/nvidia-smi")).To(Succeed(), "nvidia-smi works via /run/nvidia/driver")
+	Expect(dockerExec(ctx, container, "test", "-f", "/var/run/cdi/nvidia.yaml")).To(Succeed(), "CDI spec exists")
+	Expect(dockerExec(ctx, container, "bash", "-c", "LD_LIBRARY_PATH=/run/nvidia/driver/usr/lib64 /run/nvidia/driver/usr/bin/nvidia-smi")).To(Succeed(), "nvidia-smi works via /run/nvidia/driver")
 }
 
 func waitOperatorValidatorRunning(ctx SpecContext, h *harness.Harness) {
@@ -261,9 +259,9 @@ func waitOperatorValidatorRunning(ctx SpecContext, h *harness.Harness) {
 	assertions.WaitPodPhase(ctx, h.Kube, gpuOperatorNamespace, pod, "Running", 5*time.Minute, config.PollInterval())
 }
 
-func dockerExec(ctx context.Context, node string, args ...string) error {
+func dockerExec(ctx context.Context, container string, args ...string) error {
 	GinkgoHelper()
-	all := append([]string{"exec", node}, args...)
+	all := append([]string{"exec", container}, args...)
 	_, err := runner.Run(ctx, "docker", all...)
 	return err
 }

--- a/tests/e2e/go/scenario_nri_test.go
+++ b/tests/e2e/go/scenario_nri_test.go
@@ -592,7 +592,7 @@ var _ = Describe("nvml-mock node-wide NRI injection", Label("nri"), Ordered, fun
 			Expect(err).NotTo(HaveOccurred(), "read baseline restart count")
 
 			By("SIGSTOP the nvml-mock-nri process on " + victim.Name)
-			wedgeNRIPlugin(ctx, victim.Name)
+			wedgeNRIPlugin(ctx, victim.Container)
 		})
 
 		// The readiness probe is the detectable half of the fail-open posture:
@@ -684,16 +684,16 @@ func nriRestartCount(ctx context.Context, h *harness.Harness, pod kube.PodRef) (
 // sent to a namespace init from within that same namespace. `kubectl exec ...
 // kill -STOP 1` is silently a no-op. From the node -- an ancestor namespace --
 // the signal is delivered.
-func wedgeNRIPlugin(ctx context.Context, node string) {
+func wedgeNRIPlugin(ctx context.Context, container string) {
 	GinkgoHelper()
-	pid := nriPluginHostPID(ctx, node)
-	_, err := runner.Run(ctx, "docker", "exec", node, "kill", "-STOP", pid)
-	Expect(err).NotTo(HaveOccurred(), "SIGSTOP nvml-mock-nri (pid %s) on %s", pid, node)
+	pid := nriPluginHostPID(ctx, container)
+	_, err := runner.Run(ctx, "docker", "exec", container, "kill", "-STOP", pid)
+	Expect(err).NotTo(HaveOccurred(), "SIGSTOP nvml-mock-nri (pid %s) on %s", pid, container)
 
 	// Confirm the process really is stopped rather than trusting kill's exit
 	// code: a wedge that did not take would make every assertion below vacuous.
 	Eventually(func() (string, error) {
-		res, err := runner.RunQuiet(ctx, "docker", "exec", node, "cat", "/proc/"+pid+"/stat")
+		res, err := runner.RunQuiet(ctx, "docker", "exec", container, "cat", "/proc/"+pid+"/stat")
 		if err != nil {
 			return "", err
 		}
@@ -703,21 +703,21 @@ func wedgeNRIPlugin(ctx context.Context, node string) {
 		}
 		return fields[2], nil // state: T = stopped
 	}).WithContext(ctx).WithTimeout(30*time.Second).WithPolling(time.Second).
-		Should(Equal("T"), "nvml-mock-nri (pid %s) on %s did not enter the stopped state", pid, node)
+		Should(Equal("T"), "nvml-mock-nri (pid %s) on %s did not enter the stopped state", pid, container)
 }
 
 // nriPluginHostPID finds the plugin process in the Kind node's PID namespace.
 // It reads /proc/<pid>/exe rather than shelling out to pgrep: procps is not
 // guaranteed in the node image, and matching on a command line would also match
 // the matching process itself.
-func nriPluginHostPID(ctx context.Context, node string) string {
+func nriPluginHostPID(ctx context.Context, container string) string {
 	GinkgoHelper()
 	const script = `for p in /proc/[0-9]*; do case "$(readlink "$p/exe" 2>/dev/null)" in */nvml-mock-nri) echo "${p##*/}";; esac; done`
-	res, err := runner.Run(ctx, "docker", "exec", node, "sh", "-c", script)
-	Expect(err).NotTo(HaveOccurred(), "locate nvml-mock-nri on %s: %s", node, res.Combined())
+	res, err := runner.Run(ctx, "docker", "exec", container, "sh", "-c", script)
+	Expect(err).NotTo(HaveOccurred(), "locate nvml-mock-nri on %s: %s", container, res.Combined())
 
 	pids := strings.Fields(res.Stdout)
-	Expect(pids).NotTo(BeEmpty(), "no nvml-mock-nri process found on %s", node)
+	Expect(pids).NotTo(BeEmpty(), "no nvml-mock-nri process found on %s", container)
 	return pids[0]
 }
 


### PR DESCRIPTION
## Summary

- Pins the worker node names in `local/kind/default.kind.yaml` to `worker-0` / `worker-1` via `JoinConfiguration`, instead of letting them be derived from the cluster name (`mokka-worker`, `mokka-worker2`). Stable names make node-targeted commands and docs reproducible across cluster recreations.
- Switches `install_fleet()` in `local/nvml_mock.tiltfile` to pin each per-profile release with `nodeSelector.kubernetes.io/hostname=<worker>`, and drops the now-redundant `nvml-mock/profile` worker labels. The mapping is positional: the Nth entry of `FLEET_PROFILES` lands on `worker-N`.
- Fixes the e2e harness to discover node names from the Kubernetes API. `Cluster.Nodes()` previously enumerated `kind get nodes`, which reports **docker container** names, and passed them straight to `kubectl` — that works only while the two happen to be identical.

## Why the harness change is required

Pinning `nodeRegistration.name` decouples the Kubernetes node name from the Kind container name. Without the harness fix, every scenario that resolves a node by name fails with `Error from server (NotFound): nodes "mokka-worker" not found`.

`cluster.Node` now carries both identities: `Name` (Kubernetes, for `kubectl`) and `Container` (docker, for `docker exec`). The container name is read from Kind's provider ID, `kind://docker/<cluster>/<container>`, which keeps pointing at the container after a rename. The `docker exec` call sites in the GPU Operator and NRI scenarios were updated to use `Container`. Roles now come from the `node-role.kubernetes.io/control-plane` label rather than a `"worker"` substring match, since a pinned name need not describe its role.

The control-plane node deliberately keeps its Kind-derived name: kubeadm names the bootstrap node from `InitConfiguration`, so a `JoinConfiguration` patch there is silently ignored.

## Test plan

- [x] `make test-e2e-framework` and `make test` pass; `golangci-lint --build-tags e2e ./tests/e2e/go/...` reports 0 issues
- [x] New unit tests in `cluster_test.go` cover renamed nodes, label-derived roles, non-Kind provider IDs, ordering, and malformed input
- [x] Verified against a live Kind cluster with a renamed worker: node `worker-0` resolves to container `rename-probe-worker`
- [x] Verified unchanged behaviour on a cluster without renames: names and containers match, roles correct
- [x] `helm template` renders a flat `kubernetes.io/hostname: worker-0` under `nodeSelector`
- [x] `tilt alpha tiltfile-result -- --multi-gpu-profile` pins `a100` to `worker-0` and `t4` to `worker-1`
- [ ] Full e2e suite in CI (gpu-operator / nri / nfd / multi-node were the jobs broken by the rename)