### PR TITLE
feat(control-plane): Setup Control Plane Structured Logging

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -264,9 +264,10 @@ if with_topograph:
 # one mock GPU, so the device plugin must have registered nvidia.com/gpu
 # before the pod can start. Pod spec lives in local/gpu-validator.k8s.yaml so
 # it can be kubectl-applied standalone or edited without touching Starlark.
-k8s_yaml('local/gpu-validator.k8s.yaml')
-k8s_resource('gpu-validator',
-    auto_init=False,
-    resource_deps=nvml_mock_releases,
-    labels=['test'],
-)
+if with_gpu_operator:
+    k8s_yaml('local/gpu-validator.k8s.yaml')
+    k8s_resource('gpu-validator',
+        auto_init=False,
+        resource_deps=nvml_mock_releases,
+        labels=['test'],
+    )

--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -1,10 +1,10 @@
 // Copyright 2026 NVIDIA CORPORATION
 // SPDX-License-Identifier: Apache-2.0
 
-// mokka-control-plane is the entry point for the Mokka Control Plane
-// microservice described in MEP-0001. The init slice only serves health
-// probes; sGPU inventory management, node-agent heartbeats, and runtime
-// policy fan-out land in follow-up work on the same binary.
+// control-plane is the entry point for the Mokka Control Plane microservice
+// described in MEP-0001. The init slice only serves health probes; sGPU
+// inventory management, node-agent heartbeats, and runtime policy fan-out
+// land in follow-up work on the same binary.
 package main
 
 import (
@@ -21,7 +21,7 @@ import (
 
 func main() {
 	if err := newCLI().Run(context.Background(), os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "mokka-control-plane: %v\n", err)
+		fmt.Fprintf(os.Stderr, "control-plane: %v\n", err)
 		os.Exit(1)
 	}
 }
@@ -29,7 +29,7 @@ func main() {
 func newCLI() *cli.Command {
 	defaults := controlplane.DefaultConfig()
 	return &cli.Command{
-		Name:  "mokka-control-plane",
+		Name:  "control-plane",
 		Usage: "Mokka Control Plane",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
@@ -43,6 +43,12 @@ func newCLI() *cli.Command {
 				Value:   defaults.LogLevel,
 				Sources: cli.EnvVars("MOKKA_CP_LOG_LEVEL"),
 				Usage:   "log level: debug | info | warn | error",
+			},
+			&cli.StringFlag{
+				Name:    "log-format",
+				Value:   defaults.LogFormat,
+				Sources: cli.EnvVars("MOKKA_CP_LOG_FORMAT"),
+				Usage:   "log format: json | plain",
 			},
 			&cli.DurationFlag{
 				Name:    "shutdown-timeout",
@@ -59,6 +65,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	cfg := controlplane.Config{
 		ListenAddr:      cmd.String("listen-addr"),
 		LogLevel:        cmd.String("log-level"),
+		LogFormat:       cmd.String("log-format"),
 		ShutdownTimeout: cmd.Duration("shutdown-timeout"),
 	}
 

--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -41,13 +41,13 @@ func newCLI() *cli.Command {
 			&cli.StringFlag{
 				Name:    "log-level",
 				Value:   defaults.LogLevel,
-				Sources: cli.EnvVars("MOKKA_CP_LOG_LEVEL"),
+				Sources: cli.EnvVars("MOKKA_LOG_LEVEL"),
 				Usage:   "log level: debug | info | warn | error",
 			},
 			&cli.StringFlag{
 				Name:    "log-format",
 				Value:   defaults.LogFormat,
-				Sources: cli.EnvVars("MOKKA_CP_LOG_FORMAT"),
+				Sources: cli.EnvVars("MOKKA_LOG_FORMAT"),
 				Usage:   "log format: json | plain",
 			},
 			&cli.DurationFlag{

--- a/cmd/control-plane/main_test.go
+++ b/cmd/control-plane/main_test.go
@@ -24,25 +24,37 @@ func TestFlagsProduceExpectedConfig(t *testing.T) {
 	}{
 		{
 			name: "defaults when no flags",
-			args: []string{"mokka-control-plane"},
+			args: []string{"control-plane"},
 			want: controlplane.DefaultConfig(),
 		},
 		{
 			name: "listen-addr override",
-			args: []string{"mokka-control-plane", "--listen-addr", ":9090"},
+			args: []string{"control-plane", "--listen-addr", ":9090"},
 			want: controlplane.Config{
 				ListenAddr:      ":9090",
 				LogLevel:        "info",
+				LogFormat:       "json",
 				ShutdownTimeout: 5 * time.Second,
 			},
 		},
 		{
 			name: "log-level and shutdown-timeout override",
-			args: []string{"mokka-control-plane", "--log-level", "debug", "--shutdown-timeout", "12s"},
+			args: []string{"control-plane", "--log-level", "debug", "--shutdown-timeout", "12s"},
 			want: controlplane.Config{
 				ListenAddr:      ":8080",
 				LogLevel:        "debug",
+				LogFormat:       "json",
 				ShutdownTimeout: 12 * time.Second,
+			},
+		},
+		{
+			name: "log-format plain override",
+			args: []string{"control-plane", "--log-format", "plain"},
+			want: controlplane.Config{
+				ListenAddr:      ":8080",
+				LogLevel:        "info",
+				LogFormat:       "plain",
+				ShutdownTimeout: 5 * time.Second,
 			},
 		},
 	} {
@@ -53,6 +65,7 @@ func TestFlagsProduceExpectedConfig(t *testing.T) {
 				got = controlplane.Config{
 					ListenAddr:      c.String("listen-addr"),
 					LogLevel:        c.String("log-level"),
+					LogFormat:       c.String("log-format"),
 					ShutdownTimeout: c.Duration("shutdown-timeout"),
 				}
 				return nil

--- a/deployments/control-plane/Dockerfile
+++ b/deployments/control-plane/Dockerfile
@@ -28,10 +28,10 @@ COPY internal/ internal/
 COPY cmd/ cmd/
 RUN CGO_ENABLED=0 go build -mod=vendor \
     -ldflags="-s -w" \
-    -o /out/mokka-control-plane ./cmd/mokka-control-plane
+    -o /dist/control-plane ./cmd/control-plane
 
 FROM gcr.io/distroless/static-debian12:nonroot
-COPY --from=builder /out/mokka-control-plane /usr/local/bin/mokka-control-plane
+COPY --from=builder /dist/control-plane /usr/local/bin/control-plane
 USER nonroot:nonroot
 EXPOSE 8080
-ENTRYPOINT ["/usr/local/bin/mokka-control-plane"]
+ENTRYPOINT ["/usr/local/bin/control-plane"]

--- a/deployments/nvml-mock/helm/nvml-mock/templates/controlplane-deployment.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/controlplane-deployment.yaml
@@ -38,7 +38,8 @@ spec:
           imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}
           args:
             - --listen-addr=:{{ .Values.controlPlane.service.port }}
-            - --log-level={{ .Values.controlPlane.logLevel }}
+            - --log-level={{ .Values.controlPlane.logging.level }}
+            - --log-format={{ .Values.controlPlane.logging.format }}
           ports:
             - name: http
               containerPort: {{ .Values.controlPlane.service.port }}

--- a/deployments/nvml-mock/helm/nvml-mock/templates/controlplane-deployment.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/controlplane-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - name: mokka-control-plane
+        - name: control-plane
           image: "{{ .Values.controlPlane.image.repository }}:{{ .Values.controlPlane.image.tag }}"
           imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}
           args:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/controlplane_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/controlplane_test.yaml
@@ -44,7 +44,7 @@ tests:
           value: control-plane
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/nvidia/control-plane:latest
+          value: ghcr.io/nvidia/mokka-control-plane:latest
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent

--- a/deployments/nvml-mock/helm/nvml-mock/tests/controlplane_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/controlplane_test.yaml
@@ -184,7 +184,7 @@ tests:
             targetPort: http
             protocol: TCP
 
-  - it: should honour a custom image, replicas, and log level
+  - it: should honour a custom image, replicas, and logging knobs
     set:
       controlPlane:
         enabled: true
@@ -193,7 +193,9 @@ tests:
           repository: registry.example.com/mokka-cp
           tag: v0.1.0
           pullPolicy: Always
-        logLevel: debug
+        logging:
+          level: debug
+          format: plain
     template: templates/controlplane-deployment.yaml
     asserts:
       - equal:
@@ -208,6 +210,9 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --log-level=debug
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --log-format=plain
 
   # Moving the port must move the bind flag, the container port, and the
   # Service port together — a mismatch is exactly the silent-Ready failure
@@ -248,10 +253,20 @@ tests:
             targetPort: http
             protocol: TCP
 
-  - it: should reject an unknown logLevel via the values schema
+  - it: should reject an unknown logging.level via the values schema
     set:
       controlPlane:
         enabled: true
-        logLevel: trace
+        logging:
+          level: trace
+    asserts:
+      - failedTemplate: {}
+
+  - it: should reject an unknown logging.format via the values schema
+    set:
+      controlPlane:
+        enabled: true
+        logging:
+          format: text
     asserts:
       - failedTemplate: {}

--- a/deployments/nvml-mock/helm/nvml-mock/tests/controlplane_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/controlplane_test.yaml
@@ -41,10 +41,10 @@ tests:
           value: false
       - equal:
           path: spec.template.spec.containers[0].name
-          value: mokka-control-plane
+          value: control-plane
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/nvidia/mokka-control-plane:latest
+          value: ghcr.io/nvidia/control-plane:latest
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent

--- a/deployments/nvml-mock/helm/nvml-mock/values.schema.json
+++ b/deployments/nvml-mock/helm/nvml-mock/values.schema.json
@@ -313,10 +313,20 @@
             "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
           }
         },
-        "logLevel": {
-          "type": "string",
-          "enum": ["debug", "info", "warn", "warning", "error"],
-          "description": "Structured-logging level passed as --log-level. The binary rejects unknown values, so the enum here fails fast at helm template time instead of after the pod crashes."
+        "logging": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Structured-logging knobs. The binary rejects unknown values, so enums here fail fast at helm template time instead of after the pod crashes.",
+          "properties": {
+            "level": {
+              "type": "string",
+              "enum": ["debug", "info", "warn", "warning", "error"]
+            },
+            "format": {
+              "type": "string",
+              "enum": ["json", "plain"]
+            }
+          }
         },
         "service": {
           "type": "object",

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -381,7 +381,7 @@ controlPlane:
   enabled: false
   replicas: 1
   image:
-    repository: ghcr.io/nvidia/control-plane
+    repository: ghcr.io/nvidia/mokka-control-plane
     tag: latest
     pullPolicy: IfNotPresent
   logLevel: info                       # debug | info | warn | error

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -381,7 +381,7 @@ controlPlane:
   enabled: false
   replicas: 1
   image:
-    repository: ghcr.io/nvidia/mokka-control-plane
+    repository: ghcr.io/nvidia/control-plane
     tag: latest
     pullPolicy: IfNotPresent
   logLevel: info                       # debug | info | warn | error
@@ -389,7 +389,7 @@ controlPlane:
     type: ClusterIP
     port: 8080
   # Total shutdown budget on the pod: preStop sleep + in-flight request drain
-  # (mokka-control-plane --shutdown-timeout, default 5s) must fit inside this.
+  # (control-plane --shutdown-timeout, default 5s) must fit inside this.
   # 30s matches the kube default and leaves headroom over the current 10s
   # preStop + 5s drain; raise this together with --shutdown-timeout if the
   # CP starts holding long-lived connections. Setting it below preStop + drain

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -384,7 +384,9 @@ controlPlane:
     repository: ghcr.io/nvidia/mokka-control-plane
     tag: latest
     pullPolicy: IfNotPresent
-  logLevel: info                       # debug | info | warn | error
+  logging:
+    level: info    # debug | info | warn | error
+    format: json   # json | plain
   service:
     type: ClusterIP
     port: 8080

--- a/internal/controlplane/config.go
+++ b/internal/controlplane/config.go
@@ -13,6 +13,7 @@ import "time"
 type Config struct {
 	ListenAddr      string
 	LogLevel        string
+	LogFormat       string // "json" | "plain"
 	ShutdownTimeout time.Duration
 }
 
@@ -21,6 +22,7 @@ func DefaultConfig() Config {
 	return Config{
 		ListenAddr:      ":8080",
 		LogLevel:        "info",
+		LogFormat:       "json",
 		ShutdownTimeout: 5 * time.Second,
 	}
 }

--- a/internal/controlplane/config_test.go
+++ b/internal/controlplane/config_test.go
@@ -4,6 +4,7 @@
 package controlplane_test
 
 import (
+	"log/slog"
 	"testing"
 	"time"
 
@@ -51,16 +52,17 @@ func TestNewLogger(t *testing.T) {
 
 func TestNewLoggerFormat(t *testing.T) {
 	for _, tc := range []struct {
-		format  string
-		wantErr bool
+		format   string
+		wantErr  bool
+		wantJSON bool
 	}{
-		{"json", false},
-		{"plain", false},
-		{"JSON", false},  // Case-insensitive.
-		{"Plain", false}, // Case-insensitive.
-		{"", false},      // Empty falls back to json.
-		{"text", true},   // Not an accepted alias.
-		{"logfmt", true},
+		{"json", false, true},
+		{"plain", false, false},
+		{"JSON", false, true},   // Case-insensitive.
+		{"Plain", false, false}, // Case-insensitive.
+		{"", false, true},       // Empty falls back to json.
+		{"text", true, false},   // Not an accepted alias.
+		{"logfmt", true, false},
 	} {
 		t.Run(tc.format, func(t *testing.T) {
 			cfg := controlplane.DefaultConfig()
@@ -73,6 +75,11 @@ func TestNewLoggerFormat(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.NotNil(t, logger)
+			if tc.wantJSON {
+				require.IsType(t, (*slog.JSONHandler)(nil), logger.Handler())
+			} else {
+				require.IsType(t, (*slog.TextHandler)(nil), logger.Handler())
+			}
 		})
 	}
 }

--- a/internal/controlplane/config_test.go
+++ b/internal/controlplane/config_test.go
@@ -15,6 +15,7 @@ func TestDefaultConfig(t *testing.T) {
 	cfg := controlplane.DefaultConfig()
 	require.Equal(t, ":8080", cfg.ListenAddr)
 	require.Equal(t, "info", cfg.LogLevel)
+	require.Equal(t, "json", cfg.LogFormat)
 	require.Equal(t, 5*time.Second, cfg.ShutdownTimeout)
 }
 
@@ -36,6 +37,34 @@ func TestNewLogger(t *testing.T) {
 		t.Run(tc.level, func(t *testing.T) {
 			cfg := controlplane.DefaultConfig()
 			cfg.LogLevel = tc.level
+			logger, err := controlplane.NewLogger(cfg)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Nil(t, logger)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, logger)
+		})
+	}
+}
+
+func TestNewLoggerFormat(t *testing.T) {
+	for _, tc := range []struct {
+		format  string
+		wantErr bool
+	}{
+		{"json", false},
+		{"plain", false},
+		{"JSON", false},  // Case-insensitive.
+		{"Plain", false}, // Case-insensitive.
+		{"", false},      // Empty falls back to json.
+		{"text", true},   // Not an accepted alias.
+		{"logfmt", true},
+	} {
+		t.Run(tc.format, func(t *testing.T) {
+			cfg := controlplane.DefaultConfig()
+			cfg.LogFormat = tc.format
 			logger, err := controlplane.NewLogger(cfg)
 			if tc.wantErr {
 				require.Error(t, err)

--- a/internal/controlplane/logging.go
+++ b/internal/controlplane/logging.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 )
 
-// NewLogger returns a JSON-formatted slog.Logger writing to stdout. An
-// unrecognized level is a startup error rather than a silent fallback so a
-// typo in a Helm value fails loudly instead of running at the wrong verbosity.
+// NewLogger returns a slog.Logger writing to stdout. Unrecognized level or
+// format values are startup errors so a typo in a Helm value fails loudly
+// instead of running at the wrong verbosity or format.
 func NewLogger(cfg Config) (*slog.Logger, error) {
 	var level slog.Level
 	switch strings.ToLower(cfg.LogLevel) {
@@ -27,6 +27,16 @@ func NewLogger(cfg Config) (*slog.Logger, error) {
 	default:
 		return nil, fmt.Errorf("unknown log level %q; expected one of debug, info, warn, error", cfg.LogLevel)
 	}
-	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level})
+
+	opts := &slog.HandlerOptions{Level: level}
+	var handler slog.Handler
+	switch strings.ToLower(cfg.LogFormat) {
+	case "", "json":
+		handler = slog.NewJSONHandler(os.Stdout, opts)
+	case "plain":
+		handler = slog.NewTextHandler(os.Stdout, opts)
+	default:
+		return nil, fmt.Errorf("unknown log format %q; expected json or plain", cfg.LogFormat)
+	}
 	return slog.New(handler), nil
 }

--- a/local/compute-domain/compute_domain.tiltfile
+++ b/local/compute-domain/compute_domain.tiltfile
@@ -24,6 +24,7 @@
 # All side effects inside functions so load()ing this file is a pure import.
 
 load('ext://helm_resource', 'helm_resource')
+load('ext://k8s_attach', 'k8s_attach')
 
 _BASE_IMAGE         = 'nvml-mock:compute-domain'
 _DEMO_IMAGE         = 'nvml-mock:compute-domain-imex'
@@ -139,6 +140,15 @@ def install(active_consumers, control_plane=False):
         flags=flags,
         labels=['mokka'],
     )
+
+    if control_plane:
+        k8s_attach(
+            name='nvml-mock-control-plane',
+            obj='deployment/nvml-mock-control-plane',
+            namespace='mokka',
+            resource_deps=['nvml-mock'],
+            labels=['mokka-core'],
+        )
 
     # Scenario 1: per-node fabric identity via check-fabric. Manually
     # triggered — hitting the button asserts the topology overlay

--- a/local/nvml_mock.tiltfile
+++ b/local/nvml_mock.tiltfile
@@ -19,6 +19,7 @@
 # Tilt an image it already built and loaded, without asking it to rebuild.
 
 load('ext://helm_resource', 'helm_resource')
+load('ext://k8s_attach', 'k8s_attach')
 
 # Order matters: the Nth profile is pinned to worker-N, whose name comes from
 # the JoinConfiguration patches in local/kind/default.kind.yaml.
@@ -86,7 +87,7 @@ def build_control_plane_image():
     docker_build(
       _CONTROL_PLANE_IMAGE,
         context='.',
-        dockerfile='deployments/mokka-control-plane/Dockerfile',
+        dockerfile='deployments/control-plane/Dockerfile',
         only=[
             'go.mod',
             'go.sum',
@@ -94,7 +95,7 @@ def build_control_plane_image():
             'cmd/',
             'pkg/',
             'internal/',
-            'deployments/mokka-control-plane/',
+            'deployments/control-plane/',
         ],
     )
 
@@ -105,7 +106,7 @@ def install_control_plane_crds():
         _CRDS_CHART,
         namespace=_NAMESPACE,
         flags=['--create-namespace'],
-        labels=['mokka-control-plane'],
+        labels=['mokka-core'],
     )
 
 def _install(release, profile, active_consumers, extra_set, nvmlmock_image='', control_plane=False):
@@ -181,6 +182,15 @@ def _install(release, profile, active_consumers, extra_set, nvmlmock_image='', c
             _CHART,
             namespace=_NAMESPACE,
             flags=flags,
+            labels=['mokka-core'],
+        )
+
+    if control_plane:
+        k8s_attach(
+            name='control-plane',
+            obj='deployment/' + release + '-control-plane',
+            namespace=_NAMESPACE,
+            resource_deps=[release],
             labels=['mokka-core'],
         )
 


### PR DESCRIPTION
## What This PR Does

Setting up structured logging in control plane via slog package. Support different log levels.

Renamed mokka-control-plane to just control-plane to simply naming.

## Why

In order to be properly parsed by container log aggregators.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [ ] Tests pass (`go test -v -race ./...`)
- [ ] Linter passes (`make lint-fix`)
- [ ] New code has SPDX license headers
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (if user-facing change)
