### PR TITLE
docs: publish enhancement proposals on the documentation site

### DIFF
--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -51,12 +51,14 @@ jobs:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      # uv both installs the pinned toolchain and provisions the interpreter,
+      # so no separate Python setup step is needed. `make docs-deps` pins the
+      # version via DOCS_PYTHON_VERSION.
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: "3.12"
-          cache: pip
-          cache-dependency-path: requirements-docs.txt
+          enable-cache: true
+          cache-dependency-glob: requirements-docs.txt
 
       - name: Install documentation dependencies
         run: make docs-deps

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -14,18 +14,25 @@
 
 name: Deploy documentation to Pages
 
+# The MEPs are published from enhancements/, which `make docs` stages into the
+# docs tree. Without it in the filters a MEP-only change would build nothing and
+# never reach the site.
 on:
   push:
     branches:
       - main
     paths:
       - "docs/**"
+      - "enhancements/**"
+      - "hack/sync-enhancement-docs.sh"
       - "mkdocs.yml"
       - "requirements-docs.txt"
       - ".github/workflows/deploy-pages.yaml"
   pull_request:
     paths:
       - "docs/**"
+      - "enhancements/**"
+      - "hack/sync-enhancement-docs.sh"
       - "mkdocs.yml"
       - "requirements-docs.txt"
       - ".github/workflows/deploy-pages.yaml"

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -14,9 +14,8 @@
 
 name: Deploy documentation to Pages
 
-# The MEPs are published from enhancements/, which `make docs` stages into the
-# docs tree. Without it in the filters a MEP-only change would build nothing and
-# never reach the site.
+# make docs stages enhancements/ into the docs tree, so MEP-only edits need a
+# rebuild too.
 on:
   push:
     branches:

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -26,6 +26,7 @@ on:
       - "hack/sync-enhancement-docs.sh"
       - "mkdocs.yml"
       - "requirements-docs.txt"
+      - "Makefile"
       - ".github/workflows/deploy-pages.yaml"
   pull_request:
     paths:
@@ -34,6 +35,7 @@ on:
       - "hack/sync-enhancement-docs.sh"
       - "mkdocs.yml"
       - "requirements-docs.txt"
+      - "Makefile"
       - ".github/workflows/deploy-pages.yaml"
   workflow_dispatch:
 

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ tmp
 
 # MkDocs build output
 site/
+
+# MkDocs toolchain venv created by `make docs-deps`
+.venv-docs/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ site/
 
 # MkDocs toolchain venv created by `make docs-deps`
 .venv-docs/
+
+# Build-time copy of enhancements/ made by hack/sync-enhancement-docs.sh so the
+# MEPs can be published (MkDocs builds only what is under docs_dir). Generated,
+# never committed: edit the originals in enhancements/.
+docs/enhancements/

--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ DOCS_PYTHON_VERSION ?= 3.12
 # works for someone who has mkdocs on PATH by other means.
 DOCS_PATH := PATH="$(DOCS_VENV)/bin:$$PATH"
 
-.PHONY: docs-deps docs-build docs-serve docs-check-exclusion docs
+.PHONY: docs-deps docs-build docs-serve docs-check-exclusion docs-sync-enhancements docs
 
 # Missing uv is a hard failure, not a pip fallback. A fallback would let CI and
 # a developer resolve different interpreters while both report success, which is
@@ -377,17 +377,24 @@ docs-deps: ## Install the pinned MkDocs toolchain into .venv-docs using uv
 	$(UV) pip install --python $(DOCS_VENV) -r requirements-docs.txt
 	@echo "MkDocs installed into $(DOCS_VENV); make docs picks it up with no activation."
 
-docs-build: ## Build the documentation site (strict: broken links fail)
+# MkDocs publishes only what lives under docs_dir, and MEPs live in
+# enhancements/ where the MEP workflow puts them. Every target that runs mkdocs
+# depends on this, so the site never builds against a stale or missing copy.
+# make runs it once per invocation even though three targets ask for it.
+docs-sync-enhancements: ## Stage enhancements/ into the docs tree (gitignored copy)
+	$(CURDIR)/hack/sync-enhancement-docs.sh
+
+docs-build: docs-sync-enhancements ## Build the documentation site (strict: broken links fail)
 	$(DOCS_PATH) $(MKDOCS) build --strict
 
