### PR TITLE
feat(mocknvml): report clocks event reason counters for nvidia-smi -q

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `clocks_throttle_reasons.counters` block seeds the accrued time per cause per
   device, defaulting to `0 us` — a real answer, where `N/A` was not — and a
   device accrues further time on top of that baseline for as long as the
-  matching flag is set, so the flags and the counters cannot contradict each
-  other. `nvmlDeviceGetViolationStatus` now honours its `perfPolicyType` and
+  matching flag is set, within one process. A throttle state entered at runtime
+  therefore carries no history of its own, so seed the counter alongside the
+  flag when a GPU is meant to have been throttling for a while.
+  `nvmlDeviceGetViolationStatus` now honours its `perfPolicyType` and
   timestamps the reading, where it previously returned a zero
   `nvmlViolationTime_t` for every policy, leaving the five causes
   indistinguishable. The limiters the mock does not model (board limit, low

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   GPUs. Adds two manual triggers that inject a temperature or Xid fault through
   `nvml-mock-ctl` and fail if it never reaches Prometheus, making the scrape
   path asserted rather than eyeballed. (#597)
+- mocknvml: the `Clocks Event Reasons Counters` block of `nvidia-smi -q` now
+  reports microsecond totals instead of `N/A` for all five causes. The counters
+  are how throttling is diagnosed after the fact — a workload that ran slow is
+  investigated by reading accumulated `SW Power Capping` or `HW Thermal
+  Slowdown` time, not by sampling the instantaneous flag and hoping to catch it
+  — and the block previously contradicted the flags directly above it, which
+  stated confidently that no reason was active while the counters could not say
+  whether one ever had been. A 580-era `nvidia-smi` reads them through
+  `nvmlDeviceGetFieldValues`, which had no case for the field ids behind them, so
+  each came back per-field `NOT_SUPPORTED` while the overall call succeeded and
+  no unimplemented-symbol stub was reached. A new
+  `clocks_throttle_reasons.counters` block seeds the accrued time per cause per
+  device, defaulting to `0 us` — a real answer, where `N/A` was not — and a
+  device accrues further time on top of that baseline for as long as the
+  matching flag is set, so the flags and the counters cannot contradict each
+  other. `nvmlDeviceGetViolationStatus` now honours its `perfPolicyType` and
+  timestamps the reading, where it previously returned a zero
+  `nvmlViolationTime_t` for every policy, leaving the five causes
+  indistinguishable. A counter can also be seeded while a workload runs, with
+  `nvml-mock-ctl set --gpu <idx>
+  clocks_throttle_reasons.counters.sw_power_cap_us=<us>`. (#678)
 - mocknvml: `nvidia-smi -q` now reports the `Platform Info` block on the
   `gb200`/`gb300` profiles — chassis serial number, slot number, tray index,
   host ID, peer type and module ID, where every row previously read `N/A`. These

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   other. `nvmlDeviceGetViolationStatus` now honours its `perfPolicyType` and
   timestamps the reading, where it previously returned a zero
   `nvmlViolationTime_t` for every policy, leaving the five causes
-  indistinguishable. A counter can also be seeded while a workload runs, with
+  indistinguishable. The limiters the mock does not model (board limit, low
+  utilization, reliability, total base clocks) keep reporting `0 ns`, since they
+  are real policies that simply never fired; `NVML_PERF_POLICY_TOTAL_APP_CLOCKS`
+  now reports `NOT_SUPPORTED`, which is the one policy `nvml.h` marks
+  "DEPRECATED, Do not use", and a value outside the enum reports
+  `INVALID_ARGUMENT` rather than a zero violation time. A counter can also be
+  seeded while a workload runs, with
   `nvml-mock-ctl set --gpu <idx>
   clocks_throttle_reasons.counters.sw_power_cap_us=<us>`. (#678)
 - mocknvml: `nvidia-smi -q` now reports the `Platform Info` block on the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -257,19 +257,32 @@ device_defaults:
       hw_power_brake_slowdown_us: 0
 ```
 
+A per-device `clocks_throttle_reasons` block replaces the `device_defaults` one
+wholesale rather than merging into it, as `memory`, `power`, `thermal` and
+`clocks` already do. A `devices:` entry carrying only `counters` therefore drops
+the inherited flags, so restate the ones that still apply — which is why the
+`gpu_idle: true` above is repeated in each per-device block of
+`tests/mocknvml/util-test-config.yaml`.
+
 The counters appear under `Clocks Event Reasons Counters` in `nvidia-smi -q`,
 and are readable through `nvmlDeviceGetFieldValues` (the path DCGM uses) and
 `nvmlDeviceGetViolationStatus`. A device accrues further time on top of its
-configured baseline for as long as the matching flag is set, so the flags and
-the counters cannot contradict each other. Accrual is per process, like the
-dynamic-metrics simulator: a long-lived consumer such as dcgm-exporter watches
-the counter climb, while each `nvidia-smi` invocation reads from the configured
-baseline.
+configured baseline for as long as the matching flag is set. Accrual is per
+process, like the dynamic-metrics simulator: a long-lived consumer such as
+dcgm-exporter watches the counter climb, while each `nvidia-smi` invocation
+accrues only over its own lifetime and so reports essentially the baseline.
 
-Seed a counter at runtime with `nvml-mock-ctl`, without restarting the consumer:
+That per-process scope is why the flags and the counters have to be configured
+to agree rather than agreeing by construction. A GPU thrown into a throttle
+state at runtime carries no history: `nvidia-smi` renders the reason `Active`
+beside a counter of a microsecond or two, which is the age of that `nvidia-smi`
+process and not of the throttle. To describe a GPU that has been throttling for
+a while, seed the counter alongside the flag — both land in the same override
+document, so the second command keeps the first:
 
 ```bash
-nvml-mock-ctl set --gpu 3 clocks_throttle_reasons.counters.sw_power_cap_us=39595
+nvml-mock-ctl throttle --gpu 3 thermal
+nvml-mock-ctl set --gpu 3 clocks_throttle_reasons.counters.hw_thermal_slowdown_us=39595
 ```
 
 ### Performance

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -243,6 +243,33 @@ device_defaults:
     sync_boost: false
     sw_thermal_slowdown: false
     display_clocks_setting: false
+
+    # Cumulative time each cause has already cost the GPU, in microseconds.
+    # The flags above answer "is it throttled now"; these answer "how long has
+    # it been", which is what a slow workload is diagnosed from. Omit the block
+    # for a GPU that has never been throttled: every counter then reports 0 us,
+    # which is an answer, where the pre-#678 N/A was not.
+    counters:
+      sw_power_cap_us: 39595
+      sync_boost_us: 0
+      sw_thermal_slowdown_us: 0
+      hw_thermal_slowdown_us: 0
+      hw_power_brake_slowdown_us: 0
+```
+
+The counters appear under `Clocks Event Reasons Counters` in `nvidia-smi -q`,
+and are readable through `nvmlDeviceGetFieldValues` (the path DCGM uses) and
+`nvmlDeviceGetViolationStatus`. A device accrues further time on top of its
+configured baseline for as long as the matching flag is set, so the flags and
+the counters cannot contradict each other. Accrual is per process, like the
+dynamic-metrics simulator: a long-lived consumer such as dcgm-exporter watches
+the counter climb, while each `nvidia-smi` invocation reads from the configured
+baseline.
+
+Seed a counter at runtime with `nvml-mock-ctl`, without restarting the consumer:
+
+```bash
+nvml-mock-ctl set --gpu 3 clocks_throttle_reasons.counters.sw_power_cap_us=39595
 ```
 
 ### Performance

--- a/docs/nvml-mock-ctl.md
+++ b/docs/nvml-mock-ctl.md
@@ -325,7 +325,8 @@ equivalent.
 into the device config; the value is parsed as a YAML scalar (so numbers, bools,
 and strings get their natural type). Example paths: `thermal.temperature_gpu_c`,
 `utilization.gpu`, `ecc.mode_current`, `power.current_draw_mw`,
-`remapped_rows.availability_histogram.low`.
+`remapped_rows.availability_histogram.low`,
+`clocks_throttle_reasons.counters.sw_power_cap_us`.
 
 #### Dynamic metrics mask their static counterparts
 

--- a/pkg/gpu/mocknvml/bridge/fieldvalues.go
+++ b/pkg/gpu/mocknvml/bridge/fieldvalues.go
@@ -95,6 +95,13 @@ func nvmlDeviceGetFieldValues(device C.nvmlDevice_t, valuesCount C.int, values *
 
 		vt, val, ret := dev.GetFieldValue(fieldID, scopeID)
 		if ret != nvml.SUCCESS {
+			// Named explicitly because a declined field is otherwise invisible:
+			// the overall call still succeeds, the consumer renders the entry as
+			// a blank or N/A, and no unimplemented-symbol stub is reached. That
+			// is how the throttle counters read N/A for as long as they did
+			// (NVIDIA/k8s-test-infra#678).
+			debugLog("[NVML] nvmlDeviceGetFieldValues: field %d scope %d -> %d (declined)\n",
+				fieldID, scopeID, ret)
 			C.fvSetReturn(fv, toReturn(ret))
 			continue
 		}

--- a/pkg/gpu/mocknvml/engine/config.go
+++ b/pkg/gpu/mocknvml/engine/config.go
@@ -375,6 +375,9 @@ func mergeDeviceOverride(base *DeviceConfig, override *DeviceOverride) {
 	if override.Clocks != nil {
 		base.Clocks = override.Clocks
 	}
+	if override.ClocksThrottleReasons != nil {
+		base.ClocksThrottleReasons = override.ClocksThrottleReasons
+	}
 	if override.Utilization != nil {
 		base.Utilization = override.Utilization
 	}

--- a/pkg/gpu/mocknvml/engine/config_types.go
+++ b/pkg/gpu/mocknvml/engine/config_types.go
@@ -350,8 +350,10 @@ type ClocksThrottleReasonsConfig struct {
 // ThrottleCountersConfig is the starting value of each clocks-event counter, in
 // microseconds — the unit nvidia-smi prints them in and the unit a reading off
 // a real tray is copied from. A device accrues further time on top of these
-// while the matching flag above is set, so the flags and the counters cannot
-// contradict each other. Omitting the block means a GPU that has never been
+// while the matching flag above is set, but only within one process, so a
+// throttle state entered at runtime carries no history of its own: the baseline
+// here is what makes an Active flag read as a duration rather than as the age of
+// the calling process. Omitting the block means a GPU that has never been
 // throttled, which reports 0 rather than N/A.
 type ThrottleCountersConfig struct {
 	SWPowerCapUS           uint64 `json:"sw_power_cap_us,omitempty"`

--- a/pkg/gpu/mocknvml/engine/config_types.go
+++ b/pkg/gpu/mocknvml/engine/config_types.go
@@ -340,6 +340,25 @@ type ClocksThrottleReasonsConfig struct {
 	SyncBoost                 bool `json:"sync_boost,omitempty"`
 	SWThermalSlowdown         bool `json:"sw_thermal_slowdown,omitempty"`
 	DisplayClocksSetting      bool `json:"display_clocks_setting,omitempty"`
+
+	// Counters seeds the cumulative time each cause has already cost the GPU.
+	// The flags above answer "is it throttled now"; the counters answer "how
+	// long has it been", which is what a slow workload is diagnosed from.
+	Counters *ThrottleCountersConfig `json:"counters,omitempty"`
+}
+
+// ThrottleCountersConfig is the starting value of each clocks-event counter, in
+// microseconds — the unit nvidia-smi prints them in and the unit a reading off
+// a real tray is copied from. A device accrues further time on top of these
+// while the matching flag above is set, so the flags and the counters cannot
+// contradict each other. Omitting the block means a GPU that has never been
+// throttled, which reports 0 rather than N/A.
+type ThrottleCountersConfig struct {
+	SWPowerCapUS           uint64 `json:"sw_power_cap_us,omitempty"`
+	SyncBoostUS            uint64 `json:"sync_boost_us,omitempty"`
+	SWThermalSlowdownUS    uint64 `json:"sw_thermal_slowdown_us,omitempty"`
+	HWThermalSlowdownUS    uint64 `json:"hw_thermal_slowdown_us,omitempty"`
+	HWPowerBrakeSlowdownUS uint64 `json:"hw_power_brake_slowdown_us,omitempty"`
 }
 
 // SupportedClocksConfig defines supported clock frequencies

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -75,6 +75,12 @@ type ConfigurableDevice struct {
 	// on refresh. Read via failureInjector().
 	failure atomic.Pointer[failureInjector]
 
+	// throttle accrues per-cause clocks-event time. Created on first read
+	// (see throttleAccrual) and deliberately NOT swapped on config refresh:
+	// the time a GPU has already spent throttled is not something a runtime
+	// override can take back.
+	throttle atomic.Pointer[throttleAccrual]
+
 	// refresh bookkeeping
 	refreshMu  sync.Mutex
 	appliedGen uint64
@@ -2295,24 +2301,6 @@ func (d *ConfigurableDevice) failureLost() bool {
 	}
 	fi := d.failureInjector()
 	return fi != nil && fi.IsLost()
-}
-
-// GetViolationStatus returns the active violation time information for
-// a performance policy. The returned struct stays semantically faithful
-// to the NVML spec — both ReferenceTime and ViolationTime are reported
-// in nanoseconds for power/thermal violations. Failure injection does
-// NOT overload these fields with the configured Xid code; instead the
-// Xid is surfaced via the NVML event set
-// (NVML_EVENT_TYPE_XID_CRITICAL_ERROR) so consumers like dcgm-exporter
-// or the device plugin's health monitor see it through the API designed
-// for it. We still return ERROR_GPU_IS_LOST for tripped lost /
-// fallen_off_bus devices, matching every other guarded getter.
-func (d *ConfigurableDevice) GetViolationStatus(perfPolicyType nvml.PerfPolicyType) (nvml.ViolationTime, nvml.Return) {
-	if ret := d.tickFailure(); ret != nvml.SUCCESS {
-		return nvml.ViolationTime{}, ret
-	}
-	debugLog("[NVML] nvmlDeviceGetViolationStatus(policy=%d) -> no violation\n", perfPolicyType)
-	return nvml.ViolationTime{}, nvml.SUCCESS
 }
 
 // MockServer wraps dgxa100.Server and uses configurable devices

--- a/pkg/gpu/mocknvml/engine/failure_injector_test.go
+++ b/pkg/gpu/mocknvml/engine/failure_injector_test.go
@@ -16,6 +16,7 @@ package engine
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/stretchr/testify/require"
@@ -392,10 +393,16 @@ func TestFailureInjection_GetViolationStatus_StaysSpecCompliantAfterTrip(t *test
 	// SECOND tick, which is GetViolationStatus itself). Neither field may
 	// carry the Xid: violation time reflects the (unthrottled) device, and
 	// reference time is a timestamp.
+	before := uint64(time.Now().UnixMicro())
 	vt, ret := dev.GetViolationStatus(nvml.PERF_POLICY_POWER)
 	require.Equal(t, nvml.SUCCESS, ret, "expected SUCCESS")
 	require.Zero(t, vt.ViolationTime, "ViolationTime must be 0 ns post-trip (Xid no longer overloaded)")
-	require.NotEqual(t, uint64(64), vt.ReferenceTime, "ReferenceTime must not carry the Xid either")
+	// Bracketing the call rather than merely excluding 64: any real clock
+	// reading is ~1.7e15, so "not the Xid" is satisfied by every implementation
+	// including the one that returned zero, and would not catch a regression.
+	require.GreaterOrEqual(t, vt.ReferenceTime, before,
+		"ReferenceTime must be a CPU timestamp taken during the call, not an Xid or a zero")
+	require.LessOrEqual(t, vt.ReferenceTime, uint64(time.Now().UnixMicro()))
 }
 
 func TestFailureInjection_GetViolationStatus_LostModeReturnsError(t *testing.T) {

--- a/pkg/gpu/mocknvml/engine/failure_injector_test.go
+++ b/pkg/gpu/mocknvml/engine/failure_injector_test.go
@@ -363,8 +363,10 @@ func TestFailureInjection_GetViolationStatus_HealthyReportsNoViolation(t *testin
 	dev := newTestDeviceWithConfig(t, healthyConfig())
 	vt, ret := dev.GetViolationStatus(nvml.PERF_POLICY_POWER)
 	require.Equal(t, nvml.SUCCESS, ret, "expected SUCCESS")
-	require.Zero(t, vt.ViolationTime, "healthy device must report empty ViolationTime")
-	require.Zero(t, vt.ReferenceTime, "healthy device must report empty ReferenceTime")
+	require.Zero(t, vt.ViolationTime, "healthy device must report no accrued violation time")
+	// ReferenceTime is the CPU timestamp the reading was taken at, so it is
+	// populated even on a device that has never been throttled.
+	require.NotZero(t, vt.ReferenceTime, "healthy device must still timestamp the reading")
 }
 
 func TestFailureInjection_GetViolationStatus_StaysSpecCompliantAfterTrip(t *testing.T) {
@@ -387,13 +389,13 @@ func TestFailureInjection_GetViolationStatus_StaysSpecCompliantAfterTrip(t *test
 	require.Equal(t, nvml.SUCCESS, ret, "setup call 1")
 
 	// At this point the device has just tripped (AfterCalls=2 met by the
-	// SECOND tick, which is GetViolationStatus itself). It must NOT
-	// stuff the Xid into the violation_time field; both fields stay
-	// at their healthy zero values.
+	// SECOND tick, which is GetViolationStatus itself). Neither field may
+	// carry the Xid: violation time reflects the (unthrottled) device, and
+	// reference time is a timestamp.
 	vt, ret := dev.GetViolationStatus(nvml.PERF_POLICY_POWER)
 	require.Equal(t, nvml.SUCCESS, ret, "expected SUCCESS")
 	require.Zero(t, vt.ViolationTime, "ViolationTime must be 0 ns post-trip (Xid no longer overloaded)")
-	require.Zero(t, vt.ReferenceTime, "ReferenceTime must be 0 ns post-trip")
+	require.NotEqual(t, uint64(64), vt.ReferenceTime, "ReferenceTime must not carry the Xid either")
 }
 
 func TestFailureInjection_GetViolationStatus_LostModeReturnsError(t *testing.T) {

--- a/pkg/gpu/mocknvml/engine/field_values.go
+++ b/pkg/gpu/mocknvml/engine/field_values.go
@@ -243,6 +243,10 @@ func (d *ConfigurableDevice) getDeviceFieldValue(fieldID, scopeID uint32) (Field
 	case fiTempShutdownTlimit, fiTempSlowdownTlimit, fiTempMemMaxTlimit, fiTempGpuMaxTlimit:
 		return d.tlimitThresholdFieldValue(fieldID)
 
+	case fiPerfPolicyPower, fiPerfPolicyThermal, fiPerfPolicySyncBoost,
+		fiClocksEventSwThermSlowdown, fiClocksEventHwThermSlowdown, fiClocksEventHwPowerBrake:
+		return d.throttleCounterFieldValue(fieldID)
+
 	case fiMemoryTemp:
 		cfg := d.cfg()
 		if cfg.Thermal == nil || cfg.Thermal.TemperatureMemory_C == 0 {

--- a/pkg/gpu/mocknvml/engine/throttle_counters.go
+++ b/pkg/gpu/mocknvml/engine/throttle_counters.go
@@ -1,0 +1,241 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Cumulative clocks-event (throttle) time, per cause. The instantaneous
+// clocks_throttle_reasons flags say whether the GPU is being held back right
+// now; these counters say how long it has been held back since reset, which is
+// how throttling is diagnosed after a workload has already run slow.
+//
+// nvidia-smi renders them as the "Clocks Event Reasons Counters" block, reading
+// them through nvmlDeviceGetFieldValues rather than any dedicated getter — an
+// unhandled field id there comes back per-field NOT_SUPPORTED and renders as
+// N/A, so the counters must be answered even when the answer is zero.
+
+package engine
+
+import (
+	"sync"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+// NVML field ids for the throttle counters. All carry nanoseconds.
+//
+// Two causes have long-standing ids in the perf-policy family, which
+// NVML_FI_DEV_CLOCKS_EVENT_REASON_SW_POWER_CAP and _SYNC_BOOST are defined as;
+// NVML_FI_DEV_PERF_POLICY_THERMAL is the older name for the SW thermal counter.
+// The three slowdown causes only exist under the newer names.
+//
+// Those three are NOT taken from the header this repo vendors, which is a CUDA
+// 13 header numbering them 269-271 and reusing 251-253 for power smoothing.
+// The driver these profiles report — and the nvidia-smi 580.65.06 the image
+// bundles — has them at 251-253 and power smoothing at 256-273 instead. The
+// simulated driver's numbering is the one consumers see, so it is the one used
+// here; verified by tracing a `nvidia-smi -q` field-value batch, which asks for
+// exactly 74, 76, 251, 252 and 253 at the whole-GPU scope.
+const (
+	fiPerfPolicyPower     = 74
+	fiPerfPolicyThermal   = 75
+	fiPerfPolicySyncBoost = 76
+
+	fiClocksEventSwThermSlowdown = 251
+	fiClocksEventHwThermSlowdown = 252
+	fiClocksEventHwPowerBrake    = 253
+)
+
+// throttleCause enumerates the causes that accrue time independently. These are
+// exactly the five rows nvidia-smi prints, which is also the granularity NVML
+// exposes: the umbrella "HW Slowdown" flag has no counter of its own.
+type throttleCause int
+
+const (
+	throttleCauseSWPowerCap throttleCause = iota
+	throttleCauseSyncBoost
+	throttleCauseSWThermal
+	throttleCauseHWThermal
+	throttleCauseHWPowerBrake
+	throttleCauseCount
+)
+
+// throttleAccrual tracks how long each cause has been active on one device.
+// Time is folded in on read rather than by a background ticker: a mock has no
+// reason to burn a goroutine per device, and a counter nobody reads has no
+// observable value.
+type throttleAccrual struct {
+	device *ConfigurableDevice
+
+	// now is overridable in tests so accrual can be driven deterministically
+	// without sleeping.
+	now func() time.Time
+
+	mu sync.Mutex
+	// accrued is the time each cause has been observed active for, and
+	// activeSince is when it was last observed (zero == currently inactive).
+	// A read advances accrued to the moment of that read, so a cause the mock
+	// never saw active contributes nothing and the totals never go backwards.
+	accrued     [throttleCauseCount]time.Duration
+	activeSince [throttleCauseCount]time.Time
+}
+
+// throttleAccrual returns the device's accrual state, creating it on first use.
+// Lazy creation keeps every device-construction path (including the legacy
+// no-YAML one) from having to know about it.
+func (d *ConfigurableDevice) throttleAccrual() *throttleAccrual {
+	if a := d.throttle.Load(); a != nil {
+		return a
+	}
+	fresh := &throttleAccrual{device: d, now: time.Now}
+	if d.throttle.CompareAndSwap(nil, fresh) {
+		return fresh
+	}
+	return d.throttle.Load()
+}
+
+// resolve returns the per-cause totals in nanoseconds: the configured baseline
+// plus the time each cause has been active for.
+//
+// Accrual advances only between reads, because a read is the only moment the
+// mock knows the flag's state. A cause cleared between two reads therefore
+// stops at the last read that saw it active rather than being credited with the
+// whole gap — the counters report time observed throttled, never time assumed.
+func (a *throttleAccrual) resolve() [throttleCauseCount]uint64 {
+	cfg := a.device.cfg().ClocksThrottleReasons
+	active := activeThrottleCauses(cfg)
+	baseline := throttleCauseBaselines(cfg)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	now := a.now()
+	var out [throttleCauseCount]uint64
+	for cause := range out {
+		switch {
+		case !active[cause]:
+			a.activeSince[cause] = time.Time{}
+		case !a.activeSince[cause].IsZero():
+			a.accrued[cause] += now.Sub(a.activeSince[cause])
+			a.activeSince[cause] = now
+		default:
+			a.activeSince[cause] = now
+		}
+		out[cause] = uint64(baseline[cause] + a.accrued[cause])
+	}
+	return out
+}
+
+// activeThrottleCauses reports which causes the instantaneous flags currently
+// assert. The umbrella hw_slowdown flag is deliberately not mapped: it is the
+// disjunction the two hardware causes below it drive, so counting it would
+// double-count them.
+func activeThrottleCauses(cfg *ClocksThrottleReasonsConfig) [throttleCauseCount]bool {
+	var active [throttleCauseCount]bool
+	if cfg == nil {
+		return active
+	}
+	active[throttleCauseSWPowerCap] = cfg.SWPowerCap
+	active[throttleCauseSyncBoost] = cfg.SyncBoost
+	active[throttleCauseSWThermal] = cfg.SWThermalSlowdown
+	active[throttleCauseHWThermal] = cfg.HWThermalSlowdown
+	active[throttleCauseHWPowerBrake] = cfg.HWPowerBrakeSlowdown
+	return active
+}
+
+// throttleCauseBaselines converts the configured microsecond totals into
+// durations. An absent counters block means a GPU that has never been
+// throttled, which is a real answer of zero.
+func throttleCauseBaselines(cfg *ClocksThrottleReasonsConfig) [throttleCauseCount]time.Duration {
+	var baseline [throttleCauseCount]time.Duration
+	if cfg == nil || cfg.Counters == nil {
+		return baseline
+	}
+	c := cfg.Counters
+	baseline[throttleCauseSWPowerCap] = time.Duration(c.SWPowerCapUS) * time.Microsecond
+	baseline[throttleCauseSyncBoost] = time.Duration(c.SyncBoostUS) * time.Microsecond
+	baseline[throttleCauseSWThermal] = time.Duration(c.SWThermalSlowdownUS) * time.Microsecond
+	baseline[throttleCauseHWThermal] = time.Duration(c.HWThermalSlowdownUS) * time.Microsecond
+	baseline[throttleCauseHWPowerBrake] = time.Duration(c.HWPowerBrakeSlowdownUS) * time.Microsecond
+	return baseline
+}
+
+// throttleCounterFieldValue resolves the throttle-counter field ids. The fourth
+// return says whether the id belongs to this set, matching the convention in
+// getDeviceFieldValue.
+func (d *ConfigurableDevice) throttleCounterFieldValue(fieldID uint32) (FieldValueType, uint64, nvml.Return, bool) {
+	cause, ok := throttleCauseForField(fieldID)
+	if !ok {
+		return FieldValueUnsupported, 0, nvml.ERROR_NOT_SUPPORTED, false
+	}
+	return FieldValueUint64, d.throttleAccrual().resolve()[cause], nvml.SUCCESS, true
+}
+
+func throttleCauseForField(fieldID uint32) (throttleCause, bool) {
+	switch fieldID {
+	case fiPerfPolicyPower:
+		return throttleCauseSWPowerCap, true
+	case fiPerfPolicySyncBoost:
+		return throttleCauseSyncBoost, true
+	case fiPerfPolicyThermal, fiClocksEventSwThermSlowdown:
+		return throttleCauseSWThermal, true
+	case fiClocksEventHwThermSlowdown:
+		return throttleCauseHWThermal, true
+	case fiClocksEventHwPowerBrake:
+		return throttleCauseHWPowerBrake, true
+	default:
+		return 0, false
+	}
+}
+
+// GetViolationStatus returns how long one performance policy has held the GPU
+// below its requested clocks. It is the deprecated getter for the same state
+// the throttle-counter field ids carry, so both paths resolve from one accrual
+// and cannot disagree.
+//
+// Only the three policies NVML maps onto a clocks-event cause are answered
+// (nvml.h documents the translation). The board-limit, low-utilization and
+// reliability limiters have no counterpart on the hardware these profiles
+// describe, and NVML_PERF_POLICY_TOTAL_APP_CLOCKS is deprecated outright; all
+// of them decline rather than fabricating a zero that would read as "never
+// throttled".
+//
+// Failure injection does not overload these fields with the configured Xid
+// code — that is surfaced through the NVML event set — but a device tripped
+// into a lost state still returns ERROR_GPU_IS_LOST like every guarded getter.
+func (d *ConfigurableDevice) GetViolationStatus(perfPolicyType nvml.PerfPolicyType) (nvml.ViolationTime, nvml.Return) {
+	if ret := d.tickFailure(); ret != nvml.SUCCESS {
+		return nvml.ViolationTime{}, ret
+	}
+
+	var cause throttleCause
+	switch perfPolicyType {
+	case nvml.PERF_POLICY_POWER:
+		cause = throttleCauseSWPowerCap
+	case nvml.PERF_POLICY_THERMAL:
+		cause = throttleCauseSWThermal
+	case nvml.PERF_POLICY_SYNC_BOOST:
+		cause = throttleCauseSyncBoost
+	default:
+		debugLog("[NVML] nvmlDeviceGetViolationStatus(policy=%d) -> NOT_SUPPORTED\n", perfPolicyType)
+		return nvml.ViolationTime{}, nvml.ERROR_NOT_SUPPORTED
+	}
+
+	accrual := d.throttleAccrual()
+	violation := accrual.resolve()[cause]
+	debugLog("[NVML] nvmlDeviceGetViolationStatus(policy=%d) -> %d ns\n", perfPolicyType, violation)
+	return nvml.ViolationTime{
+		// NVML documents referenceTime as a CPU timestamp in microseconds,
+		// unlike violationTime which is nanoseconds.
+		ReferenceTime: uint64(accrual.now().UnixMicro()),
+		ViolationTime: violation,
+	}, nvml.SUCCESS
+}

--- a/pkg/gpu/mocknvml/engine/throttle_counters.go
+++ b/pkg/gpu/mocknvml/engine/throttle_counters.go
@@ -198,15 +198,17 @@ func throttleCauseForField(fieldID uint32) (throttleCause, bool) {
 
 // GetViolationStatus returns how long one performance policy has held the GPU
 // below its requested clocks. It is the deprecated getter for the same state
-// the throttle-counter field ids carry, so both paths resolve from one accrual
-// and cannot disagree.
+// the throttle-counter field ids carry, so for the three policies NVML maps
+// onto a clocks-event cause both paths resolve from one accrual and cannot
+// disagree.
 //
-// Only the three policies NVML maps onto a clocks-event cause are answered
-// (nvml.h documents the translation). The board-limit, low-utilization and
-// reliability limiters have no counterpart on the hardware these profiles
-// describe, and NVML_PERF_POLICY_TOTAL_APP_CLOCKS is deprecated outright; all
-// of them decline rather than fabricating a zero that would read as "never
-// throttled".
+// The board-limit, low-utilization, reliability and total-base-clocks limiters
+// are not modelled, but they are real policies the header maps onto their own
+// field ids, so they report zero rather than declining: zero is the answer for
+// a limiter that has never fired, where NOT_SUPPORTED says the driver cannot
+// tell — the same distinction that made these counters read N/A in the first
+// place. Only NVML_PERF_POLICY_TOTAL_APP_CLOCKS declines, because the header
+// marks it "DEPRECATED, Do not use" rather than giving it a field id.
 //
 // Failure injection does not overload these fields with the configured Xid
 // code — that is surfaced through the NVML event set — but a device tripped
@@ -216,21 +218,26 @@ func (d *ConfigurableDevice) GetViolationStatus(perfPolicyType nvml.PerfPolicyTy
 		return nvml.ViolationTime{}, ret
 	}
 
-	var cause throttleCause
 	switch perfPolicyType {
-	case nvml.PERF_POLICY_POWER:
-		cause = throttleCauseSWPowerCap
-	case nvml.PERF_POLICY_THERMAL:
-		cause = throttleCauseSWThermal
-	case nvml.PERF_POLICY_SYNC_BOOST:
-		cause = throttleCauseSyncBoost
-	default:
-		debugLog("[NVML] nvmlDeviceGetViolationStatus(policy=%d) -> NOT_SUPPORTED\n", perfPolicyType)
+	case nvml.PERF_POLICY_POWER, nvml.PERF_POLICY_THERMAL, nvml.PERF_POLICY_SYNC_BOOST,
+		nvml.PERF_POLICY_BOARD_LIMIT, nvml.PERF_POLICY_LOW_UTILIZATION,
+		nvml.PERF_POLICY_RELIABILITY, nvml.PERF_POLICY_TOTAL_BASE_CLOCKS:
+	case nvml.PERF_POLICY_TOTAL_APP_CLOCKS:
+		debugLog("[NVML] nvmlDeviceGetViolationStatus(policy=%d) -> NOT_SUPPORTED (deprecated policy)\n",
+			perfPolicyType)
 		return nvml.ViolationTime{}, nvml.ERROR_NOT_SUPPORTED
+	default:
+		// The enum has gaps (6-9) as well as an upper bound, and neither is a
+		// policy a driver would answer.
+		debugLog("[NVML] nvmlDeviceGetViolationStatus(policy=%d) -> INVALID_ARGUMENT\n", perfPolicyType)
+		return nvml.ViolationTime{}, nvml.ERROR_INVALID_ARGUMENT
 	}
 
 	accrual := d.throttleAccrual()
-	violation := accrual.resolve()[cause]
+	var violation uint64
+	if cause, modelled := throttleCauseForPolicy(perfPolicyType); modelled {
+		violation = accrual.resolve()[cause]
+	}
 	debugLog("[NVML] nvmlDeviceGetViolationStatus(policy=%d) -> %d ns\n", perfPolicyType, violation)
 	return nvml.ViolationTime{
 		// NVML documents referenceTime as a CPU timestamp in microseconds,
@@ -238,4 +245,20 @@ func (d *ConfigurableDevice) GetViolationStatus(perfPolicyType nvml.PerfPolicyTy
 		ReferenceTime: uint64(accrual.now().UnixMicro()),
 		ViolationTime: violation,
 	}, nvml.SUCCESS
+}
+
+// throttleCauseForPolicy maps the performance policies that have a clocks-event
+// counterpart, per the translation table in nvml.h. false means a policy the
+// mock does not model, which reports zero rather than declining.
+func throttleCauseForPolicy(policy nvml.PerfPolicyType) (throttleCause, bool) {
+	switch policy {
+	case nvml.PERF_POLICY_POWER:
+		return throttleCauseSWPowerCap, true
+	case nvml.PERF_POLICY_THERMAL:
+		return throttleCauseSWThermal, true
+	case nvml.PERF_POLICY_SYNC_BOOST:
+		return throttleCauseSyncBoost, true
+	default:
+		return 0, false
+	}
 }

--- a/pkg/gpu/mocknvml/engine/throttle_counters_test.go
+++ b/pkg/gpu/mocknvml/engine/throttle_counters_test.go
@@ -266,17 +266,42 @@ func TestGetViolationStatus_PerPolicyAccrual(t *testing.T) {
 // Policies the mock models no counter for decline rather than answering zero:
 // a fabricated zero is indistinguishable from "never throttled", and these
 // limiters do not exist on the hardware the profiles describe.
-func TestGetViolationStatus_UnmodeledPoliciesAreUnsupported(t *testing.T) {
+// The limiters the mock does not model are still real policies with their own
+// field ids, so they answer zero. NOT_SUPPORTED would say the driver cannot
+// tell whether the limiter ever fired, which is the same misreading that made
+// these counters render as N/A.
+func TestGetViolationStatus_UnmodeledPoliciesReportZero(t *testing.T) {
 	dev := newTestDeviceWithConfig(t, &DeviceConfig{Architecture: "blackwell"})
 
 	for _, policy := range []nvml.PerfPolicyType{
 		nvml.PERF_POLICY_BOARD_LIMIT,
 		nvml.PERF_POLICY_LOW_UTILIZATION,
 		nvml.PERF_POLICY_RELIABILITY,
-		nvml.PERF_POLICY_TOTAL_APP_CLOCKS,
 		nvml.PERF_POLICY_TOTAL_BASE_CLOCKS,
 	} {
+		vt, ret := dev.GetViolationStatus(policy)
+		require.Equal(t, nvml.SUCCESS, ret, "policy %d", policy)
+		require.Zero(t, vt.ViolationTime, "policy %d must report no accrued time, not decline", policy)
+		require.NotZero(t, vt.ReferenceTime, "policy %d must still timestamp the reading", policy)
+	}
+}
+
+// TOTAL_APP_CLOCKS is the one policy nvml.h gives no field id, marking it
+// "DEPRECATED, Do not use", so it is the one that declines.
+func TestGetViolationStatus_DeprecatedTotalAppClocksDeclines(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{Architecture: "blackwell"})
+
+	_, ret := dev.GetViolationStatus(nvml.PERF_POLICY_TOTAL_APP_CLOCKS)
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret)
+}
+
+// A value outside the enum, including its 6-9 gap, is not a policy any driver
+// answers.
+func TestGetViolationStatus_RejectsPoliciesOutsideTheEnum(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{Architecture: "blackwell"})
+
+	for _, policy := range []nvml.PerfPolicyType{7, nvml.PERF_POLICY_COUNT, -1} {
 		_, ret := dev.GetViolationStatus(policy)
-		require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret, "policy %d", policy)
+		require.Equal(t, nvml.ERROR_INVALID_ARGUMENT, ret, "policy %d", policy)
 	}
 }

--- a/pkg/gpu/mocknvml/engine/throttle_counters_test.go
+++ b/pkg/gpu/mocknvml/engine/throttle_counters_test.go
@@ -1,0 +1,282 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
+)
+
+// The five field ids nvidia-smi 580 reads for the "Clocks Event Reasons
+// Counters" block, in the order it renders them. Keeping the pairing in one
+// place means a test that sets one cause can assert on the other four.
+var throttleCounterFields = []struct {
+	name    string
+	fieldID uint32
+}{
+	{"SW Power Capping", fiPerfPolicyPower},
+	{"Sync Boost", fiPerfPolicySyncBoost},
+	{"SW Thermal Slowdown", fiClocksEventSwThermSlowdown},
+	{"HW Thermal Slowdown", fiClocksEventHwThermSlowdown},
+	{"HW Power Braking", fiClocksEventHwPowerBrake},
+}
+
+// A healthy profile has to answer these counters, not decline them: nvidia-smi
+// renders a per-field NOT_SUPPORTED as N/A, and "never throttled" is 0, not
+// "unknown". This holds with no clocks_throttle_reasons block at all, which is
+// what most shipped profiles have.
+func TestThrottleCounters_HealthyDeviceReportsZeroNotUnsupported(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{Architecture: "blackwell"})
+
+	for _, f := range throttleCounterFields {
+		vt, val, ret := dev.GetFieldValue(f.fieldID, 0)
+		require.Equal(t, nvml.SUCCESS, ret, "%s (field %d) must be supported", f.name, f.fieldID)
+		require.Equal(t, FieldValueUint64, vt, "%s value type", f.name)
+		require.Zero(t, val, "%s on a healthy device", f.name)
+	}
+}
+
+// Each cause is configured and read independently: a profile that has been
+// power-capped has not also been thermally throttled, and the field ids must
+// not alias onto one another.
+func TestThrottleCounters_ConfiguredCauseIsReportedInIsolation(t *testing.T) {
+	for _, target := range throttleCounterFields {
+		t.Run(target.name, func(t *testing.T) {
+			counters := &ThrottleCountersConfig{}
+			switch target.fieldID {
+			case fiPerfPolicyPower:
+				counters.SWPowerCapUS = 39595
+			case fiPerfPolicySyncBoost:
+				counters.SyncBoostUS = 39595
+			case fiClocksEventSwThermSlowdown:
+				counters.SWThermalSlowdownUS = 39595
+			case fiClocksEventHwThermSlowdown:
+				counters.HWThermalSlowdownUS = 39595
+			case fiClocksEventHwPowerBrake:
+				counters.HWPowerBrakeSlowdownUS = 39595
+			}
+			dev := newTestDeviceWithConfig(t, &DeviceConfig{
+				Architecture:          "blackwell",
+				ClocksThrottleReasons: &ClocksThrottleReasonsConfig{Counters: counters},
+			})
+
+			for _, f := range throttleCounterFields {
+				_, val, ret := dev.GetFieldValue(f.fieldID, 0)
+				require.Equal(t, nvml.SUCCESS, ret, "%s (field %d)", f.name, f.fieldID)
+				if f.fieldID == target.fieldID {
+					// Counters are nanoseconds on the wire, microseconds in config.
+					require.Equal(t, uint64(39595*1000), val, "%s", f.name)
+					continue
+				}
+				require.Zero(t, val, "%s must stay zero while %s is set", f.name, target.name)
+			}
+		})
+	}
+}
+
+// The three slowdown counters sit where the simulated driver puts them, not
+// where the vendored CUDA 13 header does. Pinning the numbers keeps a header
+// bump from silently moving them: the ids below are what nvidia-smi 580.65.06
+// asks for, and 269-271 are power-smoothing ramp fields to that driver, so
+// answering them with a throttle counter would fabricate readings for an
+// unrelated feature.
+func TestThrottleCounters_FieldIDsMatchTheSimulatedDriver(t *testing.T) {
+	require.Equal(t, uint32(251), uint32(fiClocksEventSwThermSlowdown))
+	require.Equal(t, uint32(252), uint32(fiClocksEventHwThermSlowdown))
+	require.Equal(t, uint32(253), uint32(fiClocksEventHwPowerBrake))
+
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Architecture: "blackwell",
+		ClocksThrottleReasons: &ClocksThrottleReasonsConfig{
+			Counters: &ThrottleCountersConfig{SWThermalSlowdownUS: 1},
+		},
+	})
+	// nvidia-smi sweeps the power-smoothing range with a profile id in scopeId.
+	// Every entry in it must still decline.
+	for fieldID := uint32(256); fieldID <= 273; fieldID++ {
+		_, _, ret := dev.GetFieldValue(fieldID, 5)
+		require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret,
+			"field %d belongs to power smoothing, not to the throttle counters", fieldID)
+	}
+}
+
+// NVML_FI_DEV_PERF_POLICY_THERMAL is the older id for the same counter
+// NVML_FI_DEV_CLOCKS_EVENT_REASON_SW_THERM_SLOWDOWN carries. DCGM-era readers
+// may ask for either, so both must resolve to the same accrual.
+func TestThrottleCounters_ThermalFieldIDsAlias(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Architecture: "blackwell",
+		ClocksThrottleReasons: &ClocksThrottleReasonsConfig{
+			Counters: &ThrottleCountersConfig{SWThermalSlowdownUS: 1234},
+		},
+	})
+
+	_, viaPerfPolicy, ret := dev.GetFieldValue(fiPerfPolicyThermal, 0)
+	require.Equal(t, nvml.SUCCESS, ret)
+	_, viaClocksEvent, ret := dev.GetFieldValue(fiClocksEventSwThermSlowdown, 0)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Equal(t, uint64(1234*1000), viaPerfPolicy)
+	require.Equal(t, viaPerfPolicy, viaClocksEvent)
+}
+
+// Throttling is a property of one board, not of a node: a tray where one GPU
+// has been power-capped and its neighbours have not is the case worth
+// simulating, so the counters have to be settable per device.
+func TestThrottleCounters_ConfigurablePerDevice(t *testing.T) {
+	e := NewEngine(&Config{
+		NumDevices:    2,
+		DriverVersion: "550.163",
+		YAMLConfig: &YAMLConfig{
+			Version: "1.0",
+			System:  SystemConfig{DriverVersion: "550.163", NumDevices: 2},
+			DeviceDefaults: DeviceConfig{
+				Architecture:          "blackwell",
+				ClocksThrottleReasons: &ClocksThrottleReasonsConfig{GPUIdle: true},
+			},
+			Devices: []DeviceOverride{{
+				Index: 1,
+				DeviceConfig: DeviceConfig{ClocksThrottleReasons: &ClocksThrottleReasonsConfig{
+					Counters: &ThrottleCountersConfig{SWPowerCapUS: 39595},
+				}},
+			}},
+		},
+	})
+	require.Equal(t, nvml.SUCCESS, e.Init())
+	t.Cleanup(func() { _ = e.Shutdown() })
+
+	for index, wantUS := range map[int]uint64{0: 0, 1: 39595} {
+		handle, ret := e.DeviceGetHandleByIndex(index)
+		require.Equal(t, nvml.SUCCESS, ret)
+		dev, ok := e.LookupDevice(handle).(*ConfigurableDevice)
+		require.True(t, ok)
+
+		_, val, ret := dev.GetFieldValue(fiPerfPolicyPower, 0)
+		require.Equal(t, nvml.SUCCESS, ret)
+		require.Equal(t, wantUS*1000, val, "GPU %d SW power capping", index)
+	}
+}
+
+// A profile that reports a throttle reason as Active cannot also report that
+// the cause has never cost the GPU any time. The counter accrues while the
+// flag is set, so the flags and the counters stay consistent.
+func TestThrottleCounters_AccrueWhileReasonActive(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Architecture: "blackwell",
+		ClocksThrottleReasons: &ClocksThrottleReasonsConfig{
+			SWPowerCap: true,
+			Counters:   &ThrottleCountersConfig{SWPowerCapUS: 1000},
+		},
+	})
+
+	clock := time.Now()
+	dev.throttleAccrual().now = func() time.Time { return clock }
+
+	// First read opens the accrual interval; the reported value is still the
+	// configured baseline because no time has passed yet.
+	_, val, ret := dev.GetFieldValue(fiPerfPolicyPower, 0)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Equal(t, uint64(1000*1000), val, "baseline before any time passes")
+
+	clock = clock.Add(2 * time.Second)
+	_, val, ret = dev.GetFieldValue(fiPerfPolicyPower, 0)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Equal(t, uint64(1000*1000)+uint64(2*time.Second), val,
+		"an active SW power cap must accrue the elapsed time")
+
+	// Causes whose flag is clear stay at their baseline of zero.
+	_, val, ret = dev.GetFieldValue(fiClocksEventHwThermSlowdown, 0)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Zero(t, val, "an inactive cause must not accrue")
+}
+
+// Accrual is monotonic across the flag clearing: the time already spent
+// throttled is what a post-mortem reads, so it must not be given back.
+func TestThrottleCounters_AccrualSurvivesReasonClearing(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Architecture:          "blackwell",
+		ClocksThrottleReasons: &ClocksThrottleReasonsConfig{SWPowerCap: true},
+	})
+
+	clock := time.Now()
+	accrual := dev.throttleAccrual()
+	accrual.now = func() time.Time { return clock }
+
+	_, _, ret := dev.GetFieldValue(fiPerfPolicyPower, 0)
+	require.Equal(t, nvml.SUCCESS, ret)
+	clock = clock.Add(3 * time.Second)
+	_, val, ret := dev.GetFieldValue(fiPerfPolicyPower, 0)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Equal(t, uint64(3*time.Second), val)
+
+	// Clear the reason the way a runtime override would, then let more time
+	// pass: the accrued 3s stays, the idle time is not added.
+	cleared := *accrual.device.cfg()
+	cleared.ClocksThrottleReasons = &ClocksThrottleReasonsConfig{}
+	dev.effective.Store(&cleared)
+
+	clock = clock.Add(10 * time.Second)
+	_, val, ret = dev.GetFieldValue(fiPerfPolicyPower, 0)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Equal(t, uint64(3*time.Second), val, "cleared reason must neither reset nor keep accruing")
+}
+
+// nvmlDeviceGetViolationStatus is the deprecated getter for the same state.
+// It must answer per policy rather than reporting one blanket verdict.
+func TestGetViolationStatus_PerPolicyAccrual(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Architecture: "blackwell",
+		ClocksThrottleReasons: &ClocksThrottleReasonsConfig{
+			Counters: &ThrottleCountersConfig{
+				SWPowerCapUS:        11,
+				SWThermalSlowdownUS: 22,
+				SyncBoostUS:         33,
+			},
+		},
+	})
+
+	for _, tt := range []struct {
+		policy nvml.PerfPolicyType
+		wantNs uint64
+	}{
+		{nvml.PERF_POLICY_POWER, 11 * 1000},
+		{nvml.PERF_POLICY_THERMAL, 22 * 1000},
+		{nvml.PERF_POLICY_SYNC_BOOST, 33 * 1000},
+	} {
+		vt, ret := dev.GetViolationStatus(tt.policy)
+		require.Equal(t, nvml.SUCCESS, ret, "policy %d", tt.policy)
+		require.Equal(t, tt.wantNs, vt.ViolationTime, "policy %d violation time", tt.policy)
+		require.NotZero(t, vt.ReferenceTime, "policy %d reference time", tt.policy)
+	}
+}
+
+// Policies the mock models no counter for decline rather than answering zero:
+// a fabricated zero is indistinguishable from "never throttled", and these
+// limiters do not exist on the hardware the profiles describe.
+func TestGetViolationStatus_UnmodeledPoliciesAreUnsupported(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{Architecture: "blackwell"})
+
+	for _, policy := range []nvml.PerfPolicyType{
+		nvml.PERF_POLICY_BOARD_LIMIT,
+		nvml.PERF_POLICY_LOW_UTILIZATION,
+		nvml.PERF_POLICY_RELIABILITY,
+		nvml.PERF_POLICY_TOTAL_APP_CLOCKS,
+		nvml.PERF_POLICY_TOTAL_BASE_CLOCKS,
+	} {
+		_, ret := dev.GetViolationStatus(policy)
+		require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret, "policy %d", policy)
+	}
+}

