### PR TITLE
test(e2e): add real-hardware nvidia-smi captures

### DIFF
--- a/tests/e2e/go/assertions/nvidiasmi/hardware_test.go
+++ b/tests/e2e/go/assertions/nvidiasmi/hardware_test.go
@@ -1,0 +1,264 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidiasmi
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func hardwareCaptures(t *testing.T) []string {
+	t.Helper()
+	files, err := filepath.Glob("testdata/hardware/*.xml")
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
+	return files
+}
+
+// The other fixtures in this package come from the mock, so on their own they
+// only prove the schema agrees with what we emit. These come from real nodes on
+// a newer driver than the mock targets, which is where an element rename would
+// show up first: a reading the schema can no longer find decodes as absent
+// rather than as an error, so the assertions here are on the readings, not on
+// ParseSnapshot succeeding.
+//
+// The coverage is the set of elements the checks in checks.go and temperature.go
+// compare, since those are the readings a rename would silently turn into "the
+// mock is wrong" for every profile at once. present() is the right test for
+// them: an unsupported query is "N/A", which passes, while a renamed element
+// leaves an empty body, which fails.
+func TestHardwareCapturesDecode(t *testing.T) {
+	for _, file := range hardwareCaptures(t) {
+		t.Run(filepath.Base(file), func(t *testing.T) {
+			raw, err := os.ReadFile(file)
+			require.NoError(t, err)
+
+			snap, err := ParseSnapshot(string(raw))
+			require.NoError(t, err)
+
+			attached, ok := snap.AttachedGPUs()
+			require.True(t, ok, "attached_gpus")
+			require.Equal(t, attached, snap.Count(), "every <gpu> block decoded")
+			require.False(t, snap.HasFailedGPU(), "captures are of healthy nodes")
+
+			for i := range snap.Count() {
+				gpu, err := snap.GPU(i)
+				require.NoError(t, err)
+				element := snap.doc.GPUs[i]
+				label := gpu.Label()
+
+				_, ok := gpu.TemperatureC()
+				require.True(t, ok, "%s: gpu_temp", label)
+				_, ok = gpu.SMClockMHz()
+				require.True(t, ok, "%s: sm_clock", label)
+				_, ok = gpu.MemoryTotalMiB()
+				require.True(t, ok, "%s: fb_memory_usage/total", label)
+				_, ok = gpu.PowerLimitW()
+				require.True(t, ok, "%s: current_power_limit", label)
+				require.NotEmpty(t, gpu.UUID(), "%s: uuid", label)
+				require.NotEmpty(t, gpu.PerformanceState(), "%s: performance_state", label)
+
+				for _, r := range comparedReadings(element) {
+					require.True(t, r.raw.present(),
+						"%s: %s is absent; the driver may have renamed it", label, r.element)
+				}
+				requireOneThresholdPresentation(t, label, element.Temperature)
+				requireOneSramRendering(t, label, element.ECCErrors)
+				requireWholeRemapBlock(t, label, element.RemappedRows)
+			}
+		})
+	}
+}
+
+// comparedReadings are the elements every board in the captures emits, whatever
+// its architecture. The architecture-dependent families are asserted separately,
+// because for those absence is the driver's way of saying "not this rendering"
+// rather than a rename.
+func comparedReadings(g gpuElement) []namedReading {
+	return []namedReading{
+		{"product_name", g.ProductName},
+		{"product_architecture", g.ProductArchitecture},
+		{"uuid", g.UUID},
+		{"board_id", g.BoardID},
+		{"c2c_mode", g.C2CMode},
+		{"fan_speed", g.FanSpeed},
+		{"performance_state", g.PerformanceState},
+		{"accounting_mode_buffer_size", g.AccountingModeBufferSize},
+
+		{"platformInfo/slot_number", g.PlatformInfo.SlotNumber},
+		{"platformInfo/tray_index", g.PlatformInfo.TrayIndex},
+		{"platformInfo/host_id", g.PlatformInfo.HostID},
+		{"platformInfo/peer_type", g.PlatformInfo.PeerType},
+		{"platformInfo/module_id", g.PlatformInfo.ModuleID},
+
+		{"pcie_gen/max_link_gen", g.PCI.GPULinkInfo.PCIeGen.Max},
+		{"pcie_gen/max_device_link_gen", g.PCI.GPULinkInfo.PCIeGen.DeviceMax},
+		{"pcie_gen/max_host_link_gen", g.PCI.GPULinkInfo.PCIeGen.HostMax},
+
+		{"fb_memory_usage/total", g.FBMemoryUsage.Total},
+		{"fb_memory_usage/used", g.FBMemoryUsage.Used},
+
+		{"utilization/gpu_util", g.Utilization.GPU},
+		{"utilization/memory_util", g.Utilization.Memory},
+		{"utilization/encoder_util", g.Utilization.Encoder},
+		{"utilization/decoder_util", g.Utilization.Decoder},
+		{"utilization/jpeg_util", g.Utilization.JPEG},
+		{"utilization/ofa_util", g.Utilization.OFA},
+
+		{"gpu_virtualization_mode/virtualization_mode", g.Virtualization.Mode},
+		{"gpu_virtualization_mode/host_vgpu_mode", g.Virtualization.HostVGPUMode},
+		{"gpu_virtualization_mode/vgpu_heterogeneous_mode", g.Virtualization.HeterogeneousMode},
+
+		{"temperature/gpu_temp", g.Temperature.GPUTemp},
+		{"temperature/gpu_temp_tlimit", g.Temperature.TLimit},
+
+		{"gpu_power_readings/current_power_limit", g.PowerReadings.CurrentPowerLimit},
+		{"gpu_power_readings/min_power_limit", g.PowerReadings.MinPowerLimit},
+		{"gpu_power_readings/max_power_limit", g.PowerReadings.MaxPowerLimit},
+		{"gpu_power_readings/average_power_draw", g.PowerReadings.AveragePowerDraw},
+		{"gpu_power_readings/instant_power_draw", g.PowerReadings.InstantPowerDraw},
+
+		{"clocks/sm_clock", g.Clocks.SMClock},
+		{"ecc_mode/current_ecc", g.ECCMode.Current},
+
+		{"encoder_stats/session_count", g.EncoderStats.SessionCount},
+		{"encoder_stats/average_fps", g.EncoderStats.AverageFPS},
+		{"encoder_stats/average_latency", g.EncoderStats.AverageLatency},
+		{"fbc_stats/session_count", g.FBCStats.SessionCount},
+		{"fbc_stats/average_fps", g.FBCStats.AverageFPS},
+		{"fbc_stats/average_latency", g.FBCStats.AverageLatency},
+
+		{"ecc_errors/volatile/sram_correctable", g.ECCErrors.Volatile.SRAMCorrectable},
+		{"ecc_errors/volatile/dram_correctable", g.ECCErrors.Volatile.DRAMCorrectable},
+		{"ecc_errors/volatile/dram_uncorrectable", g.ECCErrors.Volatile.DRAMUncorrectable},
+		{"ecc_errors/aggregate/sram_correctable", g.ECCErrors.Aggregate.SRAMCorrectable},
+		{"ecc_errors/aggregate/dram_correctable", g.ECCErrors.Aggregate.DRAMCorrectable},
+		{"ecc_errors/aggregate/dram_uncorrectable", g.ECCErrors.Aggregate.DRAMUncorrectable},
+	}
+}
+
+// requireOneThresholdPresentation is the hardware side of the gate in
+// temperature.go: nvidia-smi emits the absolute threshold trio on pre-Ada and
+// the *_tlimit_threshold trio on Ada and later, never both and never neither.
+// Asserting the split holds on real boards is what makes the gate's premise
+// evidence rather than an assumption, and a rename of either trio shows up here
+// as a board reporting no presentation at all.
+func requireOneThresholdPresentation(t *testing.T, label string, temp temperature) {
+	t.Helper()
+	absolute := presentCount(absoluteThresholds(temp))
+	tlimit := presentCount(tlimitThresholds(temp))
+	require.Contains(t, []int{0, 3}, absolute, "%s: partial absolute threshold trio", label)
+	require.Contains(t, []int{0, 3}, tlimit, "%s: partial T.Limit threshold trio", label)
+	require.Equal(t, 3, absolute+tlimit,
+		"%s: want exactly one threshold presentation, got %d absolute and %d T.Limit",
+		label, absolute, tlimit)
+}
+
+// requireOneSramRendering asserts the same either-or for the two SRAM
+// uncorrectable renderings SramECCProblems switches on: the parity and SEC-DED
+// pair on Ampere and later, the single combined element before it.
+func requireOneSramRendering(t *testing.T, label string, ecc eccErrors) {
+	t.Helper()
+	for _, scope := range []struct {
+		name     string
+		counters eccCounters
+	}{
+		{"volatile", ecc.Volatile},
+		{"aggregate", ecc.Aggregate},
+	} {
+		detailed := presentCount([]namedReading{
+			{"sram_uncorrectable_parity", scope.counters.SRAMUncorrectableParity},
+			{"sram_uncorrectable_secded", scope.counters.SRAMUncorrectableSECDED},
+		})
+		combined := presentCount([]namedReading{
+			{"sram_uncorrectable", scope.counters.SRAMUncorrectable},
+		})
+		require.Contains(t, []int{0, 2}, detailed,
+			"%s: %s has half of the parity/SEC-DED pair", label, scope.name)
+		require.Equal(t, 2, detailed+2*combined,
+			"%s: %s wants exactly one SRAM uncorrectable rendering", label, scope.name)
+	}
+}
+
+// requireWholeRemapBlock asserts <remapped_rows> is either fully populated or
+// fully absent. Pre-Ampere boards have no row remapping and omit the block, so
+// its absence is not a defect; a block missing only some of its children is,
+// and that is what a rename looks like.
+func requireWholeRemapBlock(t *testing.T, label string, rows remappedRows) {
+	t.Helper()
+	present := presentCount([]namedReading{
+		{"remapped_row_corr", rows.Correctable},
+		{"remapped_row_unc", rows.Uncorrectable},
+		{"remapped_row_pending", rows.Pending},
+		{"remapped_row_failure", rows.Failure},
+	})
+	require.Contains(t, []int{0, 4}, present,
+		"%s: <remapped_rows> is partially present, want all four counters or none", label)
+	if present == 4 {
+		require.NotEmpty(t, strings.TrimSpace(rows.Histogram.Body),
+			"%s: row_remapper_histogram", label)
+	}
+}
+
+func presentCount(readings []namedReading) int {
+	count := 0
+	for _, r := range readings {
+		if r.raw.present() {
+			count++
+		}
+	}
+	return count
+}
+
+// scrubbedIdentifiers are the elements a capture must carry as a placeholder
+// rather than as the value the node reported, with the shape hardware/README.md
+// documents for each. Without this the scrub rests on whoever adds the next
+// capture remembering to run it, and the cost of forgetting is a public commit
+// naming real hardware.
+//
+// The patterns are deliberately narrow enough that a real reading cannot satisfy
+// them: a genuine serial or PDI would have to be the placeholder to pass.
+var scrubbedIdentifiers = []struct {
+	element string
+	pattern *regexp.Regexp
+}{
+	{"serial", regexp.MustCompile(`^1650000000\d{3}$`)},
+	{"chassis_serial_number", regexp.MustCompile(`^1820000000\d{3}$`)},
+	{"uuid", regexp.MustCompile(`^GPU-000000[0-9a-f]{2}-0000-0000-0000-0000000000[0-9a-f]{2}$`)},
+	{"clusterUuid", regexp.MustCompile(`^0{7}[0-9a-f]-0000-0000-0000-0{11}[0-9a-f]$`)},
+	// pdi and gpu_fabric_guid are per-die identities that sit beside <uuid>, and
+	// on Grace-Blackwell they carry the same value as each other.
+	{"pdi", regexp.MustCompile(`^0x0{14}[0-9a-f]{2}$`)},
+	{"gpu_fabric_guid", regexp.MustCompile(`^0x0{14}[0-9a-f]{2}$`)},
+}
+
+func TestHardwareCapturesAreScrubbed(t *testing.T) {
+	for _, file := range hardwareCaptures(t) {
+		t.Run(filepath.Base(file), func(t *testing.T) {
+			raw, err := os.ReadFile(file)
+			require.NoError(t, err)
+
+			for _, id := range scrubbedIdentifiers {
+				bodies := regexp.MustCompile(
+					`<`+id.element+`>([^<]*)</`+id.element+`>`).FindAllStringSubmatch(string(raw), -1)
+				for _, body := range bodies {
+					value := strings.TrimSpace(body[1])
+					// An element the board does not answer carries no identity
+					// to scrub.
+					if value == "" || value == "N/A" {
+						continue
+					}
+					require.Regexp(t, id.pattern, value,
+						"<%s> is not a scrubbed placeholder: this capture still names real hardware",
+						id.element)
+				}
+			}
+		})
+	}
+}

--- a/tests/e2e/go/assertions/nvidiasmi/testdata/README.md
+++ b/tests/e2e/go/assertions/nvidiasmi/testdata/README.md
@@ -13,6 +13,10 @@ per-GPU indexing and override scoping.
 | `qx-gb200-lost.xml` | GPU 0 healthy, GPU 1 lost (`GPU is lost` bodies). |
 | `qx-gb200-ecc-injected.xml` | GPU 0 has a non-zero `ecc_errors/aggregate/dram_uncorrectable`. |
 
+`hardware/` holds untrimmed captures from real nodes, for checking these
+mock-produced fixtures against what the boards actually report.
+`hardware/README.md` lists which boards and on which drivers.
+
 Watch for two element names that repeat under different parents: `sm_clock`
 appears under both `clocks` (current) and `max_clocks`, and `average_power_draw`
 under `gpu_power_readings`, `gpu_memory_power_readings` and

