### PR TITLE
docs: unpublish the CUDA mock page

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Use standalone for local development and CI pipelines.
 | [Quick Start](docs/quickstart.md) | Build and run in 5 minutes |
 | [Configuration](docs/configuration.md) | YAML configuration reference |
 | [Architecture](docs/architecture.md) | System design and components |
-| [CUDA Mock](docs/cuda-mock.md) | Mock CUDA library overview |
 | [Development](docs/development.md) | Contributing and extending the library |
 | [Examples](docs/examples.md) | Usage patterns and scenarios |
 | [Troubleshooting](docs/troubleshooting.md) | Common issues and solutions |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -404,13 +404,6 @@ The HandleTable also has its own mutex for independent locking.
 - Matches real NVML behavior (static strings)
 - Prevents memory leaks from repeated allocations
 
-## Mock CUDA Architecture
-
-The CUDA mock follows the same engine/bridge pattern as NVML but at
-a smaller scale (15 functions vs 400).
-
-See [CUDA Mock](cuda-mock.md) for full details.
-
 ## Extending the Library
 
 See [Development Guide](development.md) for:

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,7 +73,6 @@ multi-node heterogeneous fleet.
 | Component | Description | Status |
 |-----------|-------------|--------|
 | Mock NVML (`libnvidia-ml.so`) | 400 NVML C API exports (111 with configurable behavior, 289 stubs), YAML-configurable GPU profiles | Production |
-| Mock CUDA (`libcuda.so`) | 15 CUDA functions: init, device, memory management | Early |
 | nvidia-smi | Real binary with RPATH patch, backed by mock NVML | Production |
 | Helm Chart | DaemonSet deployment with 7 GPU profiles | Production |
 | CDI Injection | Container Device Interface specs for GPU Operator | Production |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -138,5 +138,4 @@ Operator integration.
 - [Configuration Reference](configuration.md) - Customize GPU properties
 - [Examples](examples.md) - Common usage patterns
 - [Architecture](architecture.md) - Understand how it works
-- [CUDA Mock](cuda-mock.md) - Mock CUDA library overview
 - [fake-gpu-operator Integration](integrations/fake-gpu-operator.md) - K8s-level GPU simulation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,10 @@ docs_dir: docs
 exclude_docs: |
   plans/
   superpowers/
+  # CUDA mocking is not usable yet: 14 of its 15 exports are runtime API and
+  # real workloads never enter the mock. The page stays in the repo for
+  # contributors. Delete this line to republish once the driver surface lands.
+  cuda-mock.md
 
 theme:
   name: material
@@ -106,7 +110,6 @@ nav:
       - Configuration: configuration.md
   - Architecture:
       - Overview: architecture.md
-      - CUDA Mock: cuda-mock.md
   - Guides:
       - Examples: examples.md
       - Runtime Control: nvml-mock-ctl.md


### PR DESCRIPTION
CUDA mocking is not usable, and the site was presenting it as though it were.

Fourteen of the mock's fifteen exports are CUDA Runtime entry points and only
`cuInit` belongs to the driver API. A real workload such as
`cuda-sample:vectoradd` links cudart statically and reaches CUDA through
`dlopen` plus `cuGetProcAddress`, so it resolves 450 driver entry points, finds
one, and fails identically whether the mock is mounted or absent.

The page said all of this plainly. The problem was the framing around it: a
Mock CUDA row in the landing page components table alongside Production
entries, and a nav entry sitting beside the architecture overview. Both read as
a shipped capability. This removes them, along with the inbound links from the
quickstart, the architecture page and the top-level README.

The page itself stays in the repository. It carries the measured evidence a
contributor needs, and republishing is one deleted line in `exclude_docs` once
the driver surface exists.

Because the page is excluded from the build, `mkdocs build --strict` fails on
any inbound link left behind, so the build itself proves the removal is
complete.

Not fixed here, since the page is no longer published: it claims the
`libcudart.so.12` symlink lets vectoradd resolve to the mock, which contradicts
the measurement in its own status block. Worth a follow-up that rewrites the
page for a contributor audience.