--- a/tests/e2e/go/assertions/nvidiasmi/exec.go
+++ b/tests/e2e/go/assertions/nvidiasmi/exec.go
@@ -179,6 +179,20 @@ func FabricHealth(ctx context.Context, k *kube.Client, pod kube.PodRef) {
 		strings.Join(problems, "\n"))
 }
 
+// ThrottleCounters asserts nvidia-smi -q -x reports five zeroed clocks-event
+// counters on every GPU. Every counter read N/A while the field ids behind them
+// went unanswered, which says the driver could not report whether the GPU had
+// ever been throttled — the opposite of the "never throttled" a healthy profile
+// means. See issue #678.
+func ThrottleCounters(ctx context.Context, k *kube.Client, pod kube.PodRef) {
+	ginkgo.GinkgoHelper()
+
+	ginkgo.By("nvidia-smi -q -x reports 0 us for every clocks-event counter")
+	problems := ThrottleCounterProblems(query(ctx, k, pod), UnthrottledCounters())
+	gomega.Expect(problems).To(gomega.BeEmpty(), "clocks event reason counters wrong:\n%s",
+		strings.Join(problems, "\n"))
+}
+
 // query execs `nvidia-smi -q -x` and asserts it succeeded, returning stdout.
 func query(ctx context.Context, k *kube.Client, pod kube.PodRef) string {
 	ginkgo.GinkgoHelper()

--- a/tests/e2e/go/assertions/nvidiasmi/schema.go
+++ b/tests/e2e/go/assertions/nvidiasmi/schema.go
@@ -124,6 +124,7 @@ type gpuElement struct {
 	ECCErrors                eccErrors         `xml:"ecc_errors"`
 	RemappedRows             remappedRows      `xml:"remapped_rows"`
 	ClocksEventReasons       eventReasons      `xml:"clocks_event_reasons"`
+	ClocksEventCounters      eventCounters     `xml:"clocks_event_reasons_counters"`
 	Fabric                   fabricBlock       `xml:"fabric"`
 	Processes                struct {
 		Infos []processInfo `xml:"process_info"`
@@ -302,6 +303,21 @@ type eventReasons struct {
 	HWSlowdown        reading `xml:"clocks_event_reason_hw_slowdown"`
 	HWThermalSlowdown reading `xml:"clocks_event_reason_hw_thermal_slowdown"`
 	SWThermalSlowdown reading `xml:"clocks_event_reason_sw_thermal_slowdown"`
+}
+
+// eventCounters is <clocks_event_reasons_counters>: how long each cause has
+// held the GPU below its requested clocks, as microsecond totals. It is the
+// after-the-fact companion to the instantaneous flags in eventReasons above —
+// a workload that ran slow is diagnosed from these, not from catching a flag
+// mid-sample. Every element read N/A until the mock answered the field ids
+// behind them (#678). The element names are the NVML field names, which is why
+// they abbreviate "thermal" where the flags above spell it out.
+type eventCounters struct {
+	SWPowerCap        reading `xml:"clocks_event_reasons_counters_sw_power_cap"`
+	SyncBoost         reading `xml:"clocks_event_reasons_counters_sync_boost"`
+	SWThermalSlowdown reading `xml:"clocks_event_reasons_counters_sw_therm_slowdown"`
+	HWThermalSlowdown reading `xml:"clocks_event_reasons_counters_hw_therm_slowdown"`
+	HWPowerBrake      reading `xml:"clocks_event_reasons_counters_hw_power_brake"`
 }
 
 // fabricBlock is <fabric>: the GPU's NVLink fabric attachment. Its <status>

--- a/tests/e2e/go/assertions/nvidiasmi/testdata/README.md
+++ b/tests/e2e/go/assertions/nvidiasmi/testdata/README.md
@@ -13,6 +13,7 @@ per-GPU indexing and override scoping.
 | `qx-gb200-lost.xml` | GPU 0 healthy, GPU 1 lost (`GPU is lost` bodies). |
 | `qx-gb200-ecc-injected.xml` | GPU 0 has a non-zero `ecc_errors/aggregate/dram_uncorrectable`. |
 | `qx-gb200-fabric-degraded.xml` | GPU 0 fabric healthy, GPU 1 `route_unhealthy` (#677). Taken against the fixed library, so it is also the healthy-fabric reference. |
+| `qx-gb200-throttle-counters.xml` | GPU 0 has accrued 39595 us of `sw_power_cap`, GPU 1 none (#678). `qx-gb200-healthy.xml` predates the fix and holds the `N/A` these counters used to read. |
 
 Watch for two element names that repeat under different parents: `sm_clock`
 appears under both `clocks` (current) and `max_clocks`, and `average_power_draw`
@@ -28,6 +29,7 @@ For the lost and ECC variants, inject first and wait out the 30 s override TTL:
     kubectl exec -n mokka <pod> -- nvml-mock-ctl fail --gpu 1 --mode lost
     kubectl exec -n mokka <pod> -- nvml-mock-ctl fail --gpu 0 --mode ecc_uncorrectable --after-calls 1
     kubectl exec -n mokka <pod> -- nvml-mock-ctl fabric-health --gpu 1 route_unhealthy
+    kubectl exec -n mokka <pod> -- nvml-mock-ctl set --gpu 0 clocks_throttle_reasons.counters.sw_power_cap_us=39595
 
 Then trim to two GPUs, keeping the header and the first two `<gpu>` blocks and
 rewriting `attached_gpus` to 2.

--- a/tests/e2e/go/assertions/nvidiasmi/testdata/qx-gb200-throttle-counters.xml
+++ b/tests/e2e/go/assertions/nvidiasmi/testdata/qx-gb200-throttle-counters.xml
@@ -1,0 +1,630 @@
+<?xml version="1.0" ?>
+<!DOCTYPE nvidia_smi_log SYSTEM "nvsmi_device_v13.dtd">
+<nvidia_smi_log>
+	<timestamp>Fri Aug 21 07:09:44 2026</timestamp>
+	<driver_version>580.65.06</driver_version>
+	<cuda_version>13.0</cuda_version>
+	<attached_gpus>2</attached_gpus>
+	<gpu id="00000000:0A:00.0">
+		<product_name>NVIDIA GB200</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>No</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>N/A</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1562849103700</serial>
+		<uuid>GPU-b200b200-0000-0000-0000-000000000000</uuid>
+		<pdi>N/A</pdi>
+		<minor_number>0</minor_number>
+		<vbios_version>96.00.9E.00.01</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0xa00</board_id>
+		<board_part_number>699-2G530-0200-000</board_part_number>
+		<gpu_part_number>N/A</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>1822725100200</chassis_serial_number>
+			<slot_number>21</slot_number>
+			<tray_index>11</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>1</module_id>
+			<gpu_fabric_guid>0x0000000000000000</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G530.0200.00.01</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>1.0</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>N/A</latest_timestamp>
+			<latest_duration>N/A</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>All On</current_gom>
+			<pending_gom>All On</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Enabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>None</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>N/A</gpu_recovery_action>
+		<gsp_firmware_version>580.65.06</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>0A</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>234110DE</pci_device_id>
+			<pci_bus_id>00000000:0A:00.0</pci_bus_id>
+			<pci_sub_system_id>181710DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>6</max_link_gen>
+					<current_link_gen>6</current_link_gen>
+					<device_current_link_gen>6</device_current_link_gen>
+					<max_device_link_gen>6</max_device_link_gen>
+					<max_host_link_gen>6</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>0 KB/s</tx_util>
+			<rx_util>0 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>N/A</atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>39595 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>Disabled</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>196608 MiB</total>
+			<reserved>1024 MiB</reserved>
+			<used>0 MiB</used>
+			<free>195584 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>524288 MiB</total>
+			<used>0 MiB</used>
+			<free>524288 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>N/A</total>
+			<used>N/A</used>
+			<free>N/A</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>36 %</gpu_util>
+			<memory_util>22 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>N/A</channel_repair_pending>
+			<tpc_repair_pending>N/A</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>0</retired_count>
+				<retired_pagelist>
+				</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>0</retired_count>
+				<retired_pagelist>
+				</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>No</pending_blacklist>
+			<pending_retirement>No</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>3072 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>36 C</gpu_temp>
+			<gpu_temp_tlimit>54 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>0 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>5 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>85 C</gpu_target_temperature>
+			<memory_temp>34 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>N/A</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>85 C</gpu_target_temp_min>
+			<gpu_target_temp_max>85 C</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>145.00 W</average_power_draw>
+			<instant_power_draw>145.00 W</instant_power_draw>
+			<current_power_limit>1000.00 W</current_power_limit>
+			<requested_power_limit>1000.00 W</requested_power_limit>
+			<default_power_limit>1000.00 W</default_power_limit>
+			<min_power_limit>400.00 W</min_power_limit>
+			<max_power_limit>1200.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>N/A</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>345 MHz</graphics_clock>
+			<sm_clock>345 MHz</sm_clock>
+			<mem_clock>2500 MHz</mem_clock>
+			<video_clock>1200 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>2100 MHz</graphics_clock>
+			<mem_clock>2500 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>2100 MHz</graphics_clock>
+			<mem_clock>2500 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>2100 MHz</graphics_clock>
+			<sm_clock>2100 MHz</sm_clock>
+			<mem_clock>2500 MHz</mem_clock>
+			<video_clock>2100 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>N/A</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000001</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>Full</bandwidth>
+				<route_recovery_in_progress>False</route_recovery_in_progress>
+				<route_unhealthy>False</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>None</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>N/A</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>N/A</accounted_processes>
+		<capabilities>
+			<egm>N/A</egm>
+		</capabilities>
+	</gpu>
+	<gpu id="00000000:0B:00.0">
+		<product_name>NVIDIA GB200</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>No</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>N/A</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1562849103701</serial>
+		<uuid>GPU-b200b200-0000-0000-0000-000000000001</uuid>
+		<pdi>N/A</pdi>
+		<minor_number>1</minor_number>
+		<vbios_version>96.00.9E.00.01</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0xb00</board_id>
+		<board_part_number>699-2G530-0200-000</board_part_number>
+		<gpu_part_number>N/A</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>1822725100200</chassis_serial_number>
+			<slot_number>21</slot_number>
+			<tray_index>11</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>2</module_id>
+			<gpu_fabric_guid>0x0000000000000000</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G530.0200.00.01</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>1.0</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>N/A</latest_timestamp>
+			<latest_duration>N/A</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>All On</current_gom>
+			<pending_gom>All On</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Enabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>None</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>N/A</gpu_recovery_action>
+		<gsp_firmware_version>580.65.06</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>0B</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>234110DE</pci_device_id>
+			<pci_bus_id>00000000:0B:00.0</pci_bus_id>
+			<pci_sub_system_id>181710DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>6</max_link_gen>
+					<current_link_gen>6</current_link_gen>
+					<device_current_link_gen>6</device_current_link_gen>
+					<max_device_link_gen>6</max_device_link_gen>
+					<max_host_link_gen>6</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>0 KB/s</tx_util>
+			<rx_util>0 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>N/A</atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>0 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>Disabled</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>196608 MiB</total>
+			<reserved>1024 MiB</reserved>
+			<used>0 MiB</used>
+			<free>195584 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>524288 MiB</total>
+			<used>0 MiB</used>
+			<free>524288 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>N/A</total>
+			<used>N/A</used>
+			<free>N/A</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>40 %</gpu_util>
+			<memory_util>22 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>N/A</channel_repair_pending>
+			<tpc_repair_pending>N/A</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>0</retired_count>
+				<retired_pagelist>
+				</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>0</retired_count>
+				<retired_pagelist>
+				</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>No</pending_blacklist>
+			<pending_retirement>No</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>3072 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>36 C</gpu_temp>
+			<gpu_temp_tlimit>54 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>0 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>5 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>85 C</gpu_target_temperature>
+			<memory_temp>34 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>N/A</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>85 C</gpu_target_temp_min>
+			<gpu_target_temp_max>85 C</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>145.00 W</average_power_draw>
+			<instant_power_draw>145.00 W</instant_power_draw>
+			<current_power_limit>1000.00 W</current_power_limit>
+			<requested_power_limit>1000.00 W</requested_power_limit>
+			<default_power_limit>1000.00 W</default_power_limit>
+			<min_power_limit>400.00 W</min_power_limit>
+			<max_power_limit>1200.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>N/A</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>345 MHz</graphics_clock>
+			<sm_clock>345 MHz</sm_clock>
+			<mem_clock>2500 MHz</mem_clock>
+			<video_clock>1200 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>2100 MHz</graphics_clock>
+			<mem_clock>2500 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>2100 MHz</graphics_clock>
+			<mem_clock>2500 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>2100 MHz</graphics_clock>
+			<sm_clock>2100 MHz</sm_clock>
+			<mem_clock>2500 MHz</mem_clock>
+			<video_clock>2100 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>N/A</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000001</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>Full</bandwidth>
+				<route_recovery_in_progress>False</route_recovery_in_progress>
+				<route_unhealthy>False</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>None</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>N/A</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>N/A</accounted_processes>
+		<capabilities>
+			<egm>N/A</egm>
+		</capabilities>
+	</gpu>
+</nvidia_smi_log>

--- a/tests/e2e/go/assertions/nvidiasmi/throttle_counters.go
+++ b/tests/e2e/go/assertions/nvidiasmi/throttle_counters.go
@@ -1,0 +1,98 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidiasmi
+
+import (
+	"fmt"
+	"strings"
+)
+
+// The clocks-event counter checks, kept out of checks.go because they compare a
+// block of related readings per GPU and because the injection check compares
+// two different expectations within one document.
+
+// ThrottleCounterBlock is the <clocks_event_reasons_counters> block as
+// microsecond totals — the unit nvidia-smi prints and a real tray reports. Zero
+// is the reading of a GPU that has never been throttled by that cause, and is
+// asserted as such: before #678 every element read N/A, which says the driver
+// answered nothing, and a check that accepted both could not tell them apart.
+type ThrottleCounterBlock struct {
+	SWPowerCapUS        int
+	SyncBoostUS         int
+	SWThermalSlowdownUS int
+	HWThermalSlowdownUS int
+	HWPowerBrakeUS      int
+}
+
+// UnthrottledCounters is the block a GPU that has never been throttled reports:
+// five zeros. It is the healthy baseline every profile must produce.
+func UnthrottledCounters() ThrottleCounterBlock { return ThrottleCounterBlock{} }
+
+// ThrottleCounterProblems checks every GPU's counter block against want.
+func ThrottleCounterProblems(out string, want ThrottleCounterBlock) []string {
+	return throttleCounterProblems(out, func(int) ThrottleCounterBlock { return want })
+}
+
+// ThrottleCounterProblemsAt checks the GPU at index against want and every other
+// GPU against others. Accrued throttle time is per device, so a counter that
+// leaks onto the node's other GPUs — or one seeded on the wrong device — is a
+// defect this reports rather than one it passes over.
+func ThrottleCounterProblemsAt(out string, index int, want, others ThrottleCounterBlock) []string {
+	return throttleCounterProblems(out, func(i int) ThrottleCounterBlock {
+		if i == index {
+			return want
+		}
+		return others
+	})
+}
+
+func throttleCounterProblems(out string, want func(int) ThrottleCounterBlock) []string {
+	snap, err := ParseSnapshot(out)
+	if err != nil {
+		return []string{err.Error()}
+	}
+
+	var problems []string
+	for i, gpu := range snap.doc.GPUs {
+		problems = append(problems,
+			throttleCounterBlockProblems(gpu.label(i), gpu.ClocksEventCounters, want(i))...)
+	}
+	return problems
+}
+
+// throttleCounterBlockProblems reports one GPU's differences, one element per
+// problem, so a failure names the counter that regressed instead of dumping the
+// block. N/A is called out separately from a wrong number because the two have
+// different causes: an unanswered field id versus a miscounted duration.
+func throttleCounterBlockProblems(name string, got eventCounters, want ThrottleCounterBlock) []string {
+	var problems []string
+	for _, element := range []struct {
+		name string
+		got  reading
+		want int
+	}{
+		{"sw_power_cap", got.SWPowerCap, want.SWPowerCapUS},
+		{"sync_boost", got.SyncBoost, want.SyncBoostUS},
+		{"sw_therm_slowdown", got.SWThermalSlowdown, want.SWThermalSlowdownUS},
+		{"hw_therm_slowdown", got.HWThermalSlowdown, want.HWThermalSlowdownUS},
+		{"hw_power_brake", got.HWPowerBrake, want.HWPowerBrakeUS},
+	} {
+		body := strings.TrimSpace(string(element.got))
+		value, numeric := element.got.intValue()
+		switch {
+		case !element.got.present():
+			problems = append(problems, fmt.Sprintf(
+				"%s emits no %s counter, want %d us; the driver may have renamed it",
+				name, element.name, element.want))
+		case !numeric:
+			problems = append(problems, fmt.Sprintf(
+				"%s %s counter = %q, want %d us: the driver declined the query rather than answering it",
+				name, element.name, body, element.want))
+		case value != element.want:
+			problems = append(problems, fmt.Sprintf("%s %s counter = %d us, want %d us",
+				name, element.name, value, element.want))
+		}
+	}
+	return problems
+}

--- a/tests/e2e/go/assertions/nvidiasmi/throttle_counters_test.go
+++ b/tests/e2e/go/assertions/nvidiasmi/throttle_counters_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidiasmi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// powerCapped is the block of a GPU that has spent 39595 us under its software
+// power cap and has never been throttled for any other reason — the reading the
+// GB300 tray in #678 produced, kept verbatim so the fixture and the expectation
+// come from the same place.
+func powerCapped() ThrottleCounterBlock {
+	want := UnthrottledCounters()
+	want.SWPowerCapUS = 39595
+	return want
+}
+
+// qx-gb200-healthy.xml was captured before #678, so it is the defect itself:
+// nvidia-smi rendered all five counters as N/A because the mock left the field
+// ids behind them unanswered, so a consumer could not tell a GPU that had never
+// throttled from one whose history the driver would not report.
+func TestThrottleCounterProblems_RejectsUnansweredCounters(t *testing.T) {
+	problems := ThrottleCounterProblems(loadFixture(t, "qx-gb200-healthy.xml"), UnthrottledCounters())
+	require.Len(t, problems, 10, "five unanswered counters on each of the two GPUs")
+	joined := strings.Join(problems, "; ")
+	assert.Contains(t, joined, `sw_power_cap counter = "N/A", want 0 us`)
+	assert.Contains(t, joined, "declined the query rather than answering it",
+		"N/A must be reported as an unanswered query, not as a wrong number")
+}
+
+// The healthy direction: five zeros, which is a real answer where N/A is not.
+func TestThrottleCounterProblems_AcceptsNeverThrottledGPU(t *testing.T) {
+	out := loadFixture(t, "qx-gb200-throttle-counters.xml")
+	problems := ThrottleCounterProblemsAt(out, 0, powerCapped(), UnthrottledCounters())
+	assert.Empty(t, problems, strings.Join(problems, "; "))
+}
+
+// The assertion that gives the feature its value: a seeded cause reports its own
+// total and the other four stay at zero. A single counter answered for every
+// field id — the cheapest way to stop the N/A — would satisfy a check that only
+// looked at the seeded one.
+func TestThrottleCounterProblems_ReportsOnlyTheSeededCause(t *testing.T) {
+	problems := ThrottleCounterProblems(loadFixture(t, "qx-gb200-throttle-counters.xml"),
+		UnthrottledCounters())
+	require.Len(t, problems, 1, "only GPU 0's power-capping total may differ")
+	assert.Contains(t, problems[0], "sw_power_cap counter = 39595 us, want 0 us")
+}
+
+// Accrued time is per device, so a total reported on the wrong GPU is a defect
+// and not a pass: the same document must fail when the history is expected
+// elsewhere.
+func TestThrottleCounterProblems_RejectsHistoryOnTheWrongGPU(t *testing.T) {
+	problems := ThrottleCounterProblemsAt(loadFixture(t, "qx-gb200-throttle-counters.xml"),
+		1, powerCapped(), UnthrottledCounters())
+	require.Len(t, problems, 2, "both GPUs report the opposite of what was expected")
+	assert.Contains(t, strings.Join(problems, "; "), "sw_power_cap counter = 0 us, want 39595 us",
+		"the GPU expected to carry the history reports none")
+}
+
+// An element the driver renamed is reported as absent rather than compared as an
+// empty body, matching how the rest of the package reads the document.
+func TestThrottleCounterProblems_ReportsMissingElement(t *testing.T) {
+	out := strings.ReplaceAll(loadFixture(t, "qx-gb200-throttle-counters.xml"),
+		"<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>", "")
+	problems := ThrottleCounterProblems(out, powerCapped())
+	assert.Contains(t, strings.Join(problems, "; "), "emits no sync_boost counter")
+}
+
+func TestThrottleCounterProblems_ReportsUnparseableDocument(t *testing.T) {
+	problems := ThrottleCounterProblems("not xml", UnthrottledCounters())
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "parse nvidia-smi XML")
+}

--- a/tests/e2e/go/scenario_standalone_test.go
+++ b/tests/e2e/go/scenario_standalone_test.go
@@ -159,6 +159,15 @@ var _ = Describe("nvml-mock standalone", Ordered, func() {
 				nvidiasmi.FabricHealth(ctx, h.Kube, pod)
 			})
 
+			It("reports zeroed clocks-event counters via nvidia-smi -q -x", Label("nvidia-smi"), func(ctx SpecContext) {
+				// Issue #678: all five counters read N/A because the perf-policy
+				// field ids behind them were unhandled, so the same output block
+				// reported no throttle reason active and could not say whether
+				// one ever had been. A profile that has never throttled reports
+				// 0 us, which is an answer where N/A is not.
+				nvidiasmi.ThrottleCounters(ctx, h.Kube, pod)
+			})
+
 			It("exposes the NVLink topology (gated on fabricmanager)", Label("nvlink"), func(ctx SpecContext) {
 				assertions.FabricManagerGate(ctx, h.Kube, nvmlMockNamespace, "nvml-mock", pod, config.ReadyTimeout(), config.PollInterval())
 				assertions.NVLink(ctx, h.Kube, pod, p)
@@ -249,6 +258,14 @@ var _ = Describe("nvml-mock standalone", Ordered, func() {
 
 				It("sets a throttle reason via the nvml-mock-ctl throttle command", Label("runtime-control"), func(ctx SpecContext) {
 					assertRuntimeThrottleCommand(ctx, h, pod)
+				})
+
+				It("seeds a clocks-event counter via nvml-mock-ctl set", Label("runtime-control"), Label("nvidia-smi"), func(ctx SpecContext) {
+					// Issue #678: a GPU carrying accrued throttle time is the
+					// case worth simulating — one cause must report its own
+					// total while its four siblings and the node's other GPUs
+					// stay at zero.
+					assertRuntimeThrottleCounterSeeding(ctx, h, pod)
 				})
 
 				It("pins the performance state via the nvml-mock-ctl pstate command", Label("runtime-control"), func(ctx SpecContext) {

--- a/tests/e2e/go/scenario_throttle_counters.go
+++ b/tests/e2e/go/scenario_throttle_counters.go
@@ -1,0 +1,98 @@
+//go:build e2e
+
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/assertions/nvidiasmi"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/harness"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/kube"
+)
+
+// Clocks-event counter scenario for issue #678.
+//
+// Before #678 all five counters in `nvidia-smi -q -x` read N/A, so the output
+// contradicted itself: the flags above them stated confidently that no throttle
+// reason was active, and the counters could not say whether one ever had been.
+// The counters are how throttling is diagnosed after the fact — a workload that
+// ran slow is investigated by reading accumulated power-capping or thermal
+// time, not by sampling a flag and hoping to catch it.
+//
+// The healthy direction (five zeros on every GPU of every profile) is asserted
+// by nvidiasmi.ThrottleCounters. What this scenario adds is a GPU carrying a
+// history: one seeded cause reports its own total, its four siblings stay at
+// zero, and the node's other GPUs stay at zero too. Answering a single counter
+// for every field id is the cheapest way to stop the N/A and would pass a
+// weaker check.
+
+// throttleCounterSeedUS is the seeded power-capping total. It is deliberately
+// unlike anything the mock produces on its own — no profile baseline, no
+// accrued duration, no round number — so the assertion cannot pass by
+// coincidence.
+const throttleCounterSeedUS = 7654321
+
+// assertRuntimeThrottleCounterSeeding seeds one cause's accrued time on one GPU
+// through the generic `set` path and reads it back from nvidia-smi.
+//
+// sw_power_cap is the cause chosen because no shipped profile reports it as
+// currently active: a cause that is active accrues further time on every read,
+// which is correct behaviour but not something an exact assertion can pin. The
+// zeroed baseline is asserted first, which is both the healthy expectation and
+// the precondition that makes the exact comparison meaningful.
+func assertRuntimeThrottleCounterSeeding(ctx SpecContext, h *harness.Harness, consumer kube.PodRef) {
+	GinkgoHelper()
+	resetRuntimeOverrides(ctx, h)
+
+	target := gpuCount(ctx, h, consumer) - 1 // exercise a non-zero index where possible
+
+	By("every GPU starts with five zeroed clocks-event counters")
+	Expect(throttleCounterProblems(ctx, h, consumer, func(out string) []string {
+		return nvidiasmi.ThrottleCounterProblems(out, nvidiasmi.UnthrottledCounters())
+	})).To(BeEmpty(), "the profile must report no accrued throttle time for an exact assertion to mean anything")
+
+	seeded := nvidiasmi.UnthrottledCounters()
+	seeded.SWPowerCapUS = throttleCounterSeedUS
+
+	By("seed " + strconv.Itoa(throttleCounterSeedUS) + " us of power capping on GPU " +
+		strconv.Itoa(target) + " via nvml-mock-ctl set")
+	nvmlMockCtl(ctx, h, "set", "--gpu", strconv.Itoa(target),
+		"clocks_throttle_reasons.counters.sw_power_cap_us="+strconv.Itoa(throttleCounterSeedUS))
+
+	Eventually(func() []string {
+		return throttleCounterProblems(ctx, h, consumer, func(out string) []string {
+			return nvidiasmi.ThrottleCounterProblemsAt(out, target, seeded, nvidiasmi.UnthrottledCounters())
+		})
+	}).WithContext(ctx).WithTimeout(runtimeTTLTimeout).WithPolling(runtimeTTLPoll).
+		Should(BeEmpty(), "GPU %d should report exactly the seeded power-capping time, and only that counter", target)
+
+	By("reset runtime overrides")
+	nvmlMockCtl(ctx, h, "reset", "--gpu", "all")
+
+	Eventually(func() []string {
+		return throttleCounterProblems(ctx, h, consumer, func(out string) []string {
+			return nvidiasmi.ThrottleCounterProblems(out, nvidiasmi.UnthrottledCounters())
+		})
+	}).WithContext(ctx).WithTimeout(runtimeTTLTimeout).WithPolling(runtimeTTLPoll).
+		Should(BeEmpty(), "every counter should return to the profile baseline after reset")
+}
+
+// throttleCounterProblems reads a fresh `nvidia-smi -q -x` document from the
+// consumer and hands it to check. A failed exec is returned as a problem rather
+// than asserted, so a poll can ride out a consumer restart.
+func throttleCounterProblems(ctx SpecContext, h *harness.Harness, consumer kube.PodRef,
+	check func(string) []string,
+) []string {
+	GinkgoHelper()
+	res, err := h.Kube.ExecQuiet(ctx, consumer, "nvidia-smi", "-q", "-x")
+	if err != nil {
+		return []string{"nvidia-smi -q -x: " + err.Error() + ": " + res.Combined()}
+	}
+	return check(res.Stdout)
+}

--- a/tests/mocknvml/bridge_tests.go
+++ b/tests/mocknvml/bridge_tests.go
@@ -50,17 +50,19 @@ func bridgeTests(deviceCount int) []testResult {
 
 // --- Throttle counter tests ---
 
-// Field ids for the "Clocks Event Reasons Counters", in the numbering the
-// simulated driver uses. go-nvml names the first two (FI_DEV_PERF_POLICY_POWER
-// and _SYNC_BOOST) but has no constant for the three slowdown causes at these
-// ids: the header it vendors is newer and numbers them 269-271. See the same
-// note in engine/throttle_counters.go.
+// Field ids for the "Clocks Event Reasons Counters". This module pins go-nvml
+// v0.13.0-1, whose const.go still places the three slowdown causes at 251-253,
+// which is where the driver the mock simulates has them, so the names resolve
+// to the ids the engine answers. The root module has since moved to v0.13.3-1,
+// which renumbers them to 269-271 and reuses 251-253 for power smoothing —
+// which is why engine/throttle_counters.go states its ids literally instead of
+// naming them. checkThrottleFieldIDs guards the day this module is bumped too.
 const (
 	fiThrottleSWPowerCap      = nvml.FI_DEV_PERF_POLICY_POWER
 	fiThrottleSyncBoost       = nvml.FI_DEV_PERF_POLICY_SYNC_BOOST
-	fiThrottleSWThermSlowdown = 251
-	fiThrottleHWThermSlowdown = 252
-	fiThrottleHWPowerBrake    = 253
+	fiThrottleSWThermSlowdown = nvml.FI_DEV_CLOCKS_EVENT_REASON_SW_THERM_SLOWDOWN
+	fiThrottleHWThermSlowdown = nvml.FI_DEV_CLOCKS_EVENT_REASON_HW_THERM_SLOWDOWN
+	fiThrottleHWPowerBrake    = nvml.FI_DEV_CLOCKS_EVENT_REASON_HW_POWER_BRAKE_SLOWDOWN
 	valueTypeUnsignedLongLong = 3
 )
 
@@ -80,6 +82,8 @@ func testThrottleCounters(deviceCount int) []testResult {
 	if deviceCount == 0 {
 		return results
 	}
+
+	results = append(results, checkThrottleFieldIDs())
 
 	causes := []struct {
 		label   string
@@ -175,6 +179,35 @@ func testThrottleCounters(deviceCount int) []testResult {
 	}
 
 	return results
+}
+
+// checkThrottleFieldIDs pins the go-nvml names above to the ids the driver the
+// mock simulates uses. Without it, a go-nvml bump that renumbers them would
+// retarget this whole test at ids the engine deliberately does not answer, and
+// every counter below would fail as if the counters had regressed. This says
+// what actually happened instead.
+func checkThrottleFieldIDs() testResult {
+	const (
+		wantSWTherm      = 251
+		wantHWTherm      = 252
+		wantHWPowerBrake = 253
+	)
+	for _, id := range []struct {
+		label     string
+		got, want uint32
+	}{
+		{"sw_therm_slowdown", fiThrottleSWThermSlowdown, wantSWTherm},
+		{"hw_therm_slowdown", fiThrottleHWThermSlowdown, wantHWTherm},
+		{"hw_power_brake", fiThrottleHWPowerBrake, wantHWPowerBrake},
+	} {
+		if id.got != id.want {
+			return testResult{"throttle/field_ids", false, fmt.Sprintf(
+				"go-nvml puts %s at field %d, but the simulated driver has it at %d: "+
+					"this module's go-nvml was bumped past v0.13.0-1 and the names moved",
+				id.label, id.got, id.want)}
+		}
+	}
+	return testResult{"throttle/field_ids", true, ""}
 }
 
 // fieldValueULL reads the ullVal member of the nvmlValue_t union the bridge

--- a/tests/mocknvml/bridge_tests.go
+++ b/tests/mocknvml/bridge_tests.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"encoding/binary"
 	"fmt"
 	"log"
 	"strings"
@@ -43,7 +44,144 @@ func bridgeTests(deviceCount int) []testResult {
 	results = append(results, testInitShutdownCycles()...)
 	results = append(results, testInternalExportTable()...)
 	results = append(results, testFabricHealth(deviceCount)...)
+	results = append(results, testThrottleCounters(deviceCount)...)
 	return results
+}
+
+// --- Throttle counter tests ---
+
+// Field ids for the "Clocks Event Reasons Counters", in the numbering the
+// simulated driver uses. go-nvml names the first two (FI_DEV_PERF_POLICY_POWER
+// and _SYNC_BOOST) but has no constant for the three slowdown causes at these
+// ids: the header it vendors is newer and numbers them 269-271. See the same
+// note in engine/throttle_counters.go.
+const (
+	fiThrottleSWPowerCap      = nvml.FI_DEV_PERF_POLICY_POWER
+	fiThrottleSyncBoost       = nvml.FI_DEV_PERF_POLICY_SYNC_BOOST
+	fiThrottleSWThermSlowdown = 251
+	fiThrottleHWThermSlowdown = 252
+	fiThrottleHWPowerBrake    = 253
+	valueTypeUnsignedLongLong = 3
+)
+
+// testThrottleCounters drives nvmlDeviceGetFieldValues and the deprecated
+// nvmlDeviceGetViolationStatus through the built library. This is the only
+// place the field-value marshalling runs for real: the bridge writes the
+// nvmlValue_t union from C, so a counter that resolves correctly in the engine
+// can still reach a consumer as the wrong union member or the wrong width.
+//
+// The fixture leaves device 0 unthrottled (which must read 0, not
+// NOT_SUPPORTED — that is what nvidia-smi renders as N/A) and gives device 1
+// five distinct per-cause values, so an id that aliased onto another cause
+// fails here.
+func testThrottleCounters(deviceCount int) []testResult {
+	var results []testResult
+
+	if deviceCount == 0 {
+		return results
+	}
+
+	causes := []struct {
+		label   string
+		fieldID uint32
+		// wantUS is device 1's configured value in microseconds; device 0 is
+		// expected to report zero for every cause.
+		wantUS uint64
+	}{
+		{"sw_power_cap", fiThrottleSWPowerCap, 11111},
+		{"sync_boost", fiThrottleSyncBoost, 22222},
+		{"sw_therm_slowdown", fiThrottleSWThermSlowdown, 33333},
+		{"hw_therm_slowdown", fiThrottleHWThermSlowdown, 44444},
+		{"hw_power_brake", fiThrottleHWPowerBrake, 55555},
+	}
+
+	for index := 0; index < 2 && index < deviceCount; index++ {
+		device, ret := nvml.DeviceGetHandleByIndex(index)
+		if ret != nvml.SUCCESS {
+			results = append(results, testResult{
+				fmt.Sprintf("throttle/gpu%d", index), false,
+				fmt.Sprintf("GetHandleByIndex(%d) failed: %v", index, nvml.ErrorString(ret)),
+			})
+			continue
+		}
+
+		// One batch, the way nvidia-smi asks: a per-entry failure would
+		// otherwise be hidden by the call as a whole succeeding.
+		values := make([]nvml.FieldValue, len(causes))
+		for i, cause := range causes {
+			values[i].FieldId = cause.fieldID
+		}
+		if ret := device.GetFieldValues(values); ret != nvml.SUCCESS {
+			results = append(results, testResult{
+				fmt.Sprintf("throttle/gpu%d", index), false,
+				fmt.Sprintf("GetFieldValues failed: %v", nvml.ErrorString(ret)),
+			})
+			continue
+		}
+
+		for i, cause := range causes {
+			name := fmt.Sprintf("throttle/gpu%d/%s", index, cause.label)
+			wantNs := uint64(0)
+			if index == 1 {
+				wantNs = cause.wantUS * 1000
+			}
+			fv := values[i]
+			switch {
+			case nvml.Return(fv.NvmlReturn) != nvml.SUCCESS:
+				results = append(results, testResult{name, false, fmt.Sprintf(
+					"field %d declined with %v; a consumer renders that as N/A",
+					cause.fieldID, nvml.ErrorString(nvml.Return(fv.NvmlReturn)))})
+			case fv.ValueType != valueTypeUnsignedLongLong:
+				results = append(results, testResult{name, false, fmt.Sprintf(
+					"valueType = %d, want UNSIGNED_LONG_LONG (%d)", fv.ValueType, valueTypeUnsignedLongLong)})
+			case fieldValueULL(fv) != wantNs:
+				results = append(results, testResult{name, false, fmt.Sprintf(
+					"%d ns, want %d ns", fieldValueULL(fv), wantNs)})
+			default:
+				results = append(results, testResult{name, true, fmt.Sprintf("%d ns", wantNs)})
+			}
+		}
+
+		// The deprecated getter must agree with the field values for the three
+		// causes NVML maps onto a performance policy.
+		for _, tc := range []struct {
+			policy nvml.PerfPolicyType
+			label  string
+			wantUS uint64
+		}{
+			{nvml.PERF_POLICY_POWER, "power", 11111},
+			{nvml.PERF_POLICY_THERMAL, "thermal", 33333},
+			{nvml.PERF_POLICY_SYNC_BOOST, "sync_boost", 22222},
+		} {
+			name := fmt.Sprintf("throttle/gpu%d/violation_%s", index, tc.label)
+			wantNs := uint64(0)
+			if index == 1 {
+				wantNs = tc.wantUS * 1000
+			}
+			vt, ret := device.GetViolationStatus(tc.policy)
+			switch {
+			case ret != nvml.SUCCESS:
+				results = append(results, testResult{name, false,
+					fmt.Sprintf("GetViolationStatus failed: %v", nvml.ErrorString(ret))})
+			case vt.ViolationTime != wantNs:
+				results = append(results, testResult{name, false,
+					fmt.Sprintf("violationTime = %d ns, want %d ns", vt.ViolationTime, wantNs)})
+			case vt.ReferenceTime == 0:
+				results = append(results, testResult{name, false, "referenceTime is unset"})
+			default:
+				results = append(results, testResult{name, true, ""})
+			}
+		}
+	}
+
+	return results
+}
+
+// fieldValueULL reads the ullVal member of the nvmlValue_t union the bridge
+// wrote. CGo hands the union over as opaque bytes, so the host byte order the
+// library was built with is the one to decode with.
+func fieldValueULL(fv nvml.FieldValue) uint64 {
+	return binary.NativeEndian.Uint64(fv.Value[:])
 }
 
 // --- Fabric health tests ---

--- a/tests/mocknvml/util-test-config.yaml
+++ b/tests/mocknvml/util-test-config.yaml
@@ -344,6 +344,16 @@ devices:
       bus_id: "0000:0F:00.0"
     minor_number: 1
     processes: []   # explicit clear: empty-path coverage
+    # Distinct per-cause throttle counters, so the harness can tell the five
+    # field ids apart from one another and from device 0's untouched zeros.
+    clocks_throttle_reasons:
+      gpu_idle: true
+      counters:
+        sw_power_cap_us: 11111
+        sync_boost_us: 22222
+        sw_thermal_slowdown_us: 33333
+        hw_thermal_slowdown_us: 44444
+        hw_power_brake_slowdown_us: 55555
     # One faulted condition, so the harness can tell a per-device health mask
     # apart from a constant: only this row flips, and the summary follows.
     fabric:


### PR DESCRIPTION
Fixes #678

## Summary

All five counters in the `nvidia-smi -q` `Clocks Event Reasons Counters` block read `N/A`, so the output contradicted itself: the flags directly above them stated confidently that no throttle reason was active, and the counters could not say whether one ever had been. The counters are how throttling is diagnosed after the fact — a workload that ran slow is investigated by reading accumulated `SW Power Capping` or `HW Thermal Slowdown` time, not by sampling the instantaneous flag and hoping to catch it.

Two layers declined, for different reasons:

- `GetViolationStatus` was implemented but ignored its `perfPolicyType` and returned a zero `nvmlViolationTime_t` for every policy, leaving the five causes indistinguishable.
- That is not the path producing the `N/A`. A 580-era `nvidia-smi` reads the counters through `nvmlDeviceGetFieldValues`, and an unhandled field id there comes back per-field `NOT_SUPPORTED` while the overall call succeeds — which renders as `N/A` with no unimplemented-symbol stub reached, and is why the debug census for a full `-q` run showed nothing for this section.

Both paths now resolve from one per-device accrual, so they cannot disagree.

A `clocks_throttle_reasons.counters` block seeds the accrued time per cause per device in microseconds, defaulting to `0 us` — a real answer, where `N/A` is not. A device accrues further time on top of its baseline while the matching flag is set, within one process — see the behavioural note below for what that does and does not buy.

Against the `gb200` profile with `sw_power_cap_us: 39595` on GPU 0:

```
    Clocks Event Reasons Counters
        SW Power Capping                  : 39595 us
        Sync Boost                        : 0 us
        SW Thermal Slowdown               : 0 us
        HW Thermal Slowdown               : 0 us
        HW Power Braking                  : 0 us
```

## The field ids are not the ones the issue reports

`nvidia-smi` 580.65.06 asks for **74, 76, 251, 252 and 253** at the whole-GPU scope, established by tracing a real `-q` field-value batch. The vendored CUDA 13 header numbers the three slowdown causes 269-271 and reuses 251-253 for power smoothing, so taking the header at its word left those three still reading `N/A` after the other two were fixed. The simulated driver's numbering is what consumers see, so it is the one used here, pinned by a test that fails if a header bump moves it silently.

## Second defect found on the way

Applying the counters per device surfaced an unrelated bug: `mergeDeviceOverride` had no case for `clocks_throttle_reasons` at all, so per-device throttle config in **any** profile was being dropped.

## Behavioural note

Accrual is folded in on read and is per process, matching the dynamic-metrics simulator: a long-lived consumer such as dcgm-exporter watches a counter climb while a reason is active, and each `nvidia-smi` invocation accrues only over its own lifetime. Cross-process accrual would need shared node state, so this is documented in `docs/configuration.md` rather than worked around.

The consequence is that a throttle state entered at runtime carries no history of its own — `nvidia-smi` shows the reason `Active` beside `1 us`, the age of that `nvidia-smi` process. The counters are what make an `Active` flag read as a duration, so seed both together:

```bash
nvml-mock-ctl throttle --gpu 3 thermal
nvml-mock-ctl set --gpu 3 clocks_throttle_reasons.counters.hw_thermal_slowdown_us=39595
```

Both land in the same override document, so the second command keeps the first.

## Test plan

- [x] `make test` — engine unit tests cover each policy and each cause separately, that setting one leaves the others at zero, that accrual advances while a reason is active and survives it clearing, and that the field-id mapping matches the simulated driver
- [x] `make test-mocknvml-bridge` — reads all five counters and three violation statuses across the C ABI on two differently-configured devices, so the marshalling is exercised rather than assumed
- [x] `make helm-tests` — 169 tests, 15 snapshots, no profile churn
- [x] `nvidia-smi -q` / `-q -x` verified in the mock image against a seeded profile and, separately, through the `nvml-mock-ctl set` → read back → `reset` loop
- [x] `nvidia-smi pmon -c 1` exits 255 and `topo -m` exits 0, both unchanged from the baseline
- [ ] e2e: a `Label("nvidia-smi")` spec asserts five zeros on every profile, and a runtime spec seeds a distinctive total on one GPU and requires the other four causes — and the node's other GPUs — to stay at zero. The pre-fix capture already in `testdata` is the defect the checks must reject, which is verified by unit test; the cluster legs run in CI here.
