### PR TITLE
docs: lead with the Kubernetes install and standardize on the mokka namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ No physical NVIDIA hardware required.
 kind create cluster --name mokka
 
 helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
+    --namespace mokka --create-namespace \
     --set gpu.profile=gb300
 ```
 

--- a/docs/helm-chart.md
+++ b/docs/helm-chart.md
@@ -46,7 +46,7 @@ default. Kind clusters must have containerd NRI enabled; see
 
 ```bash
 helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
-  -n nvml-mock --create-namespace \
+  -n mokka --create-namespace \
   --set nri.enabled=true
 ```
 
@@ -904,10 +904,10 @@ Guidance:
 
 ```bash
 # Which nodes are actually injecting right now
-kubectl get pods -n nvml-mock -l app.kubernetes.io/name=nvml-mock-nri -o wide
+kubectl get pods -n mokka -l app.kubernetes.io/name=nvml-mock-nri -o wide
 
 # Why a given node is not
-kubectl describe pod -n nvml-mock <nvml-mock-nri-pod>
+kubectl describe pod -n mokka <nvml-mock-nri-pod>
 ```
 
 Both probe endpoints answer with the reason in the body, so a readiness failure
@@ -952,7 +952,7 @@ namespace, on the pod IP where the kubelet reaches it.
 | `infiniband.mockTier` | `""` (auto) | `MOCK_IB` tier: `off`, `sysfs`, or `full`. Empty auto-derives `full` for IB-enabled profiles and `sysfs` otherwise (keeps the `libibmocksys` redirect active so any real host IB is masked). `off` makes every shim a no-op and skips the daemon. An invalid value fails `helm template` |
 | `infiniband.ping.port` | `18515` | TCP port for fabric relay between nvml-mock pods (`mock-ib` / `ibping` always enabled) |
 | `infiniband.ping.networkPolicy.enabled` | `true` | Restrict inbound access to the fabric port to peer nvml-mock pods. No-op on CNIs that don't enforce NetworkPolicy (e.g. Kind's kindnet) |
-| `nri.enabled` | `false` | Deploy the `nvml-mock-nri` containerd NRI plugin DaemonSet. Injects mock overlay and environment cluster-wide into non-excluded namespaces. Always install into a dedicated namespace (`-n nvml-mock`) to avoid excluding `default`. Device node injection remains opt-in (`nvidia.com/gpu` request or `nvml-mock.nvidia.com/devices: "true"` annotation). |
+| `nri.enabled` | `false` | Deploy the `nvml-mock-nri` containerd NRI plugin DaemonSet. Injects mock overlay and environment cluster-wide into non-excluded namespaces. Always install into a dedicated namespace (`-n mokka`) to avoid excluding `default`. Device node injection remains opt-in (`nvidia.com/gpu` request or `nvml-mock.nvidia.com/devices: "true"` annotation). |
 | `nri.socketPath` | `/var/run/nri/nri.sock` | NRI socket on the host. Its directory is hostPath-mounted into the plugin |
 | `nri.pluginName` / `nri.pluginIndex` | `nvml-mock` / `"10"` | NRI registration identity. The index orders this plugin against others |
 | `nri.overlay.hostPath` / `nri.overlay.mountPath` | `/var/lib/nvml-mock` / `/opt/nvml-mock` | Host overlay staged by the main DaemonSet, and the path it is injected at inside workloads |
@@ -1414,7 +1414,8 @@ kubectl -n nvidia logs -l app.kubernetes.io/name=nvidia-dra-driver-gpu --tail=10
 
 **Privileged pods blocked**: Your cluster may have PodSecurity or OPA/Gatekeeper
 policies blocking `privileged: true`. KIND allows this by default. For managed
-clusters, you may need to create a PodSecurity exception for the nvml-mock namespace.
+clusters, you may need to create a PodSecurity exception for the nvml-mock
+release namespace.
 
 ## Related Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,8 +45,13 @@ though real hardware were present. No physical NVIDIA GPU is required.
 ```bash
 kind create cluster --name mokka
 
-helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
+    --namespace mokka --create-namespace
 ```
+
+Use `make cluster-create` instead of `kind create cluster` when you need the
+CDI-enabled Kind node image — that is what the device plugin, DRA driver and
+GPU Operator paths run on. `make cluster-delete` tears it down.
 
 The [Helm chart guide](helm-chart.md) has the full walkthrough for each
 consumer, including the device plugin, the DRA driver, the GPU Operator and a

--- a/docs/nvml-mock-ctl.md
+++ b/docs/nvml-mock-ctl.md
@@ -86,7 +86,7 @@ override that default.)
 ```bash
 # Pick the nvml-mock pod on a specific node.
 # Replace <node> with the node name; adjust -n if you installed elsewhere.
