### PR TITLE
feat(mocknvml): model SRAM ECC errors and row-remap availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   than 560, keep reporting `N/A`. The `GPU Fabric GUID` row of the same block is
   not modelled and now renders `0x0000000000000000` where it used to read `N/A`.
   (#642)
+- mocknvml: SRAM ECC errors and row-remap availability are now modelled, so SRAM
+  fault handling can be tested. Every SRAM row of `nvidia-smi -q` read `N/A`
+  while `nvmlDeviceGetSramEccErrorStatus` and
+  `nvmlDeviceGetRowRemapperHistogram` were generated stubs, which told a consumer
+  the feature was unsupported rather than that the GPU was healthy. A new
+  `ecc.sram` config block carries the correctable, uncorrectable-parity and
+  uncorrectable-SEC-DED counters for both scopes, the aggregate per-unit source
+  breakdown (L2, SM, microcontroller, PCIe, other) and the
+  `SRAM Threshold Exceeded` flag; `remapped_rows.availability_histogram` carries
+  the bank remap availability the Ampere-and-later profiles now ship (`t4` leaves
+  it out and keeps reporting the histogram unsupported, as Turing does). Errors
+  can be injected into a running workload with
+  `nvml-mock-ctl sram-ecc --gpu <idx> --type secded --source sm
+  --threshold-exceeded <count>`, and a count of `0` heals. The same values are
+  visible through the per-location ECC field values DCGM reads, and
+  `nvmlDeviceGetMemoryErrorCounter` now honours its `locationType` and
+  `counterType` arguments instead of returning the DRAM counter for every
+  location. (#641)
 - mocknvml: configured `processes:` now surface in nvidia-smi — the default
   table's Processes box, `-q`, and `--query-compute-apps` all report the
   configured PIDs, names and GPU memory instead of always reporting none.

--- a/cmd/nvml-mock-ctl/main.go
+++ b/cmd/nvml-mock-ctl/main.go
@@ -46,6 +46,11 @@ const (
 	// degrading NVLink tops out well below this; the generous cap keeps the
 	// accrual math (rate * elapsed seconds) far from overflowing uint64.
 	maxNvlinkErrorRate = 1e9
+
+	// maxSramEccCount bounds the `sram-ecc` command. A GPU is retired long
+	// before its SRAM error count approaches this, so the cap only exists to
+	// keep an obvious typo from being written as a plausible counter.
+	maxSramEccCount = 1e9
 )
 
 func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
@@ -70,6 +75,9 @@ commands:
   throttle --gpu <idx|all|uuid> <reason>[ reason ...]  set active throttle reasons ('none' clears)
   pstate --gpu <idx|all|uuid> <0-15>       pin reported performance state (P-state)
   nvlink-error --gpu <idx|all|uuid> <errors_per_sec> [--links a,b,c]  inject NVLink DL errors (0 heals)
+  sram-ecc --gpu <idx|all|uuid> <count> [--type correctable|parity|secded]
+           [--source l2|sm|microcontroller|pcie|other] [--threshold-exceeded]
+                                           inject SRAM ECC errors (0 heals)
   set    --gpu <idx|all|uuid> key.path=value [key.path=value ...]
   status [--gpu <idx>]
   reset  [--gpu <idx|all|uuid>]
@@ -86,6 +94,8 @@ global flags:
 //nolint:cyclop // existing complexity; refactor deferred
 func run(args []string, stdout, stderr io.Writer) int {
 	var configOverridePath, configPath, gpu, mode, links, socket string
+	var sramErrorType, sramSource string
+	var sramThresholdExceeded bool
 	var afterCalls int
 	var xid uint64
 	var interval time.Duration
@@ -100,6 +110,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 	fs.IntVar(&afterCalls, "after-calls", 0, "trip after N guarded calls (fail)")
 	fs.Uint64Var(&xid, "xid", 0, "Xid code to surface (fail)")
 	fs.StringVar(&links, "links", "", "comma-separated NVLink ids for nvlink-error (default: all active links)")
+	fs.StringVar(&sramErrorType, "type", "secded", "SRAM error type: correctable|parity|secded (sram-ecc)")
+	fs.StringVar(&sramSource, "source", "", "unit the SRAM errors are attributed to (sram-ecc, default: other)")
+	fs.BoolVar(&sramThresholdExceeded, "threshold-exceeded", false, "raise the SRAM error threshold flag (sram-ecc)")
 	fs.StringVar(&socket, "socket", envOr("MOCK_NVML_PODRESOURCES_SOCKET", allocwatch.DefaultSocketPath),
 		"kubelet pod-resources socket (watch-allocations)")
 	fs.DurationVar(&interval, "interval", allocwatch.DefaultInterval,
@@ -150,8 +163,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 	case "status":
 		return doStatus(configOverridePath, gpu, stdout, stderr)
 	case "fail", "temp", "temperature", "power", "fan", "util", "utilization",
-		"clocks", "throttle", "pstate", "nvlink-error", "set", "reset":
-		return mutate(cmd, configOverridePath, gpu, mode, links, afterCalls, xid, positional, cfg, base, stdout, stderr)
+		"clocks", "throttle", "pstate", "nvlink-error", "sram-ecc", "set", "reset":
+		sram := sramECCOptions{errorType: sramErrorType, source: sramSource, thresholdExceeded: sramThresholdExceeded}
+		return mutate(cmd, configOverridePath, gpu, mode, links, afterCalls, xid, positional, sram, cfg, base, stdout, stderr)
 	case "watch-allocations":
 		return doWatchAllocations(configOverridePath, socket, interval, usedFraction, cfg, stdout, stderr)
 	default:
@@ -161,9 +175,18 @@ func run(args []string, stdout, stderr io.Writer) int {
 	}
 }
 
+// sramECCOptions carries the sram-ecc command's flags: which SRAM error type to
+// inject, the unit it is attributed to, and whether the error threshold flag is
+// raised.
+type sramECCOptions struct {
+	errorType         string
+	source            string
+	thresholdExceeded bool
+}
+
 //nolint:cyclop // existing complexity; refactor deferred
 func mutate(cmd, configOverridePath, gpu, mode, links string, afterCalls int, xid uint64,
-	positional []string, cfg *engine.Config, base *engine.DeviceConfig, stdout, stderr io.Writer,
+	positional []string, sram sramECCOptions, cfg *engine.Config, base *engine.DeviceConfig, stdout, stderr io.Writer,
 ) int {
 	if gpu == "" && cmd != "reset" {
 		fprintln(stderr, "--gpu is required")
@@ -288,6 +311,20 @@ func mutate(cmd, configOverridePath, gpu, mode, links string, afterCalls int, xi
 			return 2
 		}
 		if code := applyPatch(doc, target, base, mockctl.NVLinkErrorPatch(rate, linkIDs), stderr); code != 0 {
+			return code
+		}
+	case "sram-ecc":
+		count, perr := singleIntArg(positional, cmd, 0, maxSramEccCount)
+		if perr != nil {
+			fprintf(stderr, "%v\n", perr)
+			return 2
+		}
+		patch, perr := mockctl.SramECCPatch(uint64(count), sram.errorType, sram.source, sram.thresholdExceeded)
+		if perr != nil {
+			fprintf(stderr, "%v\n", perr)
+			return 2
+		}
+		if code := applyPatch(doc, target, base, patch, stderr); code != 0 {
 			return code
 		}
 	case "set":

--- a/cmd/nvml-mock-ctl/main_test.go
+++ b/cmd/nvml-mock-ctl/main_test.go
@@ -151,6 +151,25 @@ func TestCLI_NVLinkErrorZeroHeals(t *testing.T) {
 	require.Contains(t, readConfigOverride(t, configOverride), "rate: 0")
 }
 
+func TestCLI_SramECCWritesCounters(t *testing.T) {
+	dir := t.TempDir()
+	configOverride := filepath.Join(dir, "overrides.yaml")
+	_, e, c := runCLI(t, configOverride, "sram-ecc", "--gpu", "0", "--source", "sm", "--threshold-exceeded", "4")
+	require.Equalf(t, 0, c, "sram-ecc exited %d: %s", c, e)
+	s := readConfigOverride(t, configOverride)
+	for _, want := range []string{"sram:", "uncorrectable_secded: 4", "sm: 4", "threshold_exceeded: true"} {
+		require.Containsf(t, s, want, "configOverride missing %q", want)
+	}
+}
+
+func TestCLI_SramECCZeroHeals(t *testing.T) {
+	dir := t.TempDir()
+	configOverride := filepath.Join(dir, "overrides.yaml")
+	_, e, c := runCLI(t, configOverride, "sram-ecc", "--gpu", "0", "0")
+	require.Equalf(t, 0, c, "sram-ecc exited %d: %s", c, e)
+	require.Contains(t, readConfigOverride(t, configOverride), "uncorrectable_secded: 0")
+}
+
 func TestCLI_ConvenienceArgValidation(t *testing.T) {
 	dir := t.TempDir()
 	configOverride := filepath.Join(dir, "overrides.yaml")
@@ -172,6 +191,11 @@ func TestCLI_ConvenienceArgValidation(t *testing.T) {
 		{"nvlink-error", "--gpu", "0", "-5"},                // negative rate (flag.Parse stops at -5 -> missing value)
 		{"nvlink-error", "--gpu", "0", "2000000000"},        // rate over cap
 		{"nvlink-error", "--gpu", "0", "--links", "x", "1"}, // non-integer link id
+		{"sram-ecc", "--gpu", "0"},                          // missing count
+		{"sram-ecc", "--gpu", "0", "--type", "nope", "1"},   // unknown error type
+		{"sram-ecc", "--gpu", "0", "--source", "nope", "1"}, // unknown source
+		// The per-source breakdown only covers uncorrectable errors.
+		{"sram-ecc", "--gpu", "0", "--type", "correctable", "--source", "sm", "1"},
 	}
 	for _, args := range cases {
 		_, _, code := runCLI(t, configOverride, args...)

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/a100.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/a100.yaml
@@ -256,6 +256,18 @@ device_defaults:
     uncorrectable: 0
     pending: false
     failure_occurred: false
+    # Bank remap availability: every bank still holds its full complement of
+    # spare rows, which is what a GPU that has never remapped reports. Row
+    # remapping is Ampere and later, so a pre-Ampere profile (t4) omits this
+    # block and the mock reports the histogram unsupported, as that hardware
+    # does. The bank count follows the 16-banks-per-GiB ratio a real 40 GiB
+    # A100 reports.
+    availability_histogram:
+      max: 640
+      high: 0
+      partial: 0
+      low: 0
+      none: 0
 
   # ---------------------------------------------------------------------------
   # Display configuration

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/b200.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/b200.yaml
@@ -261,6 +261,18 @@ device_defaults:
     uncorrectable: 0
     pending: false
     failure_occurred: false
+    # Bank remap availability: every bank still holds its full complement of
+    # spare rows, which is what a GPU that has never remapped reports. Row
+    # remapping is Ampere and later, so a pre-Ampere profile (t4) omits this
+    # block and the mock reports the histogram unsupported, as that hardware
+    # does. The bank count follows the 16-banks-per-GiB ratio a real 40 GiB
+    # A100 reports.
+    availability_histogram:
+      max: 3072
+      high: 0
+      partial: 0
+      low: 0
+      none: 0
 
   # ---------------------------------------------------------------------------
   # Display configuration

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
@@ -295,6 +295,18 @@ device_defaults:
     uncorrectable: 0
     pending: false
     failure_occurred: false
+    # Bank remap availability: every bank still holds its full complement of
+    # spare rows, which is what a GPU that has never remapped reports. Row
+    # remapping is Ampere and later, so a pre-Ampere profile (t4) omits this
+    # block and the mock reports the histogram unsupported, as that hardware
+    # does. The bank count follows the 16-banks-per-GiB ratio a real 40 GiB
+    # A100 reports.
+    availability_histogram:
+      max: 3072
+      high: 0
+      partial: 0
+      low: 0
+      none: 0
 
   # ---------------------------------------------------------------------------
   # Display configuration

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/gb300.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/gb300.yaml
@@ -297,6 +297,18 @@ device_defaults:
     uncorrectable: 0
     pending: false
     failure_occurred: false
+    # Bank remap availability: every bank still holds its full complement of
+    # spare rows, which is what a GPU that has never remapped reports. Row
+    # remapping is Ampere and later, so a pre-Ampere profile (t4) omits this
+    # block and the mock reports the histogram unsupported, as that hardware
+    # does. The bank count follows the 16-banks-per-GiB ratio a real 40 GiB
+    # A100 reports.
+    availability_histogram:
+      max: 4608
+      high: 0
+      partial: 0
+      low: 0
+      none: 0
 
   # ---------------------------------------------------------------------------
   # Display configuration

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/h100.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/h100.yaml
@@ -266,6 +266,18 @@ device_defaults:
     uncorrectable: 0
     pending: false
     failure_occurred: false
+    # Bank remap availability: every bank still holds its full complement of
+    # spare rows, which is what a GPU that has never remapped reports. Row
+    # remapping is Ampere and later, so a pre-Ampere profile (t4) omits this
+    # block and the mock reports the histogram unsupported, as that hardware
+    # does. The bank count follows the 16-banks-per-GiB ratio a real 40 GiB
+    # A100 reports.
+    availability_histogram:
+      max: 1280
+      high: 0
+      partial: 0
+      low: 0
+      none: 0
 
   # ---------------------------------------------------------------------------
   # Display configuration

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/l40s.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/l40s.yaml
@@ -254,6 +254,18 @@ device_defaults:
     uncorrectable: 0
     pending: false
     failure_occurred: false
+    # Bank remap availability: every bank still holds its full complement of
+    # spare rows, which is what a GPU that has never remapped reports. Row
+    # remapping is Ampere and later, so a pre-Ampere profile (t4) omits this
+    # block and the mock reports the histogram unsupported, as that hardware
+    # does. The bank count follows the 16-banks-per-GiB ratio a real 40 GiB
+    # A100 reports.
+    availability_histogram:
+      max: 768
+      high: 0
+      partial: 0
+      low: 0
+      none: 0
 
   # ---------------------------------------------------------------------------
   # Display configuration

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/t4.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/t4.yaml
@@ -261,6 +261,8 @@ device_defaults:
     uncorrectable: 0
     pending: false
     failure_occurred: false
+    # No availability_histogram: row remapping arrived with Ampere, so Turing
+    # reports the bank histogram as unsupported.
 
   # ---------------------------------------------------------------------------
   # Display configuration

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
@@ -266,6 +266,18 @@ should match snapshot with b200 profile:
             uncorrectable: 0
             pending: false
             failure_occurred: false
+            # Bank remap availability: every bank still holds its full complement of
+            # spare rows, which is what a GPU that has never remapped reports. Row
+            # remapping is Ampere and later, so a pre-Ampere profile (t4) omits this
+            # block and the mock reports the histogram unsupported, as that hardware
+            # does. The bank count follows the 16-banks-per-GiB ratio a real 40 GiB
+            # A100 reports.
+            availability_histogram:
+              max: 3072
+              high: 0
+              partial: 0
+              low: 0
+              none: 0
 
           # ---------------------------------------------------------------------------
           # Display configuration
@@ -729,6 +741,18 @@ should match snapshot with default a100 profile:
             uncorrectable: 0
             pending: false
             failure_occurred: false
+            # Bank remap availability: every bank still holds its full complement of
+            # spare rows, which is what a GPU that has never remapped reports. Row
+            # remapping is Ampere and later, so a pre-Ampere profile (t4) omits this
+            # block and the mock reports the histogram unsupported, as that hardware
+            # does. The bank count follows the 16-banks-per-GiB ratio a real 40 GiB
+            # A100 reports.
+            availability_histogram:
+              max: 640
+              high: 0
+              partial: 0
+              low: 0
+              none: 0
 
           # ---------------------------------------------------------------------------
           # Display configuration
@@ -1239,6 +1263,18 @@ should match snapshot with gb200 profile:
             uncorrectable: 0
             pending: false
             failure_occurred: false
+            # Bank remap availability: every bank still holds its full complement of
+            # spare rows, which is what a GPU that has never remapped reports. Row
+            # remapping is Ampere and later, so a pre-Ampere profile (t4) omits this
+            # block and the mock reports the histogram unsupported, as that hardware
+            # does. The bank count follows the 16-banks-per-GiB ratio a real 40 GiB
+            # A100 reports.
+            availability_histogram:
+              max: 3072
+              high: 0
+              partial: 0
+              low: 0
+              none: 0
 
           # ---------------------------------------------------------------------------
           # Display configuration
@@ -1797,6 +1833,18 @@ should match snapshot with gb300 profile:
             uncorrectable: 0
             pending: false
             failure_occurred: false
+            # Bank remap availability: every bank still holds its full complement of
+            # spare rows, which is what a GPU that has never remapped reports. Row
+            # remapping is Ampere and later, so a pre-Ampere profile (t4) omits this
+            # block and the mock reports the histogram unsupported, as that hardware
+            # does. The bank count follows the 16-banks-per-GiB ratio a real 40 GiB
+            # A100 reports.
+            availability_histogram:
+              max: 4608
+              high: 0
+              partial: 0
+              low: 0
+              none: 0
 
           # ---------------------------------------------------------------------------
           # Display configuration
@@ -2322,6 +2370,18 @@ should match snapshot with h100 profile:
             uncorrectable: 0
             pending: false
             failure_occurred: false
+            # Bank remap availability: every bank still holds its full complement of
+            # spare rows, which is what a GPU that has never remapped reports. Row
+            # remapping is Ampere and later, so a pre-Ampere profile (t4) omits this
+            # block and the mock reports the histogram unsupported, as that hardware
+            # does. The bank count follows the 16-banks-per-GiB ratio a real 40 GiB
+            # A100 reports.
+            availability_histogram:
+              max: 1280
+              high: 0
+              partial: 0
+              low: 0
+              none: 0
 
           # ---------------------------------------------------------------------------
           # Display configuration
@@ -2791,6 +2851,18 @@ should match snapshot with l40s profile:
             uncorrectable: 0
             pending: false
             failure_occurred: false
+            # Bank remap availability: every bank still holds its full complement of
+            # spare rows, which is what a GPU that has never remapped reports. Row
+            # remapping is Ampere and later, so a pre-Ampere profile (t4) omits this
+            # block and the mock reports the histogram unsupported, as that hardware
+            # does. The bank count follows the 16-banks-per-GiB ratio a real 40 GiB
+            # A100 reports.
+            availability_histogram:
+              max: 768
+              high: 0
+              partial: 0
+              low: 0
+              none: 0
 
           # ---------------------------------------------------------------------------
           # Display configuration
@@ -3226,6 +3298,8 @@ should match snapshot with t4 profile:
             uncorrectable: 0
             pending: false
             failure_occurred: false
+            # No availability_histogram: row remapping arrived with Ampere, so Turing
+            # reports the bank histogram as unsupported.
 
           # ---------------------------------------------------------------------------
           # Display configuration

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -19,7 +19,7 @@ should match snapshot with all overrides:
       template:
         metadata:
           annotations:
-            checksum/config: 1893be873c970041a080b07af3cc840fb218a12192a6f0e5c305ba70a12ce620
+            checksum/config: 3c7c93d7e37bb5597589d285c34278a619be2dfedc35d204ba0bb2dd04c09a35
           labels:
             app.kubernetes.io/component: daemon
             app.kubernetes.io/instance: custom
@@ -166,7 +166,7 @@ should match snapshot with b200 profile:
       template:
         metadata:
           annotations:
-            checksum/config: 25749368d74f6ae7ce538ddfa371e30c93ec11a4968b155c683b914e05f76b81
+            checksum/config: 34bbeafe005d65c19de791d4d2d65ac68868aa562c4fb5c00aa86f7b05d5ec5c
           labels:
             app.kubernetes.io/component: daemon
             app.kubernetes.io/instance: RELEASE-NAME
@@ -292,7 +292,7 @@ should match snapshot with default values:
       template:
         metadata:
           annotations:
-            checksum/config: 4a1427c36fb9a24923ec692eb82cd2ba449715be5e194942ae26549a1d1f81b3
+            checksum/config: a66f0f0e6622369198c9e8ba677b92c714c8e25783dba2e5ae6cf7028fecb927
           labels:
             app.kubernetes.io/component: daemon
             app.kubernetes.io/instance: RELEASE-NAME

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -287,6 +287,63 @@ device_defaults:
           total: 0
 ```
 
+#### SRAM ECC
+
+Hardware counts on-die SRAM errors separately from the DRAM counters above and
+reports them through their own API, so they are a sibling block rather than
+another memory location under `errors`. Omitting the block reports zeros, which
+is what a healthy ECC-enabled GPU does; with ECC off the counters are reported
+unsupported (`N/A`), as on real hardware.
+
+```yaml
+device_defaults:
+  ecc:
+    sram:
+      volatile:                         # reset when the driver reloads
+        correctable: 0
+        uncorrectable_parity: 0
+        uncorrectable_secded: 0
+      aggregate:                        # persisted in the InfoROM
+        correctable: 0
+        uncorrectable_parity: 0
+        uncorrectable_secded: 0
+      # Which unit reported the aggregate uncorrectable errors; nvidia-smi
+      # renders it as "Aggregate Uncorrectable SRAM Sources".
+      uncorrectable_sources:
+        l2: 0
+        sm: 0
+        microcontroller: 0
+        pcie: 0
+        other: 0
+      # Whether the accumulated errors passed the driver's threshold — the
+      # signal that the GPU needs servicing rather than just a count going up.
+      threshold_exceeded: false
+```
+
+Inject these at runtime with `nvml-mock-ctl sram-ecc` (see
+[nvml-mock-ctl.md](nvml-mock-ctl.md)).
+
+### Remapped rows
+
+`availability_histogram` is how many memory banks still have spare rows to remap
+future failures. Row remapping is Ampere and later, so leaving the block out —
+as `t4` does — reports the histogram as unsupported.
+
+```yaml
+device_defaults:
+  remapped_rows:
+    correctable: 0
+    uncorrectable: 0
+    pending: false
+    failure_occurred: false
+    availability_histogram:
+      max: 640                          # banks with full spare capacity
+      high: 0
+      partial: 0
+      low: 0
+      none: 0                           # banks with no capacity left
+```
+
 ### Display
 
 ```yaml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -323,6 +323,13 @@ device_defaults:
 Inject these at runtime with `nvml-mock-ctl sram-ecc` (see
 [nvml-mock-ctl.md](nvml-mock-ctl.md)).
 
+How `nvidia-smi` renders these counters depends on the profile's
+`architecture`, mirroring real hardware: Ampere and later split the uncorrectable
+count into `SRAM Uncorrectable Parity` and `SRAM Uncorrectable SEC-DED` and print
+the source breakdown and threshold flag, while pre-Ampere (`t4`) prints one
+combined `SRAM Uncorrectable` row and omits the rest. The configuration is the
+same either way — only the presentation differs.
+
 ### Remapped rows
 
 `availability_histogram` is how many memory banks still have spare rows to remap

--- a/docs/nvml-mock-ctl.md
+++ b/docs/nvml-mock-ctl.md
@@ -105,6 +105,9 @@ commands:
   throttle --gpu <idx|all|uuid> <reason>[ reason ...]  set active throttle reasons ('none' clears)
   pstate --gpu <idx|all|uuid> <0-15>       pin reported performance state (P-state)
   nvlink-error --gpu <idx|all|uuid> <errors_per_sec> [--links a,b,c]  inject NVLink DL errors (0 heals)
+  sram-ecc --gpu <idx|all|uuid> <count> [--type correctable|parity|secded]
+           [--source l2|sm|microcontroller|pcie|other] [--threshold-exceeded]
+                                           inject SRAM ECC errors (0 heals)
   set    --gpu <idx|all|uuid> key.path=value [key.path=value ...]
   status [--gpu <idx>]
   reset  [--gpu <idx|all|uuid>]
@@ -237,12 +240,47 @@ target all active links (the "GPU lost its switch uplinks" fault).
 > the switch-link fault NVSentinel's gpu-health-monitor can actually detect and
 > remediate.
 
+### `sram-ecc` — inject on-die SRAM ECC errors
+
+Sets the target's `ecc.sram` counters, so the GPU reports SRAM errors the way one
+that has just taken an SRAM fault does. The positional argument is the error
+**count** (0–1e9); `0` heals.
+
+```bash
+# 4 uncorrectable SEC-DED errors on GPU 0's SM, past the service threshold
+kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl sram-ecc --gpu 0 \
+  --type secded --source sm --threshold-exceeded 4
+# correctable errors (no source attribution on real hardware)
+kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl sram-ecc --gpu 0 --type correctable 12
+# heal
+kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl sram-ecc --gpu 0 0
+```
+
+| flag                   | meaning                                                                                   |
+| ---------------------- | ----------------------------------------------------------------------------------------- |
+| `--type`               | `correctable`, `parity` or `secded` (uncorrectable SEC-DED, the default)                   |
+| `--source`             | the unit the *uncorrectable* errors are attributed to; defaults to `other`                 |
+| `--threshold-exceeded` | raises `SRAM Threshold Exceeded`, the driver's "this GPU needs servicing" signal          |
+
+The count lands in **both** the volatile and aggregate scopes: hardware that has
+just taken an SRAM fault reports it in both, and pinning only one would leave a
+GPU whose history disagrees with its present. Within `ecc.sram` the command is
+*authoritative* — every counter and source is written — so repeated calls replace
+rather than accumulate, and `--source` moves the whole count to the named unit.
+The ECC mode is left alone, since a GPU with ECC off reports no SRAM counters at
+all and the injection would erase itself.
+
+Values surface in `nvidia-smi -q` under `ECC Errors` (both scopes, `SRAM
+Threshold Exceeded` and `Aggregate Uncorrectable SRAM Sources`) and through the
+per-location field values DCGM reads.
+
 ### `set` — set arbitrary fields
 
 `set` takes one or more `key.path=value` pairs. The path is the YAML/JSON path
 into the device config; the value is parsed as a YAML scalar (so numbers, bools,
 and strings get their natural type). Example paths: `thermal.temperature_gpu_c`,
-`utilization.gpu`, `ecc.mode_current`, `power.current_draw_mw`.
+`utilization.gpu`, `ecc.mode_current`, `power.current_draw_mw`,
+`remapped_rows.availability_histogram.low`.
 
 #### Dynamic metrics mask their static counterparts
 

--- a/pkg/gpu/mockctl/config_override.go
+++ b/pkg/gpu/mockctl/config_override.go
@@ -244,6 +244,89 @@ func NVLinkErrorPatch(rate float64, links []int) map[string]any {
 	return map[string]any{"nvlink_error": block}
 }
 
+// sramErrorTypeKeys maps CLI-friendly SRAM error-type names to the
+// ecc.sram counter they fill. Parity and SEC-DED are the two uncorrectable
+// flavours hardware distinguishes; correctable errors have no source
+// breakdown.
+var sramErrorTypeKeys = map[string]string{
+	"correctable": "correctable",
+	"parity":      "uncorrectable_parity",
+	"secded":      "uncorrectable_secded",
+}
+
+// sramSourceKeys maps CLI-friendly unit names to the
+// ecc.sram.uncorrectable_sources field that attributes errors to them.
+var sramSourceKeys = map[string]string{
+	"l2":              "l2",
+	"sm":              "sm",
+	"microcontroller": "microcontroller",
+	"mcu":             "microcontroller",
+	"pcie":            "pcie",
+	"other":           "other",
+}
+
+// allSramSourceKeys is the full set of source fields, written as an all-zero
+// baseline so a patch represents exactly the requested attribution.
+var allSramSourceKeys = []string{"l2", "sm", "microcontroller", "pcie", "other"}
+
+// SramECCPatch builds a config override patch that injects count SRAM ECC
+// errors of one type (correctable, uncorrectable parity or uncorrectable
+// SEC-DED), attributed to one reporting unit, optionally raising the
+// SRAM error threshold flag. A count of 0 heals the device.
+//
+// The count lands in both the volatile and aggregate scopes: hardware that has
+// just taken an SRAM fault reports it in both, and pinning only one would leave
+// the other reading as a GPU whose history disagrees with its present.
+//
+// Only the ecc.sram sub-block is written, never the whole ecc block: replacing
+// ecc would drop mode_current, and a GPU with ECC off reports no SRAM counters
+// at all, so the injection would erase itself. Within ecc.sram the patch is
+// authoritative — every counter and source is written — so repeated
+// invocations replace rather than accumulate.
+func SramECCPatch(count uint64, errorType, source string, thresholdExceeded bool) (map[string]any, error) {
+	counterKey, ok := sramErrorTypeKeys[strings.ToLower(strings.TrimSpace(errorType))]
+	if !ok {
+		return nil, fmt.Errorf("unknown SRAM error type %q (want correctable|parity|secded)", errorType)
+	}
+	correctable := counterKey == "correctable"
+	source = strings.ToLower(strings.TrimSpace(source))
+	if correctable && source != "" {
+		return nil, errors.New("--source only applies to uncorrectable SRAM errors")
+	}
+	sourceKey := ""
+	if !correctable {
+		if source == "" {
+			source = "other" // unattributed errors land in the catch-all bucket
+		}
+		if sourceKey, ok = sramSourceKeys[source]; !ok {
+			return nil, fmt.Errorf("unknown SRAM error source %q (want l2|sm|microcontroller|pcie|other)", source)
+		}
+	}
+
+	counts := func() map[string]any {
+		c := map[string]any{"correctable": 0, "uncorrectable_parity": 0, "uncorrectable_secded": 0}
+		c[counterKey] = count
+		return c
+	}
+	sources := map[string]any{}
+	for _, k := range allSramSourceKeys {
+		sources[k] = 0
+	}
+	if sourceKey != "" {
+		sources[sourceKey] = count
+	}
+	return map[string]any{
+		"ecc": map[string]any{
+			"sram": map[string]any{
+				"volatile":              counts(),
+				"aggregate":             counts(),
+				"uncorrectable_sources": sources,
+				"threshold_exceeded":    thresholdExceeded,
+			},
+		},
+	}, nil
+}
+
 // throttleReasonKeys maps CLI-friendly throttle reason names to the
 // clocks_throttle_reasons config field they enable. The canonical JSON keys are
 // accepted directly; short aliases cover the common thermal/power cases.

--- a/pkg/gpu/mockctl/config_override_test.go
+++ b/pkg/gpu/mockctl/config_override_test.go
@@ -199,6 +199,70 @@ func TestNVLinkErrorPatch_ZeroRateHeals(t *testing.T) {
 	require.InDelta(t, float64(0), merged.NVLinkError.Rate, 1e-9, "rate 0 is the healthy/no-injection value")
 }
 
+func TestSramECCPatch_InjectsCountsAndSource(t *testing.T) {
+	patch, err := SramECCPatch(5, "secded", "sm", true)
+	require.NoError(t, err)
+	require.NoError(t, Validate(&engine.DeviceConfig{}, patch))
+
+	merged, err := engine.MergeDeviceConfig(&engine.DeviceConfig{}, patch)
+	require.NoError(t, err)
+	sram := merged.ECC.SRAM
+	require.NotNil(t, sram)
+	require.Equal(t, uint64(5), sram.Volatile.UncorrectableSECDED)
+	require.Equal(t, uint64(5), sram.Aggregate.UncorrectableSECDED)
+	require.Zero(t, sram.Aggregate.UncorrectableParity, "only the requested error type is injected")
+	require.Equal(t, uint64(5), sram.UncorrectableSources.SM, "the breakdown must attribute the errors to --source")
+	require.Zero(t, sram.UncorrectableSources.L2)
+	require.True(t, sram.ThresholdExceeded)
+}
+
+// TestSramECCPatch_PreservesEccMode guards the trap in patching a nested block:
+// clobbering ecc wholesale would turn ECC off, and an ECC-off GPU reports no
+// SRAM counters at all — the injection would silently undo itself.
+func TestSramECCPatch_PreservesEccMode(t *testing.T) {
+	base := &engine.DeviceConfig{
+		ECC: &engine.ECCConfig{ModeCurrent: "enabled", ModePending: "enabled"},
+	}
+	patch, err := SramECCPatch(3, "parity", "l2", false)
+	require.NoError(t, err)
+
+	merged, err := engine.MergeDeviceConfig(base, patch)
+	require.NoError(t, err)
+	require.Equal(t, "enabled", merged.ECC.ModeCurrent)
+	require.Equal(t, uint64(3), merged.ECC.SRAM.Aggregate.UncorrectableParity)
+	require.Equal(t, uint64(3), merged.ECC.SRAM.UncorrectableSources.L2)
+}
+
+func TestSramECCPatch_ZeroCountHeals(t *testing.T) {
+	base := &engine.DeviceConfig{
+		ECC: &engine.ECCConfig{
+			ModeCurrent: "enabled",
+			SRAM: &engine.ECCSramConfig{
+				Aggregate:            &engine.ECCSramCountsConfig{UncorrectableSECDED: 9},
+				UncorrectableSources: &engine.ECCSramSourcesConfig{SM: 9},
+				ThresholdExceeded:    true,
+			},
+		},
+	}
+	patch, err := SramECCPatch(0, "secded", "", false)
+	require.NoError(t, err)
+
+	merged, err := engine.MergeDeviceConfig(base, patch)
+	require.NoError(t, err)
+	require.Zero(t, merged.ECC.SRAM.Aggregate.UncorrectableSECDED, "count 0 is the healthy value")
+	require.Zero(t, merged.ECC.SRAM.UncorrectableSources.SM, "healing must clear the source breakdown too")
+	require.False(t, merged.ECC.SRAM.ThresholdExceeded, "healing must clear the threshold flag")
+}
+
+func TestSramECCPatch_Errors(t *testing.T) {
+	_, err := SramECCPatch(1, "banana", "", false)
+	require.Error(t, err, "expected error for unknown error type")
+	_, err = SramECCPatch(1, "secded", "banana", false)
+	require.Error(t, err, "expected error for unknown source")
+	_, err = SramECCPatch(1, "correctable", "sm", false)
+	require.Error(t, err, "the source breakdown only covers uncorrectable errors")
+}
+
 func TestThrottlePatch_AuthoritativeFlags(t *testing.T) {
 	patch, err := ThrottlePatch([]string{"thermal"})
 	require.NoError(t, err)

--- a/pkg/gpu/mocknvml/bridge/ecc.go
+++ b/pkg/gpu/mocknvml/bridge/ecc.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main provides the NVML SRAM ECC and row-remap availability
+// functions. Both were generated stubs, which made every SRAM row of
+// `nvidia-smi -q` and the bank availability histogram report N/A — a consumer
+// could not tell a healthy GPU from one whose SRAM the mock simply refused to
+// describe. See issue NVIDIA/k8s-test-infra#641.
+package main
+
+/*
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "nvml_types.h"
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
+)
+
+// sramEccErrorStatusVersion is the tag a caller must stamp into
+// nvmlEccSramErrorStatus_t.version, encoding both the struct version and its
+// size the way the upstream NVML_STRUCT_VERSION macro does. Requiring an exact
+// match is what keeps the writes below inside the caller's allocation: a
+// caller built against a differently sized layout gets
+// ARGUMENT_VERSION_MISMATCH rather than a buffer overrun.
+func sramEccErrorStatusVersion() uint32 {
+	return FabricStructVersion(unsafe.Sizeof(C.nvmlEccSramErrorStatus_t{}), 1)
+}
+
+//export nvmlDeviceGetSramEccErrorStatus
+func nvmlDeviceGetSramEccErrorStatus(device C.nvmlDevice_t, status *C.nvmlEccSramErrorStatus_t) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetSramEccErrorStatus"); !ok {
+		return ret
+	}
+	if status == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	if uint32(status.version) != sramEccErrorStatusVersion() {
+		return C.NVML_ERROR_ARGUMENT_VERSION_MISMATCH
+	}
+	handle := unsafe.Pointer(device.handle)
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	sram, ret := dev.GetSramEccErrorStatus()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	status.aggregateUncParity = C.ulonglong(sram.AggregateUncParity)
+	status.aggregateUncSecDed = C.ulonglong(sram.AggregateUncSecDed)
+	status.aggregateCor = C.ulonglong(sram.AggregateCor)
+	status.volatileUncParity = C.ulonglong(sram.VolatileUncParity)
+	status.volatileUncSecDed = C.ulonglong(sram.VolatileUncSecDed)
+	status.volatileCor = C.ulonglong(sram.VolatileCor)
+	status.aggregateUncBucketL2 = C.ulonglong(sram.AggregateUncBucketL2)
+	status.aggregateUncBucketSm = C.ulonglong(sram.AggregateUncBucketSm)
+	status.aggregateUncBucketPcie = C.ulonglong(sram.AggregateUncBucketPcie)
+	status.aggregateUncBucketMcu = C.ulonglong(sram.AggregateUncBucketMcu)
+	status.aggregateUncBucketOther = C.ulonglong(sram.AggregateUncBucketOther)
+	status.bThresholdExceeded = C.uint(sram.BThresholdExceeded)
+	return C.NVML_SUCCESS
+}
+
+//export nvmlDeviceGetRowRemapperHistogram
+func nvmlDeviceGetRowRemapperHistogram(device C.nvmlDevice_t, values *C.nvmlRowRemapperHistogramValues_t) C.nvmlReturn_t {
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetRowRemapperHistogram"); !ok {
+		return ret
+	}
+	if values == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	handle := unsafe.Pointer(device.handle)
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	histogram, ret := dev.GetRowRemapperHistogram()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	values.max = C.uint(histogram.Max)
+	values.high = C.uint(histogram.High)
+	values.partial = C.uint(histogram.Partial)
+	values.low = C.uint(histogram.Low)
+	values.none = C.uint(histogram.None)
+	return C.NVML_SUCCESS
+}

--- a/pkg/gpu/mocknvml/bridge/ecc_layout_test.go
+++ b/pkg/gpu/mocknvml/bridge/ecc_layout_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Layout tests for the ECC structs the bridge writes into. See
+// fabric_layout_test.go for why the expected sizes are constants rather than
+// C.sizeof_* reads.
+//
+// The SRAM status size matters twice over: the bridge writes twelve fields into
+// a caller-allocated buffer, and the size is half of the version tag the caller
+// must present, so drift would turn every SRAM query into a version mismatch.
+
+package main
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
+)
+
+// Expected byte sizes derived from nvml_types.h field-by-field. Update in
+// lockstep with any C struct change.
+//
+//	EccSramErrorStatus: version(4) + 4 pad + 11 * 8 + bThresholdExceeded(4)
+//	                    + 4 trailing pad = 104
+//	RowRemapperHistogramValues: 5 * 4 = 20
+const (
+	expectedEccSramErrorStatusSize         uintptr = 104
+	expectedRowRemapperHistogramValuesSize uintptr = 20
+)
+
+func TestECCStructLayouts(t *testing.T) {
+	cases := []struct {
+		name     string
+		goSize   uintptr
+		expected uintptr
+	}{
+		{"EccSramErrorStatus", unsafe.Sizeof(nvml.EccSramErrorStatus{}), expectedEccSramErrorStatusSize},
+		{"EccSramErrorStatus_v1", unsafe.Sizeof(nvml.EccSramErrorStatus_v1{}), expectedEccSramErrorStatusSize},
+		{
+			"RowRemapperHistogramValues",
+			unsafe.Sizeof(nvml.RowRemapperHistogramValues{}),
+			expectedRowRemapperHistogramValuesSize,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.goSize,
+				"%s: go-nvml = %d bytes, C layout expects %d bytes — ABI drift; update either go-nvml vendor or nvml_types.h",
+				tc.name, tc.goSize, tc.expected)
+		})
+	}
+}
+
+// TestEccSramErrorStatusVersion_MatchesGoNvml pins the version tag the bridge
+// demands against the one a caller built from go-nvml's STRUCT_VERSION helper
+// produces. nvidia-smi stamps this field before calling; if the two ever
+// disagree, every SRAM query answers ARGUMENT_VERSION_MISMATCH and the SRAM
+// rows silently go back to reporting N/A.
+func TestEccSramErrorStatusVersion_MatchesGoNvml(t *testing.T) {
+	theirs := nvml.STRUCT_VERSION(nvml.EccSramErrorStatus_v1{}, 1)
+	ours := FabricStructVersion(expectedEccSramErrorStatusSize, 1)
+	require.Equal(t, theirs, ours)
+}

--- a/pkg/gpu/mocknvml/bridge/ecc_layout_test.go
+++ b/pkg/gpu/mocknvml/bridge/ecc_layout_test.go
@@ -68,8 +68,19 @@ func TestECCStructLayouts(t *testing.T) {
 // produces. nvidia-smi stamps this field before calling; if the two ever
 // disagree, every SRAM query answers ARGUMENT_VERSION_MISMATCH and the SRAM
 // rows silently go back to reporting N/A.
+//
+// Calling the production function is what makes this a real pin: it reads
+// sizeof(C.nvmlEccSramErrorStatus_t), so the C struct sits on one side of the
+// comparison and go-nvml's on the other. Recomputing the tag from
+// expectedEccSramErrorStatusSize instead would compare two Go-derived values and
+// stay green through exactly the C-side drift described above. The size constant
+// still earns its keep in TestECCStructLayouts, where it documents the
+// hand-written layout that nvml_types.h is supposed to have.
 func TestEccSramErrorStatusVersion_MatchesGoNvml(t *testing.T) {
 	theirs := nvml.STRUCT_VERSION(nvml.EccSramErrorStatus_v1{}, 1)
-	ours := FabricStructVersion(expectedEccSramErrorStatusSize, 1)
-	require.Equal(t, theirs, ours)
+	ours := sramEccErrorStatusVersion()
+	require.Equal(t, theirs, ours,
+		"bridge demands 0x%x, a go-nvml caller stamps 0x%x — every SRAM query would answer "+
+			"ARGUMENT_VERSION_MISMATCH; reconcile nvml_types.h with the vendored go-nvml struct",
+		ours, theirs)
 }

--- a/pkg/gpu/mocknvml/bridge/fabric.go
+++ b/pkg/gpu/mocknvml/bridge/fabric.go
@@ -41,9 +41,10 @@ import (
 // FabricStructVersion encodes (size, version) the same way the upstream
 // NVML_STRUCT_VERSION(struct, N) macro does — size in the low 24 bits,
 // version in the high 8 — so callers built against the real NVML header
-// produce matching tags. Used by nvmlDeviceGetGpuFabricInfoV's dispatch
-// switch; pure-Go tests in fabric_dispatch_test.go pin this against
-// go-nvml's STRUCT_VERSION helper.
+// produce matching tags. Named for its first caller,
+// nvmlDeviceGetGpuFabricInfoV's dispatch switch, but it is the encoding every
+// versioned struct uses (see ecc.go); pure-Go tests in fabric_dispatch_test.go
+// pin this against go-nvml's STRUCT_VERSION helper.
 func FabricStructVersion(size uintptr, version uint32) uint32 {
 	return uint32(size) | (version << 24)
 }

--- a/pkg/gpu/mocknvml/bridge/nvml_types.h
+++ b/pkg/gpu/mocknvml/bridge/nvml_types.h
@@ -286,7 +286,28 @@ typedef struct nvmlEccErrorCounts_st {
     unsigned long long deviceMemory;
     unsigned long long registerFile;
 } nvmlEccErrorCounts_t;
-typedef struct nvmlEccSramErrorStatus_st                    nvmlEccSramErrorStatus_t;
+/* SRAM ECC error status — full definition needed by the bridge so
+ * nvmlDeviceGetSramEccErrorStatus can populate the caller's buffer (issue
+ * #641). version is an input the caller stamps with the NVML_STRUCT_VERSION
+ * macro; the rest are outputs. Layout matches
+ * vendor/github.com/NVIDIA/go-nvml/pkg/nvml/nvml.h (v1), pinned by
+ * ecc_layout_test.go. */
+typedef struct nvmlEccSramErrorStatus_st
+{
+    unsigned int       version;                 //!< IN: NVML_STRUCT_VERSION(EccSramErrorStatus, 1)
+    unsigned long long aggregateUncParity;
+    unsigned long long aggregateUncSecDed;
+    unsigned long long aggregateCor;
+    unsigned long long volatileUncParity;
+    unsigned long long volatileUncSecDed;
+    unsigned long long volatileCor;
+    unsigned long long aggregateUncBucketL2;
+    unsigned long long aggregateUncBucketSm;
+    unsigned long long aggregateUncBucketPcie;
+    unsigned long long aggregateUncBucketMcu;
+    unsigned long long aggregateUncBucketOther;
+    unsigned int       bThresholdExceeded;
+} nvmlEccSramErrorStatus_t;
 typedef struct nvmlEccSramUniqueUncorrectedErrorCounts_st   nvmlEccSramUniqueUncorrectedErrorCounts_t;
 typedef struct nvmlEncoderSessionInfo_st                    nvmlEncoderSessionInfo_t;
 /* Event data - full definition needed by bridge so the failure-injection
@@ -535,7 +556,18 @@ typedef struct nvmlProcessUtilizationSample_st
 } nvmlProcessUtilizationSample_t;
 typedef struct nvmlProcessesUtilizationInfo_st              nvmlProcessesUtilizationInfo_t;
 typedef struct nvmlRepairStatus_st                          nvmlRepairStatus_t;
-typedef struct nvmlRowRemapperHistogramValues_st            nvmlRowRemapperHistogramValues_t;
+/* Row-remap availability histogram — full definition needed by the bridge so
+ * nvmlDeviceGetRowRemapperHistogram can populate the caller's buffer (issue
+ * #641). Each field counts the memory banks with that much remap capacity
+ * left. Layout matches the upstream NVML header. */
+typedef struct nvmlRowRemapperHistogramValues_st
+{
+    unsigned int max;
+    unsigned int high;
+    unsigned int partial;
+    unsigned int low;
+    unsigned int none;
+} nvmlRowRemapperHistogramValues_t;
 typedef struct nvmlSample_st                                nvmlSample_t;
 typedef struct nvmlSystemConfComputeSettings_st             nvmlSystemConfComputeSettings_t;
 typedef struct nvmlSystemDriverBranchInfo_st                nvmlSystemDriverBranchInfo_t;

--- a/pkg/gpu/mocknvml/bridge/stubs_generated.go
+++ b/pkg/gpu/mocknvml/bridge/stubs_generated.go
@@ -21,7 +21,7 @@ package main
 */
 import "C"
 
-// 266 stub functions for unimplemented NVML functions.
+// 264 stub functions for unimplemented NVML functions.
 // These return NVML_ERROR_NOT_SUPPORTED (3).
 
 //export nvmlComputeInstanceDestroy
@@ -464,11 +464,6 @@ func nvmlDeviceGetRepairStatus(device C.nvmlDevice_t, repairStatus *C.nvmlRepair
 	return stubReturn("nvmlDeviceGetRepairStatus")
 }
 
-//export nvmlDeviceGetRowRemapperHistogram
-func nvmlDeviceGetRowRemapperHistogram(device C.nvmlDevice_t, values *C.nvmlRowRemapperHistogramValues_t) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetRowRemapperHistogram")
-}
-
 //export nvmlDeviceGetRunningProcessDetailList
 func nvmlDeviceGetRunningProcessDetailList(device C.nvmlDevice_t, plist *C.nvmlProcessDetailList_t) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetRunningProcessDetailList")
@@ -477,11 +472,6 @@ func nvmlDeviceGetRunningProcessDetailList(device C.nvmlDevice_t, plist *C.nvmlP
 //export nvmlDeviceGetSamples
 func nvmlDeviceGetSamples(device C.nvmlDevice_t, _type C.nvmlSamplingType_t, lastSeenTimeStamp C.ulonglong, sampleValType *C.nvmlValueType_t, sampleCount *C.uint, samples *C.nvmlSample_t) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetSamples")
-}
-
-//export nvmlDeviceGetSramEccErrorStatus
-func nvmlDeviceGetSramEccErrorStatus(device C.nvmlDevice_t, status *C.nvmlEccSramErrorStatus_t) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetSramEccErrorStatus")
 }
 
 //export nvmlDeviceGetSramUniqueUncorrectedEccErrorCounts

--- a/pkg/gpu/mocknvml/engine/config_types.go
+++ b/pkg/gpu/mocknvml/engine/config_types.go
@@ -383,6 +383,42 @@ type ECCConfig struct {
 	ModePending string           `json:"mode_pending,omitempty"`
 	DefaultMode string           `json:"default_mode,omitempty"`
 	Errors      *ECCErrorsConfig `json:"errors,omitempty"`
+	SRAM        *ECCSramConfig   `json:"sram,omitempty"`
+}
+
+// ECCSramConfig defines the on-die SRAM ECC error state. Hardware counts SRAM
+// errors separately from the DRAM counters in Errors and reports them through
+// their own API (nvmlDeviceGetSramEccErrorStatus), which is why they are a
+// sibling block rather than another memory location under errors.
+type ECCSramConfig struct {
+	Volatile  *ECCSramCountsConfig `json:"volatile,omitempty"`
+	Aggregate *ECCSramCountsConfig `json:"aggregate,omitempty"`
+	// UncorrectableSources attributes the aggregate uncorrectable errors to the
+	// unit that reported them; nvidia-smi renders it as "Aggregate
+	// Uncorrectable SRAM Sources".
+	UncorrectableSources *ECCSramSourcesConfig `json:"uncorrectable_sources,omitempty"`
+	// ThresholdExceeded reports whether the accumulated SRAM errors have passed
+	// the driver's threshold — the signal that the GPU needs servicing rather
+	// than just a count that went up.
+	ThresholdExceeded bool `json:"threshold_exceeded,omitempty"`
+}
+
+// ECCSramCountsConfig defines the SRAM error counts for one scope (volatile,
+// reset at driver reload, or aggregate, persisted in the InfoROM).
+type ECCSramCountsConfig struct {
+	Correctable         uint64 `json:"correctable,omitempty"`
+	UncorrectableParity uint64 `json:"uncorrectable_parity,omitempty"`
+	UncorrectableSECDED uint64 `json:"uncorrectable_secded,omitempty"`
+}
+
+// ECCSramSourcesConfig defines the per-unit breakdown of aggregate
+// uncorrectable SRAM errors.
+type ECCSramSourcesConfig struct {
+	L2              uint64 `json:"l2,omitempty"`
+	SM              uint64 `json:"sm,omitempty"`
+	Microcontroller uint64 `json:"microcontroller,omitempty"`
+	PCIe            uint64 `json:"pcie,omitempty"`
+	Other           uint64 `json:"other,omitempty"`
 }
 
 // ECCErrorsConfig defines ECC error counts
@@ -423,10 +459,23 @@ type RetirementInfoConfig struct {
 
 // RemappedRowsConfig defines remapped rows information
 type RemappedRowsConfig struct {
-	Correctable     int  `json:"correctable,omitempty"`
-	Uncorrectable   int  `json:"uncorrectable,omitempty"`
-	Pending         bool `json:"pending,omitempty"`
-	FailureOccurred bool `json:"failure_occurred,omitempty"`
+	Correctable           int                      `json:"correctable,omitempty"`
+	Uncorrectable         int                      `json:"uncorrectable,omitempty"`
+	Pending               bool                     `json:"pending,omitempty"`
+	FailureOccurred       bool                     `json:"failure_occurred,omitempty"`
+	AvailabilityHistogram *RowRemapHistogramConfig `json:"availability_histogram,omitempty"`
+}
+
+// RowRemapHistogramConfig defines how many memory banks fall into each
+// row-remap availability bucket, i.e. how much spare capacity is left to
+// remap future failures. Row remapping is Ampere and later, so leaving this
+// unset makes the mock report the feature as unsupported.
+type RowRemapHistogramConfig struct {
+	Max     uint32 `json:"max,omitempty"`
+	High    uint32 `json:"high,omitempty"`
+	Partial uint32 `json:"partial,omitempty"`
+	Low     uint32 `json:"low,omitempty"`
+	None    uint32 `json:"none,omitempty"`
 }
 
 // DisplayConfig defines display output settings

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -1890,40 +1890,198 @@ func (d *ConfigurableDevice) GetPcieThroughput(counter nvml.PcieUtilCounter) (ui
 	return 0, nvml.SUCCESS
 }
 
-// GetTotalEccErrors returns total ECC errors. Healthy devices report
-// zero. When failure injection has tripped into ecc_uncorrectable mode
-// the running call counter is surfaced as the uncorrectable count so
-// each subsequent NVML poll sees a strictly increasing value (matching
-// real hardware accumulating ECC events).
-func (d *ConfigurableDevice) GetTotalEccErrors(errorType nvml.MemoryErrorType, _ nvml.EccCounterType) (uint64, nvml.Return) {
+// GetTotalEccErrors returns the aggregate or volatile ECC error total from
+// ecc.errors, so a profile can present a GPU that has already accumulated
+// errors. When failure injection has tripped into ecc_uncorrectable mode the
+// running call counter is added to the uncorrectable count so each subsequent
+// NVML poll sees a strictly increasing value (matching real hardware
+// accumulating ECC events).
+func (d *ConfigurableDevice) GetTotalEccErrors(errorType nvml.MemoryErrorType, counterType nvml.EccCounterType) (uint64, nvml.Return) {
 	if ret := d.tickFailure(); ret != nvml.SUCCESS {
 		return 0, ret
 	}
 	count := uint64(0)
-	if fi := d.failureInjector(); fi != nil && fi.IsECCUncorrectable() && errorType == nvml.MEMORY_ERROR_TYPE_UNCORRECTED {
-		count = uint64(fi.CallCount())
+	if errs := eccMemoryErrors(d.eccErrorCounts(counterType), errorType); errs != nil {
+		count = errs.Total
 	}
-	debugLog("[NVML] nvmlDeviceGetTotalEccErrors(errType=%d) -> %d\n", errorType, count)
+	if fi := d.failureInjector(); fi != nil && fi.IsECCUncorrectable() && errorType == nvml.MEMORY_ERROR_TYPE_UNCORRECTED {
+		count += uint64(fi.CallCount())
+	}
+	debugLog("[NVML] nvmlDeviceGetTotalEccErrors(errType=%d counterType=%d) -> %d\n", errorType, counterType, count)
 	return count, nvml.SUCCESS
 }
 
-// GetMemoryErrorCounter returns the per-location memory-error counter.
-// Healthy devices report zero. ecc_uncorrectable mode reports the running
-// call count for the uncorrected counter on device memory, mirroring the
-// total error count so callers correlating the two queries see a
-// consistent view.
-func (d *ConfigurableDevice) GetMemoryErrorCounter(errorType nvml.MemoryErrorType, _ nvml.EccCounterType, locationType nvml.MemoryLocation) (uint64, nvml.Return) {
+// GetMemoryErrorCounter returns the ECC error counter for one
+// (error type, counter type, memory location) triple. Every argument is
+// honoured: DRAM and SRAM are backed by separate configuration, so a consumer
+// reading them apart — as fault-handling software does when deciding whether a
+// fault is repairable — sees distinct counts rather than one shared number.
+// ecc_uncorrectable injection accrues on device memory, mirroring the total
+// error count so callers correlating the two queries see a consistent view.
+func (d *ConfigurableDevice) GetMemoryErrorCounter(errorType nvml.MemoryErrorType, counterType nvml.EccCounterType, locationType nvml.MemoryLocation) (uint64, nvml.Return) {
 	if ret := d.tickFailure(); ret != nvml.SUCCESS {
 		return 0, ret
 	}
-	count := uint64(0)
+	count := d.eccLocationErrors(errorType, counterType, locationType)
 	if fi := d.failureInjector(); fi != nil && fi.IsECCUncorrectable() &&
 		errorType == nvml.MEMORY_ERROR_TYPE_UNCORRECTED &&
 		locationType == nvml.MEMORY_LOCATION_DEVICE_MEMORY {
-		count = uint64(fi.CallCount())
+		count += uint64(fi.CallCount())
 	}
-	debugLog("[NVML] nvmlDeviceGetMemoryErrorCounter(errType=%d loc=%d) -> %d\n", errorType, locationType, count)
+	debugLog("[NVML] nvmlDeviceGetMemoryErrorCounter(errType=%d counterType=%d loc=%d) -> %d\n",
+		errorType, counterType, locationType, count)
 	return count, nvml.SUCCESS
+}
+
+// GetSramEccErrorStatus returns the on-die SRAM ECC error state from ecc.sram.
+// SRAM errors are the fault class that row remapping cannot repair, so
+// fault-handling software treats them differently from DRAM errors and reads
+// them through this dedicated API.
+//
+// The returned struct carries no Version: the caller's ABI is the bridge's
+// concern, not the engine's.
+func (d *ConfigurableDevice) GetSramEccErrorStatus() (nvml.EccSramErrorStatus, nvml.Return) {
+	if ret := d.tickFailure(); ret != nvml.SUCCESS {
+		return nvml.EccSramErrorStatus{}, ret
+	}
+	// SRAM counters only exist while ECC is on. Reporting zeros for a GPU with
+	// ECC disabled would claim healthy SRAM the driver is not actually
+	// watching, so answer as real hardware does: unsupported (N/A).
+	if current, _, _ := d.GetEccMode(); current != nvml.FEATURE_ENABLED {
+		debugLog("[NVML] nvmlDeviceGetSramEccErrorStatus -> NOT_SUPPORTED (ECC disabled)\n")
+		return nvml.EccSramErrorStatus{}, nvml.ERROR_NOT_SUPPORTED
+	}
+
+	var status nvml.EccSramErrorStatus
+	cfg := d.cfg()
+	if cfg.ECC != nil && cfg.ECC.SRAM != nil {
+		sram := cfg.ECC.SRAM
+		if v := sram.Volatile; v != nil {
+			status.VolatileCor = v.Correctable
+			status.VolatileUncParity = v.UncorrectableParity
+			status.VolatileUncSecDed = v.UncorrectableSECDED
+		}
+		if a := sram.Aggregate; a != nil {
+			status.AggregateCor = a.Correctable
+			status.AggregateUncParity = a.UncorrectableParity
+			status.AggregateUncSecDed = a.UncorrectableSECDED
+		}
+		if s := sram.UncorrectableSources; s != nil {
+			status.AggregateUncBucketL2 = s.L2
+			status.AggregateUncBucketSm = s.SM
+			status.AggregateUncBucketMcu = s.Microcontroller
+			status.AggregateUncBucketPcie = s.PCIe
+			status.AggregateUncBucketOther = s.Other
+		}
+		if sram.ThresholdExceeded {
+			status.BThresholdExceeded = 1
+		}
+	}
+	debugLog("[NVML] nvmlDeviceGetSramEccErrorStatus -> aggCor=%d aggUncParity=%d aggUncSecDed=%d threshold=%d\n",
+		status.AggregateCor, status.AggregateUncParity, status.AggregateUncSecDed, status.BThresholdExceeded)
+	return status, nvml.SUCCESS
+}
+
+// GetRowRemapperHistogram returns how many memory banks fall into each
+// row-remap availability bucket, i.e. how much spare capacity is left before
+// the GPU can no longer repair a failing row. Row remapping is Ampere and
+// later and the bank count is hardware-specific, so an unconfigured device
+// reports the feature as unsupported rather than inventing a bank population.
+func (d *ConfigurableDevice) GetRowRemapperHistogram() (nvml.RowRemapperHistogramValues, nvml.Return) {
+	if ret := d.tickFailure(); ret != nvml.SUCCESS {
+		return nvml.RowRemapperHistogramValues{}, ret
+	}
+	cfg := d.cfg()
+	if cfg.RemappedRows == nil || cfg.RemappedRows.AvailabilityHistogram == nil {
+		debugLog("[NVML] nvmlDeviceGetRowRemapperHistogram -> NOT_SUPPORTED (no availability_histogram configured)\n")
+		return nvml.RowRemapperHistogramValues{}, nvml.ERROR_NOT_SUPPORTED
+	}
+	h := cfg.RemappedRows.AvailabilityHistogram
+	values := nvml.RowRemapperHistogramValues{
+		Max:     h.Max,
+		High:    h.High,
+		Partial: h.Partial,
+		Low:     h.Low,
+		None:    h.None,
+	}
+	debugLog("[NVML] nvmlDeviceGetRowRemapperHistogram -> max=%d high=%d partial=%d low=%d none=%d\n",
+		values.Max, values.High, values.Partial, values.Low, values.None)
+	return values, nvml.SUCCESS
+}
+
+// eccErrorCounts returns the configured DRAM-side error counts for one counter
+// type (volatile resets on driver reload, aggregate persists in the InfoROM).
+func (d *ConfigurableDevice) eccErrorCounts(counterType nvml.EccCounterType) *ECCErrorCountsConfig {
+	c := d.cfg()
+	if c.ECC == nil || c.ECC.Errors == nil {
+		return nil
+	}
+	if counterType == nvml.AGGREGATE_ECC {
+		return c.ECC.Errors.Aggregate
+	}
+	return c.ECC.Errors.Volatile
+}
+
+// eccMemoryErrors selects the single- or double-bit bucket matching an NVML
+// error type.
+func eccMemoryErrors(counts *ECCErrorCountsConfig, errorType nvml.MemoryErrorType) *ECCMemoryErrorsConfig {
+	if counts == nil {
+		return nil
+	}
+	if errorType == nvml.MEMORY_ERROR_TYPE_UNCORRECTED {
+		return counts.DoubleBit
+	}
+	return counts.SingleBit
+}
+
+// eccLocationErrors resolves the configured error count for one memory
+// location. Locations the mock does not model (texture shared memory, CBU)
+// report zero rather than borrowing another location's count.
+func (d *ConfigurableDevice) eccLocationErrors(errorType nvml.MemoryErrorType,
+	counterType nvml.EccCounterType, locationType nvml.MemoryLocation,
+) uint64 {
+	if locationType == nvml.MEMORY_LOCATION_SRAM {
+		return d.sramLocationErrors(errorType, counterType)
+	}
+	errs := eccMemoryErrors(d.eccErrorCounts(counterType), errorType)
+	if errs == nil {
+		return 0
+	}
+	switch locationType {
+	case nvml.MEMORY_LOCATION_L1_CACHE:
+		return errs.L1Cache
+	case nvml.MEMORY_LOCATION_L2_CACHE:
+		return errs.L2Cache
+	case nvml.MEMORY_LOCATION_DEVICE_MEMORY: // == MEMORY_LOCATION_DRAM
+		return errs.DeviceMemory
+	case nvml.MEMORY_LOCATION_REGISTER_FILE:
+		return errs.RegisterFile
+	case nvml.MEMORY_LOCATION_TEXTURE_MEMORY:
+		return errs.TextureMemory
+	default:
+		return 0
+	}
+}
+
+// sramLocationErrors answers the SRAM memory location from ecc.sram. NVML
+// reports a single uncorrected counter per location, so the parity and SEC-DED
+// counts the SRAM status splits out are summed here.
+func (d *ConfigurableDevice) sramLocationErrors(errorType nvml.MemoryErrorType, counterType nvml.EccCounterType) uint64 {
+	c := d.cfg()
+	if c.ECC == nil || c.ECC.SRAM == nil {
+		return 0
+	}
+	counts := c.ECC.SRAM.Volatile
+	if counterType == nvml.AGGREGATE_ECC {
+		counts = c.ECC.SRAM.Aggregate
+	}
+	if counts == nil {
+		return 0
+	}
+	if errorType == nvml.MEMORY_ERROR_TYPE_UNCORRECTED {
+		return counts.UncorrectableParity + counts.UncorrectableSECDED
+	}
+	return counts.Correctable
 }
 
 // GetRetiredPages returns retired pages

--- a/pkg/gpu/mocknvml/engine/field_values.go
+++ b/pkg/gpu/mocknvml/engine/field_values.go
@@ -34,6 +34,32 @@ const (
 	fiEccSbeAgg  = 5
 	fiEccDbeAgg  = 6
 
+	// Per-location ECC counters. NVML has no SRAM field id — SRAM counters are
+	// only reachable through nvmlDeviceGetSramEccErrorStatus and
+	// nvmlDeviceGetMemoryErrorCounter(NVML_MEMORY_LOCATION_SRAM).
+	fiEccSbeVolL1  = 7
+	fiEccDbeVolL1  = 8
+	fiEccSbeVolL2  = 9
+	fiEccDbeVolL2  = 10
+	fiEccSbeVolDev = 11
+	fiEccDbeVolDev = 12
+	fiEccSbeVolReg = 13
+	fiEccDbeVolReg = 14
+	fiEccSbeVolTex = 15
+	fiEccDbeVolTex = 16
+	fiEccDbeVolCbu = 17
+	fiEccSbeAggL1  = 18
+	fiEccDbeAggL1  = 19
+	fiEccSbeAggL2  = 20
+	fiEccDbeAggL2  = 21
+	fiEccSbeAggDev = 22
+	fiEccDbeAggDev = 23
+	fiEccSbeAggReg = 24
+	fiEccDbeAggReg = 25
+	fiEccSbeAggTex = 26
+	fiEccDbeAggTex = 27
+	fiEccDbeAggCbu = 28
+
 	fiRetiredSbe     = 29
 	fiRetiredDbe     = 30
 	fiRetiredPending = 31
@@ -94,6 +120,42 @@ const (
 	FieldValueInt
 )
 
+// eccLocationField describes which nvmlDeviceGetMemoryErrorCounter query one
+// per-location ECC field id stands for.
+type eccLocationField struct {
+	errorType   nvml.MemoryErrorType
+	counterType nvml.EccCounterType
+	location    nvml.MemoryLocation
+}
+
+// eccLocationFields maps the per-location ECC field ids onto the counter each
+// one names, so the field-value path DCGM reads and the dedicated getter
+// nvidia-smi reads resolve from the same engine state.
+var eccLocationFields = map[uint32]eccLocationField{
+	fiEccSbeVolL1:  {nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.VOLATILE_ECC, nvml.MEMORY_LOCATION_L1_CACHE},
+	fiEccDbeVolL1:  {nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.VOLATILE_ECC, nvml.MEMORY_LOCATION_L1_CACHE},
+	fiEccSbeVolL2:  {nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.VOLATILE_ECC, nvml.MEMORY_LOCATION_L2_CACHE},
+	fiEccDbeVolL2:  {nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.VOLATILE_ECC, nvml.MEMORY_LOCATION_L2_CACHE},
+	fiEccSbeVolDev: {nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.VOLATILE_ECC, nvml.MEMORY_LOCATION_DEVICE_MEMORY},
+	fiEccDbeVolDev: {nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.VOLATILE_ECC, nvml.MEMORY_LOCATION_DEVICE_MEMORY},
+	fiEccSbeVolReg: {nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.VOLATILE_ECC, nvml.MEMORY_LOCATION_REGISTER_FILE},
+	fiEccDbeVolReg: {nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.VOLATILE_ECC, nvml.MEMORY_LOCATION_REGISTER_FILE},
+	fiEccSbeVolTex: {nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.VOLATILE_ECC, nvml.MEMORY_LOCATION_TEXTURE_MEMORY},
+	fiEccDbeVolTex: {nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.VOLATILE_ECC, nvml.MEMORY_LOCATION_TEXTURE_MEMORY},
+	fiEccDbeVolCbu: {nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.VOLATILE_ECC, nvml.MEMORY_LOCATION_CBU},
+	fiEccSbeAggL1:  {nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_L1_CACHE},
+	fiEccDbeAggL1:  {nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_L1_CACHE},
+	fiEccSbeAggL2:  {nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_L2_CACHE},
+	fiEccDbeAggL2:  {nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_L2_CACHE},
+	fiEccSbeAggDev: {nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_DEVICE_MEMORY},
+	fiEccDbeAggDev: {nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_DEVICE_MEMORY},
+	fiEccSbeAggReg: {nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_REGISTER_FILE},
+	fiEccDbeAggReg: {nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_REGISTER_FILE},
+	fiEccSbeAggTex: {nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_TEXTURE_MEMORY},
+	fiEccDbeAggTex: {nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_TEXTURE_MEMORY},
+	fiEccDbeAggCbu: {nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_CBU},
+}
+
 // GetFieldValue resolves a single nvmlDeviceGetFieldValues entry: device-scope
 // fields first, then the NVLink field set. Unmodeled field ids yield
 // (FieldValueUnsupported, 0, ERROR_NOT_SUPPORTED) so the bridge can mark just
@@ -142,6 +204,19 @@ func (d *ConfigurableDevice) getDeviceFieldValue(fieldID, scopeID uint32) (Field
 			counterType = nvml.AGGREGATE_ECC
 		}
 		count, ret := d.GetTotalEccErrors(errorType, counterType)
+		if ret != nvml.SUCCESS {
+			return FieldValueUnsupported, 0, ret, true
+		}
+		return FieldValueUint64, count, nvml.SUCCESS, true
+
+	case fiEccSbeVolL1, fiEccDbeVolL1, fiEccSbeVolL2, fiEccDbeVolL2,
+		fiEccSbeVolDev, fiEccDbeVolDev, fiEccSbeVolReg, fiEccDbeVolReg,
+		fiEccSbeVolTex, fiEccDbeVolTex, fiEccDbeVolCbu,
+		fiEccSbeAggL1, fiEccDbeAggL1, fiEccSbeAggL2, fiEccDbeAggL2,
+		fiEccSbeAggDev, fiEccDbeAggDev, fiEccSbeAggReg, fiEccDbeAggReg,
+		fiEccSbeAggTex, fiEccDbeAggTex, fiEccDbeAggCbu:
+		loc := eccLocationFields[fieldID]
+		count, ret := d.GetMemoryErrorCounter(loc.errorType, loc.counterType, loc.location)
 		if ret != nvml.SUCCESS {
 			return FieldValueUnsupported, 0, ret, true
 		}

--- a/pkg/gpu/mocknvml/engine/sram_ecc_test.go
+++ b/pkg/gpu/mocknvml/engine/sram_ecc_test.go
@@ -1,0 +1,262 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
+)
+
+// eccEnabled is the ECC block every SRAM scenario starts from: SRAM ECC
+// reporting is a property of an ECC-enabled GPU, so the mode drives whether the
+// status is answerable at all.
+func eccEnabled() *ECCConfig {
+	return &ECCConfig{ModeCurrent: "enabled", ModePending: "enabled"}
+}
+
+func TestSramEccErrorStatus_HealthyDeviceReportsZeroNotUnsupported(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{ECC: eccEnabled()})
+
+	status, ret := dev.GetSramEccErrorStatus()
+	require.Equal(t, nvml.SUCCESS, ret,
+		"an ECC-enabled GPU must answer the SRAM status so nvidia-smi renders 0 rather than N/A")
+	require.Equal(t, nvml.EccSramErrorStatus{}, status, "a healthy GPU reports every SRAM counter as zero")
+}
+
+func TestSramEccErrorStatus_UnsupportedWhenEccDisabled(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		ECC: &ECCConfig{ModeCurrent: "disabled", ModePending: "disabled"},
+	})
+
+	_, ret := dev.GetSramEccErrorStatus()
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret,
+		"a GPU with ECC off has no SRAM error state to report")
+}
+
+func TestSramEccErrorStatus_ReportsConfiguredCounters(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		ECC: &ECCConfig{
+			ModeCurrent: "enabled",
+			ModePending: "enabled",
+			SRAM: &ECCSramConfig{
+				Volatile: &ECCSramCountsConfig{
+					Correctable:         7,
+					UncorrectableParity: 2,
+					UncorrectableSECDED: 3,
+				},
+				Aggregate: &ECCSramCountsConfig{
+					Correctable:         11,
+					UncorrectableParity: 5,
+					UncorrectableSECDED: 6,
+				},
+				UncorrectableSources: &ECCSramSourcesConfig{
+					L2:              4,
+					SM:              3,
+					Microcontroller: 2,
+					PCIe:            1,
+					Other:           1,
+				},
+				ThresholdExceeded: true,
+			},
+		},
+	})
+
+	status, ret := dev.GetSramEccErrorStatus()
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Equal(t, nvml.EccSramErrorStatus{
+		VolatileCor:             7,
+		VolatileUncParity:       2,
+		VolatileUncSecDed:       3,
+		AggregateCor:            11,
+		AggregateUncParity:      5,
+		AggregateUncSecDed:      6,
+		AggregateUncBucketL2:    4,
+		AggregateUncBucketSm:    3,
+		AggregateUncBucketMcu:   2,
+		AggregateUncBucketPcie:  1,
+		AggregateUncBucketOther: 1,
+		BThresholdExceeded:      1,
+	}, status)
+}
+
+func TestSramEccErrorStatus_LostDeviceReportsGpuIsLost(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		ECC:     eccEnabled(),
+		Failure: &FailureInjectionConfig{Mode: FailureModeLost},
+	})
+
+	_, ret := dev.GetSramEccErrorStatus()
+	require.Equal(t, nvml.ERROR_GPU_IS_LOST, ret,
+		"a lost GPU must fail the SRAM query like every other guarded getter")
+}
+
+// TestMemoryErrorCounter_DistinguishesDramFromSram is the locationType half of
+// the fix: one shared counter for every location made the argument meaningless.
+func TestMemoryErrorCounter_DistinguishesDramFromSram(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		ECC: &ECCConfig{
+			ModeCurrent: "enabled",
+			ModePending: "enabled",
+			Errors: &ECCErrorsConfig{
+				Aggregate: &ECCErrorCountsConfig{
+					DoubleBit: &ECCMemoryErrorsConfig{DeviceMemory: 9, L2Cache: 4},
+				},
+			},
+			SRAM: &ECCSramConfig{
+				Aggregate: &ECCSramCountsConfig{UncorrectableParity: 2, UncorrectableSECDED: 3},
+			},
+		},
+	})
+
+	dram, ret := dev.GetMemoryErrorCounter(nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_DRAM)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Equal(t, uint64(9), dram, "DRAM reads the device-memory counter")
+
+	sram, ret := dev.GetMemoryErrorCounter(nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_SRAM)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Equal(t, uint64(5), sram, "SRAM uncorrectable is parity + SEC-DED, and must not read the DRAM counter")
+
+	l2, ret := dev.GetMemoryErrorCounter(nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_L2_CACHE)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Equal(t, uint64(4), l2, "each location reports its own configured counter")
+}
+
+func TestMemoryErrorCounter_DistinguishesVolatileFromAggregate(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		ECC: &ECCConfig{
+			ModeCurrent: "enabled",
+			ModePending: "enabled",
+			Errors: &ECCErrorsConfig{
+				Volatile:  &ECCErrorCountsConfig{SingleBit: &ECCMemoryErrorsConfig{DeviceMemory: 1}},
+				Aggregate: &ECCErrorCountsConfig{SingleBit: &ECCMemoryErrorsConfig{DeviceMemory: 12}},
+			},
+			SRAM: &ECCSramConfig{
+				Volatile:  &ECCSramCountsConfig{Correctable: 2},
+				Aggregate: &ECCSramCountsConfig{Correctable: 20},
+			},
+		},
+	})
+
+	volatileDRAM, _ := dev.GetMemoryErrorCounter(nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.VOLATILE_ECC, nvml.MEMORY_LOCATION_DRAM)
+	aggregateDRAM, _ := dev.GetMemoryErrorCounter(nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_DRAM)
+	require.Equal(t, uint64(1), volatileDRAM)
+	require.Equal(t, uint64(12), aggregateDRAM)
+
+	volatileSRAM, _ := dev.GetMemoryErrorCounter(nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.VOLATILE_ECC, nvml.MEMORY_LOCATION_SRAM)
+	aggregateSRAM, _ := dev.GetMemoryErrorCounter(nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.AGGREGATE_ECC, nvml.MEMORY_LOCATION_SRAM)
+	require.Equal(t, uint64(2), volatileSRAM)
+	require.Equal(t, uint64(20), aggregateSRAM)
+}
+
+func TestTotalEccErrors_ReadsConfiguredTotalsPerCounterType(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		ECC: &ECCConfig{
+			ModeCurrent: "enabled",
+			ModePending: "enabled",
+			Errors: &ECCErrorsConfig{
+				Volatile:  &ECCErrorCountsConfig{DoubleBit: &ECCMemoryErrorsConfig{Total: 3}},
+				Aggregate: &ECCErrorCountsConfig{DoubleBit: &ECCMemoryErrorsConfig{Total: 30}},
+			},
+		},
+	})
+
+	vol, _ := dev.GetTotalEccErrors(nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.VOLATILE_ECC)
+	agg, _ := dev.GetTotalEccErrors(nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.AGGREGATE_ECC)
+	require.Equal(t, uint64(3), vol)
+	require.Equal(t, uint64(30), agg)
+
+	cor, _ := dev.GetTotalEccErrors(nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.AGGREGATE_ECC)
+	require.Zero(t, cor, "no single-bit totals configured")
+}
+
+func TestRowRemapperHistogram_UnsupportedWhenUnconfigured(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		RemappedRows: &RemappedRowsConfig{Correctable: 1},
+	})
+
+	_, ret := dev.GetRowRemapperHistogram()
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret,
+		"bank availability is only knowable from config; pre-Ampere GPUs report nothing")
+}
+
+func TestRowRemapperHistogram_ReportsConfiguredBanks(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		RemappedRows: &RemappedRowsConfig{
+			Uncorrectable: 2,
+			AvailabilityHistogram: &RowRemapHistogramConfig{
+				Max: 636, High: 2, Partial: 1, Low: 1, None: 0,
+			},
+		},
+	})
+
+	histogram, ret := dev.GetRowRemapperHistogram()
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Equal(t, nvml.RowRemapperHistogramValues{Max: 636, High: 2, Partial: 1, Low: 1}, histogram)
+}
+
+func TestRowRemapperHistogram_LostDeviceReportsGpuIsLost(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		RemappedRows: &RemappedRowsConfig{AvailabilityHistogram: &RowRemapHistogramConfig{Max: 640}},
+		Failure:      &FailureInjectionConfig{Mode: FailureModeLost},
+	})
+
+	_, ret := dev.GetRowRemapperHistogram()
+	require.Equal(t, nvml.ERROR_GPU_IS_LOST, ret)
+}
+
+// TestFieldValues_PerLocationEccErrors pins the DCGM query path to the same
+// engine state as the getters: DCGM reads per-location ECC counters through
+// nvmlDeviceGetFieldValues, so a value only reachable through nvidia-smi would
+// leave its dashboards blank.
+func TestFieldValues_PerLocationEccErrors(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		ECC: &ECCConfig{
+			ModeCurrent: "enabled",
+			ModePending: "enabled",
+			Errors: &ECCErrorsConfig{
+				Volatile: &ECCErrorCountsConfig{
+					SingleBit: &ECCMemoryErrorsConfig{L1Cache: 1, L2Cache: 2, DeviceMemory: 3},
+					DoubleBit: &ECCMemoryErrorsConfig{RegisterFile: 4, TextureMemory: 5},
+				},
+				Aggregate: &ECCErrorCountsConfig{
+					SingleBit: &ECCMemoryErrorsConfig{L2Cache: 20},
+					DoubleBit: &ECCMemoryErrorsConfig{DeviceMemory: 30},
+				},
+			},
+		},
+	})
+
+	for _, tc := range []struct {
+		name    string
+		fieldID uint32
+		want    uint64
+	}{
+		{"volatile single-bit L1", fiEccSbeVolL1, 1},
+		{"volatile single-bit L2", fiEccSbeVolL2, 2},
+		{"volatile single-bit device memory", fiEccSbeVolDev, 3},
+		{"volatile double-bit register file", fiEccDbeVolReg, 4},
+		{"volatile double-bit texture memory", fiEccDbeVolTex, 5},
+		{"aggregate single-bit L2", fiEccSbeAggL2, 20},
+		{"aggregate double-bit device memory", fiEccDbeAggDev, 30},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			vt, val, ret := dev.GetFieldValue(tc.fieldID, 0)
+			require.Equal(t, nvml.SUCCESS, ret)
+			require.Equal(t, FieldValueUint64, vt)
+			require.Equal(t, tc.want, val)
+		})
+	}
+}