--- a/tests/e2e/go/assertions/nvidiasmi/testdata/hardware/README.md
+++ b/tests/e2e/go/assertions/nvidiasmi/testdata/hardware/README.md
@@ -1,0 +1,80 @@
+# Real-hardware nvidia-smi captures
+
+`nvidia-smi -q -x` taken from physical nodes, kept whole — every GPU, every
+element. The fixtures one directory up come from the mock and are trimmed to two
+GPUs; these are the counterpart the mock is supposed to look like, on drivers
+spread either side of the one the mock targets, so they are where an element
+rename lands first.
+
+| File | Node | Driver / CUDA |
+| --- | --- | --- |
+| `qx-b200.xml` | 8x NVIDIA B200 | 580.105.08 / 13.0 |
+| `qx-h100.xml` | 8x NVIDIA H100 80GB HBM3 | 580.105.08 / 13.0 |
+| `qx-gb200.xml` | 4x NVIDIA GB200 (`p6e-gb200.36xlarge`, arm64) | 580.173.02 / 13.0 |
+| `qx-gb300.xml` | 4x NVIDIA GB300 | 580.173.02 / 13.0 |
+| `qx-l40s.xml` | 1x NVIDIA L40S (AWS `g6e.2xlarge`) | 595.91.07 / 13.2 |
+| `qx-t4.xml` | 1x Tesla T4 (AWS `g4dn.xlarge`) | 595.91.07 / 13.2 |
+| `qx-a100.xml` | 1x NVIDIA A100-SXM4-40GB (Lambda `gpu_1x_a100_sxm4`) | 570.148.08 / 12.8 |
+
+The single-GPU captures are the no-NVLink, no-fabric end of the range — useful
+for seeing which elements a small board omits. The drivers deliberately spread
+from 570 to 595, since a spread is what exposes an element rename: the A100 is
+the oldest and the T4 and L40S the newest.
+
+The GB200 and GB300 are the only ones in a fabric cluster, so they are the only
+place `clusterUuid` and `cliqueId` carry values rather than zeros or `N/A`. The
+GB200 is also the only arm64 host, taken from a running GPU-operator driver pod
+rather than a node we control directly.
+
+The A100 matches the board `mock-nvml-config-a100.yaml` models
+(`NVIDIA A100-SXM4-40GB`). It came from a rented single-GPU VM rather than a
+node we own, so it was checked for MIG partitioning, vGPU mode and leftover
+processes before being kept; it has none, and reports `Pass-Through` like the
+rest.
+
+Use them to author and check `pkg/gpu/mocknvml/configs/mock-nvml-config-*.yaml`
+against what the real board reports, and to check `schema.go` still finds its
+elements — `hardware_test.go` asserts on the readings rather than on the parse
+succeeding, because a renamed element decodes as absent, not as an error.
+
+## Identifiers are scrubbed
+
+These files are public, so anything naming a specific piece of hardware is
+replaced with a placeholder before it lands here. Six elements need it:
+
+| Element | Placeholder |
+| --- | --- |
+| `serial` | `16500000000NN` |
+| `chassis_serial_number` | `18200000000NN` |
+| `uuid` | `GPU-000000NN-0000-0000-0000-0000000000NN` |
+| `clusterUuid` | `000000NN-0000-0000-0000-0000000000NN` |
+| `pdi` | `0x00000000000000NN` |
+| `gpu_fabric_guid` | `0x00000000000000NN` |
+
+`TestHardwareCapturesAreScrubbed` asserts these shapes over every file, so a
+capture added without scrubbing fails CI rather than merging.
+
+Everything else is verbatim. Board and part numbers, VBIOS, PCI addresses,
+clocks and thresholds describe the model rather than the unit, and are the
+reason to keep the capture at all.
+
+Two rules matter when scrubbing by hand, both of which are easy to get wrong:
+
+- Leave bodies that report an absent value — `N/A`, empty, an all-zero
+  `clusterUuid` — alone, so a scrubbed file does not claim hardware the node
+  lacks. Number `clusterUuid` placeholders from 1 for the same reason: zero is
+  how nvidia-smi says "not in a fabric cluster", and a node that was in one
+  must not come out looking like a node that was not.
+- Use one placeholder per distinct value, so GPUs that shared an identifier
+  upstream still share one here. The GB200 and GB300 modules each cover two
+  GPUs and so report a serial twice, and every GPU on a node repeats the one
+  `chassis_serial_number` and `clusterUuid`. `pdi` and `gpu_fabric_guid` share
+  one numbering for the same reason: on Grace-Blackwell they are the same value,
+  and scrubbing them apart would invent a difference the node did not report.
+
+To add a capture, take it and replace the six elements above:
+
+    nvidia-smi -q -x > qx-<node>.xml
+
+Then grep the result for each original identifier to confirm none survived, and
+read the diff for anything else that traces back to the machine.

--- a/tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-a100.xml
+++ b/tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-a100.xml
@@ -1,0 +1,398 @@
+<?xml version="1.0" ?>
+<!DOCTYPE nvidia_smi_log SYSTEM "nvsmi_device_v12.dtd">
+<nvidia_smi_log>
+	<timestamp>Fri Aug 21 10:21:36 2026</timestamp>
+	<driver_version>570.148.08</driver_version>
+	<cuda_version>12.8</cuda_version>
+	<attached_gpus>1</attached_gpus>
+	<gpu id="00000000:06:00.0">
+		<product_name>NVIDIA A100-SXM4-40GB</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Ampere</product_architecture>
+		<display_mode>Enabled</display_mode>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>HMM</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000001</serial>
+		<uuid>GPU-00000000-0000-0000-0000-000000000000</uuid>
+		<minor_number>0</minor_number>
+		<vbios_version>92.00.45.00.03</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x600</board_id>
+		<board_part_number>692-2G506-0200-003</board_part_number>
+		<gpu_part_number>20B0-884-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>N/A</chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>N/A</host_id>
+			<peer_type>N/A</peer_type>
+			<module_id>7</module_id>
+			<gpu_fabric_guid>N/A</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G506.0200.00.04</img_version>
+			<oem_object>2.0</oem_object>
+			<ecc_object>6.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>N/A</latest_timestamp>
+			<latest_duration>N/A</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>N/A</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_reset_status>
+			<reset_required>Requested functionality has been deprecated</reset_required>
+			<drain_and_reset_recommended>Requested functionality has been deprecated</drain_and_reset_recommended>
+		</gpu_reset_status>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>570.148.08</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>06</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>20B010DE</pci_device_id>
+			<pci_bus_id>00000000:06:00.0</pci_bus_id>
+			<pci_sub_system_id>134F10DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>4</max_link_gen>
+					<current_link_gen>4</current_link_gen>
+					<device_current_link_gen>4</device_current_link_gen>
+					<max_device_link_gen>4</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>350 KB/s</tx_util>
+			<rx_util>300 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>N/A</atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>40960 MiB</total>
+			<reserved>518 MiB</reserved>
+			<used>0 MiB</used>
+			<free>40443 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>65536 MiB</total>
+			<used>1 MiB</used>
+			<free>65535 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>640 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>33 C</gpu_temp>
+			<gpu_temp_tlimit>N/A</gpu_temp_tlimit>
+			<gpu_temp_max_threshold>92 C</gpu_temp_max_threshold>
+			<gpu_temp_slow_threshold>89 C</gpu_temp_slow_threshold>
+			<gpu_temp_max_gpu_threshold>85 C</gpu_temp_max_gpu_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>34 C</memory_temp>
+			<gpu_temp_max_mem_threshold>95 C</gpu_temp_max_mem_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>49.68 W</instant_power_draw>
+			<current_power_limit>400.00 W</current_power_limit>
+			<requested_power_limit>400.00 W</requested_power_limit>
+			<default_power_limit>400.00 W</default_power_limit>
+			<min_power_limit>100.00 W</min_power_limit>
+			<max_power_limit>400.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>N/A</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>210 MHz</graphics_clock>
+			<sm_clock>210 MHz</sm_clock>
+			<mem_clock>1215 MHz</mem_clock>
+			<video_clock>585 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1095 MHz</graphics_clock>
+			<mem_clock>1215 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1095 MHz</graphics_clock>
+			<mem_clock>1215 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1410 MHz</graphics_clock>
+			<sm_clock>1410 MHz</sm_clock>
+			<mem_clock>1215 MHz</mem_clock>
+			<video_clock>1290 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1410 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<voltage>
+			<graphics_volt>N/A</graphics_volt>
+		</voltage>
+		<fabric>
+			<state>N/A</state>
+			<status>N/A</status>
+			<cliqueId>N/A</cliqueId>
+			<clusterUuid>N/A</clusterUuid>
+			<health>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>N/A</access_timeout_recovery>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>1215 MHz</value>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+</nvidia_smi_log>

