### PR TITLE
fix(mocknvml): report the fields Blackwell removed as N/A

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tests/e2e/go/framework/pod`, rendered from a `Spec` carrying only what varies.
 
 ### Fixed
+- mocknvml: the Blackwell profiles no longer report features Blackwell does not
+  have. `GPU Operation Mode` (GK110-era), the whole `Retired Pages` block
+  (replaced by row remapping), `GPU Target Temperature` with its
+  `Supported GPU Target Temp` range, `Sparse Operation Mode` and the inforom
+  `Power Management Object` all carried values on `b200`/`gb200`/`gb300`, where a
+  real GB300 tray reports `N/A` for every one. This is the inverse of the usual
+  defect and the worse failure: `N/A` sends a consumer looking for another
+  source, while a target temperature of `85 C` or a retired-page count of `0` is
+  believed — code that branches on Blackwell having no page retirement took the
+  other branch. `nvmlDeviceGetGpuOperationMode`, the three
+  `nvmlDeviceGetRetiredPages*` entry points and the acoustic temperature
+  thresholds are now gated on architecture, and `pwr_object` is gone from the
+  Blackwell profiles. `nvmlDeviceGetTemperatureThreshold` returns `NOT_SUPPORTED`
+  for threshold types no profile models instead of answering every unrecognised
+  one with the max-operating value, so a threshold type NVML adds next cannot
+  inherit a wrong answer. `Sparse Operation Mode` turned out to come from a slot
+  of the internal export table rather than any public NVML entry point, which is
+  why it has no implementation to find by name; that slot now fails on
+  Blackwell. `t4`, `a100`, `h100` and `l40s` keep reporting all of these — the
+  gate is architectural, and a new e2e spec asserts both directions so widening
+  it cannot pass as a fix. (#679)
 - mocknvml: `nvmlPciInfo_t.busId` now reports the 8-digit PCI domain real NVML
   uses (`00000000:07:00.0`, `NVML_DEVICE_PCI_BUS_ID_FMT`) while `busIdLegacy`
   keeps the 4-digit one (`0000:07:00.0`). Both were filled with the profile's

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/b200.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/b200.yaml
@@ -50,7 +50,8 @@ device_defaults:
     image_version: "B200.0200.00.01"
     oem_object: "2.1"
     ecc_object: "7.16"
-    pwr_object: "1.0"
+    # No pwr_object: Blackwell carries no Power Management Object in its
+    # inforom, so the query has to fail and nvidia-smi print N/A (#679).
 
   # ---------------------------------------------------------------------------
   # Memory configuration - 192 GiB HBM3e

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
@@ -87,7 +87,8 @@ device_defaults:
     image_version: "G530.0200.00.01"
     oem_object: "2.1"
     ecc_object: "7.16"
-    pwr_object: "1.0"
+    # No pwr_object: Blackwell carries no Power Management Object in its
+    # inforom, so the query has to fail and nvidia-smi print N/A (#679).
 
   # ---------------------------------------------------------------------------
   # Memory configuration - 192 GiB HBM3e per GPU

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/gb300.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/gb300.yaml
@@ -88,7 +88,8 @@ device_defaults:
     image_version: "G530.0300.00.01"
     oem_object: "2.1"
     ecc_object: "7.20"
-    pwr_object: "1.0"
+    # No pwr_object: Blackwell carries no Power Management Object in its
+    # inforom, so the query has to fail and nvidia-smi print N/A (#679).
 
   # ---------------------------------------------------------------------------
   # Memory configuration - 288 GiB HBM3e per GPU (1.5x GB200's 192 GiB)

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
@@ -55,7 +55,8 @@ should match snapshot with b200 profile:
             image_version: "B200.0200.00.01"
             oem_object: "2.1"
             ecc_object: "7.16"
-            pwr_object: "1.0"
+            # No pwr_object: Blackwell carries no Power Management Object in its
+            # inforom, so the query has to fail and nvidia-smi print N/A (#679).
 
           # ---------------------------------------------------------------------------
           # Memory configuration - 192 GiB HBM3e
@@ -1055,7 +1056,8 @@ should match snapshot with gb200 profile:
             image_version: "G530.0200.00.01"
             oem_object: "2.1"
             ecc_object: "7.16"
-            pwr_object: "1.0"
+            # No pwr_object: Blackwell carries no Power Management Object in its
+            # inforom, so the query has to fail and nvidia-smi print N/A (#679).
 
           # ---------------------------------------------------------------------------
           # Memory configuration - 192 GiB HBM3e per GPU
@@ -1627,7 +1629,8 @@ should match snapshot with gb300 profile:
             image_version: "G530.0300.00.01"
             oem_object: "2.1"
             ecc_object: "7.20"
-            pwr_object: "1.0"
+            # No pwr_object: Blackwell carries no Power Management Object in its
+            # inforom, so the query has to fail and nvidia-smi print N/A (#679).
 
           # ---------------------------------------------------------------------------
           # Memory configuration - 288 GiB HBM3e per GPU (1.5x GB200's 192 GiB)

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -166,7 +166,7 @@ should match snapshot with b200 profile:
       template:
         metadata:
           annotations:
-            checksum/config: 34bbeafe005d65c19de791d4d2d65ac68868aa562c4fb5c00aa86f7b05d5ec5c
+            checksum/config: ff922b90cabacba1d78869321dac19086b0ae294e581f1baeca725d4c9043600
           labels:
             app.kubernetes.io/component: daemon
             app.kubernetes.io/instance: RELEASE-NAME

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -390,6 +390,10 @@ device_defaults:
     pwr_object: "1.0"
 ```
 