--- a/tests/e2e/go/assertions/nvidiasmi/checks.go
+++ b/tests/e2e/go/assertions/nvidiasmi/checks.go
@@ -328,21 +328,44 @@ type SramECCSources struct {
 	Other           int
 }
 
+// SramECCLayout selects which of the two SRAM renderings nvidia-smi uses. Which
+// one it picks depends on the GPU's architecture, so a spec asserting on the
+// SRAM rows has to say which hardware it is looking at.
+type SramECCLayout int
+
+const (
+	// SramECCDetailed is the Ampere-and-later rendering: the uncorrectable count
+	// is split into parity and SEC-DED, and the aggregate scope carries the
+	// per-unit source breakdown and the threshold flag. It is the zero value
+	// because every profile the mock ships bar t4 is Ampere or later.
+	SramECCDetailed SramECCLayout = iota
+	// SramECCCombined is the pre-Ampere rendering: one SRAM Uncorrectable row
+	// holding both uncorrectable flavours, with no source breakdown and no
+	// threshold flag at all.
+	SramECCCombined
+)
+
 // SramECCState is the whole SRAM ECC reporting a spec expects on every GPU.
 type SramECCState struct {
-	Volatile          SramECCCounters
-	Aggregate         SramECCCounters
+	Volatile  SramECCCounters
+	Aggregate SramECCCounters
+	// Sources and ThresholdExceeded are only read in the detailed layout, since
+	// pre-Ampere output has nowhere to report them.
 	Sources           SramECCSources
 	ThresholdExceeded bool
+	Layout            SramECCLayout
 }
 
 // SramECCProblems checks the SRAM half of every GPU's <ecc_errors> block: the
