### PR TITLE
ci(gh-pages): stop the archived dashboard from overwriting the docs site

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,16 +1,42 @@
+# ARCHIVED. This workflow is disabled on purpose and must stay disabled.
+#
+# GitHub Pages for this repository now serves the Mokka documentation, which is
+# built and published from the main branch by
+# .github/workflows/deploy-pages.yaml. The gh-pages branch is kept only as a
+# readable archive of the retired React CI dashboard.
+#
+# actions/deploy-pages replaces the ENTIRE Pages site, so a single run of this
+# workflow, from one push to gh-pages or one manual dispatch, would silently
+# overwrite the live documentation with the old dashboard. Both triggers are
+# therefore gone: the push filter below ignores every branch name, and the
+# manual dispatch trigger has been removed. The Pages write permissions are
+# dropped as a second stop, so even a careless re-enable cannot publish.
+# Do not add any of them back on their own.
+#
+# If you genuinely want the dashboard published again, treat it as a design
+# decision rather than a workflow edit: open an issue, pick a target that does
+# not collide with the docs site (its own repository, its own Pages site, or a
+# subdirectory owned by the docs build on main), and only then restore a
+# trigger and the two commented-out permissions below.
+#
+# See issue #696.
+
 name: Deploy React site to Pages
 
 on:
   push:
-    branches:
-      - gh-pages
-
-  workflow_dispatch:
+    # '**' matches every branch name, so no push event can match. An 'on' key
+    # is still required, since a workflow file without one is reported by
+    # GitHub as invalid; this is the inert form of it.
+    branches-ignore:
+      - "**"
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
+  # Removed with the triggers. Restore these two lines only as part of the
+  # design decision described above:
+  #   pages: write
+  #   id-token: write
 
 concurrency:
   group: "pages"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,23 @@
-# Cloud Native Test Infrastructure — Dashboard
+# Cloud Native Test Infrastructure Dashboard (archived)
+
+**This branch is an archive.** `gh-pages` holds the retired React CI dashboard,
+kept so the code and its history stay readable. It is not built, not deployed,
+and not maintained.
+
+**Live documentation: <https://nvidia.github.io/k8s-test-infra/>**, served by
+GitHub Pages from the `main` branch and built by
+`.github/workflows/deploy-pages.yaml`. It has nothing to do with this branch.
+
+The Pages deployment workflow here, `.github/workflows/deploy.yaml`, has been
+disabled and has no trigger left. `actions/deploy-pages` replaces the whole
+Pages site, so a single run of it would overwrite the live documentation with
+this old dashboard. See issue #696, and read the comment at the top of that
+file before changing anything in it.
+
+Everything below describes the dashboard as it stood when it was retired, and
+is kept for reference only.
 
 A React SPA dashboard and project portfolio for NVIDIA's cloud-native Kubernetes test infrastructure.
-
-Live at: https://nvidia.github.io/k8s-test-infra/
 
 ## Features
 
@@ -37,7 +52,8 @@ Output in `dist/`.
 
 ## Data Pipeline
 
-`artifact_fetcher.go` runs at build time in CI (every 6 hours) and produces:
+`artifact_fetcher.go` ran at build time in CI, while the deployment workflow was
+still enabled, and produced:
 
 - `public/data/results.json` — Ginkgo E2E test results
 - `public/data/workflows.json` — Latest workflow run statuses


### PR DESCRIPTION
Closes #696.

GitHub Pages now serves the Mokka documentation, built from `main` by
`deploy-pages.yaml`. This branch is kept only as an archive of the retired CI
dashboard, but its `deploy.yaml` still triggered on push and on
`workflow_dispatch`, and it calls `actions/deploy-pages`, which replaces the
entire Pages site.

The scheduled six-hourly trigger went away with #695. What remained was that a
push to this branch, or one manual dispatch, would silently overwrite the live
documentation with the dashboard, and nothing would restore it until the next
`docs/**` change landed on `main`.

The workflow file is kept rather than deleted so the dashboard stays readable
and revivable, but it can no longer fire. The README now says plainly that this
branch is an archive and where the live docs are.

No dashboard source was touched.