--- a/tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-b200.xml
+++ b/tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-b200.xml
@@ -1,0 +1,6504 @@
+<?xml version="1.0" ?>
+<!DOCTYPE nvidia_smi_log SYSTEM "nvsmi_device_v13.dtd">
+<nvidia_smi_log>
+	<timestamp>Fri Aug 21 08:39:32 2026</timestamp>
+	<driver_version>580.105.08</driver_version>
+	<cuda_version>13.0</cuda_version>
+	<attached_gpus>8</attached_gpus>
+	<gpu id="00000000:8F:00.0">
+		<product_name>NVIDIA B200</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Disabled</persistence_mode>
+		<addressing_mode>None</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000001</serial>
+		<uuid>GPU-00000000-0000-0000-0000-000000000000</uuid>
+		<pdi>0x0000000000000001</pdi>
+		<minor_number>0</minor_number>
+		<vbios_version>97.00.FA.00.09</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x8f00</board_id>
+		<board_part_number>692-2G525-0220-500</board_part_number>
+		<gpu_part_number>2901-886-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number></chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>6</module_id>
+			<gpu_fabric_guid>0x0000000000000002</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G525.0220.00.03</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>N/A</latest_timestamp>
+			<latest_duration>N/A</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Disabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.105.08</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>8F</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>290110DE</pci_device_id>
+			<pci_bus_id>00000000:8F:00.0</pci_bus_id>
+			<pci_sub_system_id>199910DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>5</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>833 KB/s</tx_util>
+			<rx_util>869 KB/s</rx_util>
+			<atomic_caps_outbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_outbound>
+			<atomic_caps_inbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>770461242 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>183359 MiB</total>
+			<reserved>728 MiB</reserved>
+			<used>0 MiB</used>
+			<free>182632 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>262144 MiB</total>
+			<used>1 MiB</used>
+			<free>262143 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>3840 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>39 C</gpu_temp>
+			<gpu_temp_tlimit>49 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-3 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>39 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>195.68 W</average_power_draw>
+			<instant_power_draw>195.79 W</instant_power_draw>
+			<current_power_limit>1000.00 W</current_power_limit>
+			<requested_power_limit>1000.00 W</requested_power_limit>
+			<default_power_limit>1000.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>1000.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>22.33 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>Insufficient Permissions</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>120 MHz</graphics_clock>
+			<sm_clock>120 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>600 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<sm_clock>1965 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>1965 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000000</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>3996 MHz</value>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>3402 MHz</value>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000000:90:00.0">
+		<product_name>NVIDIA B200</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Disabled</persistence_mode>
+		<addressing_mode>None</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000002</serial>
+		<uuid>GPU-00000001-0000-0000-0000-000000000001</uuid>
+		<pdi>0x0000000000000003</pdi>
+		<minor_number>1</minor_number>
+		<vbios_version>97.00.FA.00.09</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x9000</board_id>
+		<board_part_number>692-2G525-0220-500</board_part_number>
+		<gpu_part_number>2901-886-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number></chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>8</module_id>
+			<gpu_fabric_guid>0x0000000000000004</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G525.0220.00.03</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>N/A</latest_timestamp>
+			<latest_duration>N/A</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Disabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.105.08</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>90</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>290110DE</pci_device_id>
+			<pci_bus_id>00000000:90:00.0</pci_bus_id>
+			<pci_sub_system_id>199910DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>5</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>833 KB/s</tx_util>
+			<rx_util>868 KB/s</rx_util>
+			<atomic_caps_outbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_outbound>
+			<atomic_caps_inbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>964788758 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>183359 MiB</total>
+			<reserved>728 MiB</reserved>
+			<used>0 MiB</used>
+			<free>182632 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>262144 MiB</total>
+			<used>1 MiB</used>
+			<free>262143 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>3840 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>53 C</gpu_temp>
+			<gpu_temp_tlimit>35 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-3 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>51 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>206.00 W</average_power_draw>
+			<instant_power_draw>205.94 W</instant_power_draw>
+			<current_power_limit>1000.00 W</current_power_limit>
+			<requested_power_limit>1000.00 W</requested_power_limit>
+			<default_power_limit>1000.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>1000.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>21.36 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>Insufficient Permissions</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>120 MHz</graphics_clock>
+			<sm_clock>120 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>600 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<sm_clock>1965 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>1965 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000000</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>3996 MHz</value>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>3402 MHz</value>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000000:96:00.0">
+		<product_name>NVIDIA B200</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Disabled</persistence_mode>
+		<addressing_mode>None</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000003</serial>
+		<uuid>GPU-00000002-0000-0000-0000-000000000002</uuid>
+		<pdi>0x0000000000000005</pdi>
+		<minor_number>2</minor_number>
+		<vbios_version>97.00.FA.00.09</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x9600</board_id>
+		<board_part_number>692-2G525-0220-500</board_part_number>
+		<gpu_part_number>2901-886-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number></chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>7</module_id>
+			<gpu_fabric_guid>0x0000000000000006</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G525.0220.00.03</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>N/A</latest_timestamp>
+			<latest_duration>N/A</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Disabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.105.08</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>96</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>290110DE</pci_device_id>
+			<pci_bus_id>00000000:96:00.0</pci_bus_id>
+			<pci_sub_system_id>199910DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>5</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>848 KB/s</tx_util>
+			<rx_util>979 KB/s</rx_util>
+			<atomic_caps_outbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_outbound>
+			<atomic_caps_inbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>675948477 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>183359 MiB</total>
+			<reserved>728 MiB</reserved>
+			<used>0 MiB</used>
+			<free>182632 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>262144 MiB</total>
+			<used>1 MiB</used>
+			<free>262143 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>3840 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>38 C</gpu_temp>
+			<gpu_temp_tlimit>50 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-3 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>38 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>194.61 W</average_power_draw>
+			<instant_power_draw>194.53 W</instant_power_draw>
+			<current_power_limit>1000.00 W</current_power_limit>
+			<requested_power_limit>1000.00 W</requested_power_limit>
+			<default_power_limit>1000.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>1000.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>22.53 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>Insufficient Permissions</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>120 MHz</graphics_clock>
+			<sm_clock>120 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>600 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<sm_clock>1965 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>1965 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000000</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>3996 MHz</value>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>3402 MHz</value>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000000:97:00.0">
+		<product_name>NVIDIA B200</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Disabled</persistence_mode>
+		<addressing_mode>None</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000004</serial>
+		<uuid>GPU-00000003-0000-0000-0000-000000000003</uuid>
+		<pdi>0x0000000000000007</pdi>
+		<minor_number>3</minor_number>
+		<vbios_version>97.00.FA.00.09</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x9700</board_id>
+		<board_part_number>692-2G525-0220-500</board_part_number>
+		<gpu_part_number>2901-886-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number></chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>5</module_id>
+			<gpu_fabric_guid>0x0000000000000008</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G525.0220.00.03</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>N/A</latest_timestamp>
+			<latest_duration>N/A</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Disabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.105.08</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>97</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>290110DE</pci_device_id>
+			<pci_bus_id>00000000:97:00.0</pci_bus_id>
+			<pci_sub_system_id>199910DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>5</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>2921 KB/s</tx_util>
+			<rx_util>853 KB/s</rx_util>
+			<atomic_caps_outbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_outbound>
+			<atomic_caps_inbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>689452826 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>183359 MiB</total>
+			<reserved>728 MiB</reserved>
+			<used>0 MiB</used>
+			<free>182632 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>262144 MiB</total>
+			<used>1 MiB</used>
+			<free>262143 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>3840 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>52 C</gpu_temp>
+			<gpu_temp_tlimit>36 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-3 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>51 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>204.12 W</average_power_draw>
+			<instant_power_draw>204.43 W</instant_power_draw>
+			<current_power_limit>1000.00 W</current_power_limit>
+			<requested_power_limit>1000.00 W</requested_power_limit>
+			<default_power_limit>1000.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>1000.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>20.29 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>Insufficient Permissions</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>120 MHz</graphics_clock>
+			<sm_clock>120 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>600 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<sm_clock>1965 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>1965 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000000</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>3996 MHz</value>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>3402 MHz</value>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000000:C4:00.0">
+		<product_name>NVIDIA B200</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Disabled</persistence_mode>
+		<addressing_mode>None</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000005</serial>
+		<uuid>GPU-00000004-0000-0000-0000-000000000004</uuid>
+		<pdi>0x0000000000000009</pdi>
+		<minor_number>4</minor_number>
+		<vbios_version>97.00.FA.00.09</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0xc400</board_id>
+		<board_part_number>692-2G525-0220-500</board_part_number>
+		<gpu_part_number>2901-886-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number></chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>2</module_id>
+			<gpu_fabric_guid>0x000000000000000a</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G525.0220.00.03</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>N/A</latest_timestamp>
+			<latest_duration>N/A</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Disabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.105.08</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>C4</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>290110DE</pci_device_id>
+			<pci_bus_id>00000000:C4:00.0</pci_bus_id>
+			<pci_sub_system_id>199910DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>5</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>2943 KB/s</tx_util>
+			<rx_util>887 KB/s</rx_util>
+			<atomic_caps_outbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_outbound>
+			<atomic_caps_inbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>738601125 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>183359 MiB</total>
+			<reserved>728 MiB</reserved>
+			<used>0 MiB</used>
+			<free>182632 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>262144 MiB</total>
+			<used>1 MiB</used>
+			<free>262143 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>3840 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>38 C</gpu_temp>
+			<gpu_temp_tlimit>50 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-3 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>37 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>194.32 W</average_power_draw>
+			<instant_power_draw>193.93 W</instant_power_draw>
+			<current_power_limit>1000.00 W</current_power_limit>
+			<requested_power_limit>1000.00 W</requested_power_limit>
+			<default_power_limit>1000.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>1000.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>21.59 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>Insufficient Permissions</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>120 MHz</graphics_clock>
+			<sm_clock>120 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>600 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<sm_clock>1965 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>1965 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000000</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>3996 MHz</value>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>3402 MHz</value>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000000:C5:00.0">
+		<product_name>NVIDIA B200</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Disabled</persistence_mode>
+		<addressing_mode>None</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000006</serial>
+		<uuid>GPU-00000005-0000-0000-0000-000000000005</uuid>
+		<pdi>0x000000000000000b</pdi>
+		<minor_number>5</minor_number>
+		<vbios_version>97.00.FA.00.09</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0xc500</board_id>
+		<board_part_number>692-2G525-0220-500</board_part_number>
+		<gpu_part_number>2901-886-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number></chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>4</module_id>
+			<gpu_fabric_guid>0x000000000000000c</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G525.0220.00.03</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>N/A</latest_timestamp>
+			<latest_duration>N/A</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Disabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.105.08</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>C5</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>290110DE</pci_device_id>
+			<pci_bus_id>00000000:C5:00.0</pci_bus_id>
+			<pci_sub_system_id>199910DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>5</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>2510 KB/s</tx_util>
+			<rx_util>902 KB/s</rx_util>
+			<atomic_caps_outbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_outbound>
+			<atomic_caps_inbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>771475487 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>183359 MiB</total>
+			<reserved>728 MiB</reserved>
+			<used>0 MiB</used>
+			<free>182632 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>262144 MiB</total>
+			<used>1 MiB</used>
+			<free>262143 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>3840 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>51 C</gpu_temp>
+			<gpu_temp_tlimit>37 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-3 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>50 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>202.14 W</average_power_draw>
+			<instant_power_draw>202.57 W</instant_power_draw>
+			<current_power_limit>1000.00 W</current_power_limit>
+			<requested_power_limit>1000.00 W</requested_power_limit>
+			<default_power_limit>1000.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>1000.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>21.12 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>Insufficient Permissions</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>120 MHz</graphics_clock>
+			<sm_clock>120 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>600 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<sm_clock>1965 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>1965 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000000</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>3996 MHz</value>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>3402 MHz</value>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000000:CB:00.0">
+		<product_name>NVIDIA B200</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Disabled</persistence_mode>
+		<addressing_mode>None</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000007</serial>
+		<uuid>GPU-00000006-0000-0000-0000-000000000006</uuid>
+		<pdi>0x000000000000000d</pdi>
+		<minor_number>6</minor_number>
+		<vbios_version>97.00.FA.00.09</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0xcb00</board_id>
+		<board_part_number>692-2G525-0220-500</board_part_number>
+		<gpu_part_number>2901-886-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number></chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>3</module_id>
+			<gpu_fabric_guid>0x000000000000000e</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G525.0220.00.03</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>N/A</latest_timestamp>
+			<latest_duration>N/A</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Disabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.105.08</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>CB</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>290110DE</pci_device_id>
+			<pci_bus_id>00000000:CB:00.0</pci_bus_id>
+			<pci_sub_system_id>199910DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>5</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>857 KB/s</tx_util>
+			<rx_util>1019 KB/s</rx_util>
+			<atomic_caps_outbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_outbound>
+			<atomic_caps_inbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>645077373 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>183359 MiB</total>
+			<reserved>728 MiB</reserved>
+			<used>0 MiB</used>
+			<free>182632 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>262144 MiB</total>
+			<used>1 MiB</used>
+			<free>262143 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>3840 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>37 C</gpu_temp>
+			<gpu_temp_tlimit>51 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-3 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>37 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>194.55 W</average_power_draw>
+			<instant_power_draw>194.99 W</instant_power_draw>
+			<current_power_limit>1000.00 W</current_power_limit>
+			<requested_power_limit>1000.00 W</requested_power_limit>
+			<default_power_limit>1000.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>1000.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>24.51 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>Insufficient Permissions</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>120 MHz</graphics_clock>
+			<sm_clock>120 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>600 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<sm_clock>1965 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>1965 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000000</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>3996 MHz</value>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>3402 MHz</value>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000000:CC:00.0">
+		<product_name>NVIDIA B200</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Disabled</persistence_mode>
+		<addressing_mode>None</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000008</serial>
+		<uuid>GPU-00000007-0000-0000-0000-000000000007</uuid>
+		<pdi>0x000000000000000f</pdi>
+		<minor_number>7</minor_number>
+		<vbios_version>97.00.FA.00.09</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0xcc00</board_id>
+		<board_part_number>692-2G525-0220-500</board_part_number>
+		<gpu_part_number>2901-886-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number></chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>1</module_id>
+			<gpu_fabric_guid>0x0000000000000010</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G525.0220.00.03</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>N/A</latest_timestamp>
+			<latest_duration>N/A</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Disabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.105.08</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>CC</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>290110DE</pci_device_id>
+			<pci_bus_id>00000000:CC:00.0</pci_bus_id>
+			<pci_sub_system_id>199910DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>5</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>870 KB/s</tx_util>
+			<rx_util>877 KB/s</rx_util>
+			<atomic_caps_outbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_outbound>
+			<atomic_caps_inbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>948115299 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>183359 MiB</total>
+			<reserved>728 MiB</reserved>
+			<used>0 MiB</used>
+			<free>182632 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>262144 MiB</total>
+			<used>1 MiB</used>
+			<free>262143 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>3840 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>51 C</gpu_temp>
+			<gpu_temp_tlimit>37 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-3 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>49 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>205.21 W</average_power_draw>
+			<instant_power_draw>204.74 W</instant_power_draw>
+			<current_power_limit>1000.00 W</current_power_limit>
+			<requested_power_limit>1000.00 W</requested_power_limit>
+			<default_power_limit>1000.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>1000.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>23.57 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>Insufficient Permissions</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>120 MHz</graphics_clock>
+			<sm_clock>120 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>600 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+			<sm_clock>1965 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>1965 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1965 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000000</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>3996 MHz</value>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>3402 MHz</value>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+</nvidia_smi_log>