-POD=$(kubectl -n nvml-mock get pod -l app.kubernetes.io/name=nvml-mock \
+POD=$(kubectl -n mokka get pod -l app.kubernetes.io/name=nvml-mock \
   --field-selector spec.nodeName=<node> -o jsonpath='{.items[0].metadata.name}')
 ```
 
@@ -220,11 +220,11 @@ argument is the error **rate in errors/second** (0–1e9); `0` heals (no injecti
 
 ```bash
 # ramp 250 NVLink errors/sec on every active link of GPU 0
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl nvlink-error --gpu 0 250
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl nvlink-error --gpu 0 250
 # restrict to specific link ids
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl nvlink-error --gpu 0 250 --links 0,3,7
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl nvlink-error --gpu 0 250 --links 0,3,7
 # heal
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl nvlink-error --gpu 0 0
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl nvlink-error --gpu 0 0
 ```
 
 The count climbs monotonically off the shared counter epoch (the same accrual
@@ -253,12 +253,12 @@ that has just taken an SRAM fault does. The positional argument is the error
 
 ```bash
 # 4 uncorrectable SEC-DED errors on GPU 0's SM, past the service threshold
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl sram-ecc --gpu 0 \
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl sram-ecc --gpu 0 \
   --type secded --source sm --threshold-exceeded 4
 # correctable errors (no source attribution on real hardware)
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl sram-ecc --gpu 0 --type correctable 12
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl sram-ecc --gpu 0 --type correctable 12
 # heal
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl sram-ecc --gpu 0 0
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl sram-ecc --gpu 0 0
 ```
 
 | flag                   | meaning                                                                                   |
@@ -288,13 +288,13 @@ the conditions to report:
 
 ```bash
 # a route on GPU 0 is unhealthy
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl fabric-health --gpu 0 route_unhealthy
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl fabric-health --gpu 0 route_unhealthy
 # degraded fabric bandwidth while a route recovers
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl fabric-health --gpu 0 degraded_bandwidth route_recovery
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl fabric-health --gpu 0 degraded_bandwidth route_recovery
 # the fabric manager gave this GPU no partition
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl fabric-health --gpu 0 no_partition
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl fabric-health --gpu 0 no_partition
 # recover
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl fabric-health --gpu 0 healthy
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl fabric-health --gpu 0 healthy
 ```
 
 | condition | reported as |
@@ -392,83 +392,83 @@ All examples assume `$POD` is set as shown in [Where it runs](#where-it-runs).
 
 ```bash
 # 1) Force uncorrectable ECC on GPU 0, deliver Xid 79
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl fail --gpu 0 --mode ecc_uncorrectable --after-calls 1 --xid 79
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl fail --gpu 0 --mode ecc_uncorrectable --after-calls 1 --xid 79
 # verify from any consumer pod:
 kubectl exec <consumer> -- nvidia-smi --query-gpu=ecc.errors.uncorrected.aggregate.total --format=csv,noheader
 ```
 
 ```bash
 # 2) Mark ALL GPUs lost
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl fail --gpu all --mode lost
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl fail --gpu all --mode lost
 ```
 
 ```bash
 # 3) Pin GPU 3's reported temperature to 85 C (works whether or not the
 # profile drives temperature dynamically — the temp command handles both).
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl temp --gpu 3 85
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl temp --gpu 3 85
 # verify from any consumer pod:
 kubectl exec <consumer> -- nvidia-smi --id=3 --query-gpu=temperature.gpu --format=csv,noheader,nounits
 ```
 
 ```bash
 # 3b) Pin power draw to 350 W on all GPUs, and fan speed to 60% on GPU 0.
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl power --gpu all 350
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl fan --gpu 0 60
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl power --gpu all 350
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl fan --gpu 0 60
 # verify from any consumer pod:
 kubectl exec <consumer> -- nvidia-smi --query-gpu=index,power.draw,fan.speed --format=csv,noheader
 ```
 
 ```bash
 # 3c) Pin utilization, clocks, a throttle reason and the P-state on GPU 0.
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl util --gpu 0 90
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl clocks --gpu 0 1200
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl throttle --gpu 0 thermal
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl pstate --gpu 0 8
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl util --gpu 0 90
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl clocks --gpu 0 1200
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl throttle --gpu 0 thermal
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl pstate --gpu 0 8
 # verify from any consumer pod:
 kubectl exec <consumer> -- nvidia-smi --id=0 \
   --query-gpu=utilization.gpu,clocks.sm,clocks_throttle_reasons.hw_thermal_slowdown,pstate \
   --format=csv,noheader
 # clear the throttle reason again:
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl throttle --gpu 0 none
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl throttle --gpu 0 none
 ```
 
 ```bash
 # 3d) Degrade GPU 0's NVLink fabric route while the workload keeps running.
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl fabric-health --gpu 0 route_unhealthy
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl fabric-health --gpu 0 route_unhealthy
 # verify from any consumer pod (Fabric -> Health block):
 kubectl exec <consumer> -- nvidia-smi --id=0 -q | grep -A 7 Health
 # recover, keeping the device's other overrides:
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl fabric-health --gpu 0 healthy
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl fabric-health --gpu 0 healthy
 ```
 
 ```bash
 # 4) Set several fields on GPU 0 in one call
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl set --gpu 0 \
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl set --gpu 0 \
   ecc.mode_current=disabled \
   utilization.gpu=100
 ```
 
 ```bash
 # 5) Target by UUID (requires an explicit uuid: in the profile for that device)
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl fail --gpu GPU-12345678-1234-1234-1234-123456780000 --mode fallen_off_bus
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl fail --gpu GPU-12345678-1234-1234-1234-123456780000 --mode fallen_off_bus
 ```
 
 ```bash
 # 6) Inspect active overrides
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl status
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl status
 # or just GPU 0 (integer index only):
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl status --gpu 0
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl status --gpu 0
 ```
 
 ```bash
 # 7) Recover one GPU, then reset everything
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl fail --gpu 0 --mode healthy
-kubectl -n nvml-mock exec "$POD" -- nvml-mock-ctl reset --gpu all
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl fail --gpu 0 --mode healthy
+kubectl -n mokka exec "$POD" -- nvml-mock-ctl reset --gpu all
 ```
 
 ```bash
 # 8) Full reset via pod restart (setup.sh wipes overrides.yaml on startup)
-kubectl -n nvml-mock delete pod "$POD"
+kubectl -n mokka delete pod "$POD"
 ```
 
 ## Troubleshooting

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,39 @@
 
 Get Mock NVML running in 5 minutes.
 
-## Prerequisites
+## Kubernetes (Recommended)
+
+Requires Docker, `kind`, `kubectl`, and Helm 3.8+ (for OCI registry support).
+
+```bash
+kind create cluster --name mokka
+
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
+    --namespace mokka --create-namespace \
+    --set gpu.profile=gb300
+```
+
+Every node now reports 8 mock GB300 GPUs. `gb300` is the chart default; swap in
+`a100`, `h100`, `b200`, `gb200`, `l40s`, or `t4` for other hardware.
+
+Verify:
+
+```bash
+kubectl exec -n mokka ds/nvml-mock -- nvidia-smi -L
+```
+
+Use `make cluster-create` instead of `kind create cluster` when you need the
+CDI-enabled Kind node image — that is what the device plugin, DRA driver, and
+GPU Operator paths run on. `make cluster-delete` tears it down.
+
+See the [Helm Chart README](helm-chart.md)
+for full deployment walkthrough including device plugin, DRA driver, and GPU
+Operator integration.
+
+## Building the Library Locally
+
+The sections below build the mock `libnvidia-ml.so` directly, for local
+development and CI pipelines outside Kubernetes. They need:
 
 - Linux (x86_64 or arm64)
 - Go 1.25+ with CGo
@@ -10,9 +42,9 @@ Get Mock NVML running in 5 minutes.
 - `nvidia-smi` binary (optional -- only needed for local nvidia-smi output;
   the Kubernetes deployment includes it automatically)
 
-## Option 1: Local Build (Linux)
+### Option 1: Local Build (Linux)
 
-### Step 1: Build the Library
+#### Step 1: Build the Library
 
 ```bash
 cd pkg/gpu/mocknvml
@@ -26,14 +58,14 @@ libnvidia-ml.so.1           # Soname symlink
 libnvidia-ml.so             # Linker symlink
 ```
 
-### Step 2: Run with Default Configuration
+#### Step 2: Run with Default Configuration
 
 ```bash
 # 8x Mock A100 GPUs with default settings
 LD_LIBRARY_PATH=. nvidia-smi
 ```
 
-### Step 3: Run with YAML Configuration
+#### Step 3: Run with YAML Configuration
 
 ```bash
 # A100 profile (40GB, 400W)
@@ -46,7 +78,7 @@ LD_LIBRARY_PATH=. MOCK_NVML_CONFIG=configs/mock-nvml-config-gb200.yaml nvidia-sm
 LD_LIBRARY_PATH=. MOCK_NVML_CONFIG=configs/mock-nvml-config-gb300.yaml nvidia-smi
 ```
 
-## Option 2: Docker Build (Cross-Platform)
+### Option 2: Docker Build (Cross-Platform)
 
 Build Linux binaries from macOS or other platforms:
 
@@ -59,9 +91,9 @@ Build artifacts (shared libraries) are placed in `pkg/gpu/mocknvml/`:
 `libnvidia-ml.so`, `libnvidia-ml.so.1`, `libnvidia-ml.so.{version}`, and
 `nvidia-smi`.
 
-## Verification
+### Verification
 
-### Basic Check
+#### Basic Check
 
 ```bash
 LD_LIBRARY_PATH=. nvidia-smi -L
@@ -74,25 +106,25 @@ GPU 1: NVIDIA A100-SXM4-40GB (UUID: GPU-12345678-1234-1234-1234-123456780001)
 ...
 ```
 
-### Full Query
+#### Full Query
 
 ```bash
 LD_LIBRARY_PATH=. MOCK_NVML_CONFIG=configs/mock-nvml-config-a100.yaml nvidia-smi -q
 ```
 
-### XML Output
+#### XML Output
 
 ```bash
 LD_LIBRARY_PATH=. MOCK_NVML_CONFIG=configs/mock-nvml-config-a100.yaml nvidia-smi -x -q
 ```
 
-### CSV Query
+#### CSV Query
 
 ```bash
 LD_LIBRARY_PATH=. nvidia-smi --query-gpu=index,name,uuid,memory.total --format=csv
 ```
 
-## Debug Mode
+### Debug Mode
 
 Enable verbose logging to see NVML function calls:
 
@@ -109,7 +141,7 @@ Output includes:
 [NVML] nvmlDeviceGetTemperature(sensor=0) -> 33
 ```
 
-## Environment Variables
+### Environment Variables
 
 | Variable | Description | Default |
 |----------|-------------|---------|
@@ -117,21 +149,6 @@ Output includes:
 | `MOCK_NVML_NUM_DEVICES` | Number of GPUs (without YAML) | 8 |
 | `MOCK_NVML_DRIVER_VERSION` | Driver version (without YAML) | 550.163.01 |
 | `MOCK_NVML_DEBUG` | Enable debug logging | (disabled) |
-
-## Option 3: Kubernetes (Published Image)
-
-Deploy on a Kind cluster using the published container image:
-
-```bash
-kind create cluster --name nvml-mock-test
-docker pull ghcr.io/nvidia/nvml-mock:latest
-kind load docker-image ghcr.io/nvidia/nvml-mock:latest --name nvml-mock-test
-helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock --wait --timeout 120s
-```
-
-See the [Helm Chart README](helm-chart.md)
-for full deployment walkthrough including device plugin, DRA driver, and GPU
-Operator integration.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

- **Promote the Helm install to the top of the quickstart.** It was `Option 3`, behind two local `libnvidia-ml.so` build options, so the fastest path to simulated GPUs was the last thing a reader found. The Go 1.25/GCC prerequisites moved down with the build sections they actually apply to, since the Helm path doesn't need them. The `docker pull` / `kind load` lines are gone too — the chart already pulls `ghcr.io/nvidia/nvml-mock:latest` by default.
- **Standardize every namespace reference on `mokka`.** The install snippets used the release default while `nvml-mock-ctl.md` and the NRI guidance in `helm-chart.md` said `-n nvml-mock`, so copy-pasting between pages produced commands that resolved to nothing. `mokka` is the namespace `local/nvml_mock.tiltfile` provisions and the one the Ginkgo E2E suite queries, so the docs now match the tooling.
- **Note `make cluster-create`** in the quickstart and landing page, for readers who need the CDI-enabled Kind node image that the device plugin, DRA driver, and GPU Operator paths run on.

Docs only; no chart, code, or CI changes.

## Test plan

- [ ] `mkdocs build --strict` passes (heading levels changed in `quickstart.md`; no other page links to those anchors, verified with a repo-wide search for `quickstart.md#`).
- [ ] Follow the quickstart top to bottom on a fresh Kind cluster: `kind create cluster --name mokka`, the `helm install` with `--namespace mokka --create-namespace`, then `kubectl exec -n mokka ds/nvml-mock -- nvidia-smi -L` lists 8 GB300 GPUs.
- [ ] Spot-check a couple of `nvml-mock-ctl` examples against a release installed in `mokka`.

## Notes for reviewers

The `-n mokka` change in the `nri.enabled` values-table row is load-bearing rather than cosmetic: the NRI plugin excludes its own release namespace, so the surrounding text warning against installing into `default` still reads correctly with the new name.

`docs/demo/nv-sentinel/README.md` still uses `nvml-mock-system` and the other demo docs have their own install steps. I left those alone since each demo is self-contained and internally consistent; happy to sweep them in a follow-up if you'd prefer one name everywhere.