-// per-scope counters, the aggregate uncorrectable source breakdown and
-// sram_threshold_exceeded. Every one of them read N/A while
+// per-scope counters and, in the detailed layout, the aggregate uncorrectable
+// source breakdown and sram_threshold_exceeded. Every one of them read N/A while
 // nvmlDeviceGetSramEccErrorStatus was a stub and the DRAM counters answered for
 // SRAM locations, so a health checker could not tell a GPU with no SRAM errors
 // from one whose SRAM state is unknown (#641). Zero is a valid expectation and
 // the point of the check: a healthy GPU must report 0, not N/A.
+//
+// want.Layout must match the architecture under test, because nvidia-smi renders
+// the two differently and the elements of one are simply absent from the other.
 func SramECCProblems(out string, want SramECCState) []string {
 	snap, err := ParseSnapshot(out)
 	if err != nil {
@@ -353,9 +376,12 @@ func SramECCProblems(out string, want SramECCState) []string {
 	for i, gpu := range snap.doc.GPUs {
 		name := gpu.label(i)
 		problems = append(problems,
-			sramCountersProblems(name+" volatile", gpu.ECCErrors.Volatile, want.Volatile)...)
+			sramCountersProblems(name+" volatile", gpu.ECCErrors.Volatile, want.Volatile, want.Layout)...)
 		problems = append(problems,
-			sramCountersProblems(name+" aggregate", gpu.ECCErrors.Aggregate, want.Aggregate)...)
+			sramCountersProblems(name+" aggregate", gpu.ECCErrors.Aggregate, want.Aggregate, want.Layout)...)
+		if want.Layout == SramECCCombined {
+			continue
+		}
 		problems = append(problems, sramSourcesProblems(name, gpu.ECCErrors.SRAMSources, want.Sources)...)
 		problems = append(problems, yesNoReadingProblems(name+" aggregate sram_threshold_exceeded",
 			gpu.ECCErrors.Aggregate.SRAMThresholdExceeded, want.ThresholdExceeded)...)
@@ -363,10 +389,14 @@ func SramECCProblems(out string, want SramECCState) []string {
 	return problems
 }
 
-func sramCountersProblems(name string, got eccCounters, want SramECCCounters) []string {
-	var problems []string
-	problems = append(problems,
-		intReadingProblems(name+" sram_correctable", got.SRAMCorrectable, want.Correctable, "")...)
+func sramCountersProblems(name string, got eccCounters, want SramECCCounters, layout SramECCLayout) []string {
+	problems := intReadingProblems(name+" sram_correctable", got.SRAMCorrectable, want.Correctable, "")
+	if layout == SramECCCombined {
+		// Pre-Ampere reports one row for both uncorrectable flavours, so the
+		// expectation is their sum.
+		return append(problems, intReadingProblems(name+" sram_uncorrectable", got.SRAMUncorrectable,
+			want.UncorrectableParity+want.UncorrectableSECDED, "")...)
+	}
 	problems = append(problems, intReadingProblems(name+" sram_uncorrectable_parity",
 		got.SRAMUncorrectableParity, want.UncorrectableParity, "")...)
 	return append(problems, intReadingProblems(name+" sram_uncorrectable_secded",

--- a/tests/e2e/go/assertions/nvidiasmi/checks.go
+++ b/tests/e2e/go/assertions/nvidiasmi/checks.go
@@ -310,6 +310,176 @@ func boardIDProblems(name string, got reading, seen map[uint64]string) []string 
 	return nil
 }
 
+// SramECCCounters are the three SRAM counters of one scope, volatile or
+// aggregate.
+type SramECCCounters struct {
+	Correctable         int
+	UncorrectableParity int
+	UncorrectableSECDED int
+}
+
+// SramECCSources is the expected <aggregate_uncorrectable_sram_sources>
+// breakdown: which unit reported the aggregate uncorrectable SRAM errors.
+type SramECCSources struct {
+	L2              int
+	SM              int
+	Microcontroller int
+	PCIe            int
+	Other           int
+}
+
+// SramECCState is the whole SRAM ECC reporting a spec expects on every GPU.
+type SramECCState struct {
+	Volatile          SramECCCounters
+	Aggregate         SramECCCounters
+	Sources           SramECCSources
+	ThresholdExceeded bool
+}
+
+// SramECCProblems checks the SRAM half of every GPU's <ecc_errors> block: the
+// per-scope counters, the aggregate uncorrectable source breakdown and
+// sram_threshold_exceeded. Every one of them read N/A while
+// nvmlDeviceGetSramEccErrorStatus was a stub and the DRAM counters answered for
+// SRAM locations, so a health checker could not tell a GPU with no SRAM errors
+// from one whose SRAM state is unknown (#641). Zero is a valid expectation and
+// the point of the check: a healthy GPU must report 0, not N/A.
+func SramECCProblems(out string, want SramECCState) []string {
+	snap, err := ParseSnapshot(out)
+	if err != nil {
+		return []string{err.Error()}
+	}
+
+	var problems []string
+	for i, gpu := range snap.doc.GPUs {
+		name := gpu.label(i)
+		problems = append(problems,
+			sramCountersProblems(name+" volatile", gpu.ECCErrors.Volatile, want.Volatile)...)
+		problems = append(problems,
+			sramCountersProblems(name+" aggregate", gpu.ECCErrors.Aggregate, want.Aggregate)...)
+		problems = append(problems, sramSourcesProblems(name, gpu.ECCErrors.SRAMSources, want.Sources)...)
+		problems = append(problems, yesNoReadingProblems(name+" aggregate sram_threshold_exceeded",
+			gpu.ECCErrors.Aggregate.SRAMThresholdExceeded, want.ThresholdExceeded)...)
+	}
+	return problems
+}
+
+func sramCountersProblems(name string, got eccCounters, want SramECCCounters) []string {
+	var problems []string
+	problems = append(problems,
+		intReadingProblems(name+" sram_correctable", got.SRAMCorrectable, want.Correctable, "")...)
+	problems = append(problems, intReadingProblems(name+" sram_uncorrectable_parity",
+		got.SRAMUncorrectableParity, want.UncorrectableParity, "")...)
+	return append(problems, intReadingProblems(name+" sram_uncorrectable_secded",
+		got.SRAMUncorrectableSECDED, want.UncorrectableSECDED, "")...)
+}
+
+func sramSourcesProblems(name string, got eccSRAMSources, want SramECCSources) []string {
+	sources := []struct {
+		element string
+		got     reading
+		want    int
+	}{
+		{"sram_l2", got.L2, want.L2},
+		{"sram_sm", got.SM, want.SM},
+		{"sram_microcontroller", got.Microcontroller, want.Microcontroller},
+		{"sram_pcie", got.PCIe, want.PCIe},
+		{"sram_other", got.Other, want.Other},
+	}
+	problems := make([]string, 0, len(sources))
+	for _, source := range sources {
+		problems = append(problems,
+			intReadingProblems(name+" "+source.element, source.got, source.want, "")...)
+	}
+	return problems
+}
+
+// yesNoReadingProblems compares a reading nvidia-smi renders as Yes or No. An
+// N/A body fails: it means the getter behind the flag is missing, which is the
+// state a spec asserting on the flag exists to rule out.
+func yesNoReadingProblems(name string, got reading, want bool) []string {
+	body := strings.TrimSpace(string(got))
+	wantBody := "No"
+	if want {
+		wantBody = "Yes"
+	}
+	switch {
+	case strings.EqualFold(body, "Yes"), strings.EqualFold(body, "No"):
+		if !strings.EqualFold(body, wantBody) {
+			return []string{fmt.Sprintf("%s = %q, want %q", name, body, wantBody)}
+		}
+		return nil
+	default:
+		return []string{fmt.Sprintf(
+			"%s = %q, want %q; a body that is neither Yes nor No means the NVML getter is missing",
+			name, body, wantBody)}
+	}
+}
+
+// RowRemapState is the <remapped_rows> state a spec expects on every GPU.
+type RowRemapState struct {
+	Correctable   int
+	Uncorrectable int
+	Pending       bool
+	Failure       bool
+	// HistogramBanks is the bank count the configured histogram puts in its
+	// max-availability bucket. Zero means the GPU must report the histogram as
+	// N/A, which is what pre-Ampere hardware without row remapping does.
+	HistogramBanks int
+}
+
+// RowRemapProblems checks every GPU's <remapped_rows> block: the retired-row
+// counters, the two flags, and the bank availability histogram. The histogram
+// read N/A on every profile while nvmlDeviceGetRowRemapperHistogram was a stub,
+// which on Ampere-and-later hardware means the GPU cannot report how much remap
+// capacity is left (#641).
+//
+// The histogram is matched on its bank count appearing in the block rather than
+// by decoding buckets: the bucket element names belong to the driver's DTD,
+// while the count is what the profile configures and therefore what proves the
+// configured value reached the caller.
+func RowRemapProblems(out string, want RowRemapState) []string {
+	snap, err := ParseSnapshot(out)
+	if err != nil {
+		return []string{err.Error()}
+	}
+
+	var problems []string
+	for i := range snap.doc.GPUs {
+		gpu, rows := snap.gpu(i), snap.doc.GPUs[i].RemappedRows
+		name := gpu.Label()
+		problems = append(problems,
+			intReadingProblems(name+" remapped_row_corr", rows.Correctable, want.Correctable, "")...)
+		problems = append(problems,
+			intReadingProblems(name+" remapped_row_unc", rows.Uncorrectable, want.Uncorrectable, "")...)
+		problems = append(problems,
+			yesNoReadingProblems(name+" remapped_row_pending", rows.Pending, want.Pending)...)
+		problems = append(problems,
+			yesNoReadingProblems(name+" remapped_row_failure", rows.Failure, want.Failure)...)
+		problems = append(problems, histogramProblems(name, gpu, want.HistogramBanks)...)
+	}
+	return problems
+}
+
+func histogramProblems(name string, gpu GPU, wantBanks int) []string {
+	body := strings.TrimSpace(gpu.element.RemappedRows.Histogram.Body)
+	switch {
+	case wantBanks == 0:
+		if gpu.RowRemapHistogramPopulated() {
+			return []string{fmt.Sprintf(
+				"%s row_remapper_histogram = %q, want N/A: this profile configures no remap availability",
+				name, body)}
+		}
+	case !gpu.RowRemapHistogramPopulated():
+		return []string{fmt.Sprintf(
+			"%s row_remapper_histogram = %q, want %d banks; N/A means the histogram getter is missing",
+			name, body, wantBanks)}
+	case !strings.Contains(body, strconv.Itoa(wantBanks)):
+		return []string{fmt.Sprintf("%s row_remapper_histogram = %q, want it to report %d banks",
+			name, body, wantBanks)}
+	}
+	return nil
+}
+
 func statsBlockProblems(name string, got statsBlock, want EncoderFBCStats) []string {
 	var problems []string
 	problems = append(problems, intReadingProblems(name+" session_count", got.SessionCount, want.SessionCount, "")...)

--- a/tests/e2e/go/assertions/nvidiasmi/checks_test.go
+++ b/tests/e2e/go/assertions/nvidiasmi/checks_test.go
@@ -4,6 +4,7 @@
 package nvidiasmi
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -581,4 +582,131 @@ func TestProcessMonitorProblems_RejectsOtherAbnormalExits(t *testing.T) {
 	for _, code := range []int{-1, 134, 2} {
 		assert.NotEmpty(t, ProcessMonitorProblems(code, "output"), "exit %d", code)
 	}
+}
+
+// The captured document is the defect: every SRAM reading, the source breakdown
+// and the threshold flag are N/A, so a health checker cannot tell a GPU with no
+// SRAM errors from one whose SRAM state is unknown (#641).
+func TestSramECCProblems_RejectsCapturedNotAvailableReadings(t *testing.T) {
+	problems := SramECCProblems(loadFixture(t, "qx-a100-healthy.xml"), SramECCState{})
+	require.NotEmpty(t, problems)
+	joined := strings.Join(problems, "; ")
+	assert.Contains(t, joined, "sram_correctable")
+	assert.Contains(t, joined, "sram_threshold_exceeded")
+	assert.Contains(t, joined, "sram_l2")
+}
+
+func TestSramECCProblems_AcceptsZeroedSramReadings(t *testing.T) {
+	problems := SramECCProblems(healSramReadings(t), SramECCState{})
+	assert.Empty(t, problems, strings.Join(problems, "; "))
+}
+
+func TestSramECCProblems_RejectsWrongCounts(t *testing.T) {
+	want := SramECCState{Volatile: SramECCCounters{UncorrectableSECDED: 4}}
+	problems := SramECCProblems(healSramReadings(t), want)
+	require.Len(t, problems, 2, "both GPUs report 0 where 4 is expected")
+	assert.Contains(t, problems[0], "volatile sram_uncorrectable_secded = 0, want 4")
+}
+
+// The source breakdown must be checked per unit: attributing errors to the SM
+// and reading them back on the L2 is a wrong answer, not a rounding difference.
+func TestSramECCProblems_RejectsMisattributedSource(t *testing.T) {
+	out := strings.ReplaceAll(healSramReadings(t), "<sram_sm>0</sram_sm>", "<sram_sm>4</sram_sm>")
+
+	problems := SramECCProblems(out, SramECCState{Sources: SramECCSources{L2: 4}})
+	require.NotEmpty(t, problems)
+	joined := strings.Join(problems, "; ")
+	assert.Contains(t, joined, "sram_l2 = 0, want 4")
+	assert.Contains(t, joined, "sram_sm = 4, want 0")
+}
+
+func TestSramECCProblems_RejectsThresholdMismatch(t *testing.T) {
+	problems := SramECCProblems(healSramReadings(t), SramECCState{ThresholdExceeded: true})
+	require.Len(t, problems, 2)
+	assert.Contains(t, problems[0], `sram_threshold_exceeded = "No", want "Yes"`)
+}
+
+func TestSramECCProblems_ReportsUnparseableDocument(t *testing.T) {
+	problems := SramECCProblems("not xml", SramECCState{})
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "parse nvidia-smi XML")
+}
+
+// row_remapper_histogram read N/A on every profile while the getter was a stub,
+// which on Ampere and later means the GPU cannot report remap capacity at all.
+func TestRowRemapProblems_RejectsNotAvailableHistogram(t *testing.T) {
+	problems := RowRemapProblems(loadFixture(t, "qx-a100-healthy.xml"), RowRemapState{HistogramBanks: 640})
+	require.Len(t, problems, 2, "one per GPU")
+	assert.Contains(t, problems[0], "row_remapper_histogram")
+}
+
+func TestRowRemapProblems_AcceptsPopulatedHistogram(t *testing.T) {
+	problems := RowRemapProblems(healSramReadings(t), RowRemapState{HistogramBanks: 640})
+	assert.Empty(t, problems, strings.Join(problems, "; "))
+}
+
+// The configured bank count must reach the caller, not just some histogram.
+func TestRowRemapProblems_RejectsWrongBankCount(t *testing.T) {
+	problems := RowRemapProblems(healSramReadings(t), RowRemapState{HistogramBanks: 1280})
+	require.Len(t, problems, 2)
+	assert.Contains(t, problems[0], "want it to report 1280 banks")
+}
+
+// A profile that configures no remap availability must keep reporting N/A: a
+// populated histogram there would mean the mock claims a capability the modelled
+// hardware lacks.
+func TestRowRemapProblems_RejectsHistogramWhereUnsupportedExpected(t *testing.T) {
+	problems := RowRemapProblems(healSramReadings(t), RowRemapState{})
+	require.Len(t, problems, 2)
+	assert.Contains(t, problems[0], "want N/A")
+}
+
+func TestRowRemapProblems_AcceptsUnsupportedHistogram(t *testing.T) {
+	problems := RowRemapProblems(loadFixture(t, "qx-a100-healthy.xml"), RowRemapState{})
+	assert.Empty(t, problems, strings.Join(problems, "; "))
+}
+
+func TestRowRemapProblems_RejectsWrongCountersAndFlags(t *testing.T) {
+	want := RowRemapState{Correctable: 1, Pending: true, HistogramBanks: 640}
+	problems := RowRemapProblems(healSramReadings(t), want)
+	require.Len(t, problems, 4, "count and flag, on each of the two GPUs")
+	assert.Contains(t, strings.Join(problems, "; "), "remapped_row_corr = 0, want 1")
+	assert.Contains(t, strings.Join(problems, "; "), `remapped_row_pending = "No", want "Yes"`)
+}
+
+func TestRowRemapProblems_ReportsUnparseableDocument(t *testing.T) {
+	problems := RowRemapProblems("not xml", RowRemapState{})
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "parse nvidia-smi XML")
+}
+
+// healSramReadings rewrites the captured document into what a GPU that answers
+// the SRAM and row-remap getters reports: counters at 0 rather than N/A, the
+// threshold flag rendered No, and a populated histogram. It is derived from the
+// capture rather than written by hand so the element names stay those of the
+// driver's DTD.
+func healSramReadings(t *testing.T) string {
+	t.Helper()
+	out := loadFixture(t, "qx-a100-healthy.xml")
+	for _, element := range []string{
+		"sram_correctable", "sram_uncorrectable_parity", "sram_uncorrectable_secded",
+		"sram_l2", "sram_sm", "sram_microcontroller", "sram_pcie", "sram_other",
+	} {
+		out = strings.ReplaceAll(out,
+			fmt.Sprintf("<%s>N/A</%s>", element, element),
+			fmt.Sprintf("<%s>0</%s>", element, element))
+	}
+	out = strings.ReplaceAll(out,
+		"<sram_threshold_exceeded>N/A</sram_threshold_exceeded>",
+		"<sram_threshold_exceeded>No</sram_threshold_exceeded>")
+	// The bucket elements and their "N bank(s)" bodies are the shapes nvidia-smi
+	// 580.65.06 emits once the histogram getter answers.
+	return strings.ReplaceAll(out, "<row_remapper_histogram>N/A</row_remapper_histogram>",
+		"<row_remapper_histogram>"+
+			"<row_remapper_histogram_max>640 bank(s)</row_remapper_histogram_max>"+
+			"<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>"+
+			"<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>"+
+			"<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>"+
+			"<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>"+
+			"</row_remapper_histogram>")
 }

--- a/tests/e2e/go/assertions/nvidiasmi/checks_test.go
+++ b/tests/e2e/go/assertions/nvidiasmi/checks_test.go
@@ -5,6 +5,7 @@ package nvidiasmi
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -709,4 +710,65 @@ func healSramReadings(t *testing.T) string {
 			"<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>"+
 			"<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>"+
 			"</row_remapper_histogram>")
+}
+
+// The pre-Ampere rendering is a different set of elements, not different values:
+// one combined SRAM Uncorrectable row, no source breakdown, no threshold flag.
+// Checking it with the detailed expectation is how the t4 e2e leg failed, so both
+// directions are pinned here.
+func TestSramECCProblems_AcceptsCombinedLayout(t *testing.T) {
+	problems := SramECCProblems(combinedSramReadings(t), SramECCState{Layout: SramECCCombined})
+	assert.Empty(t, problems, strings.Join(problems, "; "))
+}
+
+// The combined row carries both uncorrectable flavours, so the expectation is
+// their sum.
+func TestSramECCProblems_CombinedLayoutSumsUncorrectableFlavours(t *testing.T) {
+	out := strings.ReplaceAll(combinedSramReadings(t),
+		"<sram_uncorrectable>0</sram_uncorrectable>", "<sram_uncorrectable>6</sram_uncorrectable>")
+	counts := SramECCCounters{UncorrectableParity: 2, UncorrectableSECDED: 4}
+
+	want := SramECCState{Volatile: counts, Aggregate: counts, Layout: SramECCCombined}
+	assert.Empty(t, SramECCProblems(out, want))
+
+	want.Volatile.UncorrectableSECDED = 3
+	problems := SramECCProblems(out, want)
+	require.NotEmpty(t, problems)
+	assert.Contains(t, problems[0], "sram_uncorrectable = 6, want 5")
+}
+
+// Asking for the detailed layout where the driver emits the combined one must
+// fail rather than silently pass on absent elements.
+func TestSramECCProblems_RejectsCombinedLayoutUnderDetailedExpectation(t *testing.T) {
+	problems := SramECCProblems(combinedSramReadings(t), SramECCState{})
+	require.NotEmpty(t, problems)
+	joined := strings.Join(problems, "; ")
+	assert.Contains(t, joined, "sram_uncorrectable_parity")
+	assert.Contains(t, joined, "sram_threshold_exceeded")
+}
+
+// And the reverse: a GPU that reports the detailed breakdown is not a pre-Ampere
+// one, so the combined expectation must not accept it.
+func TestSramECCProblems_RejectsDetailedLayoutUnderCombinedExpectation(t *testing.T) {
+	problems := SramECCProblems(healSramReadings(t), SramECCState{Layout: SramECCCombined})
+	require.NotEmpty(t, problems)
+	assert.Contains(t, strings.Join(problems, "; "), "sram_uncorrectable = \"\"")
+}
+
+// combinedSramReadings rewrites the captured document into the pre-Ampere
+// rendering nvidia-smi 580.65.06 emits for a Turing GPU: sram_correctable and a
+// single sram_uncorrectable per scope, with the source breakdown and the
+// threshold flag absent entirely.
+func combinedSramReadings(t *testing.T) string {
+	t.Helper()
+	out := healSramReadings(t)
+	out = strings.ReplaceAll(out,
+		"<sram_uncorrectable_parity>0</sram_uncorrectable_parity>\n\t\t\t\t"+
+			"<sram_uncorrectable_secded>0</sram_uncorrectable_secded>",
+		"<sram_uncorrectable>0</sram_uncorrectable>")
+	out = strings.ReplaceAll(out,
+		"<sram_threshold_exceeded>No</sram_threshold_exceeded>\n\t\t\t", "")
+	return regexp.MustCompile(
+		`(?s)\s*<aggregate_uncorrectable_sram_sources>.*?</aggregate_uncorrectable_sram_sources>`).
+		ReplaceAllString(out, "")
 }

--- a/tests/e2e/go/assertions/nvidiasmi/schema.go
+++ b/tests/e2e/go/assertions/nvidiasmi/schema.go
@@ -120,7 +120,9 @@ type gpuElement struct {
 	Temperature              temperature       `xml:"temperature"`
 	PowerReadings            powerReadings     `xml:"gpu_power_readings"`
 	Clocks                   clocks            `xml:"clocks"`
+	ECCMode                  eccMode           `xml:"ecc_mode"`
 	ECCErrors                eccErrors         `xml:"ecc_errors"`
+	RemappedRows             remappedRows      `xml:"remapped_rows"`
 	ClocksEventReasons       eventReasons      `xml:"clocks_event_reasons"`
 	Processes                struct {
 		Infos []processInfo `xml:"process_info"`
@@ -238,6 +240,9 @@ type clocks struct {
 type eccErrors struct {
 	Volatile  eccCounters `xml:"volatile"`
 	Aggregate eccCounters `xml:"aggregate"`
+	// SRAMSources is emitted as a sibling of the two scope blocks, not inside
+	// <aggregate>, even though it breaks down the aggregate uncorrectable count.
+	SRAMSources eccSRAMSources `xml:"aggregate_uncorrectable_sram_sources"`
 }
 
 type eccCounters struct {
@@ -246,6 +251,42 @@ type eccCounters struct {
 	SRAMUncorrectableSECDED reading `xml:"sram_uncorrectable_secded"`
 	DRAMCorrectable         reading `xml:"dram_correctable"`
 	DRAMUncorrectable       reading `xml:"dram_uncorrectable"`
+	// SRAMThresholdExceeded is emitted under <aggregate> only; it is absent
+	// from <volatile>, which is a threshold-free scope.
+	SRAMThresholdExceeded reading `xml:"sram_threshold_exceeded"`
+}
+
+// eccSRAMSources is <aggregate_uncorrectable_sram_sources>: which unit reported
+// the aggregate uncorrectable SRAM errors.
+type eccSRAMSources struct {
+	L2              reading `xml:"sram_l2"`
+	SM              reading `xml:"sram_sm"`
+	Microcontroller reading `xml:"sram_microcontroller"`
+	PCIe            reading `xml:"sram_pcie"`
+	Other           reading `xml:"sram_other"`
+}
+
+// eccMode is <ecc_mode>. SRAM and DRAM counters only exist while ECC is on, so
+// specs asserting on them gate against this first.
+type eccMode struct {
+	Current reading `xml:"current_ecc"`
+	Pending reading `xml:"pending_ecc"`
+}
+
+// remappedRows is <remapped_rows>: rows the GPU has retired plus how much spare
+// remap capacity is left.
+type remappedRows struct {
+	Correctable   reading `xml:"remapped_row_corr"`
+	Uncorrectable reading `xml:"remapped_row_unc"`
+	Pending       reading `xml:"remapped_row_pending"`
+	Failure       reading `xml:"remapped_row_failure"`
+	// Histogram is "N/A" when the GPU reports no bank availability and a nested
+	// block of per-bucket bank counts when it does. The raw body is kept rather
+	// than decoded: the child element names belong to the driver's DTD, and an
+	// assertion only needs to tell a populated histogram from an absent one.
+	Histogram struct {
+		Body string `xml:",innerxml"`
+	} `xml:"row_remapper_histogram"`
 }
 
 type eventReasons struct {

--- a/tests/e2e/go/assertions/nvidiasmi/schema.go
+++ b/tests/e2e/go/assertions/nvidiasmi/schema.go
@@ -246,18 +246,24 @@ type eccErrors struct {
 }
 
 type eccCounters struct {
-	SRAMCorrectable         reading `xml:"sram_correctable"`
+	SRAMCorrectable reading `xml:"sram_correctable"`
+	// The uncorrectable SRAM count comes in one of two shapes, and which one
+	// nvidia-smi emits depends on the GPU's architecture: Ampere and later split
+	// it into the parity and SEC-DED pair, pre-Ampere reports the single
+	// combined element. Both are decoded so a check can tell an absent element
+	// from a wrong value in either rendering.
 	SRAMUncorrectableParity reading `xml:"sram_uncorrectable_parity"`
 	SRAMUncorrectableSECDED reading `xml:"sram_uncorrectable_secded"`
+	SRAMUncorrectable       reading `xml:"sram_uncorrectable"`
 	DRAMCorrectable         reading `xml:"dram_correctable"`
 	DRAMUncorrectable       reading `xml:"dram_uncorrectable"`
-	// SRAMThresholdExceeded is emitted under <aggregate> only; it is absent
-	// from <volatile>, which is a threshold-free scope.
+	// SRAMThresholdExceeded is emitted under <aggregate> only; it is absent from
+	// <volatile>, which is a threshold-free scope, and from pre-Ampere output.
 	SRAMThresholdExceeded reading `xml:"sram_threshold_exceeded"`
 }
 
 // eccSRAMSources is <aggregate_uncorrectable_sram_sources>: which unit reported
-// the aggregate uncorrectable SRAM errors.
+// the aggregate uncorrectable SRAM errors. Ampere and later only.
 type eccSRAMSources struct {
 	L2              reading `xml:"sram_l2"`
 	SM              reading `xml:"sram_sm"`

--- a/tests/e2e/go/assertions/nvidiasmi/snapshot.go
+++ b/tests/e2e/go/assertions/nvidiasmi/snapshot.go
@@ -140,10 +140,9 @@ func (s Snapshot) FailedGPUs() []string {
 
 // UncorrectedECCAggregate is the total of this GPU's aggregate uncorrectable
 // counters — the XML equivalent of --query-gpu=ecc.errors.uncorrected.aggregate.total.
-// Counters reading N/A are skipped, because SRAM counters are unsupported on
-// these profiles and dropping the whole total for them would hide the DRAM
-// errors the assertion is looking for. false means no counter was numeric,
-// which is what a failed device reports.
+// Counters reading N/A are skipped so a GPU with ECC off, whose counters are all
+// N/A, does not drop the whole total. false means no counter was numeric, which
+// is what a failed device reports.
 func (g GPU) UncorrectedECCAggregate() (int, bool) {
 	total, counted := 0, false
 	for _, r := range []reading{
@@ -157,6 +156,31 @@ func (g GPU) UncorrectedECCAggregate() (int, bool) {
 		}
 	}
 	return total, counted
+}
+
+// ECCEnabled reports whether <current_ecc> reads Enabled. The SRAM and DRAM
+// counters only carry values in that mode, so checks over them gate on it
+// instead of treating a profile with ECC off as a defect.
+func (g GPU) ECCEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(string(g.element.ECCMode.Current)), "Enabled")
+}
+
+// ECCEnabled reports whether every GPU in the document has ECC on.
+func (s Snapshot) ECCEnabled() bool {
+	for i := range s.doc.GPUs {
+		if !s.gpu(i).ECCEnabled() {
+			return false
+		}
+	}
+	return len(s.doc.GPUs) > 0
+}
+
+// RowRemapHistogramPopulated reports whether <row_remapper_histogram> carries
+// bank counts rather than N/A, i.e. whether the GPU answered the histogram
+// getter at all.
+func (g GPU) RowRemapHistogramPopulated() bool {
+	body := strings.TrimSpace(g.element.RemappedRows.Histogram.Body)
+	return body != "" && !reading(body).unsupported()
 }
 
 // MaxUncorrectedECCAggregate is the largest per-GPU aggregate uncorrectable

--- a/tests/e2e/go/profile/profile.go
+++ b/tests/e2e/go/profile/profile.go
@@ -63,7 +63,12 @@ type rawProfile struct {
 		PCIe *struct {
 			MaxLinkGen int `json:"max_link_gen"`
 		} `json:"pcie"`
-		Platform *rawPlatform `json:"platform"`
+		Platform     *rawPlatform `json:"platform"`
+		RemappedRows *struct {
+			AvailabilityHistogram *struct {
+				Max int `json:"max"`
+			} `json:"availability_histogram"`
+		} `json:"remapped_rows"`
 	} `json:"device_defaults"`
 	Devices []struct {
 		Index    int          `json:"index"`
@@ -136,6 +141,8 @@ type Profile struct {
 	jpegUtilizationPct int
 	ofaUtilizationPct  int
 	maxPCIeLinkGen     int
+	rowRemapHistogram  bool
+	rowRemapBanks      int
 
 	platform    PlatformIdentity
 	hasPlatform bool
@@ -217,6 +224,10 @@ func (p *Profile) applyOptionalDeviceDefaults(raw rawProfile) {
 	}
 	if pcie := raw.DeviceDefaults.PCIe; pcie != nil {
 		p.maxPCIeLinkGen = pcie.MaxLinkGen
+	}
+	if r := raw.DeviceDefaults.RemappedRows; r != nil && r.AvailabilityHistogram != nil {
+		p.rowRemapHistogram = true
+		p.rowRemapBanks = r.AvailabilityHistogram.Max
 	}
 	if f := raw.DeviceDefaults.Fabric; f != nil {
 		p.hasFabric = true
@@ -357,6 +368,18 @@ func (p Profile) OFAUtilizationPct() int { return p.ofaUtilizationPct }
 // Ranges from 3 (t4) to 6 (Blackwell), so asserting against it pins the value
 // to config rather than a hardcoded constant.
 func (p Profile) MaxPCIeLinkGen() int { return p.maxPCIeLinkGen }
+
+// ReportsRowRemapHistogram reports whether the profile configures
+// remapped_rows.availability_histogram, i.e. whether nvidia-smi must render bank
+// counts rather than N/A for the Bank Remap Availability Histogram. Row
+// remapping is Ampere and later, so pre-Ampere profiles leave the block out and
+// the mock answers unsupported the way that hardware does (#641).
+func (p Profile) ReportsRowRemapHistogram() bool { return p.rowRemapHistogram }
+
+// RowRemapHistogramBanks is remapped_rows.availability_histogram.max: how many
+// banks a never-remapped GPU reports with their full complement of spare rows.
+// Zero when the profile configures no histogram.
+func (p Profile) RowRemapHistogramBanks() int { return p.rowRemapBanks }
 
 // ReportsTLimitTemp is true when real hardware of this architecture reports the
 // GPU T.Limit temperature field IDs (Ada and later). Pre-Ada profiles keep the

--- a/tests/e2e/go/profile/profile.go
+++ b/tests/e2e/go/profile/profile.go
@@ -369,6 +369,21 @@ func (p Profile) OFAUtilizationPct() int { return p.ofaUtilizationPct }
 // to config rather than a hardcoded constant.
 func (p Profile) MaxPCIeLinkGen() int { return p.maxPCIeLinkGen }
 
+// preAmpereArchitectures are the device_defaults.architecture values whose
+// hardware predates both row remapping and the split SRAM ECC counters.
+var preAmpereArchitectures = map[string]bool{
+	"kepler": true, "maxwell": true, "pascal": true, "volta": true, "turing": true,
+}
+
+// ReportsDetailedSramECC is true when nvidia-smi renders the Ampere-and-later
+// SRAM breakdown for this architecture: the uncorrectable count split into
+// parity and SEC-DED, plus the per-unit source list and the threshold flag.
+// Pre-Ampere output carries a single combined SRAM Uncorrectable row and none of
+// the rest, so the expectation is an architecture axis rather than a config one
+// — nvidia-smi picks the layout from the reported architecture, not from what
+// the profile configures (#641).
+func (p Profile) ReportsDetailedSramECC() bool { return !preAmpereArchitectures[p.architecture] }
+
 // ReportsRowRemapHistogram reports whether the profile configures
 // remapped_rows.availability_histogram, i.e. whether nvidia-smi must render bank
 // counts rather than N/A for the Bank Remap Availability Histogram. Row

--- a/tests/e2e/go/profile/profile_test.go
+++ b/tests/e2e/go/profile/profile_test.go
@@ -216,17 +216,19 @@ func TestPlatformIdentityModuleIDsAreDistinct(t *testing.T) {
 	}
 }
 
-// TestRowRemapHistogramIsAmpereAndLater pins the histogram as an
-// architecture axis: row remapping arrived with Ampere, so t4 must leave
-// remapped_rows.availability_histogram unset and report unsupported, while every
-// later profile configures it. Driven from KnownProfiles so a newly added
-// profile has to declare which side it belongs on (#641).
+// TestRowRemapHistogramIsAmpereAndLater pins the histogram to the same
+// architecture axis nvidia-smi uses for the SRAM layout: row remapping arrived
+// with Ampere, so t4 must leave remapped_rows.availability_histogram unset and
+// report unsupported, while every later profile configures it. Requiring the two
+// accessors to agree is what stops a profile from configuring capacity for a
+// generation whose driver output has no place to report it. Driven from
+// KnownProfiles so a newly added profile has to declare which side it belongs on
+// (#641).
 func TestRowRemapHistogramIsAmpereAndLater(t *testing.T) {
-	preAmpere := map[string]bool{"kepler": true, "maxwell": true, "pascal": true, "volta": true, "turing": true}
 	for _, name := range KnownProfiles {
 		p, err := Load(profilesDir, name)
 		require.NoError(t, err, "Load(%q)", name)
-		want := !preAmpere[p.Architecture()]
+		want := p.ReportsDetailedSramECC()
 		require.Equal(t, want, p.ReportsRowRemapHistogram(),
 			"%s (%s): remapped_rows.availability_histogram configured should be %v",
 			name, p.Architecture(), want)
@@ -234,6 +236,19 @@ func TestRowRemapHistogramIsAmpereAndLater(t *testing.T) {
 			require.Positive(t, p.RowRemapHistogramBanks(),
 				"%s: availability_histogram.max must be a real bank count", name)
 		}
+	}
+}
+
+// The SRAM layout is keyed on the architecture nvidia-smi reads, so t4 is the
+// only shipped profile on the combined side. Pinning it by name as well as by
+// architecture catches a profile that changes its architecture without the
+// expectation following.
+func TestDetailedSramECCIsAmpereAndLater(t *testing.T) {
+	for _, name := range KnownProfiles {
+		p, err := Load(profilesDir, name)
+		require.NoError(t, err, "Load(%q)", name)
+		require.Equal(t, name != "t4", p.ReportsDetailedSramECC(),
+			"%s (%s): detailed SRAM ECC rendering", name, p.Architecture())
 	}
 }
 

--- a/tests/e2e/go/profile/profile_test.go
+++ b/tests/e2e/go/profile/profile_test.go
@@ -215,3 +215,41 @@ func TestPlatformIdentityModuleIDsAreDistinct(t *testing.T) {
 		})
 	}
 }
+
+// TestRowRemapHistogramIsAmpereAndLater pins the histogram as an
+// architecture axis: row remapping arrived with Ampere, so t4 must leave
+// remapped_rows.availability_histogram unset and report unsupported, while every
+// later profile configures it. Driven from KnownProfiles so a newly added
+// profile has to declare which side it belongs on (#641).
+func TestRowRemapHistogramIsAmpereAndLater(t *testing.T) {
+	preAmpere := map[string]bool{"kepler": true, "maxwell": true, "pascal": true, "volta": true, "turing": true}
+	for _, name := range KnownProfiles {
+		p, err := Load(profilesDir, name)
+		require.NoError(t, err, "Load(%q)", name)
+		want := !preAmpere[p.Architecture()]
+		require.Equal(t, want, p.ReportsRowRemapHistogram(),
+			"%s (%s): remapped_rows.availability_histogram configured should be %v",
+			name, p.Architecture(), want)
+		if want {
+			require.Positive(t, p.RowRemapHistogramBanks(),
+				"%s: availability_histogram.max must be a real bank count", name)
+		}
+	}
+}
+
+// A profile with no remapped_rows block must load and report the histogram
+// unsupported rather than failing.
+func TestRowRemapHistogramDefaultsToUnsupported(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+device_defaults:
+  name: "NVIDIA TEST-GPU"
+devices:
+  - index: 0
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "fixture.yaml"), []byte(yaml), 0o600))
+
+	p, err := Load(dir, "fixture")
+	require.NoError(t, err, "Load(fixture)")
+	assert.False(t, p.ReportsRowRemapHistogram(), "ReportsRowRemapHistogram()")
+}

--- a/tests/e2e/go/scenario_sram_ecc.go
+++ b/tests/e2e/go/scenario_sram_ecc.go
@@ -1,0 +1,125 @@
+//go:build e2e
+
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/assertions/nvidiasmi"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/harness"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/kube"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/profile"
+)
+
+// SRAM ECC and row-remap availability (#641). Every SRAM row of nvidia-smi -q
+// read N/A while nvmlDeviceGetSramEccErrorStatus and
+// nvmlDeviceGetRowRemapperHistogram were generated stubs, so a consumer could
+// not tell a GPU with no SRAM errors from one whose SRAM state is unknown — and
+// no test could drive an SRAM fault at all.
+//
+// The distinction these scenarios rest on is that 0 and N/A are different
+// answers: zero counters are the healthy baseline the injection then moves, so a
+// spec that accepted N/A would pass against a mock that reports nothing.
+
+// sramInjectedCount is the number of SRAM errors the runtime scenario injects.
+// Small and non-zero: the assertion is that the exact configured count arrives,
+// so any value distinguishable from the zero baseline works.
+const sramInjectedCount = 4
+
+// assertSramECCBaseline covers the healthy half of the acceptance criteria: a
+// deployed profile must report 0 for every SRAM counter and a populated bank
+// availability histogram (where the modelled architecture has row remapping),
+// rather than N/A.
+func assertSramECCBaseline(ctx SpecContext, h *harness.Harness, consumer kube.PodRef, p profile.Profile) {
+	GinkgoHelper()
+	resetRuntimeOverrides(ctx, h)
+
+	By("verify every SRAM ECC counter reads 0 rather than N/A")
+	expectSmiEventually(ctx, h, consumer, "SRAM ECC counters must read 0, not N/A",
+		func(out string) []string {
+			return nvidiasmi.SramECCProblems(out, nvidiasmi.SramECCState{})
+		})
+
+	// A profile without an availability_histogram block must keep reporting
+	// N/A, so this expectation flips rather than being skipped: it is the
+	// negative control that the histogram tracks config instead of always
+	// answering.
+	By(fmt.Sprintf("verify the %s bank remap availability histogram reports %d banks",
+		p.Name, p.RowRemapHistogramBanks()))
+	want := nvidiasmi.RowRemapState{HistogramBanks: p.RowRemapHistogramBanks()}
+	expectSmiEventually(ctx, h, consumer, "remapped_rows must match the profile", func(out string) []string {
+		return nvidiasmi.RowRemapProblems(out, want)
+	})
+}
+
+// assertRuntimeSramECCInjection covers the injection half: drive SRAM ECC errors
+// into the running pod with nvml-mock-ctl, confirm nvidia-smi reports the exact
+// counts, the threshold flag and the source attribution, then clear them and
+// confirm the GPU returns to the zero baseline. The consumer is never restarted,
+// which is the capability being tested — a fault has to be injectable mid-test.
+func assertRuntimeSramECCInjection(ctx SpecContext, h *harness.Harness, consumer kube.PodRef) {
+	GinkgoHelper()
+	resetRuntimeOverrides(ctx, h)
+
+	counts := nvidiasmi.SramECCCounters{UncorrectableSECDED: sramInjectedCount}
+	injected := nvidiasmi.SramECCState{
+		Volatile:  counts,
+		Aggregate: counts,
+		// The SM is the target because a wrong implementation is most likely to
+		// report the total in the catch-all "other" bucket, which this catches.
+		Sources:           nvidiasmi.SramECCSources{SM: sramInjectedCount},
+		ThresholdExceeded: true,
+	}
+
+	By(fmt.Sprintf("inject %d uncorrectable SEC-DED SRAM errors on the SM of every GPU",
+		sramInjectedCount))
+	nvmlMockCtl(ctx, h, "sram-ecc", "--gpu", "all", "--type", "secded", "--source", "sm",
+		"--threshold-exceeded", strconv.Itoa(sramInjectedCount))
+
+	expectSmiEventually(ctx, h, consumer, "injected SRAM ECC errors must reach the running consumer",
+		func(out string) []string { return nvidiasmi.SramECCProblems(out, injected) })
+
+	By("heal the GPUs with sram-ecc count 0 and confirm the counters return to baseline")
+	nvmlMockCtl(ctx, h, "sram-ecc", "--gpu", "all", "--type", "secded", "--source", "sm", "0")
+
+	expectSmiEventually(ctx, h, consumer, "SRAM ECC counters must return to 0 after healing",
+		func(out string) []string {
+			return nvidiasmi.SramECCProblems(out, nvidiasmi.SramECCState{})
+		})
+
+	By("final reset")
+	nvmlMockCtl(ctx, h, "reset", "--gpu", "all")
+}
+
+// expectSmiEventually polls `nvidia-smi -q -x` in the consumer until check
+// reports no problems, giving the runtime override TTL time to land. Every
+// problem is reported at once so one poll names each wrong reading rather than
+// one per fix-and-rerun cycle.
+//
+// ExecQuiet keeps the ~90 KB document out of the Ginkgo log on every poll.
+func expectSmiEventually(
+	ctx SpecContext, h *harness.Harness, consumer kube.PodRef, desc string,
+	check func(out string) []string,
+) {
+	GinkgoHelper()
+	Eventually(func() error {
+		res, err := h.Kube.ExecQuiet(ctx, consumer, "nvidia-smi", "-q", "-x")
+		if err != nil {
+			return fmt.Errorf("nvidia-smi -q -x: %w: %s", err, res.Combined())
+		}
+		if problems := check(res.Stdout); len(problems) > 0 {
+			return errors.New(strings.Join(problems, "\n"))
+		}
+		return nil
+	}).WithContext(ctx).WithTimeout(runtimeTTLTimeout).WithPolling(runtimeTTLPoll).
+		Should(Succeed(), desc)
+}

--- a/tests/e2e/go/scenario_sram_ecc.go
+++ b/tests/e2e/go/scenario_sram_ecc.go
@@ -44,10 +44,9 @@ func assertSramECCBaseline(ctx SpecContext, h *harness.Harness, consumer kube.Po
 	resetRuntimeOverrides(ctx, h)
 
 	By("verify every SRAM ECC counter reads 0 rather than N/A")
+	healthy := nvidiasmi.SramECCState{Layout: sramECCLayout(p)}
 	expectSmiEventually(ctx, h, consumer, "SRAM ECC counters must read 0, not N/A",
-		func(out string) []string {
-			return nvidiasmi.SramECCProblems(out, nvidiasmi.SramECCState{})
-		})
+		func(out string) []string { return nvidiasmi.SramECCProblems(out, healthy) })
 
 	// A profile without an availability_histogram block must keep reporting
 	// N/A, so this expectation flips rather than being skipped: it is the
@@ -66,11 +65,12 @@ func assertSramECCBaseline(ctx SpecContext, h *harness.Harness, consumer kube.Po
 // counts, the threshold flag and the source attribution, then clear them and
 // confirm the GPU returns to the zero baseline. The consumer is never restarted,
 // which is the capability being tested — a fault has to be injectable mid-test.
-func assertRuntimeSramECCInjection(ctx SpecContext, h *harness.Harness, consumer kube.PodRef) {
+func assertRuntimeSramECCInjection(ctx SpecContext, h *harness.Harness, consumer kube.PodRef, p profile.Profile) {
 	GinkgoHelper()
 	resetRuntimeOverrides(ctx, h)
 
 	counts := nvidiasmi.SramECCCounters{UncorrectableSECDED: sramInjectedCount}
+	layout := sramECCLayout(p)
 	injected := nvidiasmi.SramECCState{
 		Volatile:  counts,
 		Aggregate: counts,
@@ -78,6 +78,7 @@ func assertRuntimeSramECCInjection(ctx SpecContext, h *harness.Harness, consumer
 		// report the total in the catch-all "other" bucket, which this catches.
 		Sources:           nvidiasmi.SramECCSources{SM: sramInjectedCount},
 		ThresholdExceeded: true,
+		Layout:            layout,
 	}
 
 	By(fmt.Sprintf("inject %d uncorrectable SEC-DED SRAM errors on the SM of every GPU",
@@ -91,13 +92,24 @@ func assertRuntimeSramECCInjection(ctx SpecContext, h *harness.Harness, consumer
 	By("heal the GPUs with sram-ecc count 0 and confirm the counters return to baseline")
 	nvmlMockCtl(ctx, h, "sram-ecc", "--gpu", "all", "--type", "secded", "--source", "sm", "0")
 
+	healed := nvidiasmi.SramECCState{Layout: layout}
 	expectSmiEventually(ctx, h, consumer, "SRAM ECC counters must return to 0 after healing",
-		func(out string) []string {
-			return nvidiasmi.SramECCProblems(out, nvidiasmi.SramECCState{})
-		})
+		func(out string) []string { return nvidiasmi.SramECCProblems(out, healed) })
 
 	By("final reset")
 	nvmlMockCtl(ctx, h, "reset", "--gpu", "all")
+}
+
+// sramECCLayout picks the rendering nvidia-smi uses for the profile's
+// architecture. Ampere and later split the uncorrectable count and report the
+// source breakdown; pre-Ampere reports one combined row and omits the rest, so
+// asserting on elements it never emits would fail on the mock's t4 profile even
+// though the counters behind them are correct.
+func sramECCLayout(p profile.Profile) nvidiasmi.SramECCLayout {
+	if p.ReportsDetailedSramECC() {
+		return nvidiasmi.SramECCDetailed
+	}
+	return nvidiasmi.SramECCCombined
 }
 
 // expectSmiEventually polls `nvidia-smi -q -x` in the consumer until check

--- a/tests/e2e/go/scenario_standalone_test.go
+++ b/tests/e2e/go/scenario_standalone_test.go
@@ -91,6 +91,15 @@ var _ = Describe("nvml-mock standalone", Ordered, func() {
 				assertEncoderFBCAccounting(ctx, h, pod)
 			})
 
+			It("reports SRAM ECC counters and row-remap availability via nvidia-smi -q -x", Label("nvidia-smi"), func(ctx SpecContext) {
+				// Issue #641: every SRAM row and the bank availability
+				// histogram read N/A, so a consumer saw an unsupported feature
+				// where a healthy GPU reports 0. The histogram expectation
+				// comes from the profile, which pins it populated on Ampere and
+				// later and N/A on t4.
+				assertSramECCBaseline(ctx, h, pod, p)
+			})
+
 			It("reports JPEG and OFA utilization via nvidia-smi -q -x", Label("nvidia-smi"), func(ctx SpecContext) {
 				// Issue #637: both readings were N/A because the NVML entry
 				// points were generated stubs, so every configured value was
@@ -185,6 +194,14 @@ var _ = Describe("nvml-mock standalone", Ordered, func() {
 				// (docs/nvml-mock-ctl.md) and validates the effect via nvidia-smi.
 				It("injects ECC at runtime via nvml-mock-ctl without restart", Label("runtime-control"), func(ctx SpecContext) {
 					assertRuntimeECCInjection(ctx, h, pod)
+				})
+
+				It("injects and clears SRAM ECC errors at runtime via nvml-mock-ctl", Label("runtime-control"), func(ctx SpecContext) {
+					// Issue #641: the inject-and-clear cycle is the point —
+					// simulating an SRAM fault mid-test is the capability being
+					// added, and the counters must come back to 0 rather than
+					// staying stuck or reverting to N/A.
+					assertRuntimeSramECCInjection(ctx, h, pod)
 				})
 
 				It("marks all GPUs lost and recovers via nvml-mock-ctl", Label("runtime-control"), func(ctx SpecContext) {

--- a/tests/e2e/go/scenario_standalone_test.go
+++ b/tests/e2e/go/scenario_standalone_test.go
@@ -201,7 +201,7 @@ var _ = Describe("nvml-mock standalone", Ordered, func() {
 					// simulating an SRAM fault mid-test is the capability being
 					// added, and the counters must come back to 0 rather than
 					// staying stuck or reverting to N/A.
-					assertRuntimeSramECCInjection(ctx, h, pod)
+					assertRuntimeSramECCInjection(ctx, h, pod, p)
 				})
 
 				It("marks all GPUs lost and recovers via nvml-mock-ctl", Label("runtime-control"), func(ctx SpecContext) {


### PR DESCRIPTION
## Summary

`nvmlDeviceGetSramEccErrorStatus` and `nvmlDeviceGetRowRemapperHistogram` were generated stubs, so every SRAM row of `nvidia-smi -q` and the Bank Remap Availability Histogram read `N/A`. `N/A` means "this GPU cannot tell you", which is the one answer real ECC-enabled hardware never gives — a healthy A100 reports `0` — so SRAM fault handling could not be tested at all, and the half-populated ECC section hid the gap behind the real DRAM counters beside it.

- New `ecc.sram` config block: correctable, uncorrectable-parity and uncorrectable-SEC-DED counters for the volatile and aggregate scopes, the aggregate per-unit source breakdown (L2, SM, microcontroller, PCIe, other) and the threshold-exceeded flag. Both stubbed exports are now answered from it.
- `nvmlDeviceGetMemoryErrorCounter` honours `locationType` and `counterType` instead of returning the DRAM counter for every location, and the per-location ECC field ids (7–28) resolve through it, so DCGM's field-value path reads what `nvidia-smi` reads.
- `remapped_rows.availability_histogram` carries bank remap capacity. The Ampere-and-later profiles ship it (16 banks per GiB, anchored on the 640 a real 40 GiB A100 reports); `t4` leaves it out and keeps reporting the histogram unsupported, as Turing does. An unconfigured device answers `NOT_SUPPORTED` rather than inventing a bank population, and a GPU with ECC off reports no SRAM counters at all.
- `nvml-mock-ctl sram-ecc --gpu <idx> [--type correctable|parity|secded] [--source l2|sm|microcontroller|pcie|other] [--threshold-exceeded] <count>` injects into a running workload; `0` heals. It writes both scopes (hardware that just took a fault reports it in both) and never rewrites the ECC mode, since a GPU with ECC off reports nothing and the injection would erase itself.

Fixes #641

## Test plan

- [x] `make lint-fix` — 0 golangci-lint issues (`govulncheck` reports only pre-existing Go 1.26.5 stdlib advisories)
- [x] `make test` — new unit tests cover the two exports, the C struct layouts and version tag, `locationType`/`counterType` handling, the per-location field ids, the `sram-ecc` patch builder and its CLI validation
- [x] `make helm-tests` — chart snapshots updated for the profile change
- [x] `make gen-check`
- [x] New Ginkgo specs: a `Label("nvidia-smi")` baseline asserting `0` rather than `N/A` plus the profile's configured histogram, and a `Label("failure-injection")`/`Label("runtime-control")` spec that injects at runtime, asserts the counts, the threshold flip and the source attribution, then clears and asserts the return to baseline. The `nvidia-smi` XML checks are unit-tested against the captured pre-fix fixtures, so they fail against current `main`.
- [x] Verified against the real `nvidia-smi` 580.65.06 binary over a freshly built mock (a100 profile): healthy GPUs report `0` and `SRAM Threshold Exceeded : No` with a populated `Max : 640 bank(s)`; after injection the counters read `4` in both scopes with `SRAM SM : 4` and `Yes`; healing and `reset` return to baseline with `ECC Mode : Enabled` intact; `t4` still reports the histogram `N/A`, and an ECC-disabled device reports the SRAM counters `N/A`.