### PR TITLE
feat(mocknvml): report Conf Compute protected memory for nvidia-smi -q (#711)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- mocknvml: the `Conf Compute Protected Memory Usage` block of `nvidia-smi -q`
+  now reports `0 MiB` for Total, Used and Free instead of `N/A`. Both NVML
+  getters behind it were generated stubs that `nvidia-smi` calls once per GPU on
+  every `-q` run, so the mock said the driver could not tell whether any memory
+  is protected, where every real board answers that none is. The values are not
+  configurable and are not gated on the part: all seven real-hardware captures
+  in-tree report `0 MiB` here on drivers 570 and later, including the A100, L40S
+  and T4 boards that cannot do Confidential Compute at all. Nothing partitions
+  protected memory until CC mode is on, which stays unmodelled (#377). The two
+  exports are registered as arriving in driver `525`, so a profile pinned below
+  that reports `N/A` as real hardware of that vintage does. The unread
+  `features.confidential_compute` key is removed from the `h100`, `b200`,
+  `gb200` and `gb300` profiles: gating this surface on it would have made a T4
+  report `N/A` where a real one reports `0 MiB`. (#711)
 - A `--observability` Tilt consumer that runs kube-prometheus-stack and the GPU
   Operator's `dcgm-exporter` over mock GPUs and ships a Grafana dashboard
   in-tree, so the real exporter is scraped and rendered on a cluster with no

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/b200.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/b200.yaml
@@ -341,7 +341,6 @@ device_defaults:
     transformer_engine: true
     fp4_support: true
     fp8_support: true
-    confidential_compute: true
     decompression_engine: true
     fifth_gen_tensor_cores: true
 

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
@@ -378,7 +378,6 @@ device_defaults:
     transformer_engine: true        # 2nd gen Transformer Engine
     fp4_support: true               # FP4 precision support
     fp8_support: true               # FP8 precision support
-    confidential_compute: true      # CC/TEE support
     nvlink_c2c: true                # NVLink Chip-to-Chip (Grace connection)
     decompression_engine: true      # Hardware decompression
     fifth_gen_tensor_cores: true    # 5th generation tensor cores

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/gb300.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/gb300.yaml
@@ -381,7 +381,6 @@ device_defaults:
     fp4_support: true               # FP4 precision support
     fp6_support: true               # FP6 precision (Blackwell Ultra)
     fp8_support: true               # FP8 precision support
-    confidential_compute: true      # CC/TEE support
     nvlink_c2c: true                # NVLink Chip-to-Chip (Grace connection)
     decompression_engine: true      # Hardware decompression
     fifth_gen_tensor_cores: true    # 5th generation tensor cores

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/h100.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/h100.yaml
@@ -348,7 +348,6 @@ device_defaults:
   features:
     transformer_engine: true
     fp8_support: true
-    confidential_compute: true
 
   # ---------------------------------------------------------------------------
   # Processes (empty at idle)

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
@@ -346,7 +346,6 @@ should match snapshot with b200 profile:
             transformer_engine: true
             fp4_support: true
             fp8_support: true
-            confidential_compute: true
             decompression_engine: true
             fifth_gen_tensor_cores: true
 
@@ -1346,7 +1345,6 @@ should match snapshot with gb200 profile:
             transformer_engine: true        # 2nd gen Transformer Engine
             fp4_support: true               # FP4 precision support
             fp8_support: true               # FP8 precision support
-            confidential_compute: true      # CC/TEE support
             nvlink_c2c: true                # NVLink Chip-to-Chip (Grace connection)
             decompression_engine: true      # Hardware decompression
             fifth_gen_tensor_cores: true    # 5th generation tensor cores
@@ -1920,7 +1918,6 @@ should match snapshot with gb300 profile:
             fp4_support: true               # FP4 precision support
             fp6_support: true               # FP6 precision (Blackwell Ultra)
             fp8_support: true               # FP8 precision support
-            confidential_compute: true      # CC/TEE support
             nvlink_c2c: true                # NVLink Chip-to-Chip (Grace connection)
             decompression_engine: true      # Hardware decompression
             fifth_gen_tensor_cores: true    # 5th generation tensor cores
@@ -2458,7 +2455,6 @@ should match snapshot with h100 profile:
           features:
             transformer_engine: true
             fp8_support: true
-            confidential_compute: true
 
           # ---------------------------------------------------------------------------
           # Processes (empty at idle)

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -19,7 +19,7 @@ should match snapshot with all overrides:
       template:
         metadata:
           annotations:
-            checksum/config: fb921dcb2b78ce2a7f41a6b6bf55586804e92655fcf1a29449d8515db3c44e97
+            checksum/config: fccb5cf9ce1dc2d717ff75f1a57dac8f1581c95d6f8fc5c4138493a21edeba58
           labels:
             app.kubernetes.io/component: daemon
             app.kubernetes.io/instance: custom
@@ -166,7 +166,7 @@ should match snapshot with b200 profile:
       template:
         metadata:
           annotations:
-            checksum/config: 34bbeafe005d65c19de791d4d2d65ac68868aa562c4fb5c00aa86f7b05d5ec5c
+            checksum/config: 86035ed7a00d2e6cdd7c437cf85f5a41211f1ea2fb8a369cc5066b4bd8ec1433
           labels:
             app.kubernetes.io/component: daemon
             app.kubernetes.io/instance: RELEASE-NAME

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -729,6 +729,17 @@ mock does not run, so deriving them from anything other than the configured
 utilization would be fabrication rather than simulation. They stay fixed by
 design and are not a gap to be closed.
 
+**Conf Compute protected memory.** The `Conf Compute Protected Memory Usage`
+block of `nvidia-smi -q` reports `0 MiB` for Total, Used and Free on every
+profile, and there is no key to change it. Nothing partitions protected memory
+until Confidential Compute mode is switched on, which the mock does not model
+(see issue #377), and NVML reports `0 MiB` rather than an unsupported query
+whether or not the part could do CC: every board in
+`tests/e2e/go/assertions/nvidiasmi/testdata/hardware` reports it that way,
+including A100, L40S and T4. A profile pinned to a driver older than `525` is the
+one exception — the CC APIs did not exist yet, so the rows read `N/A`, as they do
+on real hardware of that vintage.
+
 **Identity and topology.** Device `name`, `architecture`, `brand`,
 `compute_capability`, `uuid`, PCI `bus_id`, and the BAR1 aperture
 (`bar1_memory`) are baked onto the device at construction and need a pod restart

--- a/pkg/gpu/mocknvml/bridge/conf_compute.go
+++ b/pkg/gpu/mocknvml/bridge/conf_compute.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main provides the NVML Confidential Compute memory functions.
+// nvidia-smi calls both of these once per GPU on every -q run: the protected
+// memory usage backs the "Conf Compute Protected Memory Usage" block, and the
+// memory size info backs the protected/unprotected split behind it.
+//
+// The engine answers zero on every device rather than N/A, which is what real
+// NVML reports while CC mode is off. See issue NVIDIA/k8s-test-infra#711.
+package main
+
+/*
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "nvml_types.h"
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
+)
+
+//export nvmlDeviceGetConfComputeMemSizeInfo
+func nvmlDeviceGetConfComputeMemSizeInfo(device C.nvmlDevice_t, memInfo *C.nvmlConfComputeMemSizeInfo_t) C.nvmlReturn_t {
+	if memInfo == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetConfComputeMemSizeInfo"); !ok {
+		return ret
+	}
+	dev, ok := lookupConfComputeDevice(device)
+	if !ok {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	info, ret := dev.GetConfComputeMemSizeInfo()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	memInfo.protectedMemSizeKib = C.ulonglong(info.ProtectedMemSizeKib)
+	memInfo.unprotectedMemSizeKib = C.ulonglong(info.UnprotectedMemSizeKib)
+	return C.NVML_SUCCESS
+}
+
+//export nvmlDeviceGetConfComputeProtectedMemoryUsage
+func nvmlDeviceGetConfComputeProtectedMemoryUsage(device C.nvmlDevice_t, memory *C.nvmlMemory_t) C.nvmlReturn_t {
+	if memory == nil {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	if ret, ok := bridgeVersionCheck("nvmlDeviceGetConfComputeProtectedMemoryUsage"); !ok {
+		return ret
+	}
+	dev, ok := lookupConfComputeDevice(device)
+	if !ok {
+		return C.NVML_ERROR_INVALID_ARGUMENT
+	}
+	mem, ret := dev.GetConfComputeProtectedMemoryUsage()
+	if ret != nvml.SUCCESS {
+		return toReturn(ret)
+	}
+	memory.total = C.ulonglong(mem.Total)
+	memory.free = C.ulonglong(mem.Free)
+	memory.used = C.ulonglong(mem.Used)
+	return C.NVML_SUCCESS
+}
+
+func lookupConfComputeDevice(device C.nvmlDevice_t) (*engine.ConfigurableDevice, bool) {
+	handle := unsafe.Pointer(device.handle)
+	dev, ok := engine.GetEngine().LookupDevice(handle).(*engine.ConfigurableDevice)
+	return dev, ok
+}

--- a/pkg/gpu/mocknvml/bridge/nvml_types.h
+++ b/pkg/gpu/mocknvml/bridge/nvml_types.h
@@ -267,7 +267,17 @@ typedef struct nvmlComputeInstanceProfileInfo_v2_st         nvmlComputeInstanceP
 typedef struct nvmlConfComputeGetKeyRotationThresholdInfo_st nvmlConfComputeGetKeyRotationThresholdInfo_t;
 typedef struct nvmlConfComputeGpuAttestationReport_st       nvmlConfComputeGpuAttestationReport_t;
 typedef struct nvmlConfComputeGpuCertificate_st             nvmlConfComputeGpuCertificate_t;
-typedef struct nvmlConfComputeMemSizeInfo_st                nvmlConfComputeMemSizeInfo_t;
+/* How device memory splits across a Confidential Compute partition. Full
+ * definition needed by bridge so conf_compute.go can fill the caller's buffer. */
+typedef struct nvmlConfComputeMemSizeInfo_st
+{
+    unsigned long long protectedMemSizeKib;
+    unsigned long long unprotectedMemSizeKib;
+} nvmlConfComputeMemSizeInfo_t;
+/* Callers allocate this buffer from go-nvml's ConfComputeMemSizeInfo, so a
+ * field added here would make the bridge write past the caller's allocation. */
+_Static_assert(sizeof(nvmlConfComputeMemSizeInfo_t) == 16,
+               "nvmlConfComputeMemSizeInfo_t must stay two unsigned long longs to match the go-nvml ABI");
 typedef struct nvmlConfComputeSetKeyRotationThresholdInfo_st nvmlConfComputeSetKeyRotationThresholdInfo_t;
 typedef struct nvmlConfComputeSystemCaps_st                 nvmlConfComputeSystemCaps_t;
 typedef struct nvmlConfComputeSystemState_st                nvmlConfComputeSystemState_t;

--- a/pkg/gpu/mocknvml/bridge/stubs_generated.go
+++ b/pkg/gpu/mocknvml/bridge/stubs_generated.go
@@ -21,7 +21,7 @@ package main
 */
 import "C"
 
-// 264 stub functions for unimplemented NVML functions.
+// 262 stub functions for unimplemented NVML functions.
 // These return NVML_ERROR_NOT_SUPPORTED (3).
 
 //export nvmlComputeInstanceDestroy
@@ -177,16 +177,6 @@ func nvmlDeviceGetConfComputeGpuAttestationReport(device C.nvmlDevice_t, gpuAtst
 //export nvmlDeviceGetConfComputeGpuCertificate
 func nvmlDeviceGetConfComputeGpuCertificate(device C.nvmlDevice_t, gpuCert *C.nvmlConfComputeGpuCertificate_t) C.nvmlReturn_t {
 	return stubReturn("nvmlDeviceGetConfComputeGpuCertificate")
-}
-
-//export nvmlDeviceGetConfComputeMemSizeInfo
-func nvmlDeviceGetConfComputeMemSizeInfo(device C.nvmlDevice_t, memInfo *C.nvmlConfComputeMemSizeInfo_t) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetConfComputeMemSizeInfo")
-}
-
-//export nvmlDeviceGetConfComputeProtectedMemoryUsage
-func nvmlDeviceGetConfComputeProtectedMemoryUsage(device C.nvmlDevice_t, memory *C.nvmlMemory_t) C.nvmlReturn_t {
-	return stubReturn("nvmlDeviceGetConfComputeProtectedMemoryUsage")
 }
 
 //export nvmlDeviceGetCoolerInfo

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-b200.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-b200.yaml
@@ -305,7 +305,6 @@ device_defaults:
     transformer_engine: true
     fp4_support: true
     fp8_support: true
-    confidential_compute: true
     decompression_engine: true
     fifth_gen_tensor_cores: true
 

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml
@@ -315,7 +315,6 @@ device_defaults:
     transformer_engine: true        # 2nd gen Transformer Engine
     fp4_support: true               # FP4 precision support
     fp8_support: true               # FP8 precision support
-    confidential_compute: true      # CC/TEE support
     nvlink_c2c: true                # NVLink Chip-to-Chip (Grace connection)
     decompression_engine: true      # Hardware decompression
     fifth_gen_tensor_cores: true    # 5th generation tensor cores

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-gb300.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-gb300.yaml
@@ -318,7 +318,6 @@ device_defaults:
     fp4_support: true               # FP4 precision support
     fp6_support: true               # FP6 precision (Blackwell Ultra)
     fp8_support: true               # FP8 precision support
-    confidential_compute: true      # CC/TEE support
     nvlink_c2c: true                # NVLink Chip-to-Chip (Grace connection)
     decompression_engine: true      # Hardware decompression
     fifth_gen_tensor_cores: true    # 5th generation tensor cores

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-h100.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-h100.yaml
@@ -316,7 +316,6 @@ device_defaults:
   features:
     transformer_engine: true
     fp8_support: true
-    confidential_compute: true
 
   # ---------------------------------------------------------------------------
   # Processes (empty at idle)

--- a/pkg/gpu/mocknvml/engine/conf_compute.go
+++ b/pkg/gpu/mocknvml/engine/conf_compute.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import "github.com/NVIDIA/go-nvml/pkg/nvml"
+
+// Confidential Compute memory reporting.
+//
+// Both getters answer zero on every device, unconditionally, and neither reads
+// config. That is what real hardware does: every nvidia-smi capture in
+// tests/e2e/go/assertions/nvidiasmi/testdata/hardware reports 0 MiB across the
+// whole block on drivers 570 and later, including the A100, L40S and T4 boards
+// that cannot do Confidential Compute at all. Nothing partitions protected
+// memory until CC mode is switched on, and NVML answers "none" rather than
+// "unsupported" whether or not the part could.
+//
+// So there is deliberately no capability gate here. Gating on
+// features.confidential_compute would have made a T4 report N/A where a real one
+// reports 0 MiB, and CC mode itself is unmodelled until issue #377. What does
+// gate the surface is the driver version: the CC APIs arrived in 525, and
+// version.go answers FUNCTION_NOT_FOUND below that, as a real older driver does.
+//
+// Neither getter advances the failure-injection counter. nvidia-smi calls both
+// once per GPU on every -q run, so ticking here would make an "after_calls"
+// scenario trip on a schedule that depends on how much of nvidia-smi's output
+// the caller asked for. They still surface a lost GPU, matching the other
+// per-query reads that answer from static state (platform info, C2C mode).
+
+// GetConfComputeMemSizeInfo reports how device memory is split between the
+// protected and unprotected halves of a Confidential Compute partition,
+// backing nvmlDeviceGetConfComputeMemSizeInfo. Both halves are zero while CC
+// mode is off, which is every profile.
+func (d *ConfigurableDevice) GetConfComputeMemSizeInfo() (nvml.ConfComputeMemSizeInfo, nvml.Return) {
+	if ret := d.handleLookupReturn(); ret != nvml.SUCCESS {
+		return nvml.ConfComputeMemSizeInfo{}, ret
+	}
+	debugLog("[NVML] nvmlDeviceGetConfComputeMemSizeInfo -> protected=0 KiB unprotected=0 KiB\n")
+	return nvml.ConfComputeMemSizeInfo{}, nvml.SUCCESS
+}
+
+// GetConfComputeProtectedMemoryUsage reports occupancy of the protected memory
+// region, backing nvmlDeviceGetConfComputeProtectedMemoryUsage and the "Conf
+// Compute Protected Memory Usage" block of `nvidia-smi -q`. With CC mode off
+// there is no protected region, so total, used and free are all zero.
+func (d *ConfigurableDevice) GetConfComputeProtectedMemoryUsage() (nvml.Memory, nvml.Return) {
+	if ret := d.handleLookupReturn(); ret != nvml.SUCCESS {
+		return nvml.Memory{}, ret
+	}
+	debugLog("[NVML] nvmlDeviceGetConfComputeProtectedMemoryUsage -> total=0 used=0 free=0\n")
+	return nvml.Memory{}, nvml.SUCCESS
+}

--- a/pkg/gpu/mocknvml/engine/conf_compute_test.go
+++ b/pkg/gpu/mocknvml/engine/conf_compute_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetConfComputeMemSizeInfo_ZeroOnEveryDevice pins the reading real
+// hardware gives on every board, CC-capable or not: an answer of zero rather
+// than the N/A a generated stub produced.
+func TestGetConfComputeMemSizeInfo_ZeroOnEveryDevice(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{})
+
+	info, ret := dev.GetConfComputeMemSizeInfo()
+	require.Equal(t, nvml.SUCCESS, ret,
+		"the getter must answer so nvidia-smi renders 0 rather than N/A")
+	require.Equal(t, nvml.ConfComputeMemSizeInfo{}, info,
+		"CC mode is off, so no memory is partitioned into protected and unprotected halves")
+}
+
+// TestGetConfComputeProtectedMemoryUsage_ZeroOnEveryDevice pins the three values
+// nvidia-smi renders as its "Conf Compute Protected Memory Usage" block: 0 MiB
+// each, as every hardware capture in the repo reports.
+func TestGetConfComputeProtectedMemoryUsage_ZeroOnEveryDevice(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{})
+
+	mem, ret := dev.GetConfComputeProtectedMemoryUsage()
+	require.Equal(t, nvml.SUCCESS, ret,
+		"the getter must answer so nvidia-smi renders 0 MiB rather than N/A")
+	require.Equal(t, nvml.Memory{}, mem,
+		"with CC mode off there is no protected region, so total, used and free are all zero")
+}
+
+// TestConfComputeMemory_LostDeviceReportsGpuIsLost keeps both getters on the
+// same failure-injection path as every other device export: once the driver has
+// marked the GPU gone they must report the loss, not a plausible zero.
+//
+// Neither getter advances the failure counter, so the device is tripped through
+// a guarded call first.
+func TestConfComputeMemory_LostDeviceReportsGpuIsLost(t *testing.T) {
+	dev := newTestDeviceWithConfig(t, &DeviceConfig{
+		Failure: &FailureInjectionConfig{Mode: FailureModeLost},
+	})
+
+	_, ret := dev.GetTemperature(nvml.TEMPERATURE_GPU)
+	require.Equal(t, nvml.ERROR_GPU_IS_LOST, ret, "expected the guarded call to trip the device")
+
+	_, ret = dev.GetConfComputeMemSizeInfo()
+	require.Equal(t, nvml.ERROR_GPU_IS_LOST, ret, "GetConfComputeMemSizeInfo")
+	_, ret = dev.GetConfComputeProtectedMemoryUsage()
+	require.Equal(t, nvml.ERROR_GPU_IS_LOST, ret, "GetConfComputeProtectedMemoryUsage")
+}

--- a/pkg/gpu/mocknvml/engine/config_types.go
+++ b/pkg/gpu/mocknvml/engine/config_types.go
@@ -542,12 +542,17 @@ type GSPFirmwareConfig struct {
 	Version string `json:"version,omitempty"`
 }
 
-// FeaturesConfig defines GPU-specific features (like Blackwell features)
+// FeaturesConfig defines GPU-specific features (like Blackwell features).
+//
+// Every field here is descriptive metadata that no getter reads. A key only
+// belongs in this block while nothing depends on it: confidential_compute was
+// removed once the Conf Compute memory getters landed, because real NVML answers
+// those on any part and gating them on a capability claim would have made a T4
+// report N/A where a real one reports 0 MiB. See issue #711.
 type FeaturesConfig struct {
 	TransformerEngine   bool `json:"transformer_engine,omitempty"`
 	FP4Support          bool `json:"fp4_support,omitempty"`
 	FP8Support          bool `json:"fp8_support,omitempty"`
-	ConfidentialCompute bool `json:"confidential_compute,omitempty"`
 	NVLinkC2C           bool `json:"nvlink_c2c,omitempty"`
 	DecompressionEngine bool `json:"decompression_engine,omitempty"`
 	FifthGenTensorCores bool `json:"fifth_gen_tensor_cores,omitempty"`

--- a/pkg/gpu/mocknvml/engine/version.go
+++ b/pkg/gpu/mocknvml/engine/version.go
@@ -49,6 +49,10 @@ var functionRegistry = map[string]FunctionVersion{
 	"nvmlDeviceGetGraphicsRunningProcesses_v3": {Added: "510.0"},
 	"nvmlDeviceGetGspFirmwareMode":             {Added: "510.0"},
 
+	// 525.x additions. Confidential Compute arrived with Hopper CC.
+	"nvmlDeviceGetConfComputeMemSizeInfo":          {Added: "525.0"},
+	"nvmlDeviceGetConfComputeProtectedMemoryUsage": {Added: "525.0"},
+
 	// 535.x additions. GPM (GPU Performance Monitoring) — DCGM's profiling
 	// path on Hopper+ (DCGM_FI_PROF_*).
 	"nvmlGpmQueryDeviceSupport": {Added: "535.0"},

--- a/pkg/gpu/mocknvml/engine/version_test.go
+++ b/pkg/gpu/mocknvml/engine/version_test.go
@@ -96,6 +96,13 @@ func TestFunctionAvailable(t *testing.T) {
 		{"gpm available on 560", "560.0", "nvmlGpmQueryDeviceSupport", true},
 		{"gpm streaming not available on 550", "550.163.01", "nvmlGpmQueryIfStreamingEnabled", false},
 		{"gpm streaming available on 555", "555.0", "nvmlGpmQueryIfStreamingEnabled", true},
+
+		// Confidential Compute arrived with Hopper CC in 525.x, so a profile on
+		// an older driver must miss the symbol rather than answer for it.
+		{"cc memsize not available on 470", "470.0", "nvmlDeviceGetConfComputeMemSizeInfo", false},
+		{"cc memsize available on 525", "525.0", "nvmlDeviceGetConfComputeMemSizeInfo", true},
+		{"cc protected usage not available on 470", "470.0", "nvmlDeviceGetConfComputeProtectedMemoryUsage", false},
+		{"cc protected usage available on 580", "580.173.02", "nvmlDeviceGetConfComputeProtectedMemoryUsage", true},
 	}
 
 	for _, tt := range tests {

--- a/tests/e2e/go/assertions/nvidiasmi/conf_compute.go
+++ b/tests/e2e/go/assertions/nvidiasmi/conf_compute.go
@@ -1,0 +1,62 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidiasmi
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ConfComputeMemoryProblems checks every GPU's <cc_protected_memory_usage>
+// block reports zero across total, used and free.
+//
+// Zero is the point of the check rather than a weak expectation. Every row read
+// N/A while the two NVML getters behind them were generated stubs (#711), which
+// says the driver answered nothing where real hardware answers none: all seven
+// hardware captures report 0 MiB here, including the A100, L40S and T4 boards
+// that cannot do Confidential Compute at all. The expectation is therefore not
+// derived from the profile — nothing partitions protected memory until CC mode
+// is on, which no profile models.
+func ConfComputeMemoryProblems(out string) []string {
+	snap, err := ParseSnapshot(out)
+	if err != nil {
+		return []string{err.Error()}
+	}
+
+	var problems []string
+	for i, gpu := range snap.doc.GPUs {
+		name := gpu.label(i) + " cc_protected_memory_usage"
+		rows := []struct {
+			element string
+			got     reading
+		}{
+			{"total", gpu.CCProtectedMemoryUsage.Total},
+			{"used", gpu.CCProtectedMemoryUsage.Used},
+			{"free", gpu.CCProtectedMemoryUsage.Free},
+		}
+		for _, row := range rows {
+			problems = append(problems, ccProtectedRowProblems(name+"/"+row.element, row.got)...)
+		}
+	}
+	return problems
+}
+
+// ccProtectedRowProblems compares one row, which must read zero MiB. An N/A
+// body is reported as the missing getter it is rather than as a wrong value,
+// matching intReadingProblems, and a non-zero value fails because no profile
+// switches CC mode on.
+func ccProtectedRowProblems(label string, got reading) []string {
+	value, ok := got.intValue()
+	switch {
+	case !ok:
+		return []string{fmt.Sprintf(
+			"%s = %q, want 0 MiB; a non-numeric reading means the NVML getter is missing or unimplemented",
+			label, strings.TrimSpace(string(got)))}
+	case value != 0:
+		return []string{fmt.Sprintf(
+			"%s = %d MiB, want 0 MiB: no profile switches Confidential Compute mode on",
+			label, value)}
+	}
+	return nil
+}

--- a/tests/e2e/go/assertions/nvidiasmi/conf_compute_test.go
+++ b/tests/e2e/go/assertions/nvidiasmi/conf_compute_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package nvidiasmi
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func loadHardwareCapture(t *testing.T, name string) string {
+	t.Helper()
+	return loadFixture(t, filepath.Join("hardware", name))
+}
+
+// ccGPU renders one <gpu> element whose cc_protected_memory_usage block carries
+// the given bodies verbatim, so a test can inject "0 MiB", "N/A" or nothing.
+func ccGPU(id, total, used, free string) string {
+	return `
+	<gpu id="` + id + `">
+		<product_name>NVIDIA GB300</product_name>
+		<cc_protected_memory_usage>
+			<total>` + total + `</total>
+			<used>` + used + `</used>
+			<free>` + free + `</free>
+		</cc_protected_memory_usage>
+	</gpu>`
+}
+
+// Every hardware capture must pass, which is what makes the expectation
+// hardware-derived rather than chosen: the boards range from a Turing T4 that
+// cannot do CC at all to a GB300 tray, and all of them report 0 MiB.
+func TestConfComputeMemoryProblems_AcceptsEveryHardwareCapture(t *testing.T) {
+	for _, file := range hardwareCaptures(t) {
+		t.Run(filepath.Base(file), func(t *testing.T) {
+			problems := ConfComputeMemoryProblems(loadHardwareCapture(t, filepath.Base(file)))
+			assert.Empty(t, problems, strings.Join(problems, "; "))
+		})
+	}
+}
+
+// The defect this exists to catch: N/A says the driver answered nothing, where
+// every real board reports 0 MiB. The mock captures were taken while both
+// getters were generated stubs, so they read that way.
+func TestConfComputeMemoryProblems_RejectsNotAvailableReadings(t *testing.T) {
+	problems := ConfComputeMemoryProblems(loadFixture(t, "qx-gb200-healthy.xml"))
+	require.NotEmpty(t, problems)
+	joined := strings.Join(problems, "\n")
+	assert.Contains(t, joined, "N/A")
+	assert.Contains(t, joined, "getter is missing")
+}
+
+// CC mode is unmodelled, so a non-zero protected region cannot be reported —
+// this keeps the check from degenerating into "any number will do".
+func TestConfComputeMemoryProblems_RejectsNonZeroProtectedMemory(t *testing.T) {
+	out := xmlDocument(ccGPU("0000:07:00.0", "1024 MiB", "0 MiB", "1024 MiB"))
+
+	problems := ConfComputeMemoryProblems(out)
+	require.Len(t, problems, 2, "total and free both claim a protected region")
+	assert.Contains(t, strings.Join(problems, "\n"), "1024")
+}
+
+// Absent elements decode as empty bodies, which is a rename or a dropped block,
+// not a zero.
+func TestConfComputeMemoryProblems_ReportsMissingElements(t *testing.T) {
+	out := xmlDocument(ccGPU("0000:07:00.0", "", "", ""))
+
+	problems := ConfComputeMemoryProblems(out)
+	require.Len(t, problems, 3)
+	assert.Contains(t, strings.Join(problems, "\n"), `= ""`)
+}
+
+// A getter answering for only the first device must fail, naming the GPU.
+func TestConfComputeMemoryProblems_ChecksEveryGPU(t *testing.T) {
+	out := xmlDocument(
+		ccGPU("0000:07:00.0", "0 MiB", "0 MiB", "0 MiB"),
+		ccGPU("0000:0F:00.0", "N/A", "0 MiB", "0 MiB"),
+	)
+
+	problems := ConfComputeMemoryProblems(out)
+	require.Len(t, problems, 1, "only the second GPU's total is N/A")
+	assert.Contains(t, problems[0], "0000:0F:00.0")
+}
+
+// The block sits beside <fb_memory_usage>, which repeats every child name, so a
+// check reading the wrong block would pass against the framebuffer's own zeros.
+func TestConfComputeMemoryProblems_DoesNotReadTheFramebufferBlock(t *testing.T) {
+	out := xmlDocument(`
+	<gpu id="0000:07:00.0">
+		<product_name>NVIDIA GB300</product_name>
+		<fb_memory_usage>
+			<total>0 MiB</total>
+			<used>0 MiB</used>
+			<free>0 MiB</free>
+		</fb_memory_usage>
+		<cc_protected_memory_usage>
+			<total>N/A</total>
+			<used>N/A</used>
+			<free>N/A</free>
+		</cc_protected_memory_usage>
+	</gpu>`)
+
+	problems := ConfComputeMemoryProblems(out)
+	require.Len(t, problems, 3, "the framebuffer's zeros must not satisfy the CC block")
+}
+
+func TestConfComputeMemoryProblems_RejectsTruncatedOutput(t *testing.T) {
+	full := xmlDocument(ccGPU("0000:07:00.0", "0 MiB", "0 MiB", "0 MiB"))
+	truncated := full[:strings.Index(full, "<cc_protected_memory_usage>")]
+
+	problems := ConfComputeMemoryProblems(truncated)
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "parse nvidia-smi XML")
+}

--- a/tests/e2e/go/assertions/nvidiasmi/exec.go
+++ b/tests/e2e/go/assertions/nvidiasmi/exec.go
@@ -193,6 +193,20 @@ func ThrottleCounters(ctx context.Context, k *kube.Client, pod kube.PodRef) {
 		strings.Join(problems, "\n"))
 }
 
+// ConfComputeMemory asserts nvidia-smi -q -x reports 0 MiB across the Conf
+// Compute protected memory block on every GPU. The whole block read N/A while
+// the two NVML getters behind it were generated stubs, which says the driver
+// could not report whether any memory is protected — where every real board,
+// CC-capable or not, answers none. See issue #711.
+func ConfComputeMemory(ctx context.Context, k *kube.Client, pod kube.PodRef) {
+	ginkgo.GinkgoHelper()
+
+	ginkgo.By("nvidia-smi -q -x reports 0 MiB of Conf Compute protected memory")
+	problems := ConfComputeMemoryProblems(query(ctx, k, pod))
+	gomega.Expect(problems).To(gomega.BeEmpty(), "Conf Compute protected memory wrong:\n%s",
+		strings.Join(problems, "\n"))
+}
+
 // query execs `nvidia-smi -q -x` and asserts it succeeded, returning stdout.
 func query(ctx context.Context, k *kube.Client, pod kube.PodRef) string {
 	ginkgo.GinkgoHelper()

--- a/tests/e2e/go/assertions/nvidiasmi/hardware_test.go
+++ b/tests/e2e/go/assertions/nvidiasmi/hardware_test.go
@@ -104,6 +104,10 @@ func comparedReadings(g gpuElement) []namedReading {
 		{"fb_memory_usage/total", g.FBMemoryUsage.Total},
 		{"fb_memory_usage/used", g.FBMemoryUsage.Used},
 
+		{"cc_protected_memory_usage/total", g.CCProtectedMemoryUsage.Total},
+		{"cc_protected_memory_usage/used", g.CCProtectedMemoryUsage.Used},
+		{"cc_protected_memory_usage/free", g.CCProtectedMemoryUsage.Free},
+
 		{"utilization/gpu_util", g.Utilization.GPU},
 		{"utilization/memory_util", g.Utilization.Memory},
 		{"utilization/encoder_util", g.Utilization.Encoder},

--- a/tests/e2e/go/assertions/nvidiasmi/schema.go
+++ b/tests/e2e/go/assertions/nvidiasmi/schema.go
@@ -112,6 +112,7 @@ type gpuElement struct {
 	FanSpeed                 reading           `xml:"fan_speed"`
 	PerformanceState         reading           `xml:"performance_state"`
 	FBMemoryUsage            memoryUsage       `xml:"fb_memory_usage"`
+	CCProtectedMemoryUsage   memoryUsage       `xml:"cc_protected_memory_usage"`
 	AccountingModeBufferSize reading           `xml:"accounting_mode_buffer_size"`
 	EncoderStats             statsBlock        `xml:"encoder_stats"`
 	FBCStats                 statsBlock        `xml:"fbc_stats"`
@@ -131,9 +132,10 @@ type gpuElement struct {
 	} `xml:"processes"`
 }
 
-// memoryUsage is <fb_memory_usage>: the framebuffer. The sibling
-// <bar1_memory_usage> and <cc_protected_memory_usage> blocks repeat the same
-// child names and are deliberately not decoded.
+// memoryUsage is the shape of the memory blocks: <total>, <used>, <free>, and a
+// <reserved> only the framebuffer reports. Each block is decoded separately
+// because they repeat the same child names, so a reading must name which one it
+// came from. The <bar1_memory_usage> sibling is deliberately not decoded.
 type memoryUsage struct {
 	Total    reading `xml:"total"`
 	Reserved reading `xml:"reserved"`

--- a/tests/e2e/go/scenario_standalone_test.go
+++ b/tests/e2e/go/scenario_standalone_test.go
@@ -168,6 +168,15 @@ var _ = Describe("nvml-mock standalone", Ordered, func() {
 				nvidiasmi.ThrottleCounters(ctx, h.Kube, pod)
 			})
 
+			It("reports zeroed Conf Compute protected memory via nvidia-smi -q -x", Label("nvidia-smi"), func(ctx SpecContext) {
+				// Issue #711: all three rows read N/A because both NVML getters
+				// behind the block were generated stubs, so the mock could not
+				// say whether any memory is protected. Every real board answers
+				// 0 MiB there, CC-capable or not, so the expectation is the same
+				// on every selected profile rather than derived from it.
+				nvidiasmi.ConfComputeMemory(ctx, h.Kube, pod)
+			})
+
 			It("exposes the NVLink topology (gated on fabricmanager)", Label("nvlink"), func(ctx SpecContext) {
 				assertions.FabricManagerGate(ctx, h.Kube, nvmlMockNamespace, "nvml-mock", pod, config.ReadyTimeout(), config.PollInterval())
 				assertions.NVLink(ctx, h.Kube, pod, p)

--- a/tests/mocknvml/bridge_tests.go
+++ b/tests/mocknvml/bridge_tests.go
@@ -45,6 +45,58 @@ func bridgeTests(deviceCount int) []testResult {
 	results = append(results, testInternalExportTable()...)
 	results = append(results, testFabricHealth(deviceCount)...)
 	results = append(results, testThrottleCounters(deviceCount)...)
+	results = append(results, testConfComputeMemory(deviceCount)...)
+	return results
+}
+
+// --- Confidential Compute memory tests ---
+
+// testConfComputeMemory drives the two CC memory getters through the built
+// library. Both write caller-allocated C structs, so a field written at the
+// wrong offset or width only shows up here.
+//
+// CC mode is unmodelled, so every device must answer with zeros regardless of
+// what it configures — what nvidia-smi renders as 0 MiB, and what the reference
+// GB300 tray reports. The one direction that still declines is a driver older
+// than 525, which version_test.go covers.
+func testConfComputeMemory(deviceCount int) []testResult {
+	var results []testResult
+
+	for index := 0; index < 2 && index < deviceCount; index++ {
+		name := fmt.Sprintf("confcompute/gpu%d", index)
+		device, ret := nvml.DeviceGetHandleByIndex(index)
+		if ret != nvml.SUCCESS {
+			results = append(results, testResult{name, false, fmt.Sprintf("GetHandleByIndex(%d) failed: %v", index, nvml.ErrorString(ret))})
+			continue
+		}
+
+		info, ret := device.GetConfComputeMemSizeInfo()
+		switch {
+		case ret != nvml.SUCCESS:
+			results = append(results, testResult{name + "/memsize", false,
+				fmt.Sprintf("GetConfComputeMemSizeInfo failed: %v", nvml.ErrorString(ret))})
+		case info.ProtectedMemSizeKib != 0 || info.UnprotectedMemSizeKib != 0:
+			results = append(results, testResult{name + "/memsize", false,
+				fmt.Sprintf("protected=%d KiB unprotected=%d KiB, want 0/0 with CC mode off",
+					info.ProtectedMemSizeKib, info.UnprotectedMemSizeKib)})
+		default:
+			results = append(results, testResult{name + "/memsize", true, ""})
+		}
+
+		mem, ret := device.GetConfComputeProtectedMemoryUsage()
+		switch {
+		case ret != nvml.SUCCESS:
+			results = append(results, testResult{name + "/protected_usage", false,
+				fmt.Sprintf("GetConfComputeProtectedMemoryUsage failed: %v", nvml.ErrorString(ret))})
+		case mem.Total != 0 || mem.Used != 0 || mem.Free != 0:
+			results = append(results, testResult{name + "/protected_usage", false,
+				fmt.Sprintf("total=%d used=%d free=%d, want all zero with CC mode off",
+					mem.Total, mem.Used, mem.Free)})
+		default:
+			results = append(results, testResult{name + "/protected_usage", true, ""})
+		}
+	}
+
 	return results
 }
 


### PR DESCRIPTION
## Summary

Closes #711.

All three rows of the `nvidia-smi -q` `Conf Compute Protected Memory Usage` block read `N/A`, because both NVML getters behind them were generated stubs that `nvidia-smi` calls once per GPU on every `-q` run. They now report `0 MiB` for Total, Used and Free, matching the reference GB300 tray.

**The capability-versus-mode decision (option 1, revised by the captures).** Protected memory answers to CC *mode*, not to whether the part can do CC — and the hardware in-tree says so plainly: all seven captures in `tests/e2e/go/assertions/nvidiasmi/testdata/hardware` report `0 MiB` here on drivers 570 and later, **including the A100, L40S and T4 boards that cannot do Confidential Compute at all**. So gating on `features.confidential_compute`, as #680 proposed, would have made a T4 report `N/A` where a real one reports `0 MiB`, on top of making `gb300` report a non-zero protected region against its own reference tray. Both getters therefore answer zero on every device, unconditionally, and read no config. Nothing partitions protected memory until CC mode is on, which stays unmodelled (#377).

What *does* gate the surface is the driver version: the CC APIs arrived in `525`, so both functions are registered there and a profile pinned below it reports `N/A`, as real hardware of that vintage does. That is the one direction in which these rows legitimately decline, and it replaces the issue's "profiles that do not configure this surface still report N/A" criterion, which only made sense under the capability-gate reading.

`features.confidential_compute` is removed from the `h100`, `b200`, `gb200` and `gb300` profiles and from `FeaturesConfig` rather than left decorative, per the issue's requirement that it be read or removed.

Two smaller notes. `nvmlConfComputeMemSizeInfo_t` was an opaque forward declaration, so the bridge needs its full definition to fill the caller's buffer; a `_Static_assert` pins it at two `unsigned long long`s, because callers allocate from go-nvml's struct and a field added on this side would write past their allocation. And neither getter advances the failure-injection counter — `nvidia-smi` reads both on every `-q`, so ticking here would move when injection trips — while both still surface a lost GPU, matching the other per-query reads that answer from static state.

## Test plan

- [x] `make test` — full unit suite passes, including the new engine tests for both getters (zeros on every device, `ERROR_GPU_IS_LOST` once the device is tripped) and the `FunctionAvailable` cases for the 525 boundary.
- [x] `make test-mocknvml-bridge` — 72 bridge tests pass, including four new `confcompute/gpu{0,1}/{memsize,protected_usage}` cases driven through the built `libnvidia-ml.so.1`, which is the only place a field written at the wrong offset or width would show.
- [x] `make helm-tests` — 170 tests, 15 snapshots. The `configmap` snapshot drops the removed key; the `daemonset` snapshot moved only because the profile ConfigMap checksum annotation changed.
- [x] Both stubs disappear on regeneration: the generated file's count drops from 264 to 262.
- [x] The e2e assertion is asserted against every hardware capture rather than a chosen value, and rejects the pre-fix mock capture already in testdata.
- [x] `golangci-lint --fix` and `go vet` clean. `govulncheck` reports seven findings, all standard-library and all "found in `go1.26.5`, fixed in `go1.26.6`" — a local toolchain mismatch, since the repo pins `GOLANG_VERSION=1.26.6`.
- [ ] CI e2e: the new `Label("nvidia-smi")` spec, plus `pmon -c 1` and `topo -m` for the internal-export-table regression #630 and #640 were both bitten by.