### PR TITLE
feat(helm): default gpu.profile to gb300

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   public NVML APIs.
 
 ### Changed
+- The nvml-mock chart now defaults `gpu.profile` to `gb300` instead of `a100`, so
+  a bare `helm install` simulates current-generation hardware. Ampere is the
+  architecture least likely to expose a gap in software being tested against a
+  simulated fleet; GB300 exercises the newer surfaces (Grace-Blackwell C2C, FP4/FP6,
+  NVLink v5, the 570 driver line) that consumers are actually being ported to.
+  Pass `--set gpu.profile=a100` to keep the previous behaviour.
 - CI no longer depends on the third-party `ttl.sh` registry to share e2e images
   between jobs. The nvml-mock and kind-node images are exported as tarballs and
   handed to the legs that need them as run-scoped GitHub Actions artifacts, which need no

--- a/README.md
+++ b/README.md
@@ -24,21 +24,15 @@ Turn any Kubernetes cluster into a multi-GPU environment for testing.
 No physical NVIDIA hardware required.
 
 ```bash
-# 1. Create cluster
 kind create cluster --name mokka
 
-# 2. Load the published image (or build locally with: docker build -t nvml-mock:local -f deployments/nvml-mock/Dockerfile .)
-# The published image is multi-arch. `kind load docker-image` cannot load a
-# multi-arch image from Docker Desktop's containerd store and fails with
-# "ctr: content digest ...: not found", so save one platform first.
-ARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')
-docker pull ghcr.io/nvidia/nvml-mock:latest
-docker save --platform "linux/${ARCH}" ghcr.io/nvidia/nvml-mock:latest -o nvml-mock.tar
-kind load image-archive nvml-mock.tar --name mokka
-
-# 3. Install
-helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock
+helm install mokka oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
+    --namespace mokka --create-namespace \
+    --set gpu.profile=gb300
 ```
+
+Every node now reports 8 mock GB300 GPUs. `gb300` is the chart default; swap in
+`a100`, `h100`, `b200`, `gb200`, `l40s`, or `t4` for other hardware.
 
 After install, deploy a consumer to test:
 
@@ -65,11 +59,6 @@ node-wide NRI, and NFD label-provenance coverage. Run manually via
 | **Multi-Node Fleet** | Heterogeneous A100/T4 workers, mock files, InfiniBand behavior, device plugin resources, and GPU workload scheduling | Fixed multi-node topology |
 | **Node-Wide NRI Injection** | Ambient mock GPU injection into ordinary pods without GPU requests or hostPath mounts | Workflow-selected profiles |
 | **NFD Label Provenance** | That NFD creates `feature.node.kubernetes.io/pci-10de.present` from the feature file nvml-mock writes, and that nvml-mock does not write the label itself | Pinned to `a100` — the label is vendor-only and byte-identical across profiles |