--- a/tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-gb200.xml
+++ b/tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-gb200.xml
@@ -1,0 +1,2324 @@
+<?xml version="1.0" ?>
+<!DOCTYPE nvidia_smi_log SYSTEM "nvsmi_device_v13.dtd">
+<nvidia_smi_log>
+	<timestamp>Fri Aug 21 11:01:42 2026</timestamp>
+	<driver_version>580.173.02</driver_version>
+	<cuda_version>13.0</cuda_version>
+	<attached_gpus>4</attached_gpus>
+	<gpu id="00000000:29:00.0">
+		<product_name>NVIDIA GB200</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>ATS</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000001</serial>
+		<uuid>GPU-00000000-0000-0000-0000-000000000000</uuid>
+		<pdi>0x0000000000000001</pdi>
+		<minor_number>0</minor_number>
+		<vbios_version>97.00.B9.00.69</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x2900</board_id>
+		<board_part_number>900-2G548-A801-000</board_part_number>
+		<gpu_part_number>2941-892-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>1820000000001</chassis_serial_number>
+			<slot_number>14</slot_number>
+			<tray_index>4</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>2</module_id>
+			<gpu_fabric_guid>0x0000000000000001</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G548.0201.00.06</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>2026/08/20 23:33:00.497</latest_timestamp>
+			<latest_duration>61655 us</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Enabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.173.02</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>29</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>294110DE</pci_device_id>
+			<pci_bus_id>00000000:29:00.0</pci_bus_id>
+			<pci_sub_system_id>204610DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>6</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>0 KB/s</tx_util>
+			<rx_util>0 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>2354613 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>189471 MiB</total>
+			<reserved>742 MiB</reserved>
+			<used>0 MiB</used>
+			<free>188730 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>262144 MiB</total>
+			<used>0 MiB</used>
+			<free>262144 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+			<unrepairable_memory>No</unrepairable_memory>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_corr_inactive>0</remapped_row_corr_inactive>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_unc_inactive>0</remapped_row_unc_inactive>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>3968 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>27 C</gpu_temp>
+			<gpu_temp_tlimit>60 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-2 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>27 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>165.93 W</average_power_draw>
+			<instant_power_draw>165.93 W</instant_power_draw>
+			<current_power_limit>1200.00 W</current_power_limit>
+			<requested_power_limit>1200.00 W</requested_power_limit>
+			<default_power_limit>1200.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>1200.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>30.26 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>467.17 W</average_power_draw>
+			<instant_power_draw>467.68 W</instant_power_draw>
+			<current_power_limit>2500.00 W</current_power_limit>
+			<requested_power_limit>2500.00 W</requested_power_limit>
+			<default_power_limit>2500.00 W</default_power_limit>
+			<min_power_limit>500.00 W</min_power_limit>
+			<max_power_limit>2500.00 W</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>Insufficient Permissions</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>120 MHz</graphics_clock>
+			<sm_clock>120 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>600 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>2062 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>2062 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>2062 MHz</graphics_clock>
+			<sm_clock>2062 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>1890 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>2062 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>2</cliqueId>
+			<clusterUuid>00000001-0000-0000-0000-000000000001</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>Full</bandwidth>
+				<route_recovery_in_progress>False</route_recovery_in_progress>
+				<route_unhealthy>False</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+				<partition_assigned>N/A</partition_assigned>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>3996 MHz</value>
+				<supported_graphics_clock>2062 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2055 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2047 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2040 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2032 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2025 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2017 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2010 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2002 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1995 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1987 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1972 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000000:3F:00.0">
+		<product_name>NVIDIA GB200</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>ATS</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000001</serial>
+		<uuid>GPU-00000001-0000-0000-0000-000000000001</uuid>
+		<pdi>0x0000000000000002</pdi>
+		<minor_number>1</minor_number>
+		<vbios_version>97.00.B9.00.69</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x3f00</board_id>
+		<board_part_number>900-2G548-A801-000</board_part_number>
+		<gpu_part_number>2941-892-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>1820000000001</chassis_serial_number>
+			<slot_number>14</slot_number>
+			<tray_index>4</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>1</module_id>
+			<gpu_fabric_guid>0x0000000000000002</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G548.0201.00.06</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>2026/08/20 23:32:58.037</latest_timestamp>
+			<latest_duration>60789 us</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Enabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.173.02</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>3F</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>294110DE</pci_device_id>
+			<pci_bus_id>00000000:3F:00.0</pci_bus_id>
+			<pci_sub_system_id>204610DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>6</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>0 KB/s</tx_util>
+			<rx_util>0 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>3360324 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>3360324 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>189471 MiB</total>
+			<reserved>742 MiB</reserved>
+			<used>0 MiB</used>
+			<free>188730 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>262144 MiB</total>
+			<used>0 MiB</used>
+			<free>262144 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+			<unrepairable_memory>No</unrepairable_memory>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_corr_inactive>0</remapped_row_corr_inactive>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_unc_inactive>0</remapped_row_unc_inactive>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>3968 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>28 C</gpu_temp>
+			<gpu_temp_tlimit>59 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-2 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>27 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>168.57 W</average_power_draw>
+			<instant_power_draw>168.57 W</instant_power_draw>
+			<current_power_limit>1200.00 W</current_power_limit>
+			<requested_power_limit>1200.00 W</requested_power_limit>
+			<default_power_limit>1200.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>1200.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>29.16 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>460.15 W</average_power_draw>
+			<instant_power_draw>461.20 W</instant_power_draw>
+			<current_power_limit>2500.00 W</current_power_limit>
+			<requested_power_limit>2500.00 W</requested_power_limit>
+			<default_power_limit>2500.00 W</default_power_limit>
+			<min_power_limit>500.00 W</min_power_limit>
+			<max_power_limit>2500.00 W</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>Insufficient Permissions</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>120 MHz</graphics_clock>
+			<sm_clock>120 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>600 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>2062 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>2062 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>2062 MHz</graphics_clock>
+			<sm_clock>2062 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>1890 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>2062 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>2</cliqueId>
+			<clusterUuid>00000001-0000-0000-0000-000000000001</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>Full</bandwidth>
+				<route_recovery_in_progress>False</route_recovery_in_progress>
+				<route_unhealthy>False</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+				<partition_assigned>N/A</partition_assigned>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>3996 MHz</value>
+				<supported_graphics_clock>2062 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2055 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2047 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2040 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2032 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2025 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2017 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2010 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2002 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1995 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1987 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1972 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000000:9C:00.0">
+		<product_name>NVIDIA GB200</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>ATS</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000002</serial>
+		<uuid>GPU-00000002-0000-0000-0000-000000000002</uuid>
+		<pdi>0x0000000000000003</pdi>
+		<minor_number>2</minor_number>
+		<vbios_version>97.00.B9.00.69</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x9c00</board_id>
+		<board_part_number>900-2G548-A801-000</board_part_number>
+		<gpu_part_number>2941-892-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>1820000000001</chassis_serial_number>
+			<slot_number>14</slot_number>
+			<tray_index>4</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>4</module_id>
+			<gpu_fabric_guid>0x0000000000000003</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G548.0201.00.06</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>2026/08/20 23:32:56.039</latest_timestamp>
+			<latest_duration>58897 us</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Enabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.173.02</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>9C</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>294110DE</pci_device_id>
+			<pci_bus_id>00000000:9C:00.0</pci_bus_id>
+			<pci_sub_system_id>204610DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>6</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>0 KB/s</tx_util>
+			<rx_util>0 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>7337828 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>7319467 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>189471 MiB</total>
+			<reserved>742 MiB</reserved>
+			<used>0 MiB</used>
+			<free>188730 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>262144 MiB</total>
+			<used>0 MiB</used>
+			<free>262144 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+			<unrepairable_memory>No</unrepairable_memory>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_corr_inactive>0</remapped_row_corr_inactive>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_unc_inactive>0</remapped_row_unc_inactive>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>3968 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>27 C</gpu_temp>
+			<gpu_temp_tlimit>60 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-2 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>28 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>156.48 W</average_power_draw>
+			<instant_power_draw>156.48 W</instant_power_draw>
+			<current_power_limit>1200.00 W</current_power_limit>
+			<requested_power_limit>1200.00 W</requested_power_limit>
+			<default_power_limit>1200.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>1200.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>31.03 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>459.80 W</average_power_draw>
+			<instant_power_draw>459.64 W</instant_power_draw>
+			<current_power_limit>2500.00 W</current_power_limit>
+			<requested_power_limit>2500.00 W</requested_power_limit>
+			<default_power_limit>2500.00 W</default_power_limit>
+			<min_power_limit>500.00 W</min_power_limit>
+			<max_power_limit>2500.00 W</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>Insufficient Permissions</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>120 MHz</graphics_clock>
+			<sm_clock>120 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>600 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>2062 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>2062 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>2062 MHz</graphics_clock>
+			<sm_clock>2062 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>1890 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>2062 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>2</cliqueId>
+			<clusterUuid>00000001-0000-0000-0000-000000000001</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>Full</bandwidth>
+				<route_recovery_in_progress>False</route_recovery_in_progress>
+				<route_unhealthy>False</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+				<partition_assigned>N/A</partition_assigned>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>3996 MHz</value>
+				<supported_graphics_clock>2062 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2055 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2047 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2040 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2032 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2025 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2017 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2010 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2002 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1995 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1987 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1972 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000000:B2:00.0">
+		<product_name>NVIDIA GB200</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>ATS</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000002</serial>
+		<uuid>GPU-00000003-0000-0000-0000-000000000003</uuid>
+		<pdi>0x0000000000000004</pdi>
+		<minor_number>3</minor_number>
+		<vbios_version>97.00.B9.00.69</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0xb200</board_id>
+		<board_part_number>900-2G548-A801-000</board_part_number>
+		<gpu_part_number>2941-892-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>1820000000001</chassis_serial_number>
+			<slot_number>14</slot_number>
+			<tray_index>4</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>3</module_id>
+			<gpu_fabric_guid>0x0000000000000004</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G548.0201.00.06</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>2026/08/20 23:34:42.942</latest_timestamp>
+			<latest_duration>54316 us</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Enabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.173.02</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>B2</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>294110DE</pci_device_id>
+			<pci_bus_id>00000000:B2:00.0</pci_bus_id>
+			<pci_sub_system_id>204610DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>6</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>0 KB/s</tx_util>
+			<rx_util>0 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>14572115 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>7322346 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>189471 MiB</total>
+			<reserved>742 MiB</reserved>
+			<used>0 MiB</used>
+			<free>188730 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>262144 MiB</total>
+			<used>0 MiB</used>
+			<free>262144 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+			<unrepairable_memory>No</unrepairable_memory>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_corr_inactive>0</remapped_row_corr_inactive>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_unc_inactive>0</remapped_row_unc_inactive>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>3968 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>26 C</gpu_temp>
+			<gpu_temp_tlimit>61 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-2 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>27 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>171.99 W</average_power_draw>
+			<instant_power_draw>171.61 W</instant_power_draw>
+			<current_power_limit>1200.00 W</current_power_limit>
+			<requested_power_limit>1200.00 W</requested_power_limit>
+			<default_power_limit>1200.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>1200.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>34.70 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>452.43 W</average_power_draw>
+			<instant_power_draw>451.80 W</instant_power_draw>
+			<current_power_limit>2500.00 W</current_power_limit>
+			<requested_power_limit>2500.00 W</requested_power_limit>
+			<default_power_limit>2500.00 W</default_power_limit>
+			<min_power_limit>500.00 W</min_power_limit>
+			<max_power_limit>2500.00 W</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>Insufficient Permissions</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>120 MHz</graphics_clock>
+			<sm_clock>120 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>600 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>2062 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>2062 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>2062 MHz</graphics_clock>
+			<sm_clock>2062 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>1890 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>2062 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>2</cliqueId>
+			<clusterUuid>00000001-0000-0000-0000-000000000001</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>Full</bandwidth>
+				<route_recovery_in_progress>False</route_recovery_in_progress>
+				<route_unhealthy>False</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+				<partition_assigned>N/A</partition_assigned>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>3996 MHz</value>
+				<supported_graphics_clock>2062 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2055 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2047 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2040 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2032 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2025 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2017 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2010 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2002 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1995 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1987 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1972 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+</nvidia_smi_log>

