### PR TITLE
fix(local): keep nvml-mock off the control-plane node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   public NVML APIs.
 
 ### Changed
+- The local-dev and CI Kind clusters no longer run nvml-mock on the control-plane
+  node. The chart tolerates every taint, so the DaemonSet landed there too, but
+  nothing follows it: GPU Operator operands, FGO and NFD workers all stop at the
+  `NoSchedule` taint. That left a node advertising a GPU driver footprint no
+  consumer could use, and scenarios that pick a mock pod by list position
+  intermittently targeted it. Every Kind worker now carries
+  `mokka.nvidia.com/type=sgpu` and `local/nvml-mock.values.yaml` selects on it;
+  the compute-domain overlay repeats the selector because its Tiltfile installs
+  the chart without that baseline, and its `topology.yaml` gives the control
+  plane no clique to report. Pinning stays additive — Helm deep-merges maps, so
+  the FGO pool selector and `--multi-gpu-profile`'s hostname pin compose with
+  it. (#724)
 - The nvml-mock chart now defaults `gpu.profile` to `gb300` instead of `a100`, so
   a bare `helm install` simulates current-generation hardware. Ampere is the
   architecture least likely to expose a gap in software being tested against a

--- a/local/README.md
+++ b/local/README.md
@@ -42,7 +42,9 @@ make cluster-delete                         # tear down (PROFILE= must match cre
 
 ### Homogeneous fleet (single Helm release)
 
-Installs one nvml-mock release that covers every node in the cluster (control-plane + both workers) with the same GPU profile. Pick the profile via `--gpu-profile`.
+Installs one nvml-mock release that covers every worker in the cluster with the same GPU profile. Pick the profile via `--gpu-profile`.
+
+The control-plane node is excluded: `local/nvml-mock.values.yaml` pins the DaemonSet to nodes labelled `mokka.nvidia.com/type=sgpu`, which every worker in the Kind configs carries. Without it the mock lands on the control plane too — it tolerates every taint — while GPU Operator, FGO and NFD operands stop at the `NoSchedule` taint, leaving a node that advertises a driver nobody consumes.
 
 ```bash
 tilt up                                  # default: a100
@@ -158,7 +160,7 @@ Values are layered in this order (last wins):
 | File                                     | Committed           | Purpose                                                  |
 |------------------------------------------|---------------------|----------------------------------------------------------|
 | Chart defaults                           | —                   | upstream chart defaults                                  |
-| `local/nvml-mock.values.yaml`            | yes                 | shared local-dev baseline (IB mode, rollout speed, etc.) |
+| `local/nvml-mock.values.yaml`            | yes                 | shared local-dev baseline (sGPU node pinning, IB mode, etc.) |
 | `local/<consumer>/nvml-mock.values.yaml` | yes                 | per-consumer tweaks (e.g. `local/gpu-operator/`)         |
 | `local/nvml-mock.values.local.yaml`      | **no** (gitignored) | personal per-machine overrides                           |
 

--- a/local/compute-domain/nvml-mock.values.yaml
+++ b/local/compute-domain/nvml-mock.values.yaml
@@ -17,6 +17,14 @@
 gpu:
   profile: gb200
 
+# Workers only, same reason as local/nvml-mock.values.yaml — repeated here
+# because compute_domain.tiltfile installs the chart itself and does not layer
+# that baseline. Also load-bearing for this scenario: topology.yaml assigns a
+# clique per worker and nothing describes the control plane, so a mock pod there
+# would report a fabric identity the topology never declared.
+nodeSelector:
+  mokka.nvidia.com/type: sgpu
+
 # Speed up Scenario 3's DaemonSet rollout so every pod re-reads
 # MOCK_TOPOLOGY_CONFIG in seconds, not tens.
 updateStrategy:

--- a/local/kind/compute-domain.kind.yaml
+++ b/local/kind/compute-domain.kind.yaml
@@ -21,6 +21,11 @@
 # CDI + the runtimes.nvidia handler are baked into the node image
 # (deployments/kind-nvidia-cdi/), so no containerdConfigPatches are needed.
 #
+# Each worker carries mokka.nvidia.com/type=sgpu, the simulated-GPU fleet
+# marker local/compute-domain/nvml-mock.values.yaml selects on. It keeps the
+# mock off the control plane, which topology.yaml gives no clique — a mock pod
+# there would report a fabric identity the topology never declared.
+#
 # Usage:
 #   make cluster-create PROFILE=compute-domain
 #   tilt up -- --compute-domain --k8s-context=kind-nvml-mock-compute-domain
@@ -44,6 +49,7 @@ nodes:
   - role: worker
     labels:
       nvidia.com/gpu.clique: "00000000-0000-0000-0000-0000000000ab.0"
+      mokka.nvidia.com/type: sgpu
     kubeadmConfigPatches:
       - |
         kind: JoinConfiguration
@@ -52,6 +58,7 @@ nodes:
   - role: worker
     labels:
       nvidia.com/gpu.clique: "00000000-0000-0000-0000-0000000000ab.1"
+      mokka.nvidia.com/type: sgpu
     kubeadmConfigPatches:
       - |
         kind: JoinConfiguration
@@ -60,6 +67,7 @@ nodes:
   - role: worker
     labels:
       nvidia.com/gpu.clique: "00000000-0000-0000-0000-0000000000cd.0"
+      mokka.nvidia.com/type: sgpu
     kubeadmConfigPatches:
       - |
         kind: JoinConfiguration
@@ -68,6 +76,7 @@ nodes:
   - role: worker
     labels:
       nvidia.com/gpu.clique: "00000000-0000-0000-0000-0000000000cd.1"
+      mokka.nvidia.com/type: sgpu
     kubeadmConfigPatches:
       - |
         kind: JoinConfiguration

--- a/local/kind/default.kind.yaml
+++ b/local/kind/default.kind.yaml
@@ -55,6 +55,10 @@
 #     integration (a100) runs nvml-mock as the NVML shim; scale (t4) is managed
 #     entirely by FGO's fake backend. Consumers that ignore these labels see
 #     both workers as generic schedulable nodes.
+#   - mokka.nvidia.com/type=sgpu — the simulated-GPU fleet. Only labelled nodes
+#     get the mock: local/nvml-mock.values.yaml selects on it, so the control
+#     plane stays clean instead of advertising a driver no consumer follows it
+#     onto (their operands stop at the NoSchedule taint the mock tolerates).
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: mokka
@@ -76,6 +80,7 @@ nodes:
   - role: worker
     labels:
       run.ai/simulated-gpu-node-pool: integration
+      mokka.nvidia.com/type: sgpu
     kubeadmConfigPatches:
       - |
         kind: JoinConfiguration
@@ -84,6 +89,7 @@ nodes:
   - role: worker
     labels:
       run.ai/simulated-gpu-node-pool: scale
+      mokka.nvidia.com/type: sgpu
     kubeadmConfigPatches:
       - |
         kind: JoinConfiguration

--- a/local/nvml-mock.values.yaml
+++ b/local/nvml-mock.values.yaml
@@ -4,3 +4,14 @@
 # Local-dev Helm value overrides for nvml-mock (committed, shared baseline).
 # To add personal overrides that won't be committed, create:
 #   local/nvml-mock.values.local.yaml  (gitignored, wins over this file)
+
+# Keep the mock off the control-plane node. The chart tolerates every taint
+# (tolerations: operator Exists) so without a selector the DaemonSet also lands
+# on the control plane, where no consumer follows it: GPU Operator operands, FGO
+# and NFD workers all stop at the NoSchedule taint. The result is a node that
+# advertises a GPU driver nobody consumes, and scenarios that pick a mock pod by
+# position intermittently target it. Every worker in local/kind/*.kind.yaml
+# carries this label; consumer overlays add their own keys on top (helm
+# deep-merges maps), so pinning stays additive.
+nodeSelector:
+  mokka.nvidia.com/type: sgpu

--- a/tests/e2e/go/scenario_gpu_operator_test.go
+++ b/tests/e2e/go/scenario_gpu_operator_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/assertions"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/cluster"
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/config"
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/harness"
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/helm"
@@ -43,14 +44,12 @@ var _ = Describe("nvml-mock GPU Operator", Label("gpu-operator"), Ordered, func(
 			BeforeAll(func(ctx SpecContext) {
 				p, _, _ = setupStandaloneProfile(ctx, h, name)
 				// Not the node setupStandaloneProfile returns: that comes from
-				// FirstPodName over the nvml-mock DaemonSet, which can land on
-				// the CP (mock tolerates `operator: Exists`), and the Operator's
+				// FirstPodName over the nvml-mock DaemonSet, and the Operator's
 				// operands don't tolerate the CP NoSchedule taint — WaitGFDLabels
 				// and WaitAllocatableGPU would time out on a CP-derived node.
-				node = gpuOperatorTargetNode(ctx, h)
-				cp, err := h.Cluster.ControlPlane(ctx)
-				Expect(err).NotTo(HaveOccurred())
-				verifyGPUOperatorNodeSetup(ctx, cp.Container)
+				target := gpuOperatorTargetNode(ctx, h)
+				node = target.Name
+				verifyGPUOperatorNodeSetup(ctx, target.Container)
 
 				// Wait belongs here, not in a spec: every spec below reads state
 				// that only the operator publishes, and `helm --wait` covers only
@@ -119,7 +118,7 @@ const tempPinC = 85
 func assertRuntimeTempViaDCGM(ctx SpecContext, h *harness.Harness, wantC int) {
 	GinkgoHelper()
 	const targetGPU = 0
-	node := gpuOperatorTargetNode(ctx, h)
+	node := gpuOperatorTargetNode(ctx, h).Name
 
 	By(fmt.Sprintf("pin temperature to %dC on GPU %d at runtime via nvml-mock-ctl on %s (no restart)", wantC, targetGPU, node))
 	nvmlMockCtlOnNode(ctx, h, node, "temp", "--gpu", strconv.Itoa(targetGPU), strconv.Itoa(wantC))
@@ -139,7 +138,7 @@ func assertRuntimeTempViaDCGM(ctx SpecContext, h *harness.Harness, wantC int) {
 func assertRuntimePowerViaDCGM(ctx SpecContext, h *harness.Harness) {
 	GinkgoHelper()
 	const targetGPU = 0
-	node := gpuOperatorTargetNode(ctx, h)
+	node := gpuOperatorTargetNode(ctx, h).Name
 
 	pod := nvmlPodOnNode(ctx, h, node)
 	envelope := smiGPU(ctx, h, pod, targetGPU)
@@ -172,7 +171,7 @@ func assertRuntimePowerViaDCGM(ctx SpecContext, h *harness.Harness) {
 func assertRuntimeXidViaDCGM(ctx SpecContext, h *harness.Harness, xid int) {
 	GinkgoHelper()
 	const targetGPU = 0
-	node := gpuOperatorTargetNode(ctx, h)
+	node := gpuOperatorTargetNode(ctx, h).Name
 
 	By(fmt.Sprintf("inject ecc_uncorrectable + Xid on GPU 0 at runtime via nvml-mock-ctl on %s (no restart)", node))
 	nvmlMockCtlOnNode(ctx, h, node, "fail", "--gpu", strconv.Itoa(targetGPU),
@@ -189,16 +188,16 @@ func assertRuntimeXidViaDCGM(ctx SpecContext, h *harness.Harness, xid int) {
 // tolerate the CP NoSchedule taint, so any worker qualifies whenever workers
 // exist; on control-plane-only clusters the CP is the only place both
 // DaemonSets can land, so fall back to it.
-func gpuOperatorTargetNode(ctx SpecContext, h *harness.Harness) string {
+func gpuOperatorTargetNode(ctx SpecContext, h *harness.Harness) cluster.Node {
 	GinkgoHelper()
 	workers, err := h.Cluster.Workers(ctx)
 	Expect(err).NotTo(HaveOccurred())
 	if len(workers) > 0 {
-		return workers[0].Name
+		return workers[0]
 	}
 	cp, err := h.Cluster.ControlPlane(ctx)
 	Expect(err).NotTo(HaveOccurred())
-	return cp.Name
+	return cp
 }
 
 // injectXidAndValidate enables failure injection, restarts dcgm-exporter so


### PR DESCRIPTION
## Summary

The nvml-mock chart ships `tolerations: [{operator: Exists}]`, so in every local-dev and CI Kind cluster the DaemonSet landed on the control-plane node as well as the workers. Nothing follows it there — GPU Operator operands, FGO and NFD workers all stop at the `NoSchedule` taint — so the control plane advertised a GPU driver footprint (`/run/nvidia/driver`, `/var/run/cdi/nvidia.yaml`, `nvidia.com/gpu.present`) that no consumer could ever use, and scenarios that pick a mock pod by list position intermittently targeted it. Two e2e helpers already carry comments about working around exactly that.

- Label every Kind worker `mokka.nvidia.com/type=sgpu` (`local/kind/default.kind.yaml`, `local/kind/compute-domain.kind.yaml`) and select on it from `local/nvml-mock.values.yaml`, the shared local-dev baseline.
- Repeat the selector in `local/compute-domain/nvml-mock.values.yaml`: `compute_domain.tiltfile` installs the chart itself and does not layer that baseline. It is load-bearing there anyway — `topology.yaml` assigns a clique per worker and describes no control plane, so a mock pod on it reported a fabric identity the topology never declared.
- Fix the GPU Operator e2e: `verifyGPUOperatorNodeSetup` probed the *control-plane* container for the mock's driver footprint, which only existed because the mock ran there. It now probes the node the specs actually assert on (`gpuOperatorTargetNode`), which is where the Operator's operands live too.

Selector pinning stays additive: Helm deep-merges maps, so the FGO overlay (`run.ai/simulated-gpu-node-pool`) and `--multi-gpu-profile`'s `--set nodeSelector.kubernetes\.io/hostname=worker-N` compose with it rather than replacing it.

## Test plan

- [x] `make lint-fix` — 0 issues (the non-zero exit is the pre-existing `govulncheck` stdlib finding on `main`)
- [x] `make helm-tests` — 173 tests, 9 suites, 15 snapshots pass
- [x] `go vet -tags e2e ./tests/e2e/go/...`
- [x] `helm template` with each overlay combination renders the expected merged selector: baseline → `mokka.nvidia.com/type=sgpu`; compute-domain → same; FGO + `--multi-gpu-profile` → all three keys
- [ ] CI e2e (`e2e`, `dra`, `gpu-operator`, `multi-node`, `nfd`, `nri`) — all jobs create the cluster with `make cluster-create` on the default profile, so the labels are present