-
-Manual dispatch accepts a JSON array of GPU profiles; local runs default to
-`gb200`.
-
-See [`.github/workflows/nvml-mock-e2e-go.yaml`](.github/workflows/nvml-mock-e2e-go.yaml) for details.
 
 ## Mock NVML Library
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ No physical NVIDIA hardware required.
 ```bash
 kind create cluster --name mokka
 
-helm install mokka oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
-    --namespace mokka --create-namespace \
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
     --set gpu.profile=gb300
 ```
 

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -18,17 +18,6 @@ is a summary so that `helm show readme` stays useful.
 helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock
 ```
 
-On KIND the image must be loaded into the cluster first. The published image is
-multi-arch, and `kind load docker-image` cannot load a multi-arch image from
-Docker Desktop's containerd store, so save a single platform first:
-
-```bash
-ARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')
-docker pull ghcr.io/nvidia/nvml-mock:latest
-docker save --platform "linux/${ARCH}" ghcr.io/nvidia/nvml-mock:latest -o nvml-mock.tar
-kind load image-archive nvml-mock.tar --name <cluster>
-```
-
 ## GPU profiles
 
 Set `gpu.profile` to one of the profiles shipped in `profiles/`:

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -39,7 +39,7 @@ Set `gpu.profile` to one of the profiles shipped in `profiles/`:
 | `h100` | H100 80GB HBM3 | 80 GiB | Hopper |
 | `b200` | B200 | 192 GiB | Blackwell |
 | `gb200` | GB200 | 192 GiB | Blackwell |
-| `gb300` | GB300 NVL | 288 GiB | Blackwell Ultra |
+| `gb300` (default) | GB300 NVL | 288 GiB | Blackwell Ultra |
 | `l40s` | L40S | 48 GiB | Ada Lovelace |
 | `t4` | Tesla T4 | 16 GiB | Turing |
 

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
@@ -1,3 +1,486 @@
+should match snapshot with a100 profile:
+  1: |
+    apiVersion: v1
+    data:
+      config.yaml: |
+        # Mock NVML Configuration: DGX A100
+        # Full configuration for nvidia-smi -x -q compatibility
+        # Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
+
+        version: "1.0"
+
+        # =============================================================================
+        # System-level configuration
+        # =============================================================================
+        system:
+          driver_version: "550.163.01"
+          nvml_version: "12.550.163.01"
+          cuda_version: "12.4"
+          cuda_version_major: 12
+          cuda_version_minor: 4
+
+        # =============================================================================
+        # Default device configuration (applied to all devices unless overridden)
+        # =============================================================================
+        device_defaults:
+          # ---------------------------------------------------------------------------
+          # Basic identification
+          # ---------------------------------------------------------------------------
+          name: "NVIDIA A100-SXM4-40GB"
+          brand: "nvidia"                    # nvidia, tesla, quadro, geforce, etc.
+          serial: "1324821083812"
+          board_part_number: "692-2G506-0200-002"
+          vbios_version: "92.00.45.00.03"
+
+          # ---------------------------------------------------------------------------
+          # Architecture
+          # ---------------------------------------------------------------------------
+          architecture: "ampere"
+          compute_capability:
+            major: 8
+            minor: 0
+          num_gpu_cores: 6912               # CUDA cores
+
+          # ---------------------------------------------------------------------------
+          # InfoROM versions
+          # ---------------------------------------------------------------------------
+          inforom:
+            image_version: "G506.0200.00.04"
+            oem_object: "2.0"
+            ecc_object: "6.16"
+            pwr_object: "N/A"
+
+          # ---------------------------------------------------------------------------
+          # Memory configuration
+          # ---------------------------------------------------------------------------
+          memory:
+            total_bytes: 42949672960        # 40 GiB HBM2e
+            reserved_bytes: 611319808       # ~583 MiB reserved
+            free_bytes: 42338353152         # total - reserved at idle
+            used_bytes: 0
+            memory_bus_width: 5120
+
+          bar1_memory:
+            total_bytes: 68719476736        # 64 GiB
+            free_bytes: 68719476736
+            used_bytes: 0
+
+          # ---------------------------------------------------------------------------
+          # PCI configuration
+          # ---------------------------------------------------------------------------
+          pci:
+            device_id: 0x20B010DE           # A100 SXM4 40GB
+            subsystem_id: 0x134710DE
+            # bus_id is auto-generated per device if not specified
+
+          pcie:
+            max_link_gen: 4                 # PCIe Gen4
+            current_link_gen: 4
+            max_link_width: 16              # x16
+            current_link_width: 16
+            replay_counter: 0
+            tx_throughput_kbps: 0           # KB/s
+            rx_throughput_kbps: 0
+
+          # ---------------------------------------------------------------------------
+          # Power configuration
+          # ---------------------------------------------------------------------------
+          power:
+            management_supported: true
+            management_mode: "enabled"
+            default_limit_mw: 400000        # 400W
+            enforced_limit_mw: 400000
+            min_limit_mw: 100000            # 100W
+            max_limit_mw: 400000            # 400W
+            current_draw_mw: 72000          # 72W idle
+            power_state: "P0"               # P0-P12
+            total_energy_consumption_mj: 500000  # millijoules since boot
+
+          # ---------------------------------------------------------------------------
+          # Thermal configuration
+          # ---------------------------------------------------------------------------
+          thermal:
+            temperature_gpu_c: 33           # Idle temperature
+            temperature_memory_c: 31
+            shutdown_threshold_c: 92
+            slowdown_threshold_c: 87
+            max_operating_c: 83
+            target_temperature_c: 83        # For auto fan control
+
+          # ---------------------------------------------------------------------------
+          # Fan configuration (N/A for SXM form factor)
+          # ---------------------------------------------------------------------------
+          fan:
+            count: 0                        # SXM has no fans (liquid cooled)
+            speed_percent: "N/A"
+            target_speed_percent: "N/A"
+
+          # ---------------------------------------------------------------------------
+          # Clock speeds (MHz)
+          # ---------------------------------------------------------------------------
+          clocks:
+            graphics_current: 210           # Idle
+            graphics_max: 1410
+            graphics_app: 1410              # Application clock setting
+            graphics_app_default: 1410
+            sm_current: 210
+            sm_max: 1410
+            memory_current: 1215
+            memory_max: 1215
+            memory_app: 1215
+            memory_app_default: 1215
+            video_current: 585
+            video_max: 1290
+
+          # ---------------------------------------------------------------------------
+          # Clocks throttle reasons (bitmask reasons)
+          # ---------------------------------------------------------------------------
+          clocks_throttle_reasons:
+            gpu_idle: true                  # Clock is idle
+            applications_clocks_setting: false
+            sw_power_cap: false
+            hw_slowdown: false
+            hw_thermal_slowdown: false
+            hw_power_brake_slowdown: false
+            sync_boost: false
+            sw_thermal_slowdown: false
+            display_clocks_setting: false
+
+          # ---------------------------------------------------------------------------
+          # Supported clocks (for nvidia-smi -q -d SUPPORTED_CLOCKS)
+          # ---------------------------------------------------------------------------
+          supported_clocks:
+            memory_clocks:
+              - freq_mhz: 1215
+                graphics_clocks: [210, 420, 630, 840, 1050, 1215, 1275, 1335, 1410]
+
+          # ---------------------------------------------------------------------------
+          # Performance state
+          # ---------------------------------------------------------------------------
+          performance_state: "P0"           # P0 = max performance
+
+          # ---------------------------------------------------------------------------
+          # Utilization (percentage, 0-100)
+          # ---------------------------------------------------------------------------
+          utilization:
+            gpu: 0
+            memory: 0
+            encoder: 0
+            decoder: 0
+            jpeg: 0
+            ofa: 0                          # Optical flow accelerator
+
+          # ---------------------------------------------------------------------------
+          # Dynamic utilization (#506)
+          #
+          # Live without any Helm overlay, so `utilization.gpu` -- and every
+          # DCGM_FI_PROF_* fraction derived from it -- is never a constant 0.
+          # The driver is elapsed time, NOT workload: these numbers move on a fully
+          # idle node and do not rise under load. gpu_min is deliberately > 0 so
+          # "utilization is reported" is a deterministic assertion, not a flaky one.
+          # ---------------------------------------------------------------------------
+          dynamic_metrics:
+            utilization:
+              pattern: "steady"
+              gpu_min: 10
+              gpu_max: 45
+              memory_min: 5
+              memory_max: 25
+
+          # ---------------------------------------------------------------------------
+          # Encoder/Decoder statistics
+          # ---------------------------------------------------------------------------
+          encoder_stats:
+            session_count: 0
+            average_fps: 0
+            average_latency_us: 0
+
+          fbc_stats:                        # Frame buffer capture
+            session_count: 0
+            average_fps: 0
+            average_latency_us: 0
+
+          # ---------------------------------------------------------------------------
+          # ECC configuration
+          # ---------------------------------------------------------------------------
+          ecc:
+            mode_current: "enabled"
+            mode_pending: "enabled"
+            default_mode: "enabled"
+            # Error counts (all zeros for clean GPU)
+            errors:
+              volatile:
+                single_bit:
+                  device_memory: 0
+                  l1_cache: 0
+                  l2_cache: 0
+                  register_file: 0
+                  texture_memory: 0
+                  total: 0
+                double_bit:
+                  device_memory: 0
+                  l1_cache: 0
+                  l2_cache: 0
+                  register_file: 0
+                  texture_memory: 0
+                  total: 0
+              aggregate:
+                single_bit:
+                  device_memory: 0
+                  l1_cache: 0
+                  l2_cache: 0
+                  register_file: 0
+                  texture_memory: 0
+                  total: 0
+                double_bit:
+                  device_memory: 0
+                  l1_cache: 0
+                  l2_cache: 0
+                  register_file: 0
+                  texture_memory: 0
+                  total: 0
+
+          # ---------------------------------------------------------------------------
+          # Retired pages
+          # ---------------------------------------------------------------------------
+          retired_pages:
+            single_bit_retirement:
+              count: 0
+              addresses: []
+            double_bit_retirement:
+              count: 0
+              addresses: []
+            pending_blacklist: false
+            pending_retirement: false
+
+          # ---------------------------------------------------------------------------
+          # Remapped rows
+          # ---------------------------------------------------------------------------
+          remapped_rows:
+            correctable: 0
+            uncorrectable: 0
+            pending: false
+            failure_occurred: false
+            # Bank remap availability: every bank still holds its full complement of
+            # spare rows, which is what a GPU that has never remapped reports. Row
+            # remapping is Ampere and later, so a pre-Ampere profile (t4) omits this
+            # block and the mock reports the histogram unsupported, as that hardware
+            # does. The bank count follows the 16-banks-per-GiB ratio a real 40 GiB
+            # A100 reports.
+            availability_histogram:
+              max: 640
+              high: 0
+              partial: 0
+              low: 0
+              none: 0
+
+          # ---------------------------------------------------------------------------
+          # Display configuration
+          # ---------------------------------------------------------------------------
+          display:
+            mode: "disabled"                # No display output on A100
+            active: "disabled"
+
+          # ---------------------------------------------------------------------------
+          # Persistence mode
+          # ---------------------------------------------------------------------------
+          persistence_mode: "enabled"       # Typically enabled on servers
+
+          # ---------------------------------------------------------------------------
+          # Compute mode
+          # ---------------------------------------------------------------------------
+          compute_mode: "default"           # default, exclusive_thread, prohibited, exclusive_process
+
+          # ---------------------------------------------------------------------------
+          # MIG configuration
+          # ---------------------------------------------------------------------------
+          mig:
+            mode_current: "disabled"
+            mode_pending: "disabled"
+            max_gpu_instances: 7            # A100 supports up to 7 MIG instances
+            # GPU instances would be defined here if MIG enabled
+
+          # ---------------------------------------------------------------------------
+          # GPU operation mode (GOM)
+          # ---------------------------------------------------------------------------
+          gpu_operation_mode:
+            current: "all_on"               # all_on, compute, low_dp
+            pending: "all_on"
+
+          # ---------------------------------------------------------------------------
+          # Driver model (Windows only)
+          # ---------------------------------------------------------------------------
+          driver_model:
+            current: "N/A"                  # Linux: N/A, Windows: WDDM or TCC
+            pending: "N/A"
+
+          # ---------------------------------------------------------------------------
+          # Accounting mode
+          # ---------------------------------------------------------------------------
+          accounting:
+            mode: "disabled"
+            buffer_size: 4000               # Max PIDs tracked
+
+          # ---------------------------------------------------------------------------
+          # Virtualization
+          # ---------------------------------------------------------------------------
+          virtualization:
+            mode: "none"                    # none, passthrough, vgpu
+            host_vgpu_mode: "N/A"
+
+          # ---------------------------------------------------------------------------
+          # GSP Firmware
+          # ---------------------------------------------------------------------------
+          gsp_firmware:
+            mode: "enabled"                 # GSP enabled on newer drivers
+            version: "550.54.15"
+
+          # ---------------------------------------------------------------------------
+          # Processes (empty at idle)
+          # ---------------------------------------------------------------------------
+          processes: []
+
+        # =============================================================================
+        # Device-specific overrides (indexed 0-7 for DGX A100)
+        # Only specify fields that differ from device_defaults
+        # =============================================================================
+        devices:
+          - index: 0
+            uuid: "GPU-12345678-1234-1234-1234-123456780000"
+            serial: "1324821083800"
+            pci:
+              bus_id: "0000:07:00.0"
+            minor_number: 0
+
+          - index: 1
+            uuid: "GPU-12345678-1234-1234-1234-123456780001"
+            serial: "1324821083801"
+            pci:
+              bus_id: "0000:0F:00.0"
+            minor_number: 1
+
+          - index: 2
+            uuid: "GPU-12345678-1234-1234-1234-123456780002"
+            serial: "1324821083802"
+            pci:
+              bus_id: "0000:47:00.0"
+            minor_number: 2
+
+          - index: 3
+            uuid: "GPU-12345678-1234-1234-1234-123456780003"
+            serial: "1324821083803"
+            pci:
+              bus_id: "0000:4E:00.0"
+            minor_number: 3
+
+          - index: 4
+            uuid: "GPU-12345678-1234-1234-1234-123456780004"
+            serial: "1324821083804"
+            pci:
+              bus_id: "0000:87:00.0"
+            minor_number: 4
+
+          - index: 5
+            uuid: "GPU-12345678-1234-1234-1234-123456780005"
+            serial: "1324821083805"
+            pci:
+              bus_id: "0000:90:00.0"
+            minor_number: 5
+
+          - index: 6
+            uuid: "GPU-12345678-1234-1234-1234-123456780006"
+            serial: "1324821083806"
+            pci:
+              bus_id: "0000:B7:00.0"
+            minor_number: 6
+
+          - index: 7
+            uuid: "GPU-12345678-1234-1234-1234-123456780007"
+            serial: "1324821083807"
+            pci:
+              bus_id: "0000:BD:00.0"
+            minor_number: 7
+
+        # =============================================================================
+        # NVLink topology
+        # =============================================================================
+        nvlink:
+          version: 3
+          links_per_gpu: 12
+          bandwidth_per_link_mbps: 25781    # NVLink3 25.781 GB/s/link unidirectional (`nvlink -s`); 12 links ~= 309 GB/s/GPU (600 GB/s bidir)
+          c2c_enabled: false                # no Grace C2C on DGX A100
+          # DGX A100: 6x NVSwitch -> NV12 all-to-all. Switch-link auto-expansion
+          # (switches declared + links_per_gpu > 0, and no explicit per-device links)
+          # makes the engine synthesize 12 active links per GPU fanned round-robin
+          # across these NVSwitches, so `nvidia-smi topo -m` shows NV12 between every
+          # GPU pair. No fabricmanager coupling: A100 predates the GpuFabricInfo NVML
+          # API (Hopper+), so there is deliberately no device_defaults.fabric block and
+          # nvmlDeviceGetGpuFabricInfo returns NOT_SUPPORTED.
+          switches:
+            - bdf: "0000:01:00.0"
+              uuid: "NVSwitch-A100-0000-0000-0000-000000000000"
+            - bdf: "0000:02:00.0"
+              uuid: "NVSwitch-A100-0000-0000-0000-000000000001"
+            - bdf: "0000:03:00.0"
+              uuid: "NVSwitch-A100-0000-0000-0000-000000000002"
+            - bdf: "0000:04:00.0"
+              uuid: "NVSwitch-A100-0000-0000-0000-000000000003"
+            - bdf: "0000:05:00.0"
+              uuid: "NVSwitch-A100-0000-0000-0000-000000000004"
+            - bdf: "0000:06:00.0"
+              uuid: "NVSwitch-A100-0000-0000-0000-000000000005"
+
+        # =============================================================================
+        # InfiniBand topology - 1 ConnectX-6 HDR HCA per GPU (typical DGX A100)
+        # =============================================================================
+        infiniband:
+          enabled: true
+          hca_type: "MT4123"                # ConnectX-6
+          fw_version: "20.36.1010"
+          hw_rev: "0x0"
+          board_id: "MT_0000000223"
+          link_layer: "InfiniBand"
+          rate_gbps: 200                    # HDR
+          port_state: "ACTIVE"
+          phys_state: "LinkUp"
+          hcas_per_gpu: 1
+          guid_prefix: "a288c2:0300:ab"
+          node_desc_template: "{node_name} mlx5_{idx}"
+
+        # =============================================================================
+        # PCIe topology - 2 NUMA nodes (dual EPYC), 4 GPUs each.
+        # Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
+        # under MOCK_PCI_ROOT. C consumers such as `lspci` resolve the PCIe root
+        # complex through these symlinks. The NVIDIA DRA driver does NOT: it is a
+        # Go binary, and Go's os package issues raw syscalls that the LD_PRELOAD
+        # shim cannot intercept, so `dra.k8s.io/pcieRoot` stays absent from the
+        # ResourceSlices it publishes. See issue #265.
+        # =============================================================================
+        pcie_topology:
+          root_complexes:
+            - id: "pci0000:00"
+              numa_node: 0
+              devices:
+                - "0000:07:00.0"
+                - "0000:0F:00.0"
+                - "0000:47:00.0"
+                - "0000:4E:00.0"
+            - id: "pci0000:80"
+              numa_node: 1
+              devices:
+                - "0000:87:00.0"
+                - "0000:90:00.0"
+                - "0000:B7:00.0"
+                - "0000:BD:00.0"
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: nvml-mock
+        app.kubernetes.io/version: 550.163.01
+        helm.sh/chart: nvml-mock-0.3.0
+      name: RELEASE-NAME-nvml-mock-config
 should match snapshot with b200 profile:
   1: |
     apiVersion: v1
@@ -477,12 +960,12 @@ should match snapshot with b200 profile:
         app.kubernetes.io/version: 550.163.01
         helm.sh/chart: nvml-mock-0.3.0
       name: RELEASE-NAME-nvml-mock-config
-should match snapshot with default a100 profile:
+should match snapshot with default gb300 profile:
   1: |
     apiVersion: v1
     data:
       config.yaml: |
-        # Mock NVML Configuration: DGX A100
+        # Mock NVML Configuration: GB300 NVL (Grace-Blackwell Ultra Superchip)
         # Full configuration for nvidia-smi -x -q compatibility
         # Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
 
@@ -492,11 +975,18 @@ should match snapshot with default a100 profile:
         # System-level configuration
         # =============================================================================
         system:
-          driver_version: "550.163.01"
-          nvml_version: "12.550.163.01"
-          cuda_version: "12.4"
+          driver_version: "570.124.06"
+          nvml_version: "12.570.124.06"
+          cuda_version: "12.8"
           cuda_version_major: 12
-          cuda_version_minor: 4
+          cuda_version_minor: 8
+
+        # Helm-only dynamic-metrics defaults (engine ignores this key). Used when
+        # gpu.dynamicMetrics.enabled=true; base sits inside the power limits so it varies.
+        dynamic_metrics_defaults:
+          power:
+            base_mw: 800000                 # 800W, within [500W, 1600W]
+            variance_mw: 75000
 
         # =============================================================================
         # Default device configuration (applied to all devices unless overridden)
@@ -505,117 +995,155 @@ should match snapshot with default a100 profile:
           # ---------------------------------------------------------------------------
           # Basic identification
           # ---------------------------------------------------------------------------
-          name: "NVIDIA A100-SXM4-40GB"
-          brand: "nvidia"                    # nvidia, tesla, quadro, geforce, etc.
-          serial: "1324821083812"
-          board_part_number: "692-2G506-0200-002"
-          vbios_version: "92.00.45.00.03"
+          name: "NVIDIA GB300 NVL"
+          brand: "nvidia"
+          serial: "1573041103750"
+          board_part_number: "699-2G530-0300-000"
+          vbios_version: "97.00.41.00.01"
 
           # ---------------------------------------------------------------------------
-          # Architecture
+          # Architecture - Blackwell Ultra (still sm_100 family for compute_capability,
+          # but with higher TFLOPS per SM than the standard Blackwell B200/GB200)
           # ---------------------------------------------------------------------------
-          architecture: "ampere"
+          architecture: "blackwell"
           compute_capability:
-            major: 8
+            major: 10
             minor: 0
-          num_gpu_cores: 6912               # CUDA cores
+          num_gpu_cores: 21632             # Blackwell Ultra: more cores than B200/GB200
+
+          # ---------------------------------------------------------------------------
+          # NVLink fabric (GB300 ComputeDomain). The clique_id / cluster_uuid below
+          # are placeholder defaults; the topology-overlay step in the engine
+          # rewrites them per-node based on the cluster-level topology ConfigMap
+          # (set Helm value `topology.enabled=true`). Nodes that don't appear in
+          # the topology fall through to these defaults, which is sufficient for
+          # single-node experiments. See pkg/gpu/mocknvml/engine/fabric.go.
+          # ---------------------------------------------------------------------------
+          fabric:
+            cluster_uuid: "00000000-0000-0000-0000-000000000001"
+            clique_id: 0
+            state: "auto"                   # couple GPU fabric registration to fake fabricmanager readiness
+            # Health defaults to a healthy fabric (nvidia-smi -q reports Summary:
+            # Healthy, Bandwidth: Full). Add a `health:` block to fault a specific
+            # condition, or use `nvml-mock-ctl fabric-health` at runtime.
+            # See docs/configuration.md#fabric-health.
+
+          # ---------------------------------------------------------------------------
+          # Platform identity — where this node sits in the NVL72 rack, which
+          # nvidia-smi -q renders as its "Platform Info" block and rack-scale fault
+          # correlation reads to turn a GPU fault into a physical location.
+          #
+          # Every field but module_id describes the node, so all its GPUs share them:
+          # a node occupies one tray, in one slot, of one chassis. Only module_id
+          # ("ID of this GPU within the node") is set per device below.
+          #
+          # slot_number counts switch trays as well as compute trays while tray_index
+          # counts compute trays only, so slot runs ahead of tray for a tray sitting
+          # above the rack's nine switch trays: compute tray 16 lands in slot 26.
+          # ---------------------------------------------------------------------------
+          platform:
+            chassis_serial_number: "1822725100300"
+            slot_number: 26
+            tray_index: 16
+            host_id: 1                      # first of the tray's two OS domains
+            peer_type: "switch_connected"   # peers reached through the NVSwitch trays
 
           # ---------------------------------------------------------------------------
           # InfoROM versions
           # ---------------------------------------------------------------------------
           inforom:
-            image_version: "G506.0200.00.04"
-            oem_object: "2.0"
-            ecc_object: "6.16"
-            pwr_object: "N/A"
+            image_version: "G530.0300.00.01"
+            oem_object: "2.1"
+            ecc_object: "7.20"
+            pwr_object: "1.0"
 
           # ---------------------------------------------------------------------------
-          # Memory configuration
+          # Memory configuration - 288 GiB HBM3e per GPU (1.5x GB200's 192 GiB)
           # ---------------------------------------------------------------------------
           memory:
-            total_bytes: 42949672960        # 40 GiB HBM2e
-            reserved_bytes: 611319808       # ~583 MiB reserved
-            free_bytes: 42338353152         # total - reserved at idle
+            total_bytes: 309237645312       # 288 GiB HBM3e
+            reserved_bytes: 1610612736      # ~1.5 GiB reserved
+            free_bytes: 307627032576        # total - reserved at idle
             used_bytes: 0
-            memory_bus_width: 5120
+            memory_bus_width: 8192
 
           bar1_memory:
-            total_bytes: 68719476736        # 64 GiB
-            free_bytes: 68719476736
+            total_bytes: 824633720832       # 768 GiB (unified memory with Grace, grown for B300)
+            free_bytes: 824633720832
             used_bytes: 0
 
           # ---------------------------------------------------------------------------
           # PCI configuration
           # ---------------------------------------------------------------------------
           pci:
-            device_id: 0x20B010DE           # A100 SXM4 40GB
-            subsystem_id: 0x134710DE
-            # bus_id is auto-generated per device if not specified
+            device_id: 0x294110DE           # GB300 NVL (mock placeholder, Blackwell Ultra)
+            subsystem_id: 0x183010DE
 
           pcie:
-            max_link_gen: 4                 # PCIe Gen4
-            current_link_gen: 4
+            max_link_gen: 6                 # PCIe Gen6 (or NVLink-C2C to Grace)
+            current_link_gen: 6
             max_link_width: 16              # x16
             current_link_width: 16
             replay_counter: 0
-            tx_throughput_kbps: 0           # KB/s
+            tx_throughput_kbps: 0
             rx_throughput_kbps: 0
 
           # ---------------------------------------------------------------------------
-          # Power configuration
+          # Power configuration - GB300 is higher TDP than GB200
+          # (B300 GPU alone advertised at up to 1.4 kW; full superchip headroom higher)
           # ---------------------------------------------------------------------------
           power:
             management_supported: true
             management_mode: "enabled"
-            default_limit_mw: 400000        # 400W
-            enforced_limit_mw: 400000
-            min_limit_mw: 100000            # 100W
-            max_limit_mw: 400000            # 400W
-            current_draw_mw: 72000          # 72W idle
-            power_state: "P0"               # P0-P12
-            total_energy_consumption_mj: 500000  # millijoules since boot
+            default_limit_mw: 1400000       # 1400W per B300 GPU
+            enforced_limit_mw: 1400000
+            min_limit_mw: 500000            # 500W minimum
+            max_limit_mw: 1600000           # 1600W boost ceiling
+            current_draw_mw: 175000         # 175W idle (liquid cooled)
+            power_state: "P0"
+            total_energy_consumption_mj: 1000000  # millijoules since boot
 
           # ---------------------------------------------------------------------------
-          # Thermal configuration
+          # Thermal configuration (same liquid-cooled envelope as GB200)
           # ---------------------------------------------------------------------------
           thermal:
-            temperature_gpu_c: 33           # Idle temperature
-            temperature_memory_c: 31
-            shutdown_threshold_c: 92
-            slowdown_threshold_c: 87
-            max_operating_c: 83
-            target_temperature_c: 83        # For auto fan control
+            temperature_gpu_c: 38           # Idle temperature (liquid cooled)
+            temperature_memory_c: 36
+            shutdown_threshold_c: 95
+            slowdown_threshold_c: 90
+            max_operating_c: 85
+            target_temperature_c: 85
 
           # ---------------------------------------------------------------------------
-          # Fan configuration (N/A for SXM form factor)
+          # Fan configuration (N/A - liquid cooled)
           # ---------------------------------------------------------------------------
           fan:
-            count: 0                        # SXM has no fans (liquid cooled)
+            count: 0                        # Liquid cooled, no fans
             speed_percent: "N/A"
             target_speed_percent: "N/A"
 
           # ---------------------------------------------------------------------------
-          # Clock speeds (MHz)
+          # Clock speeds (MHz) - Blackwell Ultra pushes boost slightly higher
           # ---------------------------------------------------------------------------
           clocks:
-            graphics_current: 210           # Idle
-            graphics_max: 1410
-            graphics_app: 1410              # Application clock setting
-            graphics_app_default: 1410
-            sm_current: 210
-            sm_max: 1410
-            memory_current: 1215
-            memory_max: 1215
-            memory_app: 1215
-            memory_app_default: 1215
-            video_current: 585
-            video_max: 1290
+            graphics_current: 345           # Idle
+            graphics_max: 2200              # Boost
+            graphics_app: 2200
+            graphics_app_default: 2200
+            sm_current: 345
+            sm_max: 2200
+            memory_current: 2625            # HBM3e 8 Gbps (1.05x GB200's 2500)
+            memory_max: 2625
+            memory_app: 2625
+            memory_app_default: 2625
+            video_current: 1200
+            video_max: 2200
 
           # ---------------------------------------------------------------------------
-          # Clocks throttle reasons (bitmask reasons)
+          # Clocks throttle reasons
           # ---------------------------------------------------------------------------
           clocks_throttle_reasons:
-            gpu_idle: true                  # Clock is idle
+            gpu_idle: true
             applications_clocks_setting: false
             sw_power_cap: false
             hw_slowdown: false
@@ -626,17 +1154,17 @@ should match snapshot with default a100 profile:
             display_clocks_setting: false
 
           # ---------------------------------------------------------------------------
-          # Supported clocks (for nvidia-smi -q -d SUPPORTED_CLOCKS)
+          # Supported clocks
           # ---------------------------------------------------------------------------
           supported_clocks:
             memory_clocks:
-              - freq_mhz: 1215
-                graphics_clocks: [210, 420, 630, 840, 1050, 1215, 1275, 1335, 1410]
+              - freq_mhz: 2625
+                graphics_clocks: [345, 690, 1035, 1380, 1725, 1980, 2200]
 
           # ---------------------------------------------------------------------------
           # Performance state
           # ---------------------------------------------------------------------------
-          performance_state: "P0"           # P0 = max performance
+          performance_state: "P0"
 
           # ---------------------------------------------------------------------------
           # Utilization (percentage, 0-100)
@@ -647,7 +1175,7 @@ should match snapshot with default a100 profile:
             encoder: 0
             decoder: 0
             jpeg: 0
-            ofa: 0                          # Optical flow accelerator
+            ofa: 0
 
           # ---------------------------------------------------------------------------
           # Dynamic utilization (#506)
@@ -674,7 +1202,7 @@ should match snapshot with default a100 profile:
             average_fps: 0
             average_latency_us: 0
 
-          fbc_stats:                        # Frame buffer capture
+          fbc_stats:
             session_count: 0
             average_fps: 0
             average_latency_us: 0
@@ -686,7 +1214,6 @@ should match snapshot with default a100 profile:
             mode_current: "enabled"
             mode_pending: "enabled"
             default_mode: "enabled"
-            # Error counts (all zeros for clean GPU)
             errors:
               volatile:
                 single_bit:
@@ -747,7 +1274,7 @@ should match snapshot with default a100 profile:
             # does. The bank count follows the 16-banks-per-GiB ratio a real 40 GiB
             # A100 reports.
             availability_histogram:
-              max: 640
+              max: 4608
               high: 0
               partial: 0
               low: 0
@@ -757,40 +1284,39 @@ should match snapshot with default a100 profile:
           # Display configuration
           # ---------------------------------------------------------------------------
           display:
-            mode: "disabled"                # No display output on A100
+            mode: "disabled"
             active: "disabled"
 
           # ---------------------------------------------------------------------------
           # Persistence mode
           # ---------------------------------------------------------------------------
-          persistence_mode: "enabled"       # Typically enabled on servers
+          persistence_mode: "enabled"
 
           # ---------------------------------------------------------------------------
           # Compute mode
           # ---------------------------------------------------------------------------
-          compute_mode: "default"           # default, exclusive_thread, prohibited, exclusive_process
+          compute_mode: "default"
 
           # ---------------------------------------------------------------------------
-          # MIG configuration
+          # MIG configuration - GB300 supports MIG
           # ---------------------------------------------------------------------------
           mig:
             mode_current: "disabled"
             mode_pending: "disabled"
-            max_gpu_instances: 7            # A100 supports up to 7 MIG instances
-            # GPU instances would be defined here if MIG enabled
+            max_gpu_instances: 7
 
           # ---------------------------------------------------------------------------
           # GPU operation mode (GOM)
           # ---------------------------------------------------------------------------
           gpu_operation_mode:
-            current: "all_on"               # all_on, compute, low_dp
+            current: "all_on"
             pending: "all_on"
 
           # ---------------------------------------------------------------------------
           # Driver model (Windows only)
           # ---------------------------------------------------------------------------
           driver_model:
-            current: "N/A"                  # Linux: N/A, Windows: WDDM or TCC
+            current: "N/A"
             pending: "N/A"
 
           # ---------------------------------------------------------------------------
@@ -798,21 +1324,42 @@ should match snapshot with default a100 profile:
           # ---------------------------------------------------------------------------
           accounting:
             mode: "disabled"
-            buffer_size: 4000               # Max PIDs tracked
+            buffer_size: 4000
 
           # ---------------------------------------------------------------------------
           # Virtualization
           # ---------------------------------------------------------------------------
           virtualization:
-            mode: "none"                    # none, passthrough, vgpu
+            mode: "none"
             host_vgpu_mode: "N/A"
 
           # ---------------------------------------------------------------------------
           # GSP Firmware
           # ---------------------------------------------------------------------------
           gsp_firmware:
-            mode: "enabled"                 # GSP enabled on newer drivers
-            version: "550.54.15"
+            mode: "enabled"
+            version: "570.124.06"
+
+          # ---------------------------------------------------------------------------
+          # Blackwell Ultra-specific features
+          # ---------------------------------------------------------------------------
+          features:
+            transformer_engine: true        # 2nd gen Transformer Engine
+            fp4_support: true               # FP4 precision support
+            fp6_support: true               # FP6 precision (Blackwell Ultra)
+            fp8_support: true               # FP8 precision support
+            nvlink_c2c: true                # NVLink Chip-to-Chip (Grace connection)
+            decompression_engine: true      # Hardware decompression
+            fifth_gen_tensor_cores: true    # 5th generation tensor cores
+
+          # ---------------------------------------------------------------------------
+          # Grace CPU pairing (GB300 superchip)
+          # ---------------------------------------------------------------------------
+          grace_superchip:
+            enabled: true
+            cpu_cores: 72                   # Grace CPU cores (same Grace as GB200)
+            cpu_memory_gb: 480              # LPDDR5X per Grace CPU
+            coherent_memory: true           # NVLink-C2C coherent memory
 
           # ---------------------------------------------------------------------------
           # Processes (empty at idle)
@@ -820,137 +1367,160 @@ should match snapshot with default a100 profile:
           processes: []
 
         # =============================================================================
-        # Device-specific overrides (indexed 0-7 for DGX A100)
-        # Only specify fields that differ from device_defaults
+        # Device-specific overrides
+        # GB300 NVL72 has 72 GPUs, but we define 8 for testing (4 superchip trays,
+        # each with 1 Grace CPU + 2 B300 GPUs, matching the GB200 layout).
         # =============================================================================
         devices:
           - index: 0
-            uuid: "GPU-12345678-1234-1234-1234-123456780000"
-            serial: "1324821083800"
+            uuid: "GPU-b300b300-0000-0000-0000-000000000000"
+            serial: "1573041103700"
             pci:
-              bus_id: "0000:07:00.0"
+              bus_id: "0000:0A:00.0"
             minor_number: 0
+            grace_cpu_pair: 0               # Paired with Grace CPU 0
+            platform:
+              module_id: 1                  # ID of this GPU within the node
 
           - index: 1
-            uuid: "GPU-12345678-1234-1234-1234-123456780001"
-            serial: "1324821083801"
+            uuid: "GPU-b300b300-0000-0000-0000-000000000001"
+            serial: "1573041103701"
             pci:
-              bus_id: "0000:0F:00.0"
+              bus_id: "0000:0B:00.0"
             minor_number: 1
+            grace_cpu_pair: 0               # Same superchip as GPU 0
+            platform:
+              module_id: 2
 
           - index: 2
-            uuid: "GPU-12345678-1234-1234-1234-123456780002"
-            serial: "1324821083802"
+            uuid: "GPU-b300b300-0000-0000-0000-000000000002"
+            serial: "1573041103702"
             pci:
-              bus_id: "0000:47:00.0"
+              bus_id: "0000:4A:00.0"
             minor_number: 2
+            grace_cpu_pair: 1
+            platform:
+              module_id: 3
 
           - index: 3
-            uuid: "GPU-12345678-1234-1234-1234-123456780003"
-            serial: "1324821083803"
+            uuid: "GPU-b300b300-0000-0000-0000-000000000003"
+            serial: "1573041103703"
             pci:
-              bus_id: "0000:4E:00.0"
+              bus_id: "0000:4B:00.0"
             minor_number: 3
+            grace_cpu_pair: 1
+            platform:
+              module_id: 4
 
           - index: 4
-            uuid: "GPU-12345678-1234-1234-1234-123456780004"
-            serial: "1324821083804"
+            uuid: "GPU-b300b300-0000-0000-0000-000000000004"
+            serial: "1573041103704"
             pci:
-              bus_id: "0000:87:00.0"
+              bus_id: "0000:8A:00.0"
             minor_number: 4
+            grace_cpu_pair: 2
+            platform:
+              module_id: 5
 
           - index: 5
-            uuid: "GPU-12345678-1234-1234-1234-123456780005"
-            serial: "1324821083805"
+            uuid: "GPU-b300b300-0000-0000-0000-000000000005"
+            serial: "1573041103705"
             pci:
-              bus_id: "0000:90:00.0"
+              bus_id: "0000:8B:00.0"
             minor_number: 5
+            grace_cpu_pair: 2
+            platform:
+              module_id: 6
 
           - index: 6
-            uuid: "GPU-12345678-1234-1234-1234-123456780006"
-            serial: "1324821083806"
+            uuid: "GPU-b300b300-0000-0000-0000-000000000006"
+            serial: "1573041103706"
             pci:
-              bus_id: "0000:B7:00.0"
+              bus_id: "0000:CA:00.0"
             minor_number: 6
+            grace_cpu_pair: 3
+            platform:
+              module_id: 7
 
           - index: 7
-            uuid: "GPU-12345678-1234-1234-1234-123456780007"
-            serial: "1324821083807"
+            uuid: "GPU-b300b300-0000-0000-0000-000000000007"
+            serial: "1573041103707"
             pci:
-              bus_id: "0000:BD:00.0"
+              bus_id: "0000:CB:00.0"
             minor_number: 7
+            grace_cpu_pair: 3
+            platform:
+              module_id: 8
 
         # =============================================================================
-        # NVLink topology
+        # NVLink topology - GB300 uses NVLink 5.0 (same fabric as GB200)
         # =============================================================================
         nvlink:
-          version: 3
-          links_per_gpu: 12
-          bandwidth_per_link_mbps: 25781    # NVLink3 25.781 GB/s/link unidirectional (`nvlink -s`); 12 links ~= 309 GB/s/GPU (600 GB/s bidir)
-          c2c_enabled: false                # no Grace C2C on DGX A100
-          # DGX A100: 6x NVSwitch -> NV12 all-to-all. Switch-link auto-expansion
-          # (switches declared + links_per_gpu > 0, and no explicit per-device links)
-          # makes the engine synthesize 12 active links per GPU fanned round-robin
-          # across these NVSwitches, so `nvidia-smi topo -m` shows NV12 between every
-          # GPU pair. No fabricmanager coupling: A100 predates the GpuFabricInfo NVML
-          # API (Hopper+), so there is deliberately no device_defaults.fabric block and
-          # nvmlDeviceGetGpuFabricInfo returns NOT_SUPPORTED.
+          version: 5
+          links_per_gpu: 18
+          bandwidth_per_link_mbps: 53125    # NVLink5 53.125 GB/s/link unidirectional (`nvlink -s`); 18 links ~= 0.95 TB/s/GPU (1.8 TB/s bidir)
+          c2c_enabled: true                 # NVLink-C2C to Grace CPU
+          # Switch-link auto-expansion: because switches are declared and
+          # links_per_gpu > 0 (and no explicit per-device links exist), the engine
+          # synthesizes 18 active links per GPU fanned round-robin across these
+          # NVSwitches. Every switch-attached link reaches all peers through the
+          # shared fabric, so `nvidia-smi topo -m` shows NV18 between every GPU pair.
+          # Fabric-manager readiness is coupled via device_defaults.fabric.state: auto.
           switches:
             - bdf: "0000:01:00.0"
-              uuid: "NVSwitch-A100-0000-0000-0000-000000000000"
+              uuid: "NVSwitch-GB300-0000-0000-0000-000000000000"
             - bdf: "0000:02:00.0"
-              uuid: "NVSwitch-A100-0000-0000-0000-000000000001"
+              uuid: "NVSwitch-GB300-0000-0000-0000-000000000001"
             - bdf: "0000:03:00.0"
-              uuid: "NVSwitch-A100-0000-0000-0000-000000000002"
+              uuid: "NVSwitch-GB300-0000-0000-0000-000000000002"
             - bdf: "0000:04:00.0"
-              uuid: "NVSwitch-A100-0000-0000-0000-000000000003"
-            - bdf: "0000:05:00.0"
-              uuid: "NVSwitch-A100-0000-0000-0000-000000000004"
-            - bdf: "0000:06:00.0"
-              uuid: "NVSwitch-A100-0000-0000-0000-000000000005"
+              uuid: "NVSwitch-GB300-0000-0000-0000-000000000003"
 
         # =============================================================================
-        # InfiniBand topology - 1 ConnectX-6 HDR HCA per GPU (typical DGX A100)
+        # InfiniBand topology - 1 ConnectX-7 NDR HCA per GPU (typical GB300 NVL72)
         # =============================================================================
         infiniband:
           enabled: true
-          hca_type: "MT4123"                # ConnectX-6
-          fw_version: "20.36.1010"
+          hca_type: "MT4129"
+          fw_version: "28.43.1000"
           hw_rev: "0x0"
-          board_id: "MT_0000000223"
+          board_id: "MT_0000000838"
           link_layer: "InfiniBand"
-          rate_gbps: 200                    # HDR
+          rate_gbps: 400
           port_state: "ACTIVE"
           phys_state: "LinkUp"
           hcas_per_gpu: 1
-          guid_prefix: "a288c2:0300:ab"
+          guid_prefix: "9b88c2:0301:cd"
           node_desc_template: "{node_name} mlx5_{idx}"
 
         # =============================================================================
-        # PCIe topology - 2 NUMA nodes (dual EPYC), 4 GPUs each.
-        # Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
-        # under MOCK_PCI_ROOT. C consumers such as `lspci` resolve the PCIe root
-        # complex through these symlinks. The NVIDIA DRA driver does NOT: it is a
-        # Go binary, and Go's os package issues raw syscalls that the LD_PRELOAD
-        # shim cannot intercept, so `dra.k8s.io/pcieRoot` stays absent from the
-        # ResourceSlices it publishes. See issue #265.
+        # PCIe topology (consumed by render-pci-sysfs to materialize
+        # /sys/bus/pci/devices/<bdf> -> ../../../devices/pciDDDD:BB/<bdf> symlinks
+        # and per-device numa_node files). Mirrors the GB300 NVL superchip layout:
+        # one PCI root complex per Grace+2×B300 tray, NUMA-aligned per tray.
         # =============================================================================
         pcie_topology:
           root_complexes:
             - id: "pci0000:00"
               numa_node: 0
               devices:
-                - "0000:07:00.0"
-                - "0000:0F:00.0"
-                - "0000:47:00.0"
-                - "0000:4E:00.0"
-            - id: "pci0000:80"
+                - "0000:0A:00.0"
+                - "0000:0B:00.0"
+            - id: "pci0000:40"
               numa_node: 1
               devices:
-                - "0000:87:00.0"
-                - "0000:90:00.0"
-                - "0000:B7:00.0"
-                - "0000:BD:00.0"
+                - "0000:4A:00.0"
+                - "0000:4B:00.0"
+            - id: "pci0000:80"
+              numa_node: 2
+              devices:
+                - "0000:8A:00.0"
+                - "0000:8B:00.0"
+            - id: "pci0000:c0"
+              numa_node: 3
+              devices:
+                - "0000:CA:00.0"
+                - "0000:CB:00.0"
     kind: ConfigMap
     metadata:
       labels:
@@ -1498,576 +2068,6 @@ should match snapshot with gb200 profile:
         # Go binary, and Go's os package issues raw syscalls that the LD_PRELOAD
         # shim cannot intercept, so `dra.k8s.io/pcieRoot` stays absent from the
         # ResourceSlices it publishes. See issue #265.
-        # =============================================================================
-        pcie_topology:
-          root_complexes:
-            - id: "pci0000:00"
-              numa_node: 0
-              devices:
-                - "0000:0A:00.0"
-                - "0000:0B:00.0"
-            - id: "pci0000:40"
-              numa_node: 1
-              devices:
-                - "0000:4A:00.0"
-                - "0000:4B:00.0"
-            - id: "pci0000:80"
-              numa_node: 2
-              devices:
-                - "0000:8A:00.0"
-                - "0000:8B:00.0"
-            - id: "pci0000:c0"
-              numa_node: 3
-              devices:
-                - "0000:CA:00.0"
-                - "0000:CB:00.0"
-    kind: ConfigMap
-    metadata:
-      labels:
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: nvml-mock
-        app.kubernetes.io/version: 550.163.01
-        helm.sh/chart: nvml-mock-0.3.0
-      name: RELEASE-NAME-nvml-mock-config
-should match snapshot with gb300 profile:
-  1: |
-    apiVersion: v1
-    data:
-      config.yaml: |
-        # Mock NVML Configuration: GB300 NVL (Grace-Blackwell Ultra Superchip)
-        # Full configuration for nvidia-smi -x -q compatibility
-        # Use: export MOCK_NVML_CONFIG=/path/to/this/file.yaml
-
-        version: "1.0"
-
-        # =============================================================================
-        # System-level configuration
-        # =============================================================================
-        system:
-          driver_version: "570.124.06"
-          nvml_version: "12.570.124.06"
-          cuda_version: "12.8"
-          cuda_version_major: 12
-          cuda_version_minor: 8
-
-        # Helm-only dynamic-metrics defaults (engine ignores this key). Used when
-        # gpu.dynamicMetrics.enabled=true; base sits inside the power limits so it varies.
-        dynamic_metrics_defaults:
-          power:
-            base_mw: 800000                 # 800W, within [500W, 1600W]
-            variance_mw: 75000
-
-        # =============================================================================
-        # Default device configuration (applied to all devices unless overridden)
-        # =============================================================================
-        device_defaults:
-          # ---------------------------------------------------------------------------
-          # Basic identification
-          # ---------------------------------------------------------------------------
-          name: "NVIDIA GB300 NVL"
-          brand: "nvidia"
-          serial: "1573041103750"
-          board_part_number: "699-2G530-0300-000"
-          vbios_version: "97.00.41.00.01"
-
-          # ---------------------------------------------------------------------------
-          # Architecture - Blackwell Ultra (still sm_100 family for compute_capability,
-          # but with higher TFLOPS per SM than the standard Blackwell B200/GB200)
-          # ---------------------------------------------------------------------------
-          architecture: "blackwell"
-          compute_capability:
-            major: 10
-            minor: 0
-          num_gpu_cores: 21632             # Blackwell Ultra: more cores than B200/GB200
-
-          # ---------------------------------------------------------------------------
-          # NVLink fabric (GB300 ComputeDomain). The clique_id / cluster_uuid below
-          # are placeholder defaults; the topology-overlay step in the engine
-          # rewrites them per-node based on the cluster-level topology ConfigMap
-          # (set Helm value `topology.enabled=true`). Nodes that don't appear in
-          # the topology fall through to these defaults, which is sufficient for
-          # single-node experiments. See pkg/gpu/mocknvml/engine/fabric.go.
-          # ---------------------------------------------------------------------------
-          fabric:
-            cluster_uuid: "00000000-0000-0000-0000-000000000001"
-            clique_id: 0
-            state: "auto"                   # couple GPU fabric registration to fake fabricmanager readiness
-            # Health defaults to a healthy fabric (nvidia-smi -q reports Summary:
-            # Healthy, Bandwidth: Full). Add a `health:` block to fault a specific
-            # condition, or use `nvml-mock-ctl fabric-health` at runtime.
-            # See docs/configuration.md#fabric-health.
-
-          # ---------------------------------------------------------------------------
-          # Platform identity — where this node sits in the NVL72 rack, which
-          # nvidia-smi -q renders as its "Platform Info" block and rack-scale fault
-          # correlation reads to turn a GPU fault into a physical location.
-          #
-          # Every field but module_id describes the node, so all its GPUs share them:
-          # a node occupies one tray, in one slot, of one chassis. Only module_id
-          # ("ID of this GPU within the node") is set per device below.
-          #
-          # slot_number counts switch trays as well as compute trays while tray_index
-          # counts compute trays only, so slot runs ahead of tray for a tray sitting
-          # above the rack's nine switch trays: compute tray 16 lands in slot 26.
-          # ---------------------------------------------------------------------------
-          platform:
-            chassis_serial_number: "1822725100300"
-            slot_number: 26
-            tray_index: 16
-            host_id: 1                      # first of the tray's two OS domains
-            peer_type: "switch_connected"   # peers reached through the NVSwitch trays
-
-          # ---------------------------------------------------------------------------
-          # InfoROM versions
-          # ---------------------------------------------------------------------------
-          inforom:
-            image_version: "G530.0300.00.01"
-            oem_object: "2.1"
-            ecc_object: "7.20"
-            pwr_object: "1.0"
-
-          # ---------------------------------------------------------------------------
-          # Memory configuration - 288 GiB HBM3e per GPU (1.5x GB200's 192 GiB)
-          # ---------------------------------------------------------------------------
-          memory:
-            total_bytes: 309237645312       # 288 GiB HBM3e
-            reserved_bytes: 1610612736      # ~1.5 GiB reserved
-            free_bytes: 307627032576        # total - reserved at idle
-            used_bytes: 0
-            memory_bus_width: 8192
-
-          bar1_memory:
-            total_bytes: 824633720832       # 768 GiB (unified memory with Grace, grown for B300)
-            free_bytes: 824633720832
-            used_bytes: 0
-
-          # ---------------------------------------------------------------------------
-          # PCI configuration
-          # ---------------------------------------------------------------------------
-          pci:
-            device_id: 0x294110DE           # GB300 NVL (mock placeholder, Blackwell Ultra)
-            subsystem_id: 0x183010DE
-
-          pcie:
-            max_link_gen: 6                 # PCIe Gen6 (or NVLink-C2C to Grace)
-            current_link_gen: 6
-            max_link_width: 16              # x16
-            current_link_width: 16
-            replay_counter: 0
-            tx_throughput_kbps: 0
-            rx_throughput_kbps: 0
-
-          # ---------------------------------------------------------------------------
-          # Power configuration - GB300 is higher TDP than GB200
-          # (B300 GPU alone advertised at up to 1.4 kW; full superchip headroom higher)
-          # ---------------------------------------------------------------------------
-          power:
-            management_supported: true
-            management_mode: "enabled"
-            default_limit_mw: 1400000       # 1400W per B300 GPU
-            enforced_limit_mw: 1400000
-            min_limit_mw: 500000            # 500W minimum
-            max_limit_mw: 1600000           # 1600W boost ceiling
-            current_draw_mw: 175000         # 175W idle (liquid cooled)
-            power_state: "P0"
-            total_energy_consumption_mj: 1000000  # millijoules since boot
-
-          # ---------------------------------------------------------------------------
-          # Thermal configuration (same liquid-cooled envelope as GB200)
-          # ---------------------------------------------------------------------------
-          thermal:
-            temperature_gpu_c: 38           # Idle temperature (liquid cooled)
-            temperature_memory_c: 36
-            shutdown_threshold_c: 95
-            slowdown_threshold_c: 90
-            max_operating_c: 85
-            target_temperature_c: 85
-
-          # ---------------------------------------------------------------------------
-          # Fan configuration (N/A - liquid cooled)
-          # ---------------------------------------------------------------------------
-          fan:
-            count: 0                        # Liquid cooled, no fans
-            speed_percent: "N/A"
-            target_speed_percent: "N/A"
-
-          # ---------------------------------------------------------------------------
-          # Clock speeds (MHz) - Blackwell Ultra pushes boost slightly higher
-          # ---------------------------------------------------------------------------
-          clocks:
-            graphics_current: 345           # Idle
-            graphics_max: 2200              # Boost
-            graphics_app: 2200
-            graphics_app_default: 2200
-            sm_current: 345
-            sm_max: 2200
-            memory_current: 2625            # HBM3e 8 Gbps (1.05x GB200's 2500)
-            memory_max: 2625
-            memory_app: 2625
-            memory_app_default: 2625
-            video_current: 1200
-            video_max: 2200
-
-          # ---------------------------------------------------------------------------
-          # Clocks throttle reasons
-          # ---------------------------------------------------------------------------
-          clocks_throttle_reasons:
-            gpu_idle: true
-            applications_clocks_setting: false
-            sw_power_cap: false
-            hw_slowdown: false
-            hw_thermal_slowdown: false
-            hw_power_brake_slowdown: false
-            sync_boost: false
-            sw_thermal_slowdown: false
-            display_clocks_setting: false
-
-          # ---------------------------------------------------------------------------
-          # Supported clocks
-          # ---------------------------------------------------------------------------
-          supported_clocks:
-            memory_clocks:
-              - freq_mhz: 2625
-                graphics_clocks: [345, 690, 1035, 1380, 1725, 1980, 2200]
-
-          # ---------------------------------------------------------------------------
-          # Performance state
-          # ---------------------------------------------------------------------------
-          performance_state: "P0"
-
-          # ---------------------------------------------------------------------------
-          # Utilization (percentage, 0-100)
-          # ---------------------------------------------------------------------------
-          utilization:
-            gpu: 0
-            memory: 0
-            encoder: 0
-            decoder: 0
-            jpeg: 0
-            ofa: 0
-
-          # ---------------------------------------------------------------------------
-          # Dynamic utilization (#506)
-          #
-          # Live without any Helm overlay, so `utilization.gpu` -- and every
-          # DCGM_FI_PROF_* fraction derived from it -- is never a constant 0.
-          # The driver is elapsed time, NOT workload: these numbers move on a fully
-          # idle node and do not rise under load. gpu_min is deliberately > 0 so
-          # "utilization is reported" is a deterministic assertion, not a flaky one.
-          # ---------------------------------------------------------------------------
-          dynamic_metrics:
-            utilization:
-              pattern: "steady"
-              gpu_min: 10
-              gpu_max: 45
-              memory_min: 5
-              memory_max: 25
-
-          # ---------------------------------------------------------------------------
-          # Encoder/Decoder statistics
-          # ---------------------------------------------------------------------------
-          encoder_stats:
-            session_count: 0
-            average_fps: 0
-            average_latency_us: 0
-
-          fbc_stats:
-            session_count: 0
-            average_fps: 0
-            average_latency_us: 0
-
-          # ---------------------------------------------------------------------------
-          # ECC configuration
-          # ---------------------------------------------------------------------------
-          ecc:
-            mode_current: "enabled"
-            mode_pending: "enabled"
-            default_mode: "enabled"
-            errors:
-              volatile:
-                single_bit:
-                  device_memory: 0
-                  l1_cache: 0
-                  l2_cache: 0
-                  register_file: 0
-                  texture_memory: 0
-                  total: 0
-                double_bit:
-                  device_memory: 0
-                  l1_cache: 0
-                  l2_cache: 0
-                  register_file: 0
-                  texture_memory: 0
-                  total: 0
-              aggregate:
-                single_bit:
-                  device_memory: 0
-                  l1_cache: 0
-                  l2_cache: 0
-                  register_file: 0
-                  texture_memory: 0
-                  total: 0
-                double_bit:
-                  device_memory: 0
-                  l1_cache: 0
-                  l2_cache: 0
-                  register_file: 0
-                  texture_memory: 0
-                  total: 0
-
-          # ---------------------------------------------------------------------------
-          # Retired pages
-          # ---------------------------------------------------------------------------
-          retired_pages:
-            single_bit_retirement:
-              count: 0
-              addresses: []
-            double_bit_retirement:
-              count: 0
-              addresses: []
-            pending_blacklist: false
-            pending_retirement: false
-
-          # ---------------------------------------------------------------------------
-          # Remapped rows
-          # ---------------------------------------------------------------------------
-          remapped_rows:
-            correctable: 0
-            uncorrectable: 0
-            pending: false
-            failure_occurred: false
-            # Bank remap availability: every bank still holds its full complement of
-            # spare rows, which is what a GPU that has never remapped reports. Row
-            # remapping is Ampere and later, so a pre-Ampere profile (t4) omits this
-            # block and the mock reports the histogram unsupported, as that hardware
-            # does. The bank count follows the 16-banks-per-GiB ratio a real 40 GiB
-            # A100 reports.
-            availability_histogram:
-              max: 4608
-              high: 0
-              partial: 0
-              low: 0
-              none: 0
-
-          # ---------------------------------------------------------------------------
-          # Display configuration
-          # ---------------------------------------------------------------------------
-          display:
-            mode: "disabled"
-            active: "disabled"
-
-          # ---------------------------------------------------------------------------
-          # Persistence mode
-          # ---------------------------------------------------------------------------
-          persistence_mode: "enabled"
-
-          # ---------------------------------------------------------------------------
-          # Compute mode
-          # ---------------------------------------------------------------------------
-          compute_mode: "default"
-
-          # ---------------------------------------------------------------------------
-          # MIG configuration - GB300 supports MIG
-          # ---------------------------------------------------------------------------
-          mig:
-            mode_current: "disabled"
-            mode_pending: "disabled"
-            max_gpu_instances: 7
-
-          # ---------------------------------------------------------------------------
-          # GPU operation mode (GOM)
-          # ---------------------------------------------------------------------------
-          gpu_operation_mode:
-            current: "all_on"
-            pending: "all_on"
-
-          # ---------------------------------------------------------------------------
-          # Driver model (Windows only)
-          # ---------------------------------------------------------------------------
-          driver_model:
-            current: "N/A"
-            pending: "N/A"
-
-          # ---------------------------------------------------------------------------
-          # Accounting mode
-          # ---------------------------------------------------------------------------
-          accounting:
-            mode: "disabled"
-            buffer_size: 4000
-
-          # ---------------------------------------------------------------------------
-          # Virtualization
-          # ---------------------------------------------------------------------------
-          virtualization:
-            mode: "none"
-            host_vgpu_mode: "N/A"
-
-          # ---------------------------------------------------------------------------
-          # GSP Firmware
-          # ---------------------------------------------------------------------------
-          gsp_firmware:
-            mode: "enabled"
-            version: "570.124.06"
-
-          # ---------------------------------------------------------------------------
-          # Blackwell Ultra-specific features
-          # ---------------------------------------------------------------------------
-          features:
-            transformer_engine: true        # 2nd gen Transformer Engine
-            fp4_support: true               # FP4 precision support
-            fp6_support: true               # FP6 precision (Blackwell Ultra)
-            fp8_support: true               # FP8 precision support
-            nvlink_c2c: true                # NVLink Chip-to-Chip (Grace connection)
-            decompression_engine: true      # Hardware decompression
-            fifth_gen_tensor_cores: true    # 5th generation tensor cores
-
-          # ---------------------------------------------------------------------------
-          # Grace CPU pairing (GB300 superchip)
-          # ---------------------------------------------------------------------------
-          grace_superchip:
-            enabled: true
-            cpu_cores: 72                   # Grace CPU cores (same Grace as GB200)
-            cpu_memory_gb: 480              # LPDDR5X per Grace CPU
-            coherent_memory: true           # NVLink-C2C coherent memory
-
-          # ---------------------------------------------------------------------------
-          # Processes (empty at idle)
-          # ---------------------------------------------------------------------------
-          processes: []
-
-        # =============================================================================
-        # Device-specific overrides
-        # GB300 NVL72 has 72 GPUs, but we define 8 for testing (4 superchip trays,
-        # each with 1 Grace CPU + 2 B300 GPUs, matching the GB200 layout).
-        # =============================================================================
-        devices:
-          - index: 0
-            uuid: "GPU-b300b300-0000-0000-0000-000000000000"
-            serial: "1573041103700"
-            pci:
-              bus_id: "0000:0A:00.0"
-            minor_number: 0
-            grace_cpu_pair: 0               # Paired with Grace CPU 0
-            platform:
-              module_id: 1                  # ID of this GPU within the node
-
-          - index: 1
-            uuid: "GPU-b300b300-0000-0000-0000-000000000001"
-            serial: "1573041103701"
-            pci:
-              bus_id: "0000:0B:00.0"
-            minor_number: 1
-            grace_cpu_pair: 0               # Same superchip as GPU 0
-            platform:
-              module_id: 2
-
-          - index: 2
-            uuid: "GPU-b300b300-0000-0000-0000-000000000002"
-            serial: "1573041103702"
-            pci:
-              bus_id: "0000:4A:00.0"
-            minor_number: 2
-            grace_cpu_pair: 1
-            platform:
-              module_id: 3
-
-          - index: 3
-            uuid: "GPU-b300b300-0000-0000-0000-000000000003"
-            serial: "1573041103703"
-            pci:
-              bus_id: "0000:4B:00.0"
-            minor_number: 3
-            grace_cpu_pair: 1
-            platform:
-              module_id: 4
-
-          - index: 4
-            uuid: "GPU-b300b300-0000-0000-0000-000000000004"
-            serial: "1573041103704"
-            pci:
-              bus_id: "0000:8A:00.0"
-            minor_number: 4
-            grace_cpu_pair: 2
-            platform:
-              module_id: 5
-
-          - index: 5
-            uuid: "GPU-b300b300-0000-0000-0000-000000000005"
-            serial: "1573041103705"
-            pci:
-              bus_id: "0000:8B:00.0"
-            minor_number: 5
-            grace_cpu_pair: 2
-            platform:
-              module_id: 6
-
-          - index: 6
-            uuid: "GPU-b300b300-0000-0000-0000-000000000006"
-            serial: "1573041103706"
-            pci:
-              bus_id: "0000:CA:00.0"
-            minor_number: 6
-            grace_cpu_pair: 3
-            platform:
-              module_id: 7
-
-          - index: 7
-            uuid: "GPU-b300b300-0000-0000-0000-000000000007"
-            serial: "1573041103707"
-            pci:
-              bus_id: "0000:CB:00.0"
-            minor_number: 7
-            grace_cpu_pair: 3
-            platform:
-              module_id: 8
-
-        # =============================================================================
-        # NVLink topology - GB300 uses NVLink 5.0 (same fabric as GB200)
-        # =============================================================================
-        nvlink:
-          version: 5
-          links_per_gpu: 18
-          bandwidth_per_link_mbps: 53125    # NVLink5 53.125 GB/s/link unidirectional (`nvlink -s`); 18 links ~= 0.95 TB/s/GPU (1.8 TB/s bidir)
-          c2c_enabled: true                 # NVLink-C2C to Grace CPU
-          # Switch-link auto-expansion: because switches are declared and
-          # links_per_gpu > 0 (and no explicit per-device links exist), the engine
-          # synthesizes 18 active links per GPU fanned round-robin across these
-          # NVSwitches. Every switch-attached link reaches all peers through the
-          # shared fabric, so `nvidia-smi topo -m` shows NV18 between every GPU pair.
-          # Fabric-manager readiness is coupled via device_defaults.fabric.state: auto.
-          switches:
-            - bdf: "0000:01:00.0"
-              uuid: "NVSwitch-GB300-0000-0000-0000-000000000000"
-            - bdf: "0000:02:00.0"
-              uuid: "NVSwitch-GB300-0000-0000-0000-000000000001"
-            - bdf: "0000:03:00.0"
-              uuid: "NVSwitch-GB300-0000-0000-0000-000000000002"
-            - bdf: "0000:04:00.0"
-              uuid: "NVSwitch-GB300-0000-0000-0000-000000000003"
-
-        # =============================================================================
-        # InfiniBand topology - 1 ConnectX-7 NDR HCA per GPU (typical GB300 NVL72)
-        # =============================================================================
-        infiniband:
-          enabled: true
-          hca_type: "MT4129"
-          fw_version: "28.43.1000"
-          hw_rev: "0x0"
-          board_id: "MT_0000000838"
-          link_layer: "InfiniBand"
-          rate_gbps: 400
-          port_state: "ACTIVE"
-          phys_state: "LinkUp"
-          hcas_per_gpu: 1
-          guid_prefix: "9b88c2:0301:cd"
-          node_desc_template: "{node_name} mlx5_{idx}"
-
-        # =============================================================================
-        # PCIe topology (consumed by render-pci-sysfs to materialize
-        # /sys/bus/pci/devices/<bdf> -> ../../../devices/pciDDDD:BB/<bdf> symlinks
-        # and per-device numa_node files). Mirrors the GB300 NVL superchip layout:
-        # one PCI root complex per Grace+2×B300 tray, NUMA-aligned per tray.
         # =============================================================================
         pcie_topology:
           root_complexes:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -292,7 +292,7 @@ should match snapshot with default values:
       template:
         metadata:
           annotations:
-            checksum/config: a66f0f0e6622369198c9e8ba677b92c714c8e25783dba2e5ae6cf7028fecb927
+            checksum/config: b521d8084a13dcabcdfdfb3d91eeb60da163e980aab6db65779b7c7d9723cde9
           labels:
             app.kubernetes.io/component: daemon
             app.kubernetes.io/instance: RELEASE-NAME
@@ -305,7 +305,7 @@ should match snapshot with default values:
                 - name: GPU_COUNT
                   value: "8"
                 - name: DRIVER_VERSION
-                  value: 550.163.01
+                  value: 570.124.06
                 - name: NODE_NAME
                   valueFrom:
                     fieldRef:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/notes_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/notes_test.yaml.snap
@@ -73,10 +73,10 @@ should match snapshot with default values:
     |
       Mock GPU environment deployed on all nodes!
 
-        Profile: a100
+        Profile: gb300
         GPUs per node: 8
         Available profiles: a100, h100, b200, gb200, gb300, l40s, t4
-        Driver version: 550.163.01
+        Driver version: 570.124.06
         Mock driver root: /var/lib/nvml-mock/driver
         Mock config: /var/lib/nvml-mock/config/config.yaml
 

--- a/deployments/nvml-mock/helm/nvml-mock/tests/configmap_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/configmap_test.yaml
@@ -8,7 +8,15 @@ templates:
   - templates/configmap.yaml
 tests:
   # ── Snapshots ───────────────────────────────────────────────────────
-  - it: should match snapshot with default a100 profile
+  - it: should match snapshot with default gb300 profile
+    asserts:
+      - matchSnapshot: {}
+
+  - it: should match snapshot with a100 profile
+    set:
+      gpu:
+        profile: a100
+        count: 8
     asserts:
       - matchSnapshot: {}
 
@@ -32,14 +40,6 @@ tests:
     set:
       gpu:
         profile: gb200
-        count: 8
-    asserts:
-      - matchSnapshot: {}
-
-  - it: should match snapshot with gb300 profile
-    set:
-      gpu:
-        profile: gb300
         count: 8
     asserts:
       - matchSnapshot: {}
@@ -89,7 +89,11 @@ tests:
       - exists:
           path: data["config.yaml"]
 
-  - it: should load a100 profile by default
+  - it: should load a100 profile
+    set:
+      gpu:
+        profile: a100
+        count: 8
     asserts:
       - matchRegex:
           path: data["config.yaml"]
@@ -137,11 +141,7 @@ tests:
           path: data["config.yaml"]
           pattern: "architecture: .blackwell."
 
-  - it: should load gb300 profile
-    set:
-      gpu:
-        profile: gb300
-        count: 8
+  - it: should load gb300 profile by default
     asserts:
       - matchRegex:
           path: data["config.yaml"]
@@ -233,6 +233,9 @@ tests:
   # from it — are never a constant 0 without opting into the chart overlay.
   # The overlay's temperature/power simulation stays opt-in and must NOT appear.
   - it: should keep the profile's own utilization block when the overlay is disabled (default)
+    set:
+      gpu:
+        profile: a100
     asserts:
       - matchRegex:
           path: data["config.yaml"]
@@ -264,9 +267,10 @@ tests:
       - matchRegex:
           path: data["config.yaml"]
           pattern: "pattern: burst"
+      # Default profile is gb300, whose power base wins over the chart baseline.
       - matchRegex:
           path: data["config.yaml"]
-          pattern: "base_mw: 250000"
+          pattern: "base_mw: 800000"
       - matchRegex:
           path: data["config.yaml"]
           pattern: "base_c: 55"

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -134,6 +134,10 @@ tests:
             value: "8"
 
   - it: should set default DRIVER_VERSION for non-Blackwell profile
+    set:
+      gpu:
+        profile: a100
+        count: 8
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env

--- a/deployments/nvml-mock/helm/nvml-mock/tests/notes_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/notes_test.yaml
@@ -21,11 +21,11 @@ tests:
   - it: should render NOTES with default profile and count
     asserts:
       - matchRegexRaw:
-          pattern: "Profile: a100"
+          pattern: "Profile: gb300"
       - matchRegexRaw:
           pattern: "GPUs per node: 8"
       - matchRegexRaw:
-          pattern: "Driver version: 550.163.01"
+          pattern: "Driver version: 570.124.06"
 
   - it: should render NOTES with h100 profile
     set:

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 gpu:
-  profile: a100           # any *.yaml basename under profiles/ (e.g. a100, h100, b200, gb200, gb300, l40s, t4)
+  profile: gb300          # any *.yaml basename under profiles/ (e.g. a100, h100, b200, gb200, gb300, l40s, t4)
   # Number of GPUs to expose. Empty (default) derives the count from the
   # selected profile's `devices:` list (t4 -> 4, all NVSwitch baseboards/NVL
   # slices -> 8), so the profile is the single source of truth. Set to a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-The main idea of Mokka is to simulate very low-level system contracts, 
+The main idea of Mokka is to simulate very low-level system contracts,
 so that higher layer components work meaningfully without any modifications.
 
 This is achieved via simulation of device status, PCI trees, driver footprints for GPU and networking.
@@ -201,11 +201,11 @@ func (ht *HandleTable) Register(dev nvml.Device) uintptr {
     // Allocate C memory block
     cHandle := C.allocHandle(C.uint(deviceIndex))
     handle := uintptr(unsafe.Pointer(cHandle))
-    
+
     // Store bidirectional mapping
     ht.devices[handle] = dev
     ht.reverse[dev] = handle
-    
+
     return handle
 }
 ```