-docs-serve: ## Serve the documentation site locally on :8000
+docs-serve: docs-sync-enhancements ## Serve the documentation site locally on :8000
 	$(DOCS_PATH) $(MKDOCS) serve
 
 # docs/plans/ and docs/superpowers/ are gitignored scratch directories, so they
 # are absent in CI and grepping the built site for them would pass no matter
 # what. Plant a file and prove exclude_docs drops it, so this fails if that
 # config is removed.
-docs-check-exclusion: ## Verify gitignored internal plans cannot reach the site
+docs-check-exclusion: docs-sync-enhancements ## Verify gitignored internal plans cannot reach the site
 	@set -eu; \
 	export PATH="$(DOCS_VENV)/bin:$$PATH"; \
 	mkdir -p docs/plans; \

--- a/Makefile
+++ b/Makefile
@@ -340,19 +340,48 @@ e2e-nfd: ## e2e — NFD label-provenance scenario (pinned to a100)
 
 # The docs site is MkDocs Material. CI calls these same targets so a failure
 # reproduces locally with one command.
-PYTHON ?= python3
 MKDOCS ?= mkdocs
+
+# uv manages the toolchain, installed from the pinned requirements-docs.txt.
+# It goes into a project-local virtualenv rather than the system interpreter:
+# `uv pip install` refuses a non-virtual environment outright, and --system
+# resolves whichever interpreter uv happens to find first (an Xcode python3.9
+# on macOS) or trips Debian's externally-managed marker on the CI runner.
+# Naming the venv sidesteps both.
+UV                  ?= uv
+DOCS_VENV           ?= $(CURDIR)/.venv-docs
+DOCS_PYTHON_VERSION ?= 3.12
+
+# Put the venv ahead of PATH for the build targets instead of asking anyone to
+# activate it. The entry is inert when the venv is absent, so `make docs` still
+# works for someone who has mkdocs on PATH by other means.
+DOCS_PATH := PATH="$(DOCS_VENV)/bin:$$PATH"
 
 .PHONY: docs-deps docs-build docs-serve docs-check-exclusion docs
 
-docs-deps: ## Install the pinned MkDocs toolchain
-	$(PYTHON) -m pip install -r requirements-docs.txt
+# Missing uv is a hard failure, not a pip fallback. A fallback would let CI and
+# a developer resolve different interpreters while both report success, which is
+# the divergence the pinned manifest exists to prevent.
+# --clear because `uv venv` refuses to write over an existing environment, so
+# without it this target succeeds once and then fails on every re-run, which
+# is also how it would behave for anyone who already had a .venv-docs.
+docs-deps: ## Install the pinned MkDocs toolchain into .venv-docs using uv
+	@command -v $(UV) >/dev/null 2>&1 || { \
+		echo "ERROR: uv not found on PATH. The docs toolchain is managed with uv."; \
+		echo "  Install it with:  brew install uv"; \
+		echo "               or:  curl -LsSf https://astral.sh/uv/install.sh | sh"; \
+		echo "  Docs: https://docs.astral.sh/uv/getting-started/installation/"; \
+		exit 1; \
+	}
+	$(UV) venv --clear --python $(DOCS_PYTHON_VERSION) $(DOCS_VENV)
+	$(UV) pip install --python $(DOCS_VENV) -r requirements-docs.txt
+	@echo "MkDocs installed into $(DOCS_VENV); make docs picks it up with no activation."
 
 docs-build: ## Build the documentation site (strict: broken links fail)
-	$(MKDOCS) build --strict
+	$(DOCS_PATH) $(MKDOCS) build --strict
 
 docs-serve: ## Serve the documentation site locally on :8000
-	$(MKDOCS) serve
+	$(DOCS_PATH) $(MKDOCS) serve
 
 # docs/plans/ and docs/superpowers/ are gitignored scratch directories, so they
 # are absent in CI and grepping the built site for them would pass no matter
@@ -360,6 +389,7 @@ docs-serve: ## Serve the documentation site locally on :8000
 # config is removed.
 docs-check-exclusion: ## Verify gitignored internal plans cannot reach the site
 	@set -eu; \
+	export PATH="$(DOCS_VENV)/bin:$$PATH"; \
 	mkdir -p docs/plans; \
 	printf '# Internal\n\nPAGES_EXCLUSION_CANARY\n' > docs/plans/_canary.md; \
 	trap 'rm -rf docs/plans/_canary.md "$(CURDIR)/tmp/canary-site"; rmdir docs/plans 2>/dev/null || true' EXIT; \