--- a/tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-gb300.xml
+++ b/tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-gb300.xml
@@ -1,0 +1,2328 @@
+<?xml version="1.0" ?>
+<!DOCTYPE nvidia_smi_log SYSTEM "nvsmi_device_v13.dtd">
+<nvidia_smi_log>
+	<timestamp>Fri Aug 21 09:08:13 2026</timestamp>
+	<driver_version>580.173.02</driver_version>
+	<cuda_version>13.0</cuda_version>
+	<attached_gpus>4</attached_gpus>
+	<gpu id="00000008:06:00.0">
+		<product_name>NVIDIA GB300</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>ATS</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000001</serial>
+		<uuid>GPU-00000000-0000-0000-0000-000000000000</uuid>
+		<pdi>0x0000000000000001</pdi>
+		<minor_number>0</minor_number>
+		<vbios_version>97.10.4A.00.1A</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x80600</board_id>
+		<board_part_number>900-2G548-0081-000</board_part_number>
+		<gpu_part_number>31C2-893-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>1820000000001</chassis_serial_number>
+			<slot_number>25</slot_number>
+			<tray_index>15</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>2</module_id>
+			<gpu_fabric_guid>0x0000000000000001</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G548.0301.00.03</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>2026/08/20 21:55:48.288</latest_timestamp>
+			<latest_duration>69751 us</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Enabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>None</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.173.02</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>06</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0008</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>31C210DE</pci_device_id>
+			<pci_bus_id>00000008:06:00.0</pci_bus_id>
+			<pci_sub_system_id>21F110DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>6</max_link_gen>
+					<current_link_gen>6</current_link_gen>
+					<device_current_link_gen>6</device_current_link_gen>
+					<max_device_link_gen>6</max_device_link_gen>
+					<max_host_link_gen>4</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>0 KB/s</tx_util>
+			<rx_util>0 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>0 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>284208 MiB</total>
+			<reserved>947 MiB</reserved>
+			<used>0 MiB</used>
+			<free>283262 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>524288 MiB</total>
+			<used>0 MiB</used>
+			<free>524288 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+			<unrepairable_memory>No</unrepairable_memory>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_corr_inactive>0</remapped_row_corr_inactive>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_unc_inactive>0</remapped_row_unc_inactive>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>5952 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>38 C</gpu_temp>
+			<gpu_temp_tlimit>49 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-2 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>38 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>180.36 W</average_power_draw>
+			<instant_power_draw>180.29 W</instant_power_draw>
+			<current_power_limit>1400.00 W</current_power_limit>
+			<requested_power_limit>1400.00 W</requested_power_limit>
+			<default_power_limit>1400.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>1400.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>35.70 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>488.29 W</average_power_draw>
+			<instant_power_draw>487.68 W</instant_power_draw>
+			<current_power_limit>2900.00 W</current_power_limit>
+			<requested_power_limit>2900.00 W</requested_power_limit>
+			<default_power_limit>2900.00 W</default_power_limit>
+			<min_power_limit>500.00 W</min_power_limit>
+			<max_power_limit>2900.00 W</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>Insufficient Permissions</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>120 MHz</graphics_clock>
+			<sm_clock>120 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>600 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>2070 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>2070 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>2070 MHz</graphics_clock>
+			<sm_clock>2070 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>1912 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>2070 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>32766</cliqueId>
+			<clusterUuid>00000001-0000-0000-0000-000000000001</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>Full</bandwidth>
+				<route_recovery_in_progress>False</route_recovery_in_progress>
+				<route_unhealthy>False</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>None</incorrect_configuration>
+				<partition_assigned>N/A</partition_assigned>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>3996 MHz</value>
+				<supported_graphics_clock>2070 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2062 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2055 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2047 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2040 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2032 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2025 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2017 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2010 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2002 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1995 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1987 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1972 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000009:06:00.0">
+		<product_name>NVIDIA GB300</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>ATS</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000001</serial>
+		<uuid>GPU-00000001-0000-0000-0000-000000000001</uuid>
+		<pdi>0x0000000000000002</pdi>
+		<minor_number>1</minor_number>
+		<vbios_version>97.10.4A.00.1A</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x90600</board_id>
+		<board_part_number>900-2G548-0081-000</board_part_number>
+		<gpu_part_number>31C2-893-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>1820000000001</chassis_serial_number>
+			<slot_number>25</slot_number>
+			<tray_index>15</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>1</module_id>
+			<gpu_fabric_guid>0x0000000000000002</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G548.0301.00.03</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>2026/08/20 21:55:51.236</latest_timestamp>
+			<latest_duration>23732 us</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Enabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>None</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.173.02</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>06</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0009</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>31C210DE</pci_device_id>
+			<pci_bus_id>00000009:06:00.0</pci_bus_id>
+			<pci_sub_system_id>21F110DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>6</max_link_gen>
+					<current_link_gen>6</current_link_gen>
+					<device_current_link_gen>6</device_current_link_gen>
+					<max_device_link_gen>6</max_device_link_gen>
+					<max_host_link_gen>4</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>0 KB/s</tx_util>
+			<rx_util>0 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>0 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>284208 MiB</total>
+			<reserved>947 MiB</reserved>
+			<used>0 MiB</used>
+			<free>283262 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>524288 MiB</total>
+			<used>0 MiB</used>
+			<free>524288 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+			<unrepairable_memory>No</unrepairable_memory>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_corr_inactive>0</remapped_row_corr_inactive>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_unc_inactive>0</remapped_row_unc_inactive>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>5952 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>39 C</gpu_temp>
+			<gpu_temp_tlimit>48 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-2 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>38 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>176.26 W</average_power_draw>
+			<instant_power_draw>176.26 W</instant_power_draw>
+			<current_power_limit>1400.00 W</current_power_limit>
+			<requested_power_limit>1400.00 W</requested_power_limit>
+			<default_power_limit>1400.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>1400.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>36.59 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>486.30 W</average_power_draw>
+			<instant_power_draw>486.21 W</instant_power_draw>
+			<current_power_limit>2900.00 W</current_power_limit>
+			<requested_power_limit>2900.00 W</requested_power_limit>
+			<default_power_limit>2900.00 W</default_power_limit>
+			<min_power_limit>500.00 W</min_power_limit>
+			<max_power_limit>2900.00 W</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>Insufficient Permissions</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>120 MHz</graphics_clock>
+			<sm_clock>120 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>600 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>2070 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>2070 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>2070 MHz</graphics_clock>
+			<sm_clock>2070 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>1912 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>2070 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>32766</cliqueId>
+			<clusterUuid>00000001-0000-0000-0000-000000000001</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>Full</bandwidth>
+				<route_recovery_in_progress>False</route_recovery_in_progress>
+				<route_unhealthy>False</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>None</incorrect_configuration>
+				<partition_assigned>N/A</partition_assigned>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>3996 MHz</value>
+				<supported_graphics_clock>2070 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2062 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2055 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2047 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2040 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2032 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2025 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2017 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2010 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2002 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1995 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1987 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1972 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000018:06:00.0">
+		<product_name>NVIDIA GB300</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>ATS</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000002</serial>
+		<uuid>GPU-00000002-0000-0000-0000-000000000002</uuid>
+		<pdi>0x0000000000000003</pdi>
+		<minor_number>2</minor_number>
+		<vbios_version>97.10.4A.00.1A</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x180600</board_id>
+		<board_part_number>900-2G548-0081-000</board_part_number>
+		<gpu_part_number>31C2-893-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>1820000000001</chassis_serial_number>
+			<slot_number>25</slot_number>
+			<tray_index>15</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>4</module_id>
+			<gpu_fabric_guid>0x0000000000000003</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G548.0301.00.03</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>2026/08/20 21:55:53.472</latest_timestamp>
+			<latest_duration>61130 us</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Enabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>None</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.173.02</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>06</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0018</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>31C210DE</pci_device_id>
+			<pci_bus_id>00000018:06:00.0</pci_bus_id>
+			<pci_sub_system_id>21F110DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>6</max_link_gen>
+					<current_link_gen>6</current_link_gen>
+					<device_current_link_gen>6</device_current_link_gen>
+					<max_device_link_gen>6</max_device_link_gen>
+					<max_host_link_gen>4</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>0 KB/s</tx_util>
+			<rx_util>0 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>0 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>284208 MiB</total>
+			<reserved>947 MiB</reserved>
+			<used>0 MiB</used>
+			<free>283262 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>524288 MiB</total>
+			<used>0 MiB</used>
+			<free>524288 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+			<unrepairable_memory>No</unrepairable_memory>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_corr_inactive>0</remapped_row_corr_inactive>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_unc_inactive>0</remapped_row_unc_inactive>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>5952 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>39 C</gpu_temp>
+			<gpu_temp_tlimit>48 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-2 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>39 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>175.92 W</average_power_draw>
+			<instant_power_draw>175.91 W</instant_power_draw>
+			<current_power_limit>1400.00 W</current_power_limit>
+			<requested_power_limit>1400.00 W</requested_power_limit>
+			<default_power_limit>1400.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>1400.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>34.95 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>496.85 W</average_power_draw>
+			<instant_power_draw>500.53 W</instant_power_draw>
+			<current_power_limit>2900.00 W</current_power_limit>
+			<requested_power_limit>2900.00 W</requested_power_limit>
+			<default_power_limit>2900.00 W</default_power_limit>
+			<min_power_limit>500.00 W</min_power_limit>
+			<max_power_limit>2900.00 W</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>Insufficient Permissions</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>120 MHz</graphics_clock>
+			<sm_clock>120 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>600 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>2070 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>2070 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>2070 MHz</graphics_clock>
+			<sm_clock>2070 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>1912 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>2070 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>32766</cliqueId>
+			<clusterUuid>00000001-0000-0000-0000-000000000001</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>Full</bandwidth>
+				<route_recovery_in_progress>False</route_recovery_in_progress>
+				<route_unhealthy>False</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>None</incorrect_configuration>
+				<partition_assigned>N/A</partition_assigned>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>3996 MHz</value>
+				<supported_graphics_clock>2070 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2062 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2055 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2047 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2040 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2032 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2025 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2017 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2010 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2002 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1995 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1987 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1972 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000019:06:00.0">
+		<product_name>NVIDIA GB300</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Blackwell</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>ATS</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000002</serial>
+		<uuid>GPU-00000003-0000-0000-0000-000000000003</uuid>
+		<pdi>0x0000000000000004</pdi>
+		<minor_number>3</minor_number>
+		<vbios_version>97.10.4A.00.1A</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x190600</board_id>
+		<board_part_number>900-2G548-0081-000</board_part_number>
+		<gpu_part_number>31C2-893-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>1820000000001</chassis_serial_number>
+			<slot_number>25</slot_number>
+			<tray_index>15</tray_index>
+			<host_id>1</host_id>
+			<peer_type>Switch Connected</peer_type>
+			<module_id>3</module_id>
+			<gpu_fabric_guid>0x0000000000000004</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G548.0301.00.03</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>2026/08/20 21:55:54.287</latest_timestamp>
+			<latest_duration>58648 us</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Enabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>None</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.173.02</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>06</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0019</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>31C210DE</pci_device_id>
+			<pci_bus_id>00000019:06:00.0</pci_bus_id>
+			<pci_sub_system_id>21F110DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>6</max_link_gen>
+					<current_link_gen>6</current_link_gen>
+					<device_current_link_gen>6</device_current_link_gen>
+					<max_device_link_gen>6</max_device_link_gen>
+					<max_host_link_gen>4</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>0 KB/s</tx_util>
+			<rx_util>0 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>FETCHADD_32 FETCHADD_64 SWAP_32 SWAP_64 CAS_32 CAS_64 </atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>0 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>284208 MiB</total>
+			<reserved>947 MiB</reserved>
+			<used>0 MiB</used>
+			<free>283262 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>524288 MiB</total>
+			<used>0 MiB</used>
+			<free>524288 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+			<unrepairable_memory>No</unrepairable_memory>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_corr_inactive>0</remapped_row_corr_inactive>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_unc_inactive>0</remapped_row_unc_inactive>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>5952 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>39 C</gpu_temp>
+			<gpu_temp_tlimit>48 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-2 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>39 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>180.05 W</average_power_draw>
+			<instant_power_draw>180.05 W</instant_power_draw>
+			<current_power_limit>1400.00 W</current_power_limit>
+			<requested_power_limit>1400.00 W</requested_power_limit>
+			<default_power_limit>1400.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>1400.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>42.20 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>494.32 W</average_power_draw>
+			<instant_power_draw>493.09 W</instant_power_draw>
+			<current_power_limit>2900.00 W</current_power_limit>
+			<requested_power_limit>2900.00 W</requested_power_limit>
+			<default_power_limit>2900.00 W</default_power_limit>
+			<min_power_limit>500.00 W</min_power_limit>
+			<max_power_limit>2900.00 W</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>Insufficient Permissions</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>120 MHz</graphics_clock>
+			<sm_clock>120 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>600 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>2070 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>2070 MHz</graphics_clock>
+			<mem_clock>3996 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>2070 MHz</graphics_clock>
+			<sm_clock>2070 MHz</sm_clock>
+			<mem_clock>3996 MHz</mem_clock>
+			<video_clock>1912 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>2070 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>32766</cliqueId>
+			<clusterUuid>00000001-0000-0000-0000-000000000001</clusterUuid>
+			<health>
+				<summary>Healthy</summary>
+				<bandwidth>Full</bandwidth>
+				<route_recovery_in_progress>False</route_recovery_in_progress>
+				<route_unhealthy>False</route_unhealthy>
+				<access_timeout_recovery>False</access_timeout_recovery>
+				<incorrect_configuration>None</incorrect_configuration>
+				<partition_assigned>N/A</partition_assigned>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>3996 MHz</value>
+				<supported_graphics_clock>2070 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2062 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2055 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2047 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2040 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2032 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2025 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2017 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2010 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2002 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1995 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1987 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1972 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1957 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1942 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1927 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1912 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1897 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1882 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1867 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1852 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1837 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1807 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1792 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1777 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1762 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1747 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1732 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1717 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1702 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1687 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1672 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1642 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1627 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1612 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1597 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1567 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1552 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1537 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1522 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1507 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1492 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1477 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1462 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1447 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1432 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1402 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1387 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1372 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1357 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1342 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1327 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1312 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1297 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1282 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1267 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1237 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1222 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1207 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1192 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1162 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1147 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1132 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1117 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1102 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1087 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1072 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1057 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1042 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1027 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>997 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>982 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>967 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>952 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>937 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>922 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>907 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>892 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>877 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>862 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>832 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>817 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>802 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>787 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>757 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>742 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>727 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>712 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>697 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>682 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>667 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>652 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>637 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>622 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>592 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>577 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>562 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>547 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>532 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>517 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>502 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>487 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>472 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>457 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>427 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>412 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>397 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>382 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>352 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>337 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>322 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>307 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>292 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>277 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>262 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>247 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>232 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>217 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>195 MHz</supported_graphics_clock>
+				<supported_graphics_clock>187 MHz</supported_graphics_clock>
+				<supported_graphics_clock>180 MHz</supported_graphics_clock>
+				<supported_graphics_clock>172 MHz</supported_graphics_clock>
+				<supported_graphics_clock>165 MHz</supported_graphics_clock>
+				<supported_graphics_clock>157 MHz</supported_graphics_clock>
+				<supported_graphics_clock>150 MHz</supported_graphics_clock>
+				<supported_graphics_clock>142 MHz</supported_graphics_clock>
+				<supported_graphics_clock>135 MHz</supported_graphics_clock>
+				<supported_graphics_clock>127 MHz</supported_graphics_clock>
+				<supported_graphics_clock>120 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+</nvidia_smi_log>