@@ -234,7 +234,7 @@ YAMLConfig:
 func (c *Config) GetDeviceConfig(index int) *DeviceConfig {
     // Start with defaults
     merged := c.YAMLConfig.DeviceDefaults
-    
+
     // Apply per-device overrides
     for _, override := range c.YAMLConfig.Devices {
         if override.Index == index {
@@ -242,7 +242,7 @@ func (c *Config) GetDeviceConfig(index int) *DeviceConfig {
             break
         }
     }
-    
+
     return &merged
 }
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,7 +79,7 @@ device_defaults:
 
 ```yaml
 device_defaults:
-  architecture: "ampere"              # kepler, maxwell, pascal, volta, 
+  architecture: "ampere"              # kepler, maxwell, pascal, volta,
                                       # turing, ampere, ada, hopper
   compute_capability:
     major: 8
@@ -96,7 +96,7 @@ device_defaults:
     reserved_bytes: 0
     free_bytes: 42949672960
     used_bytes: 0
-  
+
   bar1_memory:
     total_bytes: 68719476736          # 64 GiB
     free_bytes: 68719476736
@@ -111,7 +111,7 @@ device_defaults:
     device_id: 0x20B010DE             # A100 device ID
     subsystem_id: 0x134710DE
     bus_id: "0000:07:00.0"        # Usually per-device
-  
+
   pcie:
     max_link_gen: 4
     current_link_gen: 4
@@ -232,7 +232,7 @@ device_defaults:
     memory_app_default: 1215
     video_current: 585
     video_max: 1290
-  
+
   clocks_throttle_reasons:
     gpu_idle: true
     applications_clocks_setting: false
@@ -290,7 +290,7 @@ nvml-mock-ctl set --gpu 3 clocks_throttle_reasons.counters.hw_thermal_slowdown_u
 ```yaml
 device_defaults:
   performance_state: "P0"             # P0-P15
-  
+
   utilization:
     gpu: 0                            # 0-100%
     memory: 0
@@ -405,7 +405,7 @@ device_defaults:
 ```yaml
 device_defaults:
   persistence_mode: "enabled"
-  compute_mode: "default"             # default, exclusive_thread, 
+  compute_mode: "default"             # default, exclusive_thread,
                                       # prohibited, exclusive_process
 ```
 
@@ -447,7 +447,7 @@ device_defaults:
     session_count: 0
     average_fps: 0
     average_latency_us: 0
-  
+
   fbc_stats:
     session_count: 0
     average_fps: 0
@@ -497,7 +497,7 @@ devices:
     # Override thermal for this device only
     thermal:
       temperature_gpu_c: 35
-  
+
   - index: 1
     uuid: "GPU-12345678-1234-1234-1234-123456780001"
     minor_number: 1
@@ -637,11 +637,11 @@ Standalone configuration files are provided for each supported GPU model:
 
 | File | GPU Model | Memory | Architecture |
 |------|-----------|--------|--------------|
-| `pkg/gpu/mocknvml/configs/mock-nvml-config-a100.yaml` | NVIDIA A100-SXM4-40GB | 40 GiB | Ampere |
-| `pkg/gpu/mocknvml/configs/mock-nvml-config-h100.yaml` | NVIDIA H100 80GB HBM3 | 80 GiB | Hopper |
-| `pkg/gpu/mocknvml/configs/mock-nvml-config-b200.yaml` | NVIDIA B200 | 192 GiB | Blackwell |
-| `pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml` | NVIDIA GB200 NVL | 192 GiB | Blackwell |
 | `pkg/gpu/mocknvml/configs/mock-nvml-config-gb300.yaml` | NVIDIA GB300 NVL | 288 GiB | Blackwell Ultra |
+| `pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml` | NVIDIA GB200 NVL | 192 GiB | Blackwell |
+| `pkg/gpu/mocknvml/configs/mock-nvml-config-b200.yaml` | NVIDIA B200 | 192 GiB | Blackwell |
+| `pkg/gpu/mocknvml/configs/mock-nvml-config-h100.yaml` | NVIDIA H100 80GB HBM3 | 80 GiB | Hopper |
+| `pkg/gpu/mocknvml/configs/mock-nvml-config-a100.yaml` | NVIDIA A100-SXM4-40GB | 40 GiB | Ampere |
 | `pkg/gpu/mocknvml/configs/mock-nvml-config-l40s.yaml` | NVIDIA L40S | 48 GiB | Ada Lovelace |
 | `pkg/gpu/mocknvml/configs/mock-nvml-config-t4.yaml` | NVIDIA T4 | 16 GiB | Turing |
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -149,7 +149,7 @@ func (d *ConfigurableDevice) GetNewFunction() (ReturnType, nvml.Return) {
         debugLog("[NVML] nvmlDeviceGetNewFunction -> %v\n", value)
         return value, nvml.SUCCESS
     }
-    
+
     // No config = not supported
     debugLog("[NVML] nvmlDeviceGetNewFunction -> NOT_SUPPORTED\n")
     return ReturnType{}, nvml.ERROR_NOT_SUPPORTED
@@ -321,7 +321,7 @@ func TestNewFunction(t *testing.T) {
             wantErr:  nvml.ERROR_NOT_SUPPORTED,
         },
     }