--- a/docs/helm-chart.md
+++ b/docs/helm-chart.md
@@ -872,7 +872,7 @@ containerd reject container creation outright.
 
 Neither mode changes *whether* a container is served. A container the NVIDIA
 device plugin already served keeps exactly its allocation in both modes, per
-[MEP-0002](https://github.com/NVIDIA/k8s-test-infra/blob/main/enhancements/meps/0002-device-plugin-nri-composition/README.md).
+[MEP-0002](enhancements/meps/0002-device-plugin-nri-composition/README.md).
 
 ## NRI plugin failure modes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,21 @@ though real hardware were present. No physical NVIDIA GPU is required.
 
 ## Try it
 
+There are two ways in, and they are not interchangeable. Pick by what you have
+on disk.
+
+| | Path 1 | Path 2 |
+|---|---|---|
+| You need | `kind`, `helm`, `docker` | a repo clone, plus `tilt` |
+| Cluster | `kind create cluster` | `make cluster-create` |
+| Covers | the mock driver, `nvidia-smi`, the device plugin | everything, including the GPU Operator, DRA, NRI and multi-node |
+| Gated by CI | no | yes |
+
+### Path 1: you have kind and Helm
+
+Nothing is cloned. Both the image and the chart come from `ghcr.io`, so you
+need network access to it plus `docker`, `kind`, `helm` and `kubectl`.
+
 ```bash
 kind create cluster --name mokka
 
@@ -49,12 +64,94 @@ helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
     --namespace mokka --create-namespace
 ```
 
-Use `make cluster-create` instead of `kind create cluster` when you need the
-CDI-enabled Kind node image — that is what the device plugin, DRA driver and
-GPU Operator paths run on. `make cluster-delete` tears it down.
+The chart tolerates every taint, so it schedules on the single control-plane
+node that a bare `kind create cluster` gives you. Check the result:
 
-The [Helm chart guide](helm-chart.md) has the full walkthrough for each
-consumer, including the device plugin, the DRA driver, the GPU Operator and a
+```bash
+kubectl rollout status daemonset/nvml-mock --timeout=60s
+kubectl exec daemonset/nvml-mock -- nvidia-smi -L
+```
+
+```
+GPU 0: NVIDIA A100-SXM4-40GB (UUID: GPU-12345678-1234-1234-1234-123456780000)
+GPU 1: NVIDIA A100-SXM4-40GB (UUID: GPU-12345678-1234-1234-1234-123456780001)
+...
+```
+
+**What Path 1 gives you**
+
+- The mock driver root staged on the node under `/var/lib/nvml-mock/driver`:
+  `libnvidia-ml.so`, `libcuda.so`, a patched `nvidia-smi`, `/dev/nvidia*`
+  device nodes, the PCI sysfs tree and the InfiniBand mock.
+- The node label `nvidia.com/gpu.present=true`.
+- Anything you can observe from inside the nvml-mock pod: `nvidia-smi`,
+  `nvidia-smi -q`, `nvidia-smi topo -m`, `ibv_devinfo`, and
+  [runtime fault injection](nvml-mock-ctl.md).
+- The NVIDIA device plugin, if you also apply
+  [`tests/e2e/device-plugin-mock.yaml`](https://github.com/NVIDIA/k8s-test-infra/blob/main/tests/e2e/device-plugin-mock.yaml),
+  the one file you need from the repository. It reads the mock library through
+  a hostPath and passes device specs to kubelet itself, so it needs nothing
+  from the container runtime. `nvidia.com/gpu` then becomes allocatable and
+  pods that request it schedule. Walkthrough:
+  [Device Plugin on KIND](helm-chart.md#quick-start-device-plugin-on-kind).
+
+**What Path 1 does not give you**
+
+- **The GPU Operator.** It needs `nvidia-container-toolkit` on the node and an
+  `nvidia` containerd runtime handler, neither of which a stock kind node has.
+- **The DRA driver.** It needs the `DynamicResourceAllocation` feature gate and
+  `resource.k8s.io/v1beta1` in the API server runtime config, so it publishes
+  no ResourceSlices here.
+- **NRI device injection.** It needs the containerd NRI socket.
+- **Anything multi-node**: a heterogeneous fleet, fake-gpu-operator node pools,
+  or NVLink clique topology. A bare `kind create cluster` is one node.
+- **Automatic library injection into your own pods.** A pod that requests
+  `nvidia.com/gpu` gets its `/dev/nvidiaN` device node and nothing else, with
+  no `nvidia-smi` and no `libnvidia-ml.so` on its filesystem. Mount the driver
+  root and set `LD_LIBRARY_PATH` yourself, the way
+  [`local/gpu-validator.k8s.yaml`](https://github.com/NVIDIA/k8s-test-infra/blob/main/local/gpu-validator.k8s.yaml)
+  does. This is a boundary of the path, not a bug.
+
+### Path 2: you cloned the repository
+
+Every scenario Path 1 cannot reach needs a cluster built for it, and that is
+what `make cluster-create` is. It builds a Kind node image carrying
+`nvidia-container-toolkit` with CDI enabled in containerd, then creates a
+cluster (1 control-plane and 2 workers) with the DRA feature gate, the NRI
+socket, and the node names and labels the multi-node scenarios select on.
+[Tilt](https://tilt.dev/) is the installer on top: it builds nvml-mock from
+source and applies the Helm value overlays each consumer needs.
+
+Add `tilt` to the Path 1 tool list. Then:
+
+```bash
+make cluster-create   # build the node image, create the cluster
+tilt up               # install nvml-mock with the a100 profile on every node
+```
+
+`tilt up` takes scenario flags after `--`:
+
+| Command | Scenario |
+|---|---|
+| `tilt up -- --gpu-profile h100` | a different GPU profile |
+| `tilt up -- --multi-gpu-profile` | heterogeneous fleet: a100 on `worker-0`, t4 on `worker-1` |
+| `tilt up -- --gpu-operator` | NVIDIA GPU Operator in CDI mode |
+| `tilt up -- --dra` | NVIDIA DRA driver publishing ResourceSlices |
+| `tilt up -- --fgo` | Run:ai fake-gpu-operator sharing the fleet with nvml-mock |
+| `tilt up -- --observability` | Prometheus, Grafana and a real `dcgm-exporter` |
+| `make cluster-create PROFILE=compute-domain` then `tilt up -- --compute-domain` | 4 workers with NVLink cliques |
+
+This is the environment CI exercises. Every job in the Go E2E workflow runs
+`make cluster-create` and then `tilt ci` with these same flags, so a scenario
+that works here is the one the tests gate.
+
+Tear down with `make cluster-delete`, passing the same `PROFILE=` you created
+with. The full flag reference, including which combinations are mutually
+exclusive, is in
+[`local/README.md`](https://github.com/NVIDIA/k8s-test-infra/blob/main/local/README.md).
+
+Either way, the [Helm chart guide](helm-chart.md) has the per-consumer
+walkthrough for the device plugin, the DRA driver, the GPU Operator and a
 multi-node heterogeneous fleet.
 
 ## How it fits together
@@ -86,15 +183,18 @@ multi-node heterogeneous fleet.
 
 ## Tested consumers
 
-| Consumer | Role | Status |
-|----------|------|--------|
-| NVIDIA Device Plugin | `nvidia.com/gpu` extended resources | Tested |
-| NVIDIA DRA Driver | Dynamic Resource Allocation | Tested |
-| NVIDIA GPU Operator | Full stack device plugin, GFD and validator | Tested |
-| GPU Feature Discovery | Node labeling from NVML | Tested |
+Software that runs unmodified against the mock driver. Most of it is NVIDIA's
+own GPU stack. fake-gpu-operator is a third-party project Mokka composes with
+rather than replaces, which is the only reason it is called out separately in
+the Type column.
 
-## Integrations
+| Consumer | Type | Role | Coverage |
+|----------|------|------|----------|
+| NVIDIA Device Plugin | NVIDIA component | `nvidia.com/gpu` extended resources | CI |
+| NVIDIA DRA Driver | NVIDIA component | Dynamic Resource Allocation | CI |
+| NVIDIA GPU Operator | NVIDIA component | Full stack device plugin, GFD and validator | CI |
+| GPU Feature Discovery | NVIDIA component | Node labeling from NVML | CI |
+| [fake-gpu-operator](integrations/fake-gpu-operator.md) | Third party (Run:ai) | Kubernetes-level GPU simulation for the nodes nvml-mock does not cover | `tilt up -- --fgo` and the [with-fgo demo](demo/with-fgo/README.md) |
 
-| Integration | Description |
-|-------------|-------------|
-| [fake-gpu-operator](integrations/fake-gpu-operator.md) | Run:ai's K8s-level GPU simulation plus nvml-mock driver fidelity |
+"CI" means a job in the Go E2E workflow asserts against it on every run.
+fake-gpu-operator has a Tilt path and a runnable demo but no CI job.

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,16 +84,29 @@ GPU 3: NVIDIA GB300 NVL (UUID: GPU-b300b300-0000-0000-0000-000000000003)
 - The mock driver root staged on the node under `/var/lib/nvml-mock/driver`:
   `libnvidia-ml.so`, `libcuda.so`, a patched `nvidia-smi`, `/dev/nvidia*`
   device nodes, the PCI sysfs tree and the InfiniBand mock.
-- The node label `nvidia.com/gpu.present=true`.
+- An NFD feature file under
+  `/etc/kubernetes/node-feature-discovery/features.d`. Node Feature Discovery
+  turns that into `nvidia.com/gpu.present=true`; a bare KIND cluster is not
+  running NFD, so on Path 1 the file is written and the label is not.
 - Anything you can observe from inside the nvml-mock pod: `nvidia-smi`,
   `nvidia-smi -q`, `nvidia-smi topo -m`, `ibv_devinfo`, and
   [runtime fault injection](nvml-mock-ctl.md).
 - The NVIDIA device plugin, if you also apply
   [`tests/e2e/device-plugin-mock.yaml`](https://github.com/NVIDIA/k8s-test-infra/blob/main/tests/e2e/device-plugin-mock.yaml),
-  the one file you need from the repository. It reads the mock library through
-  a hostPath and passes device specs to kubelet itself, so it needs nothing
-  from the container runtime. `nvidia.com/gpu` then becomes allocatable and
-  pods that request it schedule. Walkthrough:
+  the one file you need from the repository. It selects
+  `mokka.nvidia.com/type=sgpu`, which the multi-node KIND configs set but a bare
+  `kind create cluster` does not, so label the node first or the DaemonSet stays
+  at zero replicas:
+
+    ```bash
+    kubectl label node --all mokka.nvidia.com/type=sgpu
+    kubectl apply -f tests/e2e/device-plugin-mock.yaml
+    ```
+
+  It reads the mock library through a hostPath and passes device specs to
+  kubelet itself, so it needs nothing from the container runtime.
+  `nvidia.com/gpu` then becomes allocatable and pods that request it schedule.
+  Walkthrough:
   [Device Plugin on KIND](helm-chart.md#quick-start-device-plugin-on-kind).
 
 **What Path 1 does not give you**

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ on disk.
 
 | | Path 1 | Path 2 |
 |---|---|---|
-| You need | `kind`, `helm`, `docker` | a repo clone, plus `tilt` |
+| You need | `kind`, `helm`, `docker`, `kubectl` | a repo clone, plus `make`, `docker`, `kind`, `helm`, `kubectl` and `tilt` |
 | Cluster | `kind create cluster` | `make cluster-create` |
 | Covers | the mock driver, `nvidia-smi`, the device plugin | everything, including the GPU Operator, DRA, NRI and multi-node |
 | Gated by CI | no | yes |
@@ -68,14 +68,15 @@ The chart tolerates every taint, so it schedules on the single control-plane
 node that a bare `kind create cluster` gives you. Check the result:
 
 ```bash
-kubectl rollout status daemonset/nvml-mock --timeout=60s
-kubectl exec daemonset/nvml-mock -- nvidia-smi -L
+kubectl rollout status -n mokka daemonset/nvml-mock --timeout=300s
+kubectl exec -n mokka daemonset/nvml-mock -- nvidia-smi -L
 ```
 
 ```
-GPU 0: NVIDIA A100-SXM4-40GB (UUID: GPU-12345678-1234-1234-1234-123456780000)
-GPU 1: NVIDIA A100-SXM4-40GB (UUID: GPU-12345678-1234-1234-1234-123456780001)
-...
+GPU 0: NVIDIA GB300 NVL (UUID: GPU-b300b300-0000-0000-0000-000000000000)
+GPU 1: NVIDIA GB300 NVL (UUID: GPU-b300b300-0000-0000-0000-000000000001)
+GPU 2: NVIDIA GB300 NVL (UUID: GPU-b300b300-0000-0000-0000-000000000002)
+GPU 3: NVIDIA GB300 NVL (UUID: GPU-b300b300-0000-0000-0000-000000000003)
 ```
 
 **What Path 1 gives you**

--- a/enhancements/README.md
+++ b/enhancements/README.md
@@ -43,3 +43,16 @@ whether a MEP is needed.
 
 Superseded or withdrawn MEPs stay in `meps/` with their status updated —
 history is preserved, not rewritten.
+
+## Publishing
+
+Merged MEPs are published on the [documentation site][site] under Enhancement
+Proposals. `make docs` copies this directory into the MkDocs tree at build time,
+so proposals stay here where you wrote them; a new MEP needs one nav entry in
+`mkdocs.yml`.
+
+Link to repo files outside `enhancements/` with an ordinary relative path, the
+way you would for GitHub. The copy step rewrites those links to point at GitHub,
+so they resolve both here and on the site.
+
+[site]: https://nvidia.github.io/k8s-test-infra/

--- a/hack/sync-enhancement-docs.sh
+++ b/hack/sync-enhancement-docs.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Copyright 2026 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Stage enhancements/ into the MkDocs docs_dir so the MEPs publish on the site.
+#
+# MkDocs builds only what lives under docs_dir. The MEP workflow in
+# enhancements/README.md tells contributors to add proposals under
+# enhancements/meps/, so the site takes a build-time copy rather than moving the
+# source and invalidating that workflow, along with every link already pointing
+# at enhancements/ on GitHub.
+#
+# The copy is gitignored and the destination is deleted before every run, so a
+# renamed or removed MEP cannot linger in a later build.
+#
+# MEP text is written to render on GitHub, so some links reach repo source
+# outside enhancements/ (three levels up into pkg/ or tests/). Those have no
+# target inside docs_dir and `mkdocs build --strict` fails them. This script
+# rewrites them to GitHub blob URLs in the copy; the source keeps its relative
+# form and stays correct on GitHub.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_DIR="${REPO_ROOT}/enhancements"
+DST_DIR="${REPO_ROOT}/docs/enhancements"
+
+# Pinned to main, matching edit_uri in mkdocs.yml: the published site tracks
+# main, so a link leaving the site should land on main too.
+BLOB_URL="https://github.com/NVIDIA/k8s-test-infra/blob/main"
+
+if [[ ! -d "${SRC_DIR}" ]]; then
+  echo "ERROR: ${SRC_DIR} does not exist" >&2
+  exit 1
+fi
+
+rm -rf "${DST_DIR}"
+mkdir -p "${DST_DIR}"
+cp -R "${SRC_DIR}/." "${DST_DIR}/"
+
+while IFS= read -r -d '' md; do
+  rel="${md#"${DST_DIR}/"}"
+  dir="$(dirname "${rel}")"
+
+  # How many ../ segments a link in this file needs to reach the repo root: one
+  # per directory between the file and enhancements/, plus one for enhancements/
+  # itself. A file sitting directly in enhancements/ needs one.
+  if [[ "${dir}" == "." ]]; then
+    depth=1
+  else
+    depth=$(($(tr -cd '/' <<<"${dir}" | wc -c) + 2))
+  fi
+
+  root_literal=""
+  root_regex=""
+  for ((i = 0; i < depth; i++)); do
+    root_literal+="../"
+    root_regex+='\.\./'
+  done
+
+  # Inline links `](../../../x)` and reference definitions `]: ../../../x`.
+  tmp="${md}.tmp"
+  sed -e "s|](${root_regex}|](${BLOB_URL}/|g" \
+    -e "s|]:[[:space:]]*${root_regex}|]: ${BLOB_URL}/|g" \
+    "${md}" >"${tmp}"
+  command mv -f "${tmp}" "${md}"
+
+  # Prove the rewrite landed. A sed that silently matches nothing (a bad escape,
+  # a wrong depth, a delimiter collision) would leave the original text here and
+  # surface much later as an opaque strict-mode failure.
+  if grep -qE "\]\(${root_regex}|\]:[[:space:]]*${root_regex}" "${md}"; then
+    echo "ERROR: ${rel} still links above enhancements/ (${root_literal}) after rewriting" >&2
+    exit 1
+  fi
+done < <(find "${DST_DIR}" -type f -name '*.md' -print0)
+
+echo "staged $(find "${DST_DIR}" -type f -name '*.md' | wc -l | tr -d ' ') MEP pages into docs/enhancements/"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,5 +124,14 @@ nav:
       - NVSentinel: demo/nv-sentinel/README.md
   - Integrations:
       - fake-gpu-operator: integrations/fake-gpu-operator.md
+  # These pages are a build-time copy of enhancements/ staged by
+  # hack/sync-enhancement-docs.sh; docs/enhancements/ is gitignored. Adding a MEP
+  # means adding it to enhancements/meps/ and listing it here.
+  - Enhancement Proposals:
+      - Overview: enhancements/README.md
+      - "MEP-0001: Mokka Control Plane": enhancements/meps/0001-mokka-control-plane/README.md
+      - "MEP-0002: Device Plugin and NRI Composition": enhancements/meps/0002-device-plugin-nri-composition/README.md
+      - "MEP-0003: Mokka Node Agent": enhancements/meps/0003-node-agent/README.md
+      - Template: enhancements/template.md
   - Contributing:
       - Development Guide: development.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,14 +124,16 @@ nav:
       - NVSentinel: demo/nv-sentinel/README.md
   - Integrations:
       - fake-gpu-operator: integrations/fake-gpu-operator.md
-  # These pages are a build-time copy of enhancements/ staged by
-  # hack/sync-enhancement-docs.sh; docs/enhancements/ is gitignored. Adding a MEP
-  # means adding it to enhancements/meps/ and listing it here.
-  - Enhancement Proposals:
-      - Overview: enhancements/README.md
-      - "MEP-0001: Mokka Control Plane": enhancements/meps/0001-mokka-control-plane/README.md
-      - "MEP-0002: Device Plugin and NRI Composition": enhancements/meps/0002-device-plugin-nri-composition/README.md
-      - "MEP-0003: Mokka Node Agent": enhancements/meps/0003-node-agent/README.md
-      - Template: enhancements/template.md
   - Contributing:
       - Development Guide: development.md
+      # These pages are a build-time copy of enhancements/ staged by
+      # hack/sync-enhancement-docs.sh; docs/enhancements/ is gitignored. Adding a
+      # MEP means adding it to enhancements/meps/ and listing it here.
+      # The section is named for the documents, not the process, so it stays
+      # distinct from a page describing how to write one.
+      - "Proposals (MEPs)":
+          - Overview: enhancements/README.md
+          - "MEP-0001: Mokka Control Plane": enhancements/meps/0001-mokka-control-plane/README.md
+          - "MEP-0002: Device Plugin and NRI Composition": enhancements/meps/0002-device-plugin-nri-composition/README.md
+          - "MEP-0003: Mokka Node Agent": enhancements/meps/0003-node-agent/README.md
+          - Template: enhancements/template.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,8 +1,8 @@
 # Build dependencies for the Mokka documentation site.
 #
-#   pip install -r requirements-docs.txt
-#   mkdocs serve          # local preview at http://127.0.0.1:8000
-#   mkdocs build --strict # what CI runs
+#   make docs-deps        # uv installs these into .venv-docs
+#   make docs-serve       # local preview at http://127.0.0.1:8000
+#   make docs             # what CI runs (exclusion check + strict build)
 #
 # Pinned so a docs build is reproducible and so a transitive bump cannot break
 # the site without an explicit commit. Dependabot tracks this file.


### PR DESCRIPTION
Closes #698.

`enhancements/meps/` holds two proposals with architecture diagrams that were
only reachable as links out to GitHub, because MkDocs publishes nothing outside
`docs_dir`.

Rather than move them, `hack/sync-enhancement-docs.sh` stages them into the
docs tree at build time. That keeps the MEP process where contributors expect
it: a new MEP lands in `enhancements/` as it always has and appears on the site
with no second location to remember. The staged copy is gitignored and rebuilt
from scratch each run, so a stale copy cannot survive.

Every target that runs mkdocs depends on the sync, so `make docs`, `make
docs-serve` and the exclusion guard all see the same tree, and CI needs no
special-casing.

One deviation from the issue as filed: `deploy-pages.yaml` does change. Its path
filters had to learn about `enhancements/**` and the sync script, because
without that a MEP edit would not rebuild the site and the published copy would
drift from the source.

`docs/helm-chart.md` previously linked MEP-0002 by absolute GitHub URL; it now
points at the in-site page.

`make docs` passes, and the MEP images are emitted into the built site rather
than only the pages that reference them.