--- a/tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-h100.xml
+++ b/tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-h100.xml
@@ -1,0 +1,4312 @@
+<?xml version="1.0" ?>
+<!DOCTYPE nvidia_smi_log SYSTEM "nvsmi_device_v13.dtd">
+<nvidia_smi_log>
+	<timestamp>Fri Aug 21 08:54:01 2026</timestamp>
+	<driver_version>580.105.08</driver_version>
+	<cuda_version>13.0</cuda_version>
+	<attached_gpus>8</attached_gpus>
+	<gpu id="00000000:53:00.0">
+		<product_name>NVIDIA H100 80GB HBM3</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Hopper</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>HMM</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000001</serial>
+		<uuid>GPU-00000000-0000-0000-0000-000000000000</uuid>
+		<pdi>0x0000000000000001</pdi>
+		<minor_number>0</minor_number>
+		<vbios_version>96.00.99.00.01</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x5300</board_id>
+		<board_part_number>692-2G520-0200-000</board_part_number>
+		<gpu_part_number>2330-885-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>N/A</chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>N/A</host_id>
+			<peer_type>N/A</peer_type>
+			<module_id>7</module_id>
+			<gpu_fabric_guid>N/A</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G520.0200.00.05</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>2026/08/20 14:59:03.740</latest_timestamp>
+			<latest_duration>93088 us</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Disabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.105.08</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>53</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>233010DE</pci_device_id>
+			<pci_bus_id>00000000:53:00.0</pci_bus_id>
+			<pci_sub_system_id>16C110DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>5</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>150</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>502 KB/s</tx_util>
+			<rx_util>578 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>N/A</atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>7015662857 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>Disabled</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>81559 MiB</total>
+			<reserved>480 MiB</reserved>
+			<used>0 MiB</used>
+			<free>81080 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>131072 MiB</total>
+			<used>1 MiB</used>
+			<free>131071 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>2560 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>29 C</gpu_temp>
+			<gpu_temp_tlimit>58 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-8 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-2 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>37 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>68.57 W</average_power_draw>
+			<instant_power_draw>68.92 W</instant_power_draw>
+			<current_power_limit>700.00 W</current_power_limit>
+			<requested_power_limit>700.00 W</requested_power_limit>
+			<default_power_limit>700.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>700.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>32.98 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>N/A</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>345 MHz</graphics_clock>
+			<sm_clock>345 MHz</sm_clock>
+			<mem_clock>2619 MHz</mem_clock>
+			<video_clock>765 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<mem_clock>2619 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<mem_clock>2619 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<sm_clock>1980 MHz</sm_clock>
+			<mem_clock>2619 MHz</mem_clock>
+			<video_clock>1545 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000000</clusterUuid>
+			<health>
+				<summary>N/A</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>N/A</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>2619 MHz</value>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>1593 MHz</value>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000000:64:00.0">
+		<product_name>NVIDIA H100 80GB HBM3</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Hopper</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>HMM</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000002</serial>
+		<uuid>GPU-00000001-0000-0000-0000-000000000001</uuid>
+		<pdi>0x0000000000000002</pdi>
+		<minor_number>1</minor_number>
+		<vbios_version>96.00.99.00.01</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x6400</board_id>
+		<board_part_number>692-2G520-0200-000</board_part_number>
+		<gpu_part_number>2330-885-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>N/A</chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>N/A</host_id>
+			<peer_type>N/A</peer_type>
+			<module_id>5</module_id>
+			<gpu_fabric_guid>N/A</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G520.0200.00.05</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>2026/08/20 14:58:56.412</latest_timestamp>
+			<latest_duration>130280 us</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Disabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.105.08</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>64</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>233010DE</pci_device_id>
+			<pci_bus_id>00000000:64:00.0</pci_bus_id>
+			<pci_sub_system_id>16C110DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>5</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>144</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>506 KB/s</tx_util>
+			<rx_util>484 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>N/A</atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>7015392538 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>Disabled</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>81559 MiB</total>
+			<reserved>480 MiB</reserved>
+			<used>0 MiB</used>
+			<free>81080 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>131072 MiB</total>
+			<used>1 MiB</used>
+			<free>131071 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>2560 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>30 C</gpu_temp>
+			<gpu_temp_tlimit>56 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-8 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-2 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>39 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>67.01 W</average_power_draw>
+			<instant_power_draw>67.16 W</instant_power_draw>
+			<current_power_limit>700.00 W</current_power_limit>
+			<requested_power_limit>700.00 W</requested_power_limit>
+			<default_power_limit>700.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>700.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>39.71 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>N/A</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>345 MHz</graphics_clock>
+			<sm_clock>345 MHz</sm_clock>
+			<mem_clock>2619 MHz</mem_clock>
+			<video_clock>765 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<mem_clock>2619 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<mem_clock>2619 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<sm_clock>1980 MHz</sm_clock>
+			<mem_clock>2619 MHz</mem_clock>
+			<video_clock>1545 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000000</clusterUuid>
+			<health>
+				<summary>N/A</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>N/A</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>2619 MHz</value>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>1593 MHz</value>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000000:75:00.0">
+		<product_name>NVIDIA H100 80GB HBM3</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Hopper</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>HMM</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000003</serial>
+		<uuid>GPU-00000002-0000-0000-0000-000000000002</uuid>
+		<pdi>0x0000000000000003</pdi>
+		<minor_number>2</minor_number>
+		<vbios_version>96.00.99.00.01</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x7500</board_id>
+		<board_part_number>692-2G520-0200-000</board_part_number>
+		<gpu_part_number>2330-885-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>N/A</chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>N/A</host_id>
+			<peer_type>N/A</peer_type>
+			<module_id>6</module_id>
+			<gpu_fabric_guid>N/A</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G520.0200.00.05</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>2026/08/20 14:58:50.544</latest_timestamp>
+			<latest_duration>102741 us</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Disabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.105.08</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>75</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>233010DE</pci_device_id>
+			<pci_bus_id>00000000:75:00.0</pci_bus_id>
+			<pci_sub_system_id>16C110DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>5</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>174</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>508 KB/s</tx_util>
+			<rx_util>455 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>N/A</atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>7015478833 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>Disabled</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>81559 MiB</total>
+			<reserved>480 MiB</reserved>
+			<used>0 MiB</used>
+			<free>81080 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>131072 MiB</total>
+			<used>1 MiB</used>
+			<free>131071 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>2560 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>29 C</gpu_temp>
+			<gpu_temp_tlimit>57 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-8 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-2 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>38 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>67.45 W</average_power_draw>
+			<instant_power_draw>67.74 W</instant_power_draw>
+			<current_power_limit>700.00 W</current_power_limit>
+			<requested_power_limit>700.00 W</requested_power_limit>
+			<default_power_limit>700.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>700.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>39.92 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>N/A</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>345 MHz</graphics_clock>
+			<sm_clock>345 MHz</sm_clock>
+			<mem_clock>2619 MHz</mem_clock>
+			<video_clock>765 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<mem_clock>2619 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<mem_clock>2619 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<sm_clock>1980 MHz</sm_clock>
+			<mem_clock>2619 MHz</mem_clock>
+			<video_clock>1545 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000000</clusterUuid>
+			<health>
+				<summary>N/A</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>N/A</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>2619 MHz</value>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>1593 MHz</value>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000000:86:00.0">
+		<product_name>NVIDIA H100 80GB HBM3</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Hopper</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>HMM</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000004</serial>
+		<uuid>GPU-00000003-0000-0000-0000-000000000003</uuid>
+		<pdi>0x0000000000000004</pdi>
+		<minor_number>3</minor_number>
+		<vbios_version>96.00.99.00.01</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x8600</board_id>
+		<board_part_number>965-2G520-A800-000</board_part_number>
+		<gpu_part_number>2330-885-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>N/A</chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>N/A</host_id>
+			<peer_type>N/A</peer_type>
+			<module_id>8</module_id>
+			<gpu_fabric_guid>N/A</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G520.0200.00.05</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>2026/08/20 15:06:44.234</latest_timestamp>
+			<latest_duration>92480 us</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Disabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.105.08</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>86</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>233010DE</pci_device_id>
+			<pci_bus_id>00000000:86:00.0</pci_bus_id>
+			<pci_sub_system_id>16C110DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>5</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>158</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>512 KB/s</tx_util>
+			<rx_util>418 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>N/A</atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>7015722115 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>Disabled</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>81559 MiB</total>
+			<reserved>480 MiB</reserved>
+			<used>0 MiB</used>
+			<free>81080 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>131072 MiB</total>
+			<used>1 MiB</used>
+			<free>131071 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>2560 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>32 C</gpu_temp>
+			<gpu_temp_tlimit>55 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-8 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-2 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>39 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>71.37 W</average_power_draw>
+			<instant_power_draw>71.77 W</instant_power_draw>
+			<current_power_limit>700.00 W</current_power_limit>
+			<requested_power_limit>700.00 W</requested_power_limit>
+			<default_power_limit>700.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>700.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>46.07 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>N/A</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>345 MHz</graphics_clock>
+			<sm_clock>345 MHz</sm_clock>
+			<mem_clock>2619 MHz</mem_clock>
+			<video_clock>765 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<mem_clock>2619 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<mem_clock>2619 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<sm_clock>1980 MHz</sm_clock>
+			<mem_clock>2619 MHz</mem_clock>
+			<video_clock>1545 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000000</clusterUuid>
+			<health>
+				<summary>N/A</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>N/A</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>2619 MHz</value>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>1593 MHz</value>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000000:97:00.0">
+		<product_name>NVIDIA H100 80GB HBM3</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Hopper</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>HMM</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000005</serial>
+		<uuid>GPU-00000004-0000-0000-0000-000000000004</uuid>
+		<pdi>0x0000000000000005</pdi>
+		<minor_number>4</minor_number>
+		<vbios_version>96.00.99.00.01</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x9700</board_id>
+		<board_part_number>692-2G520-0200-000</board_part_number>
+		<gpu_part_number>2330-885-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>N/A</chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>N/A</host_id>
+			<peer_type>N/A</peer_type>
+			<module_id>1</module_id>
+			<gpu_fabric_guid>N/A</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G520.0200.00.05</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>2026/08/20 15:03:09.388</latest_timestamp>
+			<latest_duration>95106 us</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Disabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.105.08</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>97</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>233010DE</pci_device_id>
+			<pci_bus_id>00000000:97:00.0</pci_bus_id>
+			<pci_sub_system_id>16C110DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>5</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>145</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>514 KB/s</tx_util>
+			<rx_util>438 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>N/A</atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>7015815635 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>Disabled</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>81559 MiB</total>
+			<reserved>480 MiB</reserved>
+			<used>0 MiB</used>
+			<free>81080 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>131072 MiB</total>
+			<used>1 MiB</used>
+			<free>131071 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>2560 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>32 C</gpu_temp>
+			<gpu_temp_tlimit>55 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-8 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-2 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>37 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>66.66 W</average_power_draw>
+			<instant_power_draw>66.34 W</instant_power_draw>
+			<current_power_limit>700.00 W</current_power_limit>
+			<requested_power_limit>700.00 W</requested_power_limit>
+			<default_power_limit>700.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>700.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>36.03 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>N/A</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>345 MHz</graphics_clock>
+			<sm_clock>345 MHz</sm_clock>
+			<mem_clock>2619 MHz</mem_clock>
+			<video_clock>765 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<mem_clock>2619 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<mem_clock>2619 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<sm_clock>1980 MHz</sm_clock>
+			<mem_clock>2619 MHz</mem_clock>
+			<video_clock>1545 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000000</clusterUuid>
+			<health>
+				<summary>N/A</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>N/A</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>2619 MHz</value>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>1593 MHz</value>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000000:A8:00.0">
+		<product_name>NVIDIA H100 80GB HBM3</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Hopper</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>HMM</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000006</serial>
+		<uuid>GPU-00000005-0000-0000-0000-000000000005</uuid>
+		<pdi>0x0000000000000006</pdi>
+		<minor_number>5</minor_number>
+		<vbios_version>96.00.99.00.01</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0xa800</board_id>
+		<board_part_number>692-2G520-0200-000</board_part_number>
+		<gpu_part_number>2330-885-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>N/A</chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>N/A</host_id>
+			<peer_type>N/A</peer_type>
+			<module_id>3</module_id>
+			<gpu_fabric_guid>N/A</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G520.0200.00.05</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>2026/08/20 15:05:06.582</latest_timestamp>
+			<latest_duration>92698 us</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Disabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.105.08</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>A8</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>233010DE</pci_device_id>
+			<pci_bus_id>00000000:A8:00.0</pci_bus_id>
+			<pci_sub_system_id>16C110DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>5</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>172</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>1572 KB/s</tx_util>
+			<rx_util>464 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>N/A</atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>7015263757 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>Disabled</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>81559 MiB</total>
+			<reserved>480 MiB</reserved>
+			<used>0 MiB</used>
+			<free>81080 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>131072 MiB</total>
+			<used>1 MiB</used>
+			<free>131071 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>2560 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>29 C</gpu_temp>
+			<gpu_temp_tlimit>58 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-8 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-2 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>37 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>68.11 W</average_power_draw>
+			<instant_power_draw>68.25 W</instant_power_draw>
+			<current_power_limit>700.00 W</current_power_limit>
+			<requested_power_limit>700.00 W</requested_power_limit>
+			<default_power_limit>700.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>700.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>36.70 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>N/A</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>345 MHz</graphics_clock>
+			<sm_clock>345 MHz</sm_clock>
+			<mem_clock>2619 MHz</mem_clock>
+			<video_clock>765 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<mem_clock>2619 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<mem_clock>2619 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<sm_clock>1980 MHz</sm_clock>
+			<mem_clock>2619 MHz</mem_clock>
+			<video_clock>1545 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000000</clusterUuid>
+			<health>
+				<summary>N/A</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>N/A</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>2619 MHz</value>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>1593 MHz</value>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000000:B9:00.0">
+		<product_name>NVIDIA H100 80GB HBM3</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Hopper</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>HMM</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000007</serial>
+		<uuid>GPU-00000006-0000-0000-0000-000000000006</uuid>
+		<pdi>0x0000000000000007</pdi>
+		<minor_number>6</minor_number>
+		<vbios_version>96.00.99.00.01</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0xb900</board_id>
+		<board_part_number>692-2G520-0200-000</board_part_number>
+		<gpu_part_number>2330-885-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>N/A</chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>N/A</host_id>
+			<peer_type>N/A</peer_type>
+			<module_id>4</module_id>
+			<gpu_fabric_guid>N/A</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G520.0200.00.05</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>2026/08/20 15:01:21.066</latest_timestamp>
+			<latest_duration>133594 us</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Disabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.105.08</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>B9</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>233010DE</pci_device_id>
+			<pci_bus_id>00000000:B9:00.0</pci_bus_id>
+			<pci_sub_system_id>16C110DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>5</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>162</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>510 KB/s</tx_util>
+			<rx_util>425 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>N/A</atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>7015401606 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>Disabled</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>81559 MiB</total>
+			<reserved>480 MiB</reserved>
+			<used>0 MiB</used>
+			<free>81080 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>131072 MiB</total>
+			<used>1 MiB</used>
+			<free>131071 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>2560 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>31 C</gpu_temp>
+			<gpu_temp_tlimit>56 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-8 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-2 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>37 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>69.80 W</average_power_draw>
+			<instant_power_draw>70.01 W</instant_power_draw>
+			<current_power_limit>700.00 W</current_power_limit>
+			<requested_power_limit>700.00 W</requested_power_limit>
+			<default_power_limit>700.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>700.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>35.37 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>N/A</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>345 MHz</graphics_clock>
+			<sm_clock>345 MHz</sm_clock>
+			<mem_clock>2619 MHz</mem_clock>
+			<video_clock>765 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<mem_clock>2619 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<mem_clock>2619 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<sm_clock>1980 MHz</sm_clock>
+			<mem_clock>2619 MHz</mem_clock>
+			<video_clock>1545 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000000</clusterUuid>
+			<health>
+				<summary>N/A</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>N/A</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>2619 MHz</value>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>1593 MHz</value>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+	<gpu id="00000000:CA:00.0">
+		<product_name>NVIDIA H100 80GB HBM3</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Hopper</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>HMM</addressing_mode>
+		<mig_mode>
+			<current_mig>Disabled</current_mig>
+			<pending_mig>Disabled</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000008</serial>
+		<uuid>GPU-00000007-0000-0000-0000-000000000007</uuid>
+		<pdi>0x0000000000000008</pdi>
+		<minor_number>7</minor_number>
+		<vbios_version>96.00.99.00.01</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0xca00</board_id>
+		<board_part_number>692-2G520-0200-000</board_part_number>
+		<gpu_part_number>2330-885-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>N/A</chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>N/A</host_id>
+			<peer_type>N/A</peer_type>
+			<module_id>2</module_id>
+			<gpu_fabric_guid>N/A</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G520.0200.00.05</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>7.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>2026/08/20 15:02:33.433</latest_timestamp>
+			<latest_duration>92203 us</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>Disabled</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>580.105.08</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>CA</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>233010DE</pci_device_id>
+			<pci_bus_id>00000000:CA:00.0</pci_bus_id>
+			<pci_sub_system_id>16C110DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>5</max_link_gen>
+					<current_link_gen>5</current_link_gen>
+					<device_current_link_gen>5</device_current_link_gen>
+					<max_device_link_gen>5</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>16x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>106</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>512 KB/s</tx_util>
+			<rx_util>600 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>N/A</atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>7014307013 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>Disabled</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>81559 MiB</total>
+			<reserved>480 MiB</reserved>
+			<used>0 MiB</used>
+			<free>81080 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>131072 MiB</total>
+			<used>1 MiB</used>
+			<free>131071 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>2560 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>29 C</gpu_temp>
+			<gpu_temp_tlimit>57 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-8 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-2 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>38 C</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>0 C</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>68.07 W</average_power_draw>
+			<instant_power_draw>68.18 W</instant_power_draw>
+			<current_power_limit>700.00 W</current_power_limit>
+			<requested_power_limit>700.00 W</requested_power_limit>
+			<default_power_limit>700.00 W</default_power_limit>
+			<min_power_limit>200.00 W</min_power_limit>
+			<max_power_limit>700.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>36.89 W</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>P0</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>N/A</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<clocks>
+			<graphics_clock>345 MHz</graphics_clock>
+			<sm_clock>345 MHz</sm_clock>
+			<mem_clock>2619 MHz</mem_clock>
+			<video_clock>765 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<mem_clock>2619 MHz</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<mem_clock>2619 MHz</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+			<sm_clock>1980 MHz</sm_clock>
+			<mem_clock>2619 MHz</mem_clock>
+			<video_clock>1545 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1980 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>Completed</state>
+			<status>Success</status>
+			<cliqueId>0</cliqueId>
+			<clusterUuid>00000000-0000-0000-0000-000000000000</clusterUuid>
+			<health>
+				<summary>N/A</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>N/A</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>2619 MHz</value>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>1593 MHz</value>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+</nvidia_smi_log>