-    
+
     for _, tt := range tests {
         t.Run(tt.name, func(t *testing.T) {
             dev := &ConfigurableDevice{config: tt.config}

--- a/docs/helm-chart.md
+++ b/docs/helm-chart.md
@@ -924,7 +924,7 @@ namespace, on the pod IP where the kubelet reaches it.
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `gpu.profile` | `a100` | GPU profile: `a100`, `h100`, `b200`, `gb200`, `gb300`, `l40s`, or `t4` |
+| `gpu.profile` | `gb300` | GPU profile: `a100`, `h100`, `b200`, `gb200`, `gb300`, `l40s`, or `t4` |
 | `gpu.count` | `8` | Number of mock GPUs per node |
 | `gpu.customConfig` | `""` | Inline YAML to override profile config entirely |
 | `gpu.dynamicMetrics.enabled` | `false` | Make the mock return time-varying temperature / power / utilization readings instead of the static profile values. See [Dynamic Metrics](#dynamic-metrics) below. |
@@ -1068,11 +1068,11 @@ helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
 
 #### When to Use Each Profile
 
-- **`a100`** (default) — broadest compatibility. Most NVIDIA software assumes A100 in docs and examples. Use this unless you need a specific architecture.
+- **`a100`** — broadest compatibility. Most NVIDIA software assumes A100 in docs and examples. Use it when a test targets Ampere or trips over newer architectures.
 - **`h100`** — testing Hopper-specific features: FP8, Transformer Engine, PCIe Gen5, or NVLink v4 topology.
 - **`b200`** — testing next-gen Blackwell features: FP4, NVLink v5, PCIe Gen6. Standalone GPU (no Grace CPU).
 - **`gb200`** — testing Grace-Blackwell Superchip: NVLink-C2C to Grace CPU, unified memory, and Blackwell features.
-- **`gb300`** — testing Grace-Blackwell Ultra Superchip: 288 GiB HBM3e per GPU, 1.4 kW TDP, FP6 in addition to FP4/FP8, and Blackwell Ultra driver line (570.124.06).
+- **`gb300`** (default) — testing Grace-Blackwell Ultra Superchip: 288 GiB HBM3e per GPU, 1.4 kW TDP, FP6 in addition to FP4/FP8, and Blackwell Ultra driver line (570.124.06).
 - **`l40s`** — testing Ada Lovelace inference workloads: FP8, PCIe Gen4, no NVLink (PCIe-only topology).
 - **`t4`** — testing Turing inference GPUs: low power (70W), small memory (16 GiB), 4 GPUs per node.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,18 +43,8 @@ though real hardware were present. No physical NVIDIA GPU is required.
 ## Try it
 
 ```bash
-# 1. Create a cluster
 kind create cluster --name mokka
 
-# 2. Load the published image. It is multi-arch, and `kind load docker-image`
-# cannot load a multi-arch image from Docker Desktop's containerd store, so
-# save a single platform first.
-ARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')
-docker pull ghcr.io/nvidia/nvml-mock:latest
-docker save --platform "linux/${ARCH}" ghcr.io/nvidia/nvml-mock:latest -o nvml-mock.tar
-kind load image-archive nvml-mock.tar --name mokka
-
-# 3. Install
 helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,11 +71,11 @@ multi-node heterogeneous fleet.
 
 | Profile | GPU Name | VRAM | Architecture |
 |---------|----------|------|--------------|
-| `a100` | A100-SXM4-40GB | 40 GiB | Ampere |
-| `h100` | H100 80GB HBM3 | 80 GiB | Hopper |
-| `b200` | B200 | 192 GiB | Blackwell |
-| `gb200` | GB200 | 192 GiB | Blackwell |
 | `gb300` | GB300 NVL | 288 GiB | Blackwell Ultra |
+| `gb200` | GB200 | 192 GiB | Blackwell |
+| `b200` | B200 | 192 GiB | Blackwell |
+| `h100` | H100 80GB HBM3 | 80 GiB | Hopper |
+| `a100` | A100-SXM4-40GB | 40 GiB | Ampere |
 | `l40s` | L40S | 48 GiB | Ada Lovelace |
 | `t4` | Tesla T4 | 16 GiB | Turing |
 


### PR DESCRIPTION
## What This PR Does

Flips the nvml-mock chart default `gpu.profile` from `a100` to `gb300`, so a bare `helm install` simulates a Grace-Blackwell Ultra fleet. `--set gpu.profile=a100` restores the previous behaviour.

Three chart tests silently relied on `a100` being the default and now pin the profile explicitly: the non-Blackwell `DRIVER_VERSION` check in the DaemonSet suite, and the two ConfigMap dynamic-metrics cases whose expectations only hold for a profile that has no power base of its own. The snapshot suites swap roles — `gb300` covers the default case, `a100` gets its own explicit case — so per-profile coverage is unchanged.

The quick start also loses the kind image preload, in the root README, in `docs/index.md` and in the packaged chart README, which each presented it as mandatory. The multi-arch `kind load docker-image` failure those blocks cite is a limitation of preloading, not a prerequisite for installing: the published image is an OCI index with `linux/amd64` and `linux/arm64` manifests, so a node's containerd resolves its own platform when it pulls directly. `docs/troubleshooting.md` keeps the `docker save --platform` workaround for anyone who does preload.

Finally, the quick start installs release `nvml-mock` into the default namespace instead of `mokka` into a `mokka` namespace. Release name feeds the chart's fullname template, so `mokka` renders `mokka-nvml-mock` and the `daemonset/nvml-mock` commands in the consumer guides this page links to would not have resolved.

## Why

Ampere is the architecture least likely to expose a gap in software being tested against a mock fleet. GB300 exercises what consumers are actually being ported to: NVLink-C2C to Grace, FP4/FP6, NVLink v5, PCIe Gen6, and the 570 driver line. The default should be the hardware people are porting to, not the one their code already handles.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`go test -v -race ./...`) — plus `make helm-tests`: 170 passed, 15 snapshots, and `make docs-build` (strict)
- [x] Linter passes (`make lint-fix`) — `golangci-lint` clean; `govulncheck` flags pre-existing stdlib CVEs fixed in go1.26.6, unrelated to this change (no Go files touched)
- [x] New code has SPDX license headers — n/a, no new files
- [x] Documentation updated (if applicable) — root README, `docs/index.md`, `docs/helm-chart.md` values table and profile guidance, and the packaged chart README
- [x] CHANGELOG.md updated (if user-facing change)