+Omit a key to report the object as unsupported, which `nvidia-smi` renders as
+`N/A`. The Blackwell profiles omit `pwr_object` for that reason: those boards
+carry no Power Management Object.
+
 ### Accounting
 
 ```yaml

--- a/pkg/gpu/mocknvml/bridge/internal.go
+++ b/pkg/gpu/mocknvml/bridge/internal.go
@@ -41,6 +41,10 @@ extern unsigned int mockInternalFillProcessList(void* handle, void* buf, unsigne
 // below in Go). Returns 0 when the device is unknown or configures no PCIe block.
 extern unsigned int mockInternalHostMaxPcieLinkGen(void* handle);
 
+// Forward declaration of the sparse-operation-mode architecture gate (defined
+// below in Go). Returns 1 when the device's architecture reports the mode.
+extern int mockInternalReportsSparseOperationMode(void* handle);
+
 // Debug mode - check MOCK_NVML_DEBUG env var once at startup
 static int debugChecked = 0;
 static int debugEnabled = 0;
@@ -63,6 +67,7 @@ static int isDebugEnabled() {
 #define MOCK_SLOT_PROCESS_LIST_FIRST 213
 #define MOCK_SLOT_PROCESS_LIST_LAST 215
 #define MOCK_SLOT_HOST_MAX_PCIE_LINK_GEN 230
+#define MOCK_SLOT_SPARSE_OPERATION_MODE 249
 
 // C stub function for internal export table
 // This gets called by nvidia-smi via the export table function pointers
@@ -144,6 +149,24 @@ static nvmlReturn_t internalStubFunction(unsigned int slot, void* arg0, void* ar
         }
     }
 
+    // Sparse Operation Mode: fn(nvmlDevice_t device, unsigned int* out).
+    // nvidia-smi's "Sparse Operation Mode" row comes from here -- no public
+    // NVML entry point exposes it, which is why a repository-wide search for
+    // the name finds nothing. Falling through to the zero write below is what
+    // made every profile, Blackwell included, report "Disabled" (issue #679);
+    // real Blackwell has no such mode and reports N/A, which is what an error
+    // from this slot renders as. Slot located by its position in the -q call
+    // sequence: it fires between the clocks-event-reason field values and
+    // nvmlDeviceGetMemoryInfo_v2, exactly where the row sits in the output.
+    if (slot == MOCK_SLOT_SPARSE_OPERATION_MODE &&
+        !mockInternalReportsSparseOperationMode(arg0)) {
+        if (isDebugEnabled()) {
+            fprintf(stderr, "[C-STUB] slot %u sparse operation mode (handle=%p) -> NOT_SUPPORTED\n",
+                    slot, arg0);
+        }
+        return NVML_ERROR_NOT_SUPPORTED;
+    }
+
     // Every other per-device call still gets an explicit zero count. Leaving it
     // at the caller's pre-filled capacity makes nvidia-smi walk an array we
     // never wrote: that is the phantom-process bug for the list views, and a
@@ -218,6 +241,20 @@ func mockInternalHostMaxPcieLinkGen(handle unsafe.Pointer) C.uint {
 		return 0
 	}
 	return C.uint(dev.HostMaxPcieLinkGeneration())
+}
+
+// mockInternalReportsSparseOperationMode reports whether the device nvidia-smi
+// passed through the internal export table answers the Sparse Operation Mode
+// query. An unknown handle reports 1 so an unrecognised device keeps the
+// zero-count fall-through rather than turning into an error.
+//
+//export mockInternalReportsSparseOperationMode
+func mockInternalReportsSparseOperationMode(handle unsafe.Pointer) C.int {
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil || dev.ReportsSparseOperationMode() {
+		return 1
+	}
+	return 0
 }
 
 // Layout of one entry in the internal process-list array, recovered by probing

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-b200.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-b200.yaml
@@ -43,7 +43,8 @@ device_defaults:
     image_version: "B200.0200.00.01"
     oem_object: "2.1"
     ecc_object: "7.16"
-    pwr_object: "1.0"
+    # No pwr_object: Blackwell carries no Power Management Object in its
+    # inforom, so the query has to fail and nvidia-smi print N/A (#679).
 
   # ---------------------------------------------------------------------------
   # Memory configuration - 192 GiB HBM3e

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml
@@ -55,7 +55,8 @@ device_defaults:
     image_version: "G530.0200.00.01"
     oem_object: "2.1"
     ecc_object: "7.16"
-    pwr_object: "1.0"
+    # No pwr_object: Blackwell carries no Power Management Object in its
+    # inforom, so the query has to fail and nvidia-smi print N/A (#679).
 
   # ---------------------------------------------------------------------------
   # Memory configuration - 192 GiB HBM3e per GPU

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-gb300.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-gb300.yaml
@@ -56,7 +56,8 @@ device_defaults:
     image_version: "G530.0300.00.01"
     oem_object: "2.1"
     ecc_object: "7.20"
-    pwr_object: "1.0"
+    # No pwr_object: Blackwell carries no Power Management Object in its
+    # inforom, so the query has to fail and nvidia-smi print N/A (#679).
 
   # ---------------------------------------------------------------------------
   # Memory configuration - 288 GiB HBM3e per GPU (1.5x GB200's 192 GiB)

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -704,7 +704,12 @@ func (d *ConfigurableDevice) GetTemperature(sensor nvml.TemperatureSensors) (uin
 	return temp, nvml.SUCCESS
 }
 
-// GetTemperatureThreshold returns temperature thresholds
+// GetTemperatureThreshold returns temperature thresholds.
+//
+// Threshold types the profiles do not model report NOT_SUPPORTED rather than
+// falling through to the max-operating value: a catch-all answer is wrong for
+// whichever row nvidia-smi asked about and would silently extend to any
+// threshold type NVML adds next (#679).
 func (d *ConfigurableDevice) GetTemperatureThreshold(thresholdType nvml.TemperatureThresholds) (uint32, nvml.Return) {
 	c := d.cfg()
 	if c.Thermal == nil {
@@ -718,11 +723,48 @@ func (d *ConfigurableDevice) GetTemperatureThreshold(thresholdType nvml.Temperat
 		temp = uint32(c.Thermal.SlowdownThreshold_C)
 	case nvml.TEMPERATURE_THRESHOLD_GPU_MAX:
 		temp = uint32(c.Thermal.MaxOperating_C)
-	default:
+	case nvml.TEMPERATURE_THRESHOLD_MEM_MAX:
+		// No profile models a separate memory throttle limit, so the
+		// max-operating value stands in for it, as it always has on the
+		// architectures that print the row.
 		temp = uint32(c.Thermal.MaxOperating_C)
+	case nvml.TEMPERATURE_THRESHOLD_ACOUSTIC_CURR,
+		nvml.TEMPERATURE_THRESHOLD_ACOUSTIC_MIN,
+		nvml.TEMPERATURE_THRESHOLD_ACOUSTIC_MAX:
+		// The acoustic thresholds are nvidia-smi's "GPU Target Temperature"
+		// row and its supported min/max pair. Blackwell has no target
+		// temperature to report and answers N/A.
+		if !d.preBlackwell() {
+			return 0, nvml.ERROR_NOT_SUPPORTED
+		}
+		temp = uint32(c.Thermal.MaxOperating_C)
+	default:
+		return 0, nvml.ERROR_NOT_SUPPORTED
 	}
 	debugLog("[NVML] nvmlDeviceGetTemperatureThreshold(type=%d) -> %d\n", thresholdType, temp)
 	return temp, nvml.SUCCESS
+}
+
+// preBlackwell is the architecture gate shared by the surfaces Blackwell
+// removed: GPU Operation Mode, page retirement, the acoustic (target)
+// temperature thresholds and the internal sparse-operation-mode query. Real
+// Blackwell answers all of them NOT_SUPPORTED, which nvidia-smi renders as
+// N/A; the mock answering them instead is worse than a wrong value, because a
+// consumer that would look elsewhere on seeing N/A believes a fabricated one
+// (#679). An unset architecture counts as pre-Blackwell so a profile that
+// declares none keeps the output it has today.
+func (d *ConfigurableDevice) preBlackwell() bool {
+	return d.Config.Architecture < nvml.DEVICE_ARCH_BLACKWELL ||
+		d.Config.Architecture == nvml.DEVICE_ARCH_UNKNOWN
+}
+
+// ReportsSparseOperationMode reports whether the device's architecture answers
+// nvidia-smi's Sparse Operation Mode query. That query arrives through a slot
+// of the internal export table rather than a public NVML entry point, so the
+// bridge -- which sees only a device handle -- needs the architecture answer
+// from here.
+func (d *ConfigurableDevice) ReportsSparseOperationMode() bool {
+	return d.preBlackwell()
 }
 
 // reportsTLimit is the architecture gate shared by every T.Limit surface: the
@@ -1389,8 +1431,13 @@ func (d *ConfigurableDevice) GetFBCSessions() ([]nvml.FBCSessionInfo, nvml.Retur
 	return []nvml.FBCSessionInfo{}, nvml.SUCCESS
 }
 
-// GetGpuOperationMode returns GPU operation mode
+// GetGpuOperationMode returns GPU operation mode. The feature shipped on
+// GK110-era Tesla boards only; Blackwell reports N/A, and claiming "All On"
+// there describes a different generation of hardware.
 func (d *ConfigurableDevice) GetGpuOperationMode() (nvml.GpuOperationMode, nvml.GpuOperationMode, nvml.Return) {
+	if !d.preBlackwell() {
+		return 0, 0, nvml.ERROR_NOT_SUPPORTED
+	}
 	debugLog("[NVML] nvmlDeviceGetGpuOperationMode -> ALL_ON\n")
 	return nvml.GOM_ALL_ON, nvml.GOM_ALL_ON, nvml.SUCCESS
 }
@@ -2084,20 +2131,35 @@ func (d *ConfigurableDevice) sramLocationErrors(errorType nvml.MemoryErrorType, 
 	return counts.Correctable
 }
 
+// Page retirement was replaced by row remapping on Blackwell, so the three
+// retirement getters report NOT_SUPPORTED there -- see GetRemappedRows for the
+// surface that took over. Succeeding with an empty list is not a harmless
+// approximation: nvidia-smi renders it as a retired count of 0 and a "No"
+// blacklist, which tells a consumer that the feature exists and found nothing.
+
 // GetRetiredPages returns retired pages
 func (d *ConfigurableDevice) GetRetiredPages(_ nvml.PageRetirementCause) ([]uint64, nvml.Return) {
+	if !d.preBlackwell() {
+		return nil, nvml.ERROR_NOT_SUPPORTED
+	}
 	debugLog("[NVML] nvmlDeviceGetRetiredPages -> []\n")
 	return []uint64{}, nvml.SUCCESS
 }
 
 // GetRetiredPages_v2 returns retired pages with timestamps
 func (d *ConfigurableDevice) GetRetiredPages_v2(_ nvml.PageRetirementCause) ([]uint64, []uint64, nvml.Return) {
+	if !d.preBlackwell() {
+		return nil, nil, nvml.ERROR_NOT_SUPPORTED
+	}
 	debugLog("[NVML] nvmlDeviceGetRetiredPages_v2 -> [], []\n")
 	return []uint64{}, []uint64{}, nvml.SUCCESS
 }
 
 // GetRetiredPagesPendingStatus returns whether there are pending retired pages
 func (d *ConfigurableDevice) GetRetiredPagesPendingStatus() (nvml.EnableState, nvml.Return) {
+	if !d.preBlackwell() {
+		return nvml.FEATURE_DISABLED, nvml.ERROR_NOT_SUPPORTED
+	}
 	debugLog("[NVML] nvmlDeviceGetRetiredPagesPendingStatus -> NOT_PENDING\n")
 	return nvml.FEATURE_DISABLED, nvml.SUCCESS // No pending pages
 }

--- a/pkg/gpu/mocknvml/engine/device_test.go
+++ b/pkg/gpu/mocknvml/engine/device_test.go
@@ -451,6 +451,143 @@ func TestConfigurableDevice_GetPowerManagementMode_Default(t *testing.T) {
 }
 
 // =============================================================================
+// Surfaces Blackwell removed (#679)
+// =============================================================================
+
+func TestGetGpuOperationMode_PreBlackwellReportsAllOn(t *testing.T) {
+	for _, arch := range []string{"turing", "ampere", "ada_lovelace", "hopper"} {
+		t.Run(arch, func(t *testing.T) {
+			dev := newTestDeviceWithConfig(t, &DeviceConfig{Architecture: arch})
+			current, pending, ret := dev.GetGpuOperationMode()
+			require.Equal(t, nvml.SUCCESS, ret)
+			require.Equal(t, nvml.GOM_ALL_ON, current)
+			require.Equal(t, nvml.GOM_ALL_ON, pending)
+		})
+	}
+}
+
+func TestGetGpuOperationMode_BlackwellNotSupported(t *testing.T) {
+	// GPU Operation Mode is a GK110-era feature. Real Blackwell answers
+	// NOT_SUPPORTED and nvidia-smi renders the current and pending rows as
+	// N/A; reporting "All On" claims a different generation of hardware.
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{Architecture: "blackwell"})
+	_, _, ret := dev.GetGpuOperationMode()
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret)
+}
+
+func TestRetiredPages_PreBlackwellReportsEmptyLists(t *testing.T) {
+	for _, arch := range []string{"turing", "ampere"} {
+		t.Run(arch, func(t *testing.T) {
+			dev := newTestDeviceWithConfig(t, &DeviceConfig{Architecture: arch})
+
+			pages, ret := dev.GetRetiredPages(nvml.PAGE_RETIREMENT_CAUSE_DOUBLE_BIT_ECC_ERROR)
+			require.Equal(t, nvml.SUCCESS, ret)
+			require.Empty(t, pages)
+
+			pages, timestamps, ret := dev.GetRetiredPages_v2(nvml.PAGE_RETIREMENT_CAUSE_DOUBLE_BIT_ECC_ERROR)
+			require.Equal(t, nvml.SUCCESS, ret)
+			require.Empty(t, pages)
+			require.Empty(t, timestamps)
+
+			state, ret := dev.GetRetiredPagesPendingStatus()
+			require.Equal(t, nvml.SUCCESS, ret)
+			require.Equal(t, nvml.FEATURE_DISABLED, state)
+		})
+	}
+}
+
+func TestRetiredPages_BlackwellNotSupported(t *testing.T) {
+	// Blackwell replaced page retirement with row remapping, which the mock
+	// models separately. Succeeding with an empty list is what makes
+	// nvidia-smi print a Retired Pages count of 0 and a "No" blacklist —
+	// a consumer branching on "Blackwell has no page retirement" is told the
+	// opposite. Real hardware returns NOT_SUPPORTED, printed as N/A.
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{Architecture: "blackwell"})
+
+	_, ret := dev.GetRetiredPages(nvml.PAGE_RETIREMENT_CAUSE_DOUBLE_BIT_ECC_ERROR)
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret)
+
+	_, _, ret = dev.GetRetiredPages_v2(nvml.PAGE_RETIREMENT_CAUSE_MULTIPLE_SINGLE_BIT_ECC_ERRORS)
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret)
+
+	_, ret = dev.GetRetiredPagesPendingStatus()
+	require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret)
+
+	// Row remapping, the surface that replaced it, still answers.
+	_, _, _, _, ret = dev.GetRemappedRows()
+	require.Equal(t, nvml.SUCCESS, ret)
+}
+
+func TestGetTemperatureThreshold_TargetTemperatureBlackwellNotSupported(t *testing.T) {
+	// nvidia-smi reads the acoustic thresholds for its "GPU Target
+	// Temperature" row and the Supported GPU Target Temp min/max pair. Real
+	// Blackwell reports N/A for all three.
+	thermal := &ThermalConfig{
+		ShutdownThreshold_C: 92,
+		SlowdownThreshold_C: 87,
+		MaxOperating_C:      85,
+	}
+	acoustic := []nvml.TemperatureThresholds{
+		nvml.TEMPERATURE_THRESHOLD_ACOUSTIC_CURR,
+		nvml.TEMPERATURE_THRESHOLD_ACOUSTIC_MIN,
+		nvml.TEMPERATURE_THRESHOLD_ACOUSTIC_MAX,
+	}
+
+	blackwell := newTestDeviceWithConfig(t, &DeviceConfig{Architecture: "blackwell", Thermal: thermal})
+	for _, threshold := range acoustic {
+		_, ret := blackwell.GetTemperatureThreshold(threshold)
+		require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret,
+			"blackwell must not report acoustic threshold %d", threshold)
+	}
+
+	// Pre-Blackwell keeps the max-operating stand-in it has always reported.
+	ampere := newTestDeviceWithConfig(t, &DeviceConfig{Architecture: "ampere", Thermal: thermal})
+	for _, threshold := range acoustic {
+		temp, ret := ampere.GetTemperatureThreshold(threshold)
+		require.Equal(t, nvml.SUCCESS, ret, "acoustic threshold %d", threshold)
+		require.Equal(t, uint32(85), temp)
+	}
+}
+
+func TestGetTemperatureThreshold_UnmodeledThresholdNotSupported(t *testing.T) {
+	// A catch-all that answers every unrecognised threshold type with the
+	// max-operating value is a defect generator: it silently gives any
+	// threshold NVML gains next a wrong answer. GPS_CURR is board-level and
+	// modeled by no profile, so it must report NOT_SUPPORTED on every
+	// architecture.
+	for _, arch := range []string{"ampere", "hopper", "blackwell"} {
+		t.Run(arch, func(t *testing.T) {
+			dev := newTestDeviceWithConfig(t, &DeviceConfig{
+				Architecture: arch,
+				Thermal:      &ThermalConfig{MaxOperating_C: 85},
+			})
+			_, ret := dev.GetTemperatureThreshold(nvml.TEMPERATURE_THRESHOLD_GPS_CURR)
+			require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret)
+		})
+	}
+}
+
+func TestReportsSparseOperationMode_BlackwellDoesNot(t *testing.T) {
+	// nvidia-smi asks for Sparse Operation Mode through a slot of the internal
+	// export table, not a public NVML entry point, so the bridge needs the
+	// architecture answer here to decide whether to fail that slot.
+	for _, tc := range []struct {
+		arch string
+		want bool
+	}{
+		{"turing", true},
+		{"ampere", true},
+		{"hopper", true},
+		{"blackwell", false},
+	} {
+		t.Run(tc.arch, func(t *testing.T) {
+			dev := newTestDeviceWithConfig(t, &DeviceConfig{Architecture: tc.arch})
+			require.Equal(t, tc.want, dev.ReportsSparseOperationMode())
+		})
+	}
+}
+
+// =============================================================================
 // Batch 2 Test Helper
 // =============================================================================
 

--- a/pkg/gpu/mocknvml/engine/field_values_test.go
+++ b/pkg/gpu/mocknvml/engine/field_values_test.go
@@ -232,6 +232,29 @@ func TestGetFieldValue_TlimitThresholds_PreAdaNotSupported(t *testing.T) {
 	}
 }
 
+func TestGetFieldValue_RetiredPages_BlackwellNotSupported(t *testing.T) {
+	// The DCGM-facing retirement field IDs read the same NVML surface the
+	// nvidia-smi Retired Pages block does, so the architecture gate has to
+	// reach them too: a zero count here is the same fabricated answer.
+	blackwell := newTestDeviceWithConfig(t, &DeviceConfig{Architecture: "blackwell"})
+	for _, fieldID := range []uint32{
+		fiRetiredSbe,
+		fiRetiredDbe,
+		fiRetiredPending,
+		fiRetiredPendingSbe,
+		fiRetiredPendingDbe,
+	} {
+		_, _, ret := blackwell.GetFieldValue(fieldID, 0)
+		require.Equal(t, nvml.ERROR_NOT_SUPPORTED, ret,
+			"blackwell must not answer retirement field %d", fieldID)
+	}
+
+	ampere := newTestDeviceWithConfig(t, &DeviceConfig{Architecture: "ampere"})
+	_, count, ret := ampere.GetFieldValue(fiRetiredDbe, 0)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Equal(t, uint64(0), count)
+}
+
 func TestGetFieldValue_UnknownFieldNotSupported(t *testing.T) {
 	dev := newTestDeviceWithConfig(t, &DeviceConfig{Architecture: "hopper"})
 	vt, _, ret := dev.GetFieldValue(9999, 0)

--- a/tests/e2e/go/assertions/nvidiasmi/blackwell.go
+++ b/tests/e2e/go/assertions/nvidiasmi/blackwell.go
@@ -1,0 +1,88 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidiasmi
+
+import "fmt"
+
+// blackwellRemovedFields are the rows a real Blackwell tray answers N/A because
+// the hardware feature behind each was removed or never existed: GPU Operation
+// Mode is GK110-era, page retirement gave way to row remapping, the target
+// temperature and its supported range come from acoustic thresholds Blackwell
+// does not implement, and Sparse Operation Mode arrives through an internal
+// export-table slot the hardware fails. Older hardware does report them, so
+// they are an architecture axis and checked in both directions.
+//
+// The direction of this check is the inverse of most: it fails a reading that
+// is present. A fabricated answer is worse than a missing one, because N/A
+// prompts a consumer to look elsewhere while "85 C" or a retired-page count of
+// 0 is believed (#679).
+func blackwellRemovedFields(gpu gpuElement) []namedReading {
+	return []namedReading{
+		{"gpu_operation_mode/current_gom", gpu.OperationMode.Current},
+		{"gpu_operation_mode/pending_gom", gpu.OperationMode.Pending},
+		{"sparse_operation_mode", gpu.SparseOperationMode},
+		{"retired_pages/multiple_single_bit_retirement/retired_count", gpu.RetiredPages.SingleBit.Count},
+		{"retired_pages/double_bit_retirement/retired_count", gpu.RetiredPages.DoubleBit.Count},
+		{"retired_pages/pending_blacklist", gpu.RetiredPages.PendingBlacklist},
+		{"retired_pages/pending_retirement", gpu.RetiredPages.PendingRetirement},
+		{"temperature/gpu_target_temperature", gpu.Temperature.TargetTemperature},
+		{"supported_gpu_target_temp/gpu_target_temp_min", gpu.SupportedTargetTemp.Min},
+		{"supported_gpu_target_temp/gpu_target_temp_max", gpu.SupportedTargetTemp.Max},
+	}
+}
+
+// blackwellAbsentBoardData are rows Blackwell must report N/A that are board
+// data rather than an architecture feature. The Power Management Object is
+// absent from a Blackwell inforom, but whether an older board carries one is a
+// property of that board -- every non-Blackwell profile the mock ships also
+// reports N/A -- so the pre-Blackwell direction asserts nothing about it.
+func blackwellAbsentBoardData(gpu gpuElement) []namedReading {
+	return []namedReading{
+		{"inforom_version/pwr_object", gpu.InforomVersion.PWRObject},
+	}
+}
+
+// BlackwellRemovedFieldProblems checks the architecture presentation of the
+// fields Blackwell removed, for every GPU in a `nvidia-smi -q -x` document:
+//
+//   - Blackwell (preBlackwell=false): every field is absent or N/A. Both are
+//     correct — nvidia-smi drops the Supported GPU Target Temp section from the
+//     human table once the query fails but keeps the elements with N/A bodies
+//     in the XML — so the check rejects a reading rather than requiring one.
+//   - pre-Blackwell (preBlackwell=true): every field still carries a reading.
+//
+// The second half is what makes this a fidelity check rather than a blanket
+// "must be N/A": disabling the surfaces everywhere would satisfy the first half
+// while silently regressing the Turing and Ampere profiles, whose hardware does
+// report them.
+func BlackwellRemovedFieldProblems(out string, preBlackwell bool) []string {
+	doc, err := parse(out)
+	if err != nil {
+		return []string{err.Error()}
+	}
+
+	var problems []string
+	for i, gpu := range doc.GPUs {
+		name := gpu.label(i)
+		fields := blackwellRemovedFields(gpu)
+		if preBlackwell {
+			for _, field := range fields {
+				if !field.raw.present() || field.raw.unsupported() {
+					problems = append(problems, fmt.Sprintf(
+						"%s: no longer reports %s (body %q)",
+						name, field.element, string(field.raw)))
+				}
+			}
+			continue
+		}
+		for _, field := range append(fields, blackwellAbsentBoardData(gpu)...) {
+			if field.raw.present() && !field.raw.unsupported() {
+				problems = append(problems, fmt.Sprintf(
+					"%s: %s = %q, want N/A on Blackwell",
+					name, field.element, string(field.raw)))
+			}
+		}
+	}
+	return problems
+}

--- a/tests/e2e/go/assertions/nvidiasmi/blackwell_test.go
+++ b/tests/e2e/go/assertions/nvidiasmi/blackwell_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidiasmi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The issue #679 defect, verbatim from the mock before the fix: the eight rows
+// a real GB300 tray answers N/A, each carrying a value.
+const blackwellFabricatedElements = `
+		<inforom_version>
+			<pwr_object>1.0</pwr_object>
+		</inforom_version>
+		<gpu_operation_mode>
+			<current_gom>All On</current_gom>
+			<pending_gom>All On</pending_gom>
+		</gpu_operation_mode>
+		<sparse_operation_mode>Disabled</sparse_operation_mode>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>0</retired_count>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>0</retired_count>
+			</double_bit_retirement>
+			<pending_blacklist>No</pending_blacklist>
+			<pending_retirement>No</pending_retirement>
+		</retired_pages>
+		<temperature>
+			<gpu_target_temperature>85 C</gpu_target_temperature>
+		</temperature>`
+
+// blackwellXML renders a one-GPU document carrying the given element lines, so
+// a test can state a combination no capture shows.
+func blackwellXML(elements string) string {
+	return `<?xml version="1.0" ?>
+<nvidia_smi_log>
+	<attached_gpus>1</attached_gpus>
+	<gpu id="0000:0A:00.0">
+		<product_name>NVIDIA GB300 NVL</product_name>` + elements + `
+	</gpu>
+</nvidia_smi_log>`
+}
+
+func TestBlackwellRemovedFieldProblems_AcceptsCapturedBlackwellDocument(t *testing.T) {
+	problems := BlackwellRemovedFieldProblems(loadFixture(t, "qx-gb300-healthy.xml"), false)
+	assert.Empty(t, problems, strings.Join(problems, "; "))
+}
+
+// The pre-Blackwell half of the check is the point of it: an assertion that
+// only demanded N/A would also pass with the features disabled everywhere,
+// which would be a fidelity regression on Turing and Ampere.
+func TestBlackwellRemovedFieldProblems_AcceptsCapturedAmpereDocument(t *testing.T) {
+	problems := BlackwellRemovedFieldProblems(loadFixture(t, "qx-a100-healthy.xml"), true)
+	assert.Empty(t, problems, strings.Join(problems, "; "))
+}
+
+func TestBlackwellRemovedFieldProblems_RejectsFabricatedValuesOnBlackwell(t *testing.T) {
+	problems := BlackwellRemovedFieldProblems(blackwellXML(blackwellFabricatedElements), false)
+	require.NotEmpty(t, problems, "pre-fix Blackwell output must fail")
+	joined := strings.Join(problems, "; ")
+	for _, element := range []string{
+		"pwr_object",
+		"current_gom",
+		"pending_gom",
+		"sparse_operation_mode",
+		"multiple_single_bit_retirement/retired_count",
+		"double_bit_retirement/retired_count",
+		"pending_blacklist",
+		"gpu_target_temperature",
+	} {
+		assert.Contains(t, joined, element, "every fabricated row must be named")
+	}
+}
+
+func TestBlackwellRemovedFieldProblems_RejectsNotAvailableOnPreBlackwell(t *testing.T) {
+	problems := BlackwellRemovedFieldProblems(loadFixture(t, "qx-gb300-healthy.xml"), true)
+	require.NotEmpty(t, problems, "a pre-Blackwell profile must still report these")
+	assert.Contains(t, strings.Join(problems, "; "), "no longer reports")
+}
+
+// An N/A body and an absent element are both correct on Blackwell: nvidia-smi
+// drops the Supported GPU Target Temp section from -q once the query fails,
+// while -q -x keeps the elements with N/A bodies.
+func TestBlackwellRemovedFieldProblems_AcceptsAbsentElementsOnBlackwell(t *testing.T) {
+	problems := BlackwellRemovedFieldProblems(blackwellXML(""), false)
+	assert.Empty(t, problems, strings.Join(problems, "; "))
+}
+
+func TestBlackwellRemovedFieldProblems_ReportsUnparseableDocument(t *testing.T) {
+	problems := BlackwellRemovedFieldProblems("not xml", false)
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "parse nvidia-smi XML")
+}
+
+// A per-device gate that answers for only one GPU must be caught.
+func TestBlackwellRemovedFieldProblems_ChecksEveryGPU(t *testing.T) {
+	problems := BlackwellRemovedFieldProblems(loadFixture(t, "qx-gb200-healthy.xml"), false)
+	require.NotEmpty(t, problems)
+	assert.Contains(t, strings.Join(problems, "; "), "0000:0B:00.0",
+		"the second GPU must be reported too")
+}

--- a/tests/e2e/go/assertions/nvidiasmi/exec.go
+++ b/tests/e2e/go/assertions/nvidiasmi/exec.go
@@ -126,6 +126,23 @@ func TemperatureThresholds(ctx context.Context, k *kube.Client, pod kube.PodRef,
 		p.Name, strings.Join(problems, "\n"))
 }
 
+// BlackwellRemovedFields asserts nvidia-smi -q -x reports the fields Blackwell
+// removed the way the profile's hardware does: N/A on a Blackwell profile, and
+// still carrying readings on an older one. Both directions come from the
+// profile, so one spec covers them as the CI matrix moves across profiles --
+// and the pre-Blackwell direction is what stops the gate from being widened
+// into a fidelity regression on t4 and a100. See issue #679.
+func BlackwellRemovedFields(ctx context.Context, k *kube.Client, pod kube.PodRef, p profile.Profile) {
+	ginkgo.GinkgoHelper()
+
+	ginkgo.By(fmt.Sprintf("nvidia-smi -q -x Blackwell-removed fields on %s (arch=%s, pre_blackwell=%v)",
+		p.Name, p.Architecture(), p.PreBlackwell()))
+	problems := BlackwellRemovedFieldProblems(query(ctx, k, pod), p.PreBlackwell())
+	gomega.Expect(problems).To(gomega.BeEmpty(),
+		"Blackwell-removed fields wrong for profile %s:\n%s",
+		p.Name, strings.Join(problems, "\n"))
+}
+
 // C2CMode asserts nvidia-smi -q -x reports the C2C state the profile declares:
 // Enabled on a Grace board, N/A on every other one. The expectation is derived
 // from the profile rather than passed in, so the same spec covers both

--- a/tests/e2e/go/assertions/nvidiasmi/schema.go
+++ b/tests/e2e/go/assertions/nvidiasmi/schema.go
@@ -101,30 +101,35 @@ type document struct {
 // gpuElement holds the elements assertions read; add fields as more are needed.
 // Every body is a reading rather than a number for the reasons on that type.
 type gpuElement struct {
-	ID                       string            `xml:"id,attr"`
-	ProductName              reading           `xml:"product_name"`
-	ProductArchitecture      reading           `xml:"product_architecture"`
-	UUID                     reading           `xml:"uuid"`
-	BoardID                  reading           `xml:"board_id"`
-	C2CMode                  reading           `xml:"c2c_mode"`
-	PlatformInfo             platformInfo      `xml:"platformInfo"`
-	PCI                      pciInfo           `xml:"pci"`
-	FanSpeed                 reading           `xml:"fan_speed"`
-	PerformanceState         reading           `xml:"performance_state"`
-	FBMemoryUsage            memoryUsage       `xml:"fb_memory_usage"`
-	AccountingModeBufferSize reading           `xml:"accounting_mode_buffer_size"`
-	EncoderStats             statsBlock        `xml:"encoder_stats"`
-	FBCStats                 statsBlock        `xml:"fbc_stats"`
-	Utilization              utilization       `xml:"utilization"`
-	Virtualization           gpuVirtualization `xml:"gpu_virtualization_mode"`
-	Temperature              temperature       `xml:"temperature"`
-	PowerReadings            powerReadings     `xml:"gpu_power_readings"`
-	Clocks                   clocks            `xml:"clocks"`
-	ECCMode                  eccMode           `xml:"ecc_mode"`
-	ECCErrors                eccErrors         `xml:"ecc_errors"`
-	RemappedRows             remappedRows      `xml:"remapped_rows"`
-	ClocksEventReasons       eventReasons      `xml:"clocks_event_reasons"`
-	Fabric                   fabricBlock       `xml:"fabric"`
+	ID                       string              `xml:"id,attr"`
+	ProductName              reading             `xml:"product_name"`
+	ProductArchitecture      reading             `xml:"product_architecture"`
+	UUID                     reading             `xml:"uuid"`
+	BoardID                  reading             `xml:"board_id"`
+	C2CMode                  reading             `xml:"c2c_mode"`
+	InforomVersion           inforomVersion      `xml:"inforom_version"`
+	OperationMode            gpuOperationMode    `xml:"gpu_operation_mode"`
+	SparseOperationMode      reading             `xml:"sparse_operation_mode"`
+	RetiredPages             retiredPages        `xml:"retired_pages"`
+	SupportedTargetTemp      supportedTargetTemp `xml:"supported_gpu_target_temp"`
+	PlatformInfo             platformInfo        `xml:"platformInfo"`
+	PCI                      pciInfo             `xml:"pci"`
+	FanSpeed                 reading             `xml:"fan_speed"`
+	PerformanceState         reading             `xml:"performance_state"`
+	FBMemoryUsage            memoryUsage         `xml:"fb_memory_usage"`
+	AccountingModeBufferSize reading             `xml:"accounting_mode_buffer_size"`
+	EncoderStats             statsBlock          `xml:"encoder_stats"`
+	FBCStats                 statsBlock          `xml:"fbc_stats"`
+	Utilization              utilization         `xml:"utilization"`
+	Virtualization           gpuVirtualization   `xml:"gpu_virtualization_mode"`
+	Temperature              temperature         `xml:"temperature"`
+	PowerReadings            powerReadings       `xml:"gpu_power_readings"`
+	Clocks                   clocks              `xml:"clocks"`
+	ECCMode                  eccMode             `xml:"ecc_mode"`
+	ECCErrors                eccErrors           `xml:"ecc_errors"`
+	RemappedRows             remappedRows        `xml:"remapped_rows"`
+	ClocksEventReasons       eventReasons        `xml:"clocks_event_reasons"`
+	Fabric                   fabricBlock         `xml:"fabric"`
 	Processes                struct {
 		Infos []processInfo `xml:"process_info"`
 	} `xml:"processes"`
@@ -138,6 +143,51 @@ type memoryUsage struct {
 	Reserved reading `xml:"reserved"`
 	Used     reading `xml:"used"`
 	Free     reading `xml:"free"`
+}
+
+// inforomVersion is <inforom_version>: the versions of the objects held in the
+// board's inforom. Only pwr_object is decoded — the Power Management Object is
+// absent from Blackwell boards, so it is the one that has to report N/A there.
+// The sibling <inforom_bbx_flush> block names its children differently.
+type inforomVersion struct {
+	PWRObject reading `xml:"pwr_object"`
+}
+
+// gpuOperationMode is <gpu_operation_mode>: the GK110-era feature that let a
+// board disable its double-precision or graphics units. Nothing since reports
+// it, so both children read N/A on modern hardware.
+type gpuOperationMode struct {
+	Current reading `xml:"current_gom"`
+	Pending reading `xml:"pending_gom"`
+}
+
+// retiredPages is <retired_pages>: the pages a GPU has taken out of service
+// after repeated ECC errors. Blackwell replaced the mechanism with row
+// remapping, decoded as remappedRows, and reports every element here as N/A.
+// Both retirement causes name their children identically, hence the shared
+// type.
+type retiredPages struct {
+	SingleBit         retirementCause `xml:"multiple_single_bit_retirement"`
+	DoubleBit         retirementCause `xml:"double_bit_retirement"`
+	PendingBlacklist  reading         `xml:"pending_blacklist"`
+	PendingRetirement reading         `xml:"pending_retirement"`
+}
+
+type retirementCause struct {
+	Count reading `xml:"retired_count"`
+	// PageList holds the addresses when there are any. Its body is kept raw:
+	// an assertion only needs to tell a populated list from an N/A one.
+	PageList reading `xml:"retired_pagelist"`
+}
+
+// supportedTargetTemp is <supported_gpu_target_temp>: the range the GPU accepts
+// for its target temperature. It comes from the same acoustic thresholds as
+// temperature.TargetTemperature, so the three answer or fail together — and
+// nvidia-smi drops the whole section from -q when they fail, while -q -x keeps
+// the elements with N/A bodies.
+type supportedTargetTemp struct {
+	Min reading `xml:"gpu_target_temp_min"`
+	Max reading `xml:"gpu_target_temp_max"`
 }
 
 // platformInfo is <platformInfo> — the one camelCase container in the document.

--- a/tests/e2e/go/assertions/nvidiasmi/testdata/README.md
+++ b/tests/e2e/go/assertions/nvidiasmi/testdata/README.md
@@ -9,7 +9,8 @@ per-GPU indexing and override scoping.
 | File | Content |
 | --- | --- |
 | `qx-a100-healthy.xml` | Ampere. Absolute temperature thresholds, `gpu_temp_tlimit` = `N/A`. |
-| `qx-gb200-healthy.xml` | Blackwell. `*_tlimit_threshold` elements; the absolute ones are absent. |
+| `qx-gb200-healthy.xml` | Blackwell, captured before #679. `*_tlimit_threshold` elements; the absolute ones are absent. Still carries the fields Blackwell removed (`current_gom`, `retired_count`, `sparse_operation_mode`, ...), so `BlackwellRemovedFieldProblems` rejects it — that is deliberate: it is the pre-fix document the check has to fail. Use `qx-gb300-healthy.xml` as the current Blackwell reference. |
+| `qx-gb300-healthy.xml` | Blackwell, captured after #679. Same threshold shape as `qx-gb200-healthy.xml`, with the removed fields reporting N/A. |
 | `qx-gb200-lost.xml` | GPU 0 healthy, GPU 1 lost (`GPU is lost` bodies). |
 | `qx-gb200-ecc-injected.xml` | GPU 0 has a non-zero `ecc_errors/aggregate/dram_uncorrectable`. |
 | `qx-gb200-fabric-degraded.xml` | GPU 0 fabric healthy, GPU 1 `route_unhealthy` (#677). Taken against the fixed library, so it is also the healthy-fabric reference. |

--- a/tests/e2e/go/assertions/nvidiasmi/testdata/qx-gb300-healthy.xml
+++ b/tests/e2e/go/assertions/nvidiasmi/testdata/qx-gb300-healthy.xml
@@ -1,0 +1,626 @@
+<?xml version="1.0" ?>
+<!DOCTYPE nvidia_smi_log SYSTEM "nvsmi_device_v13.dtd">
+<nvidia_smi_log>
+	<timestamp>Fri Aug 21 08:19:17 2026</timestamp>
+	<driver_version>570.124.06</driver_version>
+	<cuda_version>12.8</cuda_version>
+	<attached_gpus>2</attached_gpus>
+	<gpu id="00000000:0A:00.0">
+		<product_name>NVIDIA GB300 NVL</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>No</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>N/A</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1573041103700</serial>
+		<uuid>GPU-b300b300-0000-0000-0000-000000000000</uuid>
+		<pdi>N/A</pdi>
+		<minor_number>0</minor_number>
+		<vbios_version>97.00.41.00.01</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0xa00</board_id>
+		<board_part_number>699-2G530-0300-000</board_part_number>
+		<gpu_part_number>N/A</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>1822725100300</chassis_serial_number>
+			<slot_number>26</slot_number>
+			<tray_index>16</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>1</module_id>
+			<gpu_fabric_guid>0x0000000000000000</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G530.0300.00.01</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.20</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>N/A</latest_timestamp>
+			<latest_duration>N/A</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Enabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>None</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>N/A</gpu_recovery_action>
+		<gsp_firmware_version>570.124.06</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>0A</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>294110DE</pci_device_id>
+			<pci_bus_id>00000000:0A:00.0</pci_bus_id>
+			<pci_sub_system_id>183010DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>6</max_link_gen>
+					<current_link_gen>6</current_link_gen>
+					<device_current_link_gen>6</device_current_link_gen>
+					<max_device_link_gen>6</max_device_link_gen>
+					<max_host_link_gen>6</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>0 KB/s</tx_util>
+			<rx_util>0 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>N/A</atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>N/A</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>N/A</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>N/A</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>N/A</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>N/A</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>294912 MiB</total>
+			<reserved>1536 MiB</reserved>
+			<used>0 MiB</used>
+			<free>293376 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>786432 MiB</total>
+			<used>0 MiB</used>
+			<free>786432 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>N/A</total>
+			<used>N/A</used>
+			<free>N/A</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>12 %</gpu_util>
+			<memory_util>16 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>N/A</channel_repair_pending>
+			<tpc_repair_pending>N/A</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>4608 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>38 C</gpu_temp>
+			<gpu_temp_tlimit>52 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>0 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>5 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>36 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>N/A</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>175.00 W</average_power_draw>
+			<instant_power_draw>175.00 W</instant_power_draw>
+			<current_power_limit>1400.00 W</current_power_limit>
+			<requested_power_limit>1400.00 W</requested_power_limit>
+			<default_power_limit>1400.00 W</default_power_limit>
+			<min_power_limit>500.00 W</min_power_limit>
+			<max_power_limit>1600.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>N/A</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>345 MHz</graphics_clock>
+			<sm_clock>345 MHz</sm_clock>
+			<mem_clock>2625 MHz</mem_clock>
+			<video_clock>1200 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>2200 MHz</graphics_clock>
+			<mem_clock>2625 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>2200 MHz</graphics_clock>
+			<mem_clock>2625 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>2200 MHz</graphics_clock>
+			<sm_clock>2200 MHz</sm_clock>
+			<mem_clock>2625 MHz</mem_clock>
+			<video_clock>2200 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>N/A</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000001</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>Full</bandwidth>
+				<route_recovery_in_progress>False</route_recovery_in_progress>
+				<route_unhealthy>False</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>None</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>N/A</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>N/A</accounted_processes>
+		<capabilities>
+			<egm>N/A</egm>
+		</capabilities>
+	</gpu>
+	<gpu id="00000000:0B:00.0">
+		<product_name>NVIDIA GB300 NVL</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>No</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>N/A</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1573041103701</serial>
+		<uuid>GPU-b300b300-0000-0000-0000-000000000001</uuid>
+		<pdi>N/A</pdi>
+		<minor_number>1</minor_number>
+		<vbios_version>97.00.41.00.01</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0xb00</board_id>
+		<board_part_number>699-2G530-0300-000</board_part_number>
+		<gpu_part_number>N/A</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>1822725100300</chassis_serial_number>
+			<slot_number>26</slot_number>
+			<tray_index>16</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>2</module_id>
+			<gpu_fabric_guid>0x0000000000000000</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G530.0300.00.01</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.20</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>N/A</latest_timestamp>
+			<latest_duration>N/A</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Enabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>None</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>N/A</gpu_recovery_action>
+		<gsp_firmware_version>570.124.06</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>0B</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>294110DE</pci_device_id>
+			<pci_bus_id>00000000:0B:00.0</pci_bus_id>
+			<pci_sub_system_id>183010DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>6</max_link_gen>
+					<current_link_gen>6</current_link_gen>
+					<device_current_link_gen>6</device_current_link_gen>
+					<max_device_link_gen>6</max_device_link_gen>
+					<max_host_link_gen>6</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>0 KB/s</tx_util>
+			<rx_util>0 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>N/A</atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>N/A</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>N/A</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>N/A</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>N/A</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>N/A</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>294912 MiB</total>
+			<reserved>1536 MiB</reserved>
+			<used>0 MiB</used>
+			<free>293376 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>786432 MiB</total>
+			<used>0 MiB</used>
+			<free>786432 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>N/A</total>
+			<used>N/A</used>
+			<free>N/A</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>33 %</gpu_util>
+			<memory_util>16 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>N/A</channel_repair_pending>
+			<tpc_repair_pending>N/A</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>4608 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>38 C</gpu_temp>
+			<gpu_temp_tlimit>52 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>0 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>5 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>36 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>N/A</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>175.00 W</average_power_draw>
+			<instant_power_draw>175.00 W</instant_power_draw>
+			<current_power_limit>1400.00 W</current_power_limit>
+			<requested_power_limit>1400.00 W</requested_power_limit>
+			<default_power_limit>1400.00 W</default_power_limit>
+			<min_power_limit>500.00 W</min_power_limit>
+			<max_power_limit>1600.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>N/A</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>345 MHz</graphics_clock>
+			<sm_clock>345 MHz</sm_clock>
+			<mem_clock>2625 MHz</mem_clock>
+			<video_clock>1200 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>2200 MHz</graphics_clock>
+			<mem_clock>2625 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>2200 MHz</graphics_clock>
+			<mem_clock>2625 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>2200 MHz</graphics_clock>
+			<sm_clock>2200 MHz</sm_clock>
+			<mem_clock>2625 MHz</mem_clock>
+			<video_clock>2200 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>N/A</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000001</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>Full</bandwidth>
+				<route_recovery_in_progress>False</route_recovery_in_progress>
+				<route_unhealthy>False</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>None</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>N/A</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>N/A</accounted_processes>
+		<capabilities>
+			<egm>N/A</egm>
+		</capabilities>
+	</gpu>
+</nvidia_smi_log>

--- a/tests/e2e/go/profile/profile.go
+++ b/tests/e2e/go/profile/profile.go
@@ -396,6 +396,20 @@ func (p Profile) ReportsRowRemapHistogram() bool { return p.rowRemapHistogram }
 // Zero when the profile configures no histogram.
 func (p Profile) RowRemapHistogramBanks() int { return p.rowRemapBanks }
 
+// PreBlackwell reports whether this profile's hardware predates Blackwell, and
+// so still answers the surfaces Blackwell removed: GPU Operation Mode, page
+// retirement, the GPU target temperature and Sparse Operation Mode. Real
+// Blackwell reports all of them as N/A (#679). An architecture the mock does
+// not recognise counts as pre-Blackwell, matching the engine gate.
+func (p Profile) PreBlackwell() bool {
+	switch p.architecture {
+	case "blackwell", "rubin":
+		return false
+	default:
+		return true
+	}
+}
+
 // ReportsTLimitTemp is true when real hardware of this architecture reports the
 // GPU T.Limit temperature field IDs (Ada and later). Pre-Ada profiles keep the
 // legacy absolute threshold rows via nvmlDeviceGetTemperatureThreshold.

--- a/tests/e2e/go/profile/profile_test.go
+++ b/tests/e2e/go/profile/profile_test.go
@@ -37,19 +37,20 @@ func TestDerivations(t *testing.T) {
 		pciRoots      int
 		architecture  string
 		reportsTLimit bool
+		preBlackwell  bool
 		c2c           bool
 		shutdownC     int
 		slowdownC     int
 		maxOperatingC int
 		maxLinkGen    int
 	}{
-		{"a100", "NVIDIA A100-SXM4-40GB", 8, 8, 12, true, false, true, 2, "ampere", false, false, 92, 87, 83, 4}, // NVSwitch (FabricMgr) but no ComputeDomain fabric block
-		{"h100", "NVIDIA H100 80GB HBM3", 8, 8, 18, true, true, true, 2, "hopper", true, false, 92, 87, 83, 5},
-		{"b200", "NVIDIA B200", 8, 8, 0, false, false, true, 2, "blackwell", true, false, 95, 90, 85, 6}, // NVLink negative control, IB enabled
-		{"gb200", "NVIDIA GB200", 8, 8, 18, true, true, true, 4, "blackwell", true, true, 95, 90, 85, 6},
-		{"gb300", "NVIDIA GB300 NVL", 8, 8, 18, true, true, true, 4, "blackwell", true, true, 95, 90, 85, 6},
-		{"l40s", "NVIDIA L40S", 8, 0, 0, false, false, false, 2, "ada_lovelace", true, false, 96, 93, 89, 4}, // IB + NVLink negative control
-		{"t4", "NVIDIA T4", 4, 0, 0, false, false, false, 1, "turing", false, false, 96, 93, 89, 3},
+		{"a100", "NVIDIA A100-SXM4-40GB", 8, 8, 12, true, false, true, 2, "ampere", false, true, false, 92, 87, 83, 4}, // NVSwitch (FabricMgr) but no ComputeDomain fabric block
+		{"h100", "NVIDIA H100 80GB HBM3", 8, 8, 18, true, true, true, 2, "hopper", true, true, false, 92, 87, 83, 5},
+		{"b200", "NVIDIA B200", 8, 8, 0, false, false, true, 2, "blackwell", true, false, false, 95, 90, 85, 6}, // NVLink negative control, IB enabled
+		{"gb200", "NVIDIA GB200", 8, 8, 18, true, true, true, 4, "blackwell", true, false, true, 95, 90, 85, 6},
+		{"gb300", "NVIDIA GB300 NVL", 8, 8, 18, true, true, true, 4, "blackwell", true, false, true, 95, 90, 85, 6},
+		{"l40s", "NVIDIA L40S", 8, 0, 0, false, false, false, 2, "ada_lovelace", true, true, false, 96, 93, 89, 4}, // IB + NVLink negative control
+		{"t4", "NVIDIA T4", 4, 0, 0, false, false, false, 1, "turing", false, true, false, 96, 93, 89, 3},
 	}
 
 	for _, c := range cases {
@@ -74,6 +75,7 @@ func TestDerivations(t *testing.T) {
 				{"ExpectedPCIRoots", p.ExpectedPCIRoots(), c.pciRoots},
 				{"Architecture", p.Architecture(), c.architecture},
 				{"ReportsTLimitTemp", p.ReportsTLimitTemp(), c.reportsTLimit},
+				{"PreBlackwell", p.PreBlackwell(), c.preBlackwell},
 				{"C2CEnabled", p.C2CEnabled(), c.c2c},
 				{"ShutdownThresholdC", p.ShutdownThresholdC(), c.shutdownC},
 				{"SlowdownThresholdC", p.SlowdownThresholdC(), c.slowdownC},

--- a/tests/e2e/go/scenario_standalone_test.go
+++ b/tests/e2e/go/scenario_standalone_test.go
@@ -84,6 +84,19 @@ var _ = Describe("nvml-mock standalone", Ordered, func() {
 				nvidiasmi.TemperatureThresholds(ctx, h.Kube, pod, p)
 			})
 
+			It("reports the fields Blackwell removed as N/A via nvidia-smi -q -x", Label("nvidia-smi"), func(ctx SpecContext) {
+				// Issue #679: GPU Operation Mode, the Retired Pages block, the
+				// GPU target temperature, Sparse Operation Mode and the inforom
+				// Power Management Object all carried values on gb200/gb300,
+				// where a real GB300 tray answers N/A -- a fabricated answer a
+				// consumer believes, rather than one it would look past. The
+				// expectation comes from the profile, so this same spec pins
+				// N/A on the Blackwell profiles and asserts t4/a100/h100/l40s
+				// still report them: gating the surfaces everywhere would fix
+				// Blackwell by regressing the rest.
+				nvidiasmi.BlackwellRemovedFields(ctx, h.Kube, pod, p)
+			})
+
 			It("reports configured encoder and FBC stats via nvidia-smi -q -x", Label("nvidia-smi"), func(ctx SpecContext) {
 				// Issue #636: encoder_stats / fbc_stats were accepted by the
 				// engine but silently stubbed at the C ABI. Non-zero overrides


### PR DESCRIPTION
Fixes #679

## Summary

`GPU Operation Mode`, the whole `Retired Pages` block, `GPU Target Temperature` with its `Supported GPU Target Temp` range, `Sparse Operation Mode` and the inforom `Power Management Object` all carried values on `b200`/`gb200`/`gb300`. A real GB300 tray reports `N/A` for every one of them.

This is the inverse of the usual fidelity defect and the worse failure. `N/A` sends a consumer looking for another source; a target temperature of `85 C` or a retired-page count of `0` is believed. Code that branches on Blackwell having no page retirement took the other branch and read a fabricated answer as fact.

- **The getters are gated on architecture, not disabled.** `t4`, `a100`, `h100` and `l40s` keep reporting what their hardware does. A shared `preBlackwell()` covers `nvmlDeviceGetGpuOperationMode`, the three `nvmlDeviceGetRetiredPages*` entry points and the acoustic temperature thresholds; an unset architecture counts as pre-Blackwell, so a profile declaring none keeps today's output.
- **`GPU Target Temperature` is the acoustic threshold trio.** Gating `TEMPERATURE_THRESHOLD_ACOUSTIC_CURR/_MIN/_MAX` also removes the `Supported GPU Target Temp` range that comes from the same source. `nvidia-smi` drops that section from `-q` entirely once the queries fail, which is what the reference tray does too, while `-q -x` keeps the elements with `N/A` bodies.
- **`nvmlDeviceGetTemperatureThreshold` no longer has a catch-all.** Threshold types no profile models return `NOT_SUPPORTED` instead of being answered with the max-operating value, so whichever row `nvidia-smi` asked about gets a truthful answer and a threshold type NVML adds next cannot inherit a wrong one. `MEM_MAX` is now explicit about standing in for the memory limit.
- **`Sparse Operation Mode` has no public NVML entry point.** A repository-wide search for the name finds nothing because `nvidia-smi` asks for it through slot 249 of the internal export table, where the bridge's default zero-count fall-through rendered `Disabled`. That slot now fails on Blackwell. The slot was located by its position in the `-q` call sequence: it fires between the clocks-event-reason field values and `nvmlDeviceGetMemoryInfo_v2`, exactly where the row sits in the output.
- **`Power Management Object` is profile data, not an architecture axis.** `pwr_object` is dropped from the Blackwell profiles in both the chart `profiles/` and engine `configs/` copies. This includes `b200`, which the issue does not list: it declared `1.0` while every non-Blackwell profile the repo ships already declares `N/A`, and a real Blackwell board has no such object.

## Verification against a real GB300 tray

Built the library from this branch, layered it onto the mock image (which bundles the real `nvidia-smi` 580.65.06) and ran `-q`/`-q -x` for all seven profiles, before and after. Compared against `nvidia-smi -q` from a physical GB300 tray on driver 580.173.02.

| Row | Before | After | Real GB300 |
| --- | --- | --- | --- |
| `Power Management Object` | `1.0` | `N/A` | `N/A` |
| `GPU Operation Mode / Current` | `All On` | `N/A` | `N/A` |
| `GPU Operation Mode / Pending` | `All On` | `N/A` | `N/A` |
| `Sparse Operation Mode` | `Disabled` | `N/A` | `N/A` |
| `Retired Pages / Single Bit ECC` | `0` | `N/A` | `N/A` |
| `Retired Pages / Double Bit ECC` | `0` | `N/A` | `N/A` |
| `Retired Pages / Pending Page Blacklist` | `No` | `N/A` | `N/A` |
| `GPU Target Temperature` | `85 C` | `N/A` | `N/A` |

To check the class of defect rather than the eight known instances, a throwaway script flattened both documents to `path -> value` and listed every row where the real tray reports `N/A` and the mock answers. It finds **8 rows against pre-fix `main` — exactly the eight above — and 0 after the fix.**

The new check was also run directly against that tray's own `-q -x` document, which it accepts, and against pre-fix container captures of all three Blackwell profiles, which it rejects.

Pre-Blackwell profiles are unchanged: `t4`, `a100`, `h100` and `l40s` diff clean before/after once live readings (timestamps, utilization, power, temperatures) are filtered out. `nvidia-smi`, `-L`, `topo -m`, `pmon -c 1` and `--query-gpu` were smoke-tested on the fixed image.

Every fixture in `testdata/` comes from the mock, so a check can agree with the mock and still be wrong about hardware — which is exactly what this issue was. Committing that real tray capture as a fixture, with its instance identifiers scrubbed, is worth doing on its own and **follows in a separate PR** rather than riding along here.

## Out of scope

The same comparison surfaced two rows where the mock and the tray disagree in the other direction. Both belong to #635's T.Limit model rather than to this fix, and neither is touched here:

- `memory_max_operating_tlimit` reads `0 C` on the tray and `N/A` on the mock.
- The T.Limit offsets are `-5 / -2 / 0` (shutdown / slowdown / max-operating) on the tray against the profiles' `-5 / 0 / +5`: real hardware anchors the reference at the max-operating limit, the mock at slowdown.

(`max_host_link_gen` also differs — `4` on that tray against the profiles' `6` — but the host bridge sets it, so it is a property of that machine rather than a fidelity gap.)

## Test plan

- [x] `make test` — engine gating written TDD (`GetGpuOperationMode`, the three retired-pages getters, the acoustic thresholds, the removed catch-all, and the retired-pages field-value path); `Profile.PreBlackwell()` added to the `TestDerivations` oracle table so the chart and engine profile copies cannot drift past it
- [x] `BlackwellRemovedFieldProblems` unit tests — the captured post-fix and Ampere documents pass; a synthetic document carrying the pre-fix values is rejected and every fabricated row named; absent elements and `N/A` bodies both accepted on Blackwell; a pre-Blackwell profile reporting `N/A` is rejected; every GPU checked, not just the first
- [x] Check validated against the real tray's own `-q -x` (accepted) and against pre-fix container captures of all three Blackwell profiles (rejected)
- [x] `make lint-fix` — 0 lint issues (`govulncheck` reports pre-existing Go stdlib advisories on the local toolchain; unmodified `main` fails identically)
- [x] `make helm-tests` — 169 tests, 15 snapshots; profile checksums and the `pwr_object` removal refreshed
- [x] Real `nvidia-smi` 580.65.06 against the built library for all seven profiles, as above
- [ ] New Ginkgo spec in CI: `nvidiasmi.BlackwellRemovedFields` derives its expectation from the profile, so the same spec pins `N/A` on the Blackwell profiles and asserts `t4`/`a100`/`h100`/`l40s` still report the fields — widening the gate cannot pass as a fix. Selected by `--label-filter="nvidia-smi"`.

## Docs

`CHANGELOG.md` entry under `[Unreleased]` → `Fixed`. `docs/configuration.md` notes that omitting an inforom key reports the object as unsupported and why the Blackwell profiles omit `pwr_object`. `testdata/README.md` gains the new post-fix `qx-gb300-healthy.xml` reference and flags that `qx-gb200-healthy.xml` is a pre-#679 capture the new check must reject.