--- a/tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-l40s.xml
+++ b/tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-l40s.xml
@@ -1,0 +1,500 @@
+<?xml version="1.0" ?>
+<!DOCTYPE nvidia_smi_log SYSTEM "nvsmi_device_v13.dtd">
+<nvidia_smi_log>
+	<timestamp>Fri Aug 21 09:34:04 2026</timestamp>
+	<driver_version>595.91.07</driver_version>
+	<cuda_version>13.2</cuda_version>
+	<attached_gpus>1</attached_gpus>
+	<gpu id="00000000:30:00.0">
+		<product_name>NVIDIA L40S</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Ada Lovelace</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>HMM</addressing_mode>
+		<mig_mode>
+			<current_mig>N/A</current_mig>
+			<pending_mig>N/A</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000001</serial>
+		<uuid>GPU-00000000-0000-0000-0000-000000000000</uuid>
+		<pdi>0x0000000000000001</pdi>
+		<minor_number>0</minor_number>
+		<vbios_version>95.02.66.00.15</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x3000</board_id>
+		<board_part_number>900-2G133-A880-000</board_part_number>
+		<gpu_part_number>26B9-896-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>N/A</chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>N/A</host_id>
+			<peer_type>N/A</peer_type>
+			<module_id>1</module_id>
+			<gpu_fabric_guid>N/A</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G133.0242.00.03</img_version>
+			<oem_object>2.1</oem_object>
+			<ecc_object>6.16</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>N/A</latest_timestamp>
+			<latest_duration>N/A</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>N/A</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>595.91.07</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>30</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>26B910DE</pci_device_id>
+			<pci_bus_id>00000000:30:00.0</pci_bus_id>
+			<pci_sub_system_id>185110DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>4</max_link_gen>
+					<current_link_gen>4</current_link_gen>
+					<device_current_link_gen>4</device_current_link_gen>
+					<max_device_link_gen>4</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>8x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>585 KB/s</tx_util>
+			<rx_util>292 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>N/A</atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>0 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>46068 MiB</total>
+			<reserved>609 MiB</reserved>
+			<used>0 MiB</used>
+			<free>45460 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>65536 MiB</total>
+			<used>0 MiB</used>
+			<free>65536 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable_parity>0</sram_uncorrectable_parity>
+				<sram_uncorrectable_secded>0</sram_uncorrectable_secded>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+				<sram_threshold_exceeded>No</sram_threshold_exceeded>
+			</aggregate>
+			<aggregate_uncorrectable_sram_sources>
+				<sram_l2>0</sram_l2>
+				<sram_sm>0</sram_sm>
+				<sram_microcontroller>0</sram_microcontroller>
+				<sram_pcie>0</sram_pcie>
+				<sram_other>0</sram_other>
+			</aggregate_uncorrectable_sram_sources>
+			<channel_repair_pending>No</channel_repair_pending>
+			<tpc_repair_pending>No</tpc_repair_pending>
+			<unrepairable_memory>N/A</unrepairable_memory>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>
+			<remapped_row_corr>0</remapped_row_corr>
+			<remapped_row_corr_inactive>0</remapped_row_corr_inactive>
+			<remapped_row_unc>0</remapped_row_unc>
+			<remapped_row_unc_inactive>0</remapped_row_unc_inactive>
+			<remapped_row_pending>No</remapped_row_pending>
+			<remapped_row_failure>No</remapped_row_failure>
+			<row_remapper_histogram>
+				<row_remapper_histogram_max>192 bank(s)</row_remapper_histogram_max>
+				<row_remapper_histogram_high>0 bank(s)</row_remapper_histogram_high>
+				<row_remapper_histogram_partial>0 bank(s)</row_remapper_histogram_partial>
+				<row_remapper_histogram_low>0 bank(s)</row_remapper_histogram_low>
+				<row_remapper_histogram_none>0 bank(s)</row_remapper_histogram_none>
+			</row_remapper_histogram>
+		</remapped_rows>
+		<temperature>
+			<gpu_temp>29 C</gpu_temp>
+			<gpu_temp_tlimit>59 C</gpu_temp_tlimit>
+			<gpu_temp_max_tlimit_threshold>-5 C</gpu_temp_max_tlimit_threshold>
+			<gpu_temp_slow_tlimit_threshold>-2 C</gpu_temp_slow_tlimit_threshold>
+			<gpu_temp_max_gpu_tlimit_threshold>0 C</gpu_temp_max_gpu_tlimit_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>N/A</memory_temp>
+			<gpu_temp_max_mem_tlimit_threshold>N/A</gpu_temp_max_mem_tlimit_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>Requested functionality has been deprecated</power_state>
+			<average_power_draw>65.64 W</average_power_draw>
+			<instant_power_draw>66.16 W</instant_power_draw>
+			<current_power_limit>350.00 W</current_power_limit>
+			<requested_power_limit>350.00 W</requested_power_limit>
+			<default_power_limit>350.00 W</default_power_limit>
+			<min_power_limit>100.00 W</min_power_limit>
+			<max_power_limit>350.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>Requested functionality has been deprecated</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>N/A</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<edpp_multiplier>N/A</edpp_multiplier>
+		<clocks>
+			<graphics_clock>2040 MHz</graphics_clock>
+			<sm_clock>2040 MHz</sm_clock>
+			<mem_clock>9001 MHz</mem_clock>
+			<video_clock>1725 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>Requested functionality has been deprecated</graphics_clock>
+			<mem_clock>Requested functionality has been deprecated</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>Requested functionality has been deprecated</graphics_clock>
+			<mem_clock>Requested functionality has been deprecated</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>2520 MHz</graphics_clock>
+			<sm_clock>2520 MHz</sm_clock>
+			<mem_clock>9001 MHz</mem_clock>
+			<video_clock>1965 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>2520 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>N/A</state>
+			<status>N/A</status>
+			<cliqueId>N/A</cliqueId>
+			<clusterUuid>N/A</clusterUuid>
+			<health>
+				<summary>N/A</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>N/A</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+				<partition_assigned>N/A</partition_assigned>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>9001 MHz</value>
+				<supported_graphics_clock>2520 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2505 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2490 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2475 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2460 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2445 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2430 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2415 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2400 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2385 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2370 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2355 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2340 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2325 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2310 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2295 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2280 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2265 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2250 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2235 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2220 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2205 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2190 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2175 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2160 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2145 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2130 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2115 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2100 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2085 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2070 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2055 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2040 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2025 MHz</supported_graphics_clock>
+				<supported_graphics_clock>2010 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1995 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1980 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1965 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1950 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1935 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1920 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1905 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1890 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1875 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1845 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1830 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1815 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1800 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1785 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1770 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1755 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1740 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1725 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1710 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1680 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1665 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1650 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1635 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1605 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>405 MHz</value>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+				<supported_graphics_clock>285 MHz</supported_graphics_clock>
+				<supported_graphics_clock>270 MHz</supported_graphics_clock>
+				<supported_graphics_clock>255 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>225 MHz</supported_graphics_clock>
+				<supported_graphics_clock>210 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+</nvidia_smi_log>

--- a/tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-t4.xml
+++ b/tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-t4.xml
@@ -1,0 +1,417 @@
+<?xml version="1.0" ?>
+<!DOCTYPE nvidia_smi_log SYSTEM "nvsmi_device_v13.dtd">
+<nvidia_smi_log>
+	<timestamp>Fri Aug 21 09:23:10 2026</timestamp>
+	<driver_version>595.91.07</driver_version>
+	<cuda_version>13.2</cuda_version>
+	<attached_gpus>1</attached_gpus>
+	<gpu id="00000000:00:1E.0">
+		<product_name>Tesla T4</product_name>
+		<product_brand>NVIDIA</product_brand>
+		<product_architecture>Turing</product_architecture>
+		<display_mode>Requested functionality has been deprecated</display_mode>
+		<display_attached>Yes</display_attached>
+		<display_active>Disabled</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<addressing_mode>HMM</addressing_mode>
+		<mig_mode>
+			<current_mig>N/A</current_mig>
+			<pending_mig>N/A</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>1650000000001</serial>
+		<uuid>GPU-00000000-0000-0000-0000-000000000000</uuid>
+		<pdi>0x0000000000000001</pdi>
+		<minor_number>0</minor_number>
+		<vbios_version>90.04.96.00.02</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x1e</board_id>
+		<board_part_number>900-2G183-A800-001</board_part_number>
+		<gpu_part_number>1EB8-895-A1</gpu_part_number>
+		<gpu_fru_part_number>N/A</gpu_fru_part_number>
+		<platformInfo>
+			<chassis_serial_number>N/A</chassis_serial_number>
+			<slot_number>N/A</slot_number>
+			<tray_index>N/A</tray_index>
+			<host_id>N/A</host_id>
+			<peer_type>N/A</peer_type>
+			<module_id>1</module_id>
+			<gpu_fabric_guid>N/A</gpu_fabric_guid>
+		</platformInfo>
+		<inforom_version>
+			<img_version>G183.0200.00.02</img_version>
+			<oem_object>1.1</oem_object>
+			<ecc_object>5.0</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<inforom_bbx_flush>
+			<latest_timestamp>N/A</latest_timestamp>
+			<latest_duration>N/A</latest_duration>
+		</inforom_bbx_flush>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<c2c_mode>N/A</c2c_mode>
+		<gpu_virtualization_mode>
+			<virtualization_mode>Pass-Through</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+			<vgpu_heterogeneous_mode>N/A</vgpu_heterogeneous_mode>
+		</gpu_virtualization_mode>
+		<gpu_recovery_action>None</gpu_recovery_action>
+		<gsp_firmware_version>595.91.07</gsp_firmware_version>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>00</pci_bus>
+			<pci_device>1E</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_base_class>3</pci_base_class>
+			<pci_sub_class>2</pci_sub_class>
+			<pci_device_id>1EB810DE</pci_device_id>
+			<pci_bus_id>00000000:00:1E.0</pci_bus_id>
+			<pci_sub_system_id>12A210DE</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>3</max_link_gen>
+					<current_link_gen>3</current_link_gen>
+					<device_current_link_gen>3</device_current_link_gen>
+					<max_device_link_gen>3</max_device_link_gen>
+					<max_host_link_gen>N/A</max_host_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>16x</max_link_width>
+					<current_link_width>8x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>439 KB/s</tx_util>
+			<rx_util>292 KB/s</rx_util>
+			<atomic_caps_outbound>N/A</atomic_caps_outbound>
+			<atomic_caps_inbound>N/A</atomic_caps_inbound>
+		</pci>
+		<fan_speed>N/A</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_event_reasons>
+			<clocks_event_reason_gpu_idle>Active</clocks_event_reason_gpu_idle>
+			<clocks_event_reason_applications_clocks_setting>Not Active</clocks_event_reason_applications_clocks_setting>
+			<clocks_event_reason_sw_power_cap>Not Active</clocks_event_reason_sw_power_cap>
+			<clocks_event_reason_hw_slowdown>Not Active</clocks_event_reason_hw_slowdown>
+			<clocks_event_reason_hw_thermal_slowdown>Not Active</clocks_event_reason_hw_thermal_slowdown>
+			<clocks_event_reason_hw_power_brake_slowdown>Not Active</clocks_event_reason_hw_power_brake_slowdown>
+			<clocks_event_reason_sync_boost>Not Active</clocks_event_reason_sync_boost>
+			<clocks_event_reason_sw_thermal_slowdown>Not Active</clocks_event_reason_sw_thermal_slowdown>
+			<clocks_event_reason_display_clocks_setting>Not Active</clocks_event_reason_display_clocks_setting>
+		</clocks_event_reasons>
+		<clocks_event_reasons_counters>
+			<clocks_event_reasons_counters_sw_power_cap>0 us</clocks_event_reasons_counters_sw_power_cap>
+			<clocks_event_reasons_counters_sync_boost>0 us</clocks_event_reasons_counters_sync_boost>
+			<clocks_event_reasons_counters_sw_therm_slowdown>0 us</clocks_event_reasons_counters_sw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_therm_slowdown>0 us</clocks_event_reasons_counters_hw_therm_slowdown>
+			<clocks_event_reasons_counters_hw_power_brake>0 us</clocks_event_reasons_counters_hw_power_brake>
+		</clocks_event_reasons_counters>
+		<sparse_operation_mode>N/A</sparse_operation_mode>
+		<fb_memory_usage>
+			<total>15360 MiB</total>
+			<reserved>448 MiB</reserved>
+			<used>0 MiB</used>
+			<free>14913 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>256 MiB</total>
+			<used>2 MiB</used>
+			<free>254 MiB</free>
+		</bar1_memory_usage>
+		<cc_protected_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</cc_protected_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>0 %</memory_util>
+			<encoder_util>0 %</encoder_util>
+			<decoder_util>0 %</decoder_util>
+			<jpeg_util>0 %</jpeg_util>
+			<ofa_util>0 %</ofa_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<dram_encryption_mode>
+			<current_dram_encryption>N/A</current_dram_encryption>
+			<pending_dram_encryption>N/A</pending_dram_encryption>
+		</dram_encryption_mode>
+		<ecc_mode>
+			<current_ecc>Enabled</current_ecc>
+			<pending_ecc>Enabled</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable>0</sram_uncorrectable>
+				<dram_correctable>0</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</volatile>
+			<aggregate>
+				<sram_correctable>0</sram_correctable>
+				<sram_uncorrectable>0</sram_uncorrectable>
+				<dram_correctable>1</dram_correctable>
+				<dram_uncorrectable>0</dram_uncorrectable>
+			</aggregate>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>0</retired_count>
+				<retired_pagelist>
+				</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>0</retired_count>
+				<retired_pagelist>
+				</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>No</pending_blacklist>
+			<pending_retirement>No</pending_retirement>
+		</retired_pages>
+		<remapped_rows>N/A</remapped_rows>
+		<temperature>
+			<gpu_temp>33 C</gpu_temp>
+			<gpu_temp_tlimit>N/A</gpu_temp_tlimit>
+			<gpu_temp_max_threshold>96 C</gpu_temp_max_threshold>
+			<gpu_temp_slow_threshold>93 C</gpu_temp_slow_threshold>
+			<gpu_temp_max_gpu_threshold>85 C</gpu_temp_max_gpu_threshold>
+			<gpu_target_temperature>N/A</gpu_target_temperature>
+			<memory_temp>N/A</memory_temp>
+			<gpu_temp_max_mem_threshold>N/A</gpu_temp_max_mem_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>N/A</gpu_target_temp_min>
+			<gpu_target_temp_max>N/A</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<gpu_power_readings>
+			<power_state>Requested functionality has been deprecated</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>33.51 W</instant_power_draw>
+			<current_power_limit>70.00 W</current_power_limit>
+			<requested_power_limit>70.00 W</requested_power_limit>
+			<default_power_limit>70.00 W</default_power_limit>
+			<min_power_limit>60.00 W</min_power_limit>
+			<max_power_limit>70.00 W</max_power_limit>
+		</gpu_power_readings>
+		<gpu_memory_power_readings>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+		</gpu_memory_power_readings>
+		<module_power_readings>
+			<power_state>Requested functionality has been deprecated</power_state>
+			<average_power_draw>N/A</average_power_draw>
+			<instant_power_draw>N/A</instant_power_draw>
+			<current_power_limit>N/A</current_power_limit>
+			<requested_power_limit>N/A</requested_power_limit>
+			<default_power_limit>N/A</default_power_limit>
+			<min_power_limit>N/A</min_power_limit>
+			<max_power_limit>N/A</max_power_limit>
+		</module_power_readings>
+		<power_smoothing>N/A</power_smoothing>
+		<power_profiles>
+			<power_profile_requested_profiles>N/A</power_profile_requested_profiles>
+			<power_profile_enforced_profiles>N/A</power_profile_enforced_profiles>
+		</power_profiles>
+		<edpp_multiplier>N/A</edpp_multiplier>
+		<clocks>
+			<graphics_clock>1590 MHz</graphics_clock>
+			<sm_clock>1590 MHz</sm_clock>
+			<mem_clock>5000 MHz</mem_clock>
+			<video_clock>1470 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>Requested functionality has been deprecated</graphics_clock>
+			<mem_clock>Requested functionality has been deprecated</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>Requested functionality has been deprecated</graphics_clock>
+			<mem_clock>Requested functionality has been deprecated</mem_clock>
+		</default_applications_clocks>
+		<deferred_clocks>
+			<mem_clock>N/A</mem_clock>
+		</deferred_clocks>
+		<max_clocks>
+			<graphics_clock>1590 MHz</graphics_clock>
+			<sm_clock>1590 MHz</sm_clock>
+			<mem_clock>5001 MHz</mem_clock>
+			<video_clock>1470 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>1590 MHz</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<fabric>
+			<state>N/A</state>
+			<status>N/A</status>
+			<cliqueId>N/A</cliqueId>
+			<clusterUuid>N/A</clusterUuid>
+			<health>
+				<summary>N/A</summary>
+				<bandwidth>N/A</bandwidth>
+				<route_recovery_in_progress>N/A</route_recovery_in_progress>
+				<route_unhealthy>N/A</route_unhealthy>
+				<access_timeout_recovery>N/A</access_timeout_recovery>
+				<incorrect_configuration>N/A</incorrect_configuration>
+				<partition_assigned>N/A</partition_assigned>
+			</health>
+		</fabric>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>5001 MHz</value>
+				<supported_graphics_clock>1590 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1575 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1560 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1545 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1530 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1515 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1500 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1485 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1470 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1440 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1425 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1410 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1395 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1380 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1365 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1350 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1335 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1320 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1305 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1275 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1260 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1245 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1230 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1200 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1185 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1170 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1155 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1140 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1125 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1110 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1095 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1080 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1065 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1035 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1020 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1005 MHz</supported_graphics_clock>
+				<supported_graphics_clock>990 MHz</supported_graphics_clock>
+				<supported_graphics_clock>975 MHz</supported_graphics_clock>
+				<supported_graphics_clock>960 MHz</supported_graphics_clock>
+				<supported_graphics_clock>945 MHz</supported_graphics_clock>
+				<supported_graphics_clock>930 MHz</supported_graphics_clock>
+				<supported_graphics_clock>915 MHz</supported_graphics_clock>
+				<supported_graphics_clock>900 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>870 MHz</supported_graphics_clock>
+				<supported_graphics_clock>855 MHz</supported_graphics_clock>
+				<supported_graphics_clock>840 MHz</supported_graphics_clock>
+				<supported_graphics_clock>825 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>795 MHz</supported_graphics_clock>
+				<supported_graphics_clock>780 MHz</supported_graphics_clock>
+				<supported_graphics_clock>765 MHz</supported_graphics_clock>
+				<supported_graphics_clock>750 MHz</supported_graphics_clock>
+				<supported_graphics_clock>735 MHz</supported_graphics_clock>
+				<supported_graphics_clock>720 MHz</supported_graphics_clock>
+				<supported_graphics_clock>705 MHz</supported_graphics_clock>
+				<supported_graphics_clock>690 MHz</supported_graphics_clock>
+				<supported_graphics_clock>675 MHz</supported_graphics_clock>
+				<supported_graphics_clock>660 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>405 MHz</value>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>630 MHz</supported_graphics_clock>
+				<supported_graphics_clock>615 MHz</supported_graphics_clock>
+				<supported_graphics_clock>600 MHz</supported_graphics_clock>
+				<supported_graphics_clock>585 MHz</supported_graphics_clock>
+				<supported_graphics_clock>570 MHz</supported_graphics_clock>
+				<supported_graphics_clock>555 MHz</supported_graphics_clock>
+				<supported_graphics_clock>540 MHz</supported_graphics_clock>
+				<supported_graphics_clock>525 MHz</supported_graphics_clock>
+				<supported_graphics_clock>510 MHz</supported_graphics_clock>
+				<supported_graphics_clock>495 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>465 MHz</supported_graphics_clock>
+				<supported_graphics_clock>450 MHz</supported_graphics_clock>
+				<supported_graphics_clock>435 MHz</supported_graphics_clock>
+				<supported_graphics_clock>420 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>390 MHz</supported_graphics_clock>
+				<supported_graphics_clock>375 MHz</supported_graphics_clock>
+				<supported_graphics_clock>360 MHz</supported_graphics_clock>
+				<supported_graphics_clock>345 MHz</supported_graphics_clock>
+				<supported_graphics_clock>330 MHz</supported_graphics_clock>
+				<supported_graphics_clock>315 MHz</supported_graphics_clock>
+				<supported_graphics_clock>300 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+		<capabilities>
+			<egm>disabled</egm>
+		</capabilities>
+	</gpu>
+
+</nvidia_smi_log>


### PR DESCRIPTION
## Summary

Adds `nvidia-smi -q -x` captures from real GPU nodes under `tests/e2e/go/assertions/nvidiasmi/testdata/hardware/`, kept whole rather than trimmed to two GPUs like the mock-produced fixtures one directory up.

Every nvidia-smi fixture we had came from the mock, so together they only proved that `schema.go` agrees with what we emit. These are the counterpart the mock is supposed to look like.

| File | Node | Driver / CUDA |
| --- | --- | --- |
| `qx-a100.xml` | 1x A100-SXM4-40GB | 570.148.08 / 12.8 |
| `qx-b200.xml` | 8x B200 | 580.105.08 / 13.0 |
| `qx-gb200.xml` | 4x GB200 (arm64) | 580.173.02 / 13.0 |
| `qx-gb300.xml` | 4x GB300 | 580.173.02 / 13.0 |
| `qx-h100.xml` | 8x H100 80GB HBM3 | 580.105.08 / 13.0 |
| `qx-l40s.xml` | 1x L40S | 595.91.07 / 13.2 |
| `qx-t4.xml` | 1x Tesla T4 | 595.91.07 / 13.2 |

The driver spread from 570 to 595 is deliberate: a driver bump can rename an element, and a renamed element decodes as an absent reading rather than as a parse error, so `hardware_test.go` asserts on the readings instead of on `ParseSnapshot` succeeding.

Coverage worth calling out:

- GB200 and GB300 are the only nodes in a fabric cluster, so the only captures where `clusterUuid` and `cliqueId` carry values rather than zeros or `N/A`.
- GB200 is the only arm64 host.
- A100 matches the board `mock-nvml-config-a100.yaml` models (`NVIDIA A100-SXM4-40GB`).
- T4 and L40S are the single-GPU, no-NVLink, no-fabric end of the range.

## Identifiers

Per-unit identifiers are replaced with placeholders: GPU serials and UUIDs, the chassis serial, the fabric `clusterUuid`, and the `pdi` and `gpu_fabric_guid` that name an individual die. Model-level fields are verbatim, since board and part numbers, VBIOS, PCI addresses, clocks and thresholds are what makes a capture worth keeping.

Two subtleties are documented in the directory README, because both are easy to get wrong when adding a capture:

- Bodies reporting an absent value (`N/A`, empty, an all-zero `clusterUuid`) are left alone, so a scrubbed file does not claim hardware the node lacks. `clusterUuid` placeholders are numbered from 1 for the same reason: zero is how nvidia-smi says "not in a fabric cluster".
- One placeholder per distinct value, so GPUs that shared an identifier upstream still share one here — the GB200 and GB300 modules each cover two GPUs and so report a serial twice. `pdi` and `gpu_fabric_guid` share one numbering, since Grace-Blackwell reports the same value in both.

`TestHardwareCapturesAreScrubbed` asserts the placeholder shapes over every file, so a capture added without scrubbing fails CI rather than merging. The patterns are narrow enough that a real reading cannot satisfy them.

## Test plan

- [x] `go test ./tests/e2e/go/assertions/...` passes; all seven captures decode and every asserted reading resolves
- [x] `make lint-fix` reports 0 issues and vet passes
- [x] Captures verified against the source: byte-identical by SHA-256 where the transport allowed it, and otherwise well-formed with `attached_gpus` matching the number of `<gpu>` blocks
- [x] Checked for MIG partitioning, vGPU mode and leftover process lists; none present, all report `Pass-Through`

Note: `make lint-fix` also runs `govulncheck`, which fails on pre-existing Go standard library advisories (needs go1.26.6) unrelated to this change; no Go dependencies are touched here.

