### PR TITLE
fix(profiles): model gb200/gb300 as a 4-GPU NVL72 compute tray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is now the pipeline's critical path.
 - Test pod manifests moved into a generic `pod.tpl.yaml` under
   `tests/e2e/go/framework/pod`, rendered from a `Spec` carrying only what varies.
+- The `gb200` and `gb300` profiles now model 4 GPUs per node over 2 PCI root
+  complexes, not 8 over 4. Both were written to the 8-GPU baseboard shape the
+  other profiles use, but an NVL72 rack reaches 72 GPUs as 18 compute trays of
+  4, and `nvidia-smi` runs per node: the real captures in
+  `tests/e2e/go/assertions/nvidiasmi/testdata/hardware/` report 4 attached GPUs
+  on one tray, in one slot, of one chassis. A node twice its real size inflates
+  every count a consumer derives from it — allocatable GPUs, GFD's
+  `nvidia.com/gpu.count`, ResourceSlice sizes — and invents a second pair of
+  Grace CPUs and NUMA nodes that no such node has. Two details the captures
+  report are now reproduced with it: the two GPUs of a superchip share one board
+  serial, and `module_id` does not follow the device index (2, 1, 4, 3 across
+  devices 0..3), so a consumer that assumes either breaks here rather than on
+  real hardware. `gpu.count` left empty still derives from the profile, so the
+  chart needs no change, but `gb300` is the chart default: a default install now
+  exposes 4 GPUs per node rather than 8. Set `gpu.profile` to one of the 8-GPU
+  baseboards, or `gpu.count` explicitly, for a larger node. The standalone and
+  node-wide demos now default the count from the selected profile's device list
+  instead of a hardcoded 8.
 
 ### Fixed
 - mocknvml: `nvmlPciInfo_t.busId` now reports the 8-digit PCI domain real NVML

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
     --set gpu.profile=gb300
 ```
 
-Every node now reports 8 mock GB300 GPUs. `gb300` is the chart default; swap in
+Every node now reports 4 mock GB300 GPUs, one NVL72 compute tray. `gb300` is the
+chart default; swap in
 `a100`, `h100`, `b200`, `gb200`, `l40s`, or `t4` for other hardware.
 
 After install, deploy a consumer to test:

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
@@ -77,7 +77,7 @@ device_defaults:
     chassis_serial_number: "1822725100200"
     slot_number: 21
     tray_index: 11
-    host_id: 1                      # first of the tray's two OS domains
+    host_id: 1                      # the tray's OS domain; all its GPUs report it
     peer_type: "switch_connected"   # peers reached through the NVSwitch trays
 
   # ---------------------------------------------------------------------------
@@ -398,89 +398,58 @@ device_defaults:
 
 # =============================================================================
 # Device-specific overrides
-# GB200 NVL72 has 72 GPUs, but we'll define 8 for testing
-# In a real GB200 system, GPUs are paired in superchips with Grace CPUs
+#
+# Four GPUs, because that is what one GB200 NVL72 compute tray presents to one
+# OS domain: two Grace-Blackwell superchips, so 2 Grace CPUs and 4 B200 GPUs.
+# The rack's 72 GPUs are 18 such trays, and nvidia-smi runs per node — see
+# tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-gb200.xml, which
+# reports 4 attached GPUs sharing one tray, slot and chassis.
+#
+# Two properties of that capture are deliberately reproduced here, because a
+# consumer that assumes them away breaks on real hardware: the two GPUs of a
+# superchip report the SAME board serial, and module_id does not follow the
+# device index (the capture reports 2, 1, 4, 3 across devices 0..3).
 # =============================================================================
 devices:
   - index: 0
     uuid: "GPU-b200b200-0000-0000-0000-000000000000"
-    serial: "1562849103700"
+    serial: "1562849103700"         # superchip board serial, shared with GPU 1
     pci:
       bus_id: "0000:0A:00.0"
     minor_number: 0
     grace_cpu_pair: 0               # Paired with Grace CPU 0
     platform:
-      module_id: 1                  # ID of this GPU within the node
+      module_id: 2                  # ID of this GPU within the node
 
   - index: 1
     uuid: "GPU-b200b200-0000-0000-0000-000000000001"
-    serial: "1562849103701"
+    serial: "1562849103700"
     pci:
       bus_id: "0000:0B:00.0"
     minor_number: 1
     grace_cpu_pair: 0               # Same superchip as GPU 0
     platform:
-      module_id: 2
+      module_id: 1
 
   - index: 2
     uuid: "GPU-b200b200-0000-0000-0000-000000000002"
-    serial: "1562849103702"
+    serial: "1562849103701"         # second superchip, shared with GPU 3
     pci:
       bus_id: "0000:4A:00.0"
     minor_number: 2
     grace_cpu_pair: 1
     platform:
-      module_id: 3
+      module_id: 4
 
   - index: 3
     uuid: "GPU-b200b200-0000-0000-0000-000000000003"
-    serial: "1562849103703"
+    serial: "1562849103701"
     pci:
       bus_id: "0000:4B:00.0"
     minor_number: 3
     grace_cpu_pair: 1
     platform:
-      module_id: 4
-
-  - index: 4
-    uuid: "GPU-b200b200-0000-0000-0000-000000000004"
-    serial: "1562849103704"
-    pci:
-      bus_id: "0000:8A:00.0"
-    minor_number: 4
-    grace_cpu_pair: 2
-    platform:
-      module_id: 5
-
-  - index: 5
-    uuid: "GPU-b200b200-0000-0000-0000-000000000005"
-    serial: "1562849103705"
-    pci:
-      bus_id: "0000:8B:00.0"
-    minor_number: 5
-    grace_cpu_pair: 2
-    platform:
-      module_id: 6
-
-  - index: 6
-    uuid: "GPU-b200b200-0000-0000-0000-000000000006"
-    serial: "1562849103706"
-    pci:
-      bus_id: "0000:CA:00.0"
-    minor_number: 6
-    grace_cpu_pair: 3
-    platform:
-      module_id: 7
-
-  - index: 7
-    uuid: "GPU-b200b200-0000-0000-0000-000000000007"
-    serial: "1562849103707"
-    pci:
-      bus_id: "0000:CB:00.0"
-    minor_number: 7
-    grace_cpu_pair: 3
-    platform:
-      module_id: 8
+      module_id: 3
 
 # =============================================================================
 # NVLink topology - GB200 uses NVLink 5.0
@@ -524,7 +493,7 @@ infiniband:
   node_desc_template: "{node_name} mlx5_{idx}"
 
 # =============================================================================
-# PCIe topology - GB200, 4 Grace CPU pairs -> 4 NUMA nodes, 2 GPUs each.
+# PCIe topology - GB200, 2 Grace CPUs -> 2 NUMA nodes, 2 GPUs each.
 # Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
 # under MOCK_PCI_ROOT. C consumers such as `lspci` resolve the PCIe root
 # complex through these symlinks. The NVIDIA DRA driver does NOT: it is a
@@ -544,13 +513,3 @@ pcie_topology:
       devices:
         - "0000:4A:00.0"
         - "0000:4B:00.0"
-    - id: "pci0000:80"
-      numa_node: 2
-      devices:
-        - "0000:8A:00.0"
-        - "0000:8B:00.0"
-    - id: "pci0000:c0"
-      numa_node: 3
-      devices:
-        - "0000:CA:00.0"
-        - "0000:CB:00.0"

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/gb300.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/gb300.yaml
@@ -78,7 +78,7 @@ device_defaults:
     chassis_serial_number: "1822725100300"
     slot_number: 26
     tray_index: 16
-    host_id: 1                      # first of the tray's two OS domains
+    host_id: 1                      # the tray's OS domain; all its GPUs report it
     peer_type: "switch_connected"   # peers reached through the NVSwitch trays
 
   # ---------------------------------------------------------------------------
@@ -401,89 +401,58 @@ device_defaults:
 
 # =============================================================================
 # Device-specific overrides
-# GB300 NVL72 has 72 GPUs, but we define 8 for testing (4 superchip trays,
-# each with 1 Grace CPU + 2 B300 GPUs, matching the GB200 layout).
+#
+# Four GPUs, because that is what one GB300 NVL72 compute tray presents to one
+# OS domain: two Grace-Blackwell Ultra superchips, so 2 Grace CPUs and 4 B300
+# GPUs. The rack's 72 GPUs are 18 such trays, and nvidia-smi runs per node —
+# see tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-gb300.xml, which
+# reports 4 attached GPUs sharing one tray, slot and chassis.
+#
+# Two properties of that capture are deliberately reproduced here, because a
+# consumer that assumes them away breaks on real hardware: the two GPUs of a
+# superchip report the SAME board serial, and module_id does not follow the
+# device index (the capture reports 2, 1, 4, 3 across devices 0..3).
 # =============================================================================
 devices:
   - index: 0
     uuid: "GPU-b300b300-0000-0000-0000-000000000000"
-    serial: "1573041103700"
+    serial: "1573041103700"         # superchip board serial, shared with GPU 1
     pci:
       bus_id: "0000:0A:00.0"
     minor_number: 0
     grace_cpu_pair: 0               # Paired with Grace CPU 0
     platform:
-      module_id: 1                  # ID of this GPU within the node
+      module_id: 2                  # ID of this GPU within the node
 
   - index: 1
     uuid: "GPU-b300b300-0000-0000-0000-000000000001"
-    serial: "1573041103701"
+    serial: "1573041103700"
     pci:
       bus_id: "0000:0B:00.0"
     minor_number: 1
     grace_cpu_pair: 0               # Same superchip as GPU 0
     platform:
-      module_id: 2
+      module_id: 1
 
   - index: 2
     uuid: "GPU-b300b300-0000-0000-0000-000000000002"
-    serial: "1573041103702"
+    serial: "1573041103701"         # second superchip, shared with GPU 3
     pci:
       bus_id: "0000:4A:00.0"
     minor_number: 2
     grace_cpu_pair: 1
     platform:
-      module_id: 3
+      module_id: 4
 
   - index: 3
     uuid: "GPU-b300b300-0000-0000-0000-000000000003"
-    serial: "1573041103703"
+    serial: "1573041103701"
     pci:
       bus_id: "0000:4B:00.0"
     minor_number: 3
     grace_cpu_pair: 1
     platform:
-      module_id: 4
-
-  - index: 4
-    uuid: "GPU-b300b300-0000-0000-0000-000000000004"
-    serial: "1573041103704"
-    pci:
-      bus_id: "0000:8A:00.0"
-    minor_number: 4
-    grace_cpu_pair: 2
-    platform:
-      module_id: 5
-
-  - index: 5
-    uuid: "GPU-b300b300-0000-0000-0000-000000000005"
-    serial: "1573041103705"
-    pci:
-      bus_id: "0000:8B:00.0"
-    minor_number: 5
-    grace_cpu_pair: 2
-    platform:
-      module_id: 6
-
-  - index: 6
-    uuid: "GPU-b300b300-0000-0000-0000-000000000006"
-    serial: "1573041103706"
-    pci:
-      bus_id: "0000:CA:00.0"
-    minor_number: 6
-    grace_cpu_pair: 3
-    platform:
-      module_id: 7
-
-  - index: 7
-    uuid: "GPU-b300b300-0000-0000-0000-000000000007"
-    serial: "1573041103707"
-    pci:
-      bus_id: "0000:CB:00.0"
-    minor_number: 7
-    grace_cpu_pair: 3
-    platform:
-      module_id: 8
+      module_id: 3
 
 # =============================================================================
 # NVLink topology - GB300 uses NVLink 5.0 (same fabric as GB200)
@@ -530,7 +499,7 @@ infiniband:
 # PCIe topology (consumed by render-pci-sysfs to materialize
 # /sys/bus/pci/devices/<bdf> -> ../../../devices/pciDDDD:BB/<bdf> symlinks
 # and per-device numa_node files). Mirrors the GB300 NVL superchip layout:
-# one PCI root complex per Grace+2×B300 tray, NUMA-aligned per tray.
+# one PCI root complex per Grace+2×B300 superchip, NUMA-aligned per superchip.
 # =============================================================================
 pcie_topology:
   root_complexes:
@@ -544,13 +513,3 @@ pcie_topology:
       devices:
         - "0000:4A:00.0"
         - "0000:4B:00.0"
-    - id: "pci0000:80"
-      numa_node: 2
-      devices:
-        - "0000:8A:00.0"
-        - "0000:8B:00.0"
-    - id: "pci0000:c0"
-      numa_node: 3
-      devices:
-        - "0000:CA:00.0"
-        - "0000:CB:00.0"

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
@@ -1045,7 +1045,7 @@ should match snapshot with default gb300 profile:
             chassis_serial_number: "1822725100300"
             slot_number: 26
             tray_index: 16
-            host_id: 1                      # first of the tray's two OS domains
+            host_id: 1                      # the tray's OS domain; all its GPUs report it
             peer_type: "switch_connected"   # peers reached through the NVSwitch trays
 
           # ---------------------------------------------------------------------------
@@ -1368,89 +1368,58 @@ should match snapshot with default gb300 profile:
 
         # =============================================================================
         # Device-specific overrides
-        # GB300 NVL72 has 72 GPUs, but we define 8 for testing (4 superchip trays,
-        # each with 1 Grace CPU + 2 B300 GPUs, matching the GB200 layout).
+        #
+        # Four GPUs, because that is what one GB300 NVL72 compute tray presents to one
+        # OS domain: two Grace-Blackwell Ultra superchips, so 2 Grace CPUs and 4 B300
+        # GPUs. The rack's 72 GPUs are 18 such trays, and nvidia-smi runs per node —
+        # see tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-gb300.xml, which
+        # reports 4 attached GPUs sharing one tray, slot and chassis.
+        #
+        # Two properties of that capture are deliberately reproduced here, because a
+        # consumer that assumes them away breaks on real hardware: the two GPUs of a
+        # superchip report the SAME board serial, and module_id does not follow the
+        # device index (the capture reports 2, 1, 4, 3 across devices 0..3).
         # =============================================================================
         devices:
           - index: 0
             uuid: "GPU-b300b300-0000-0000-0000-000000000000"
-            serial: "1573041103700"
+            serial: "1573041103700"         # superchip board serial, shared with GPU 1
             pci:
               bus_id: "0000:0A:00.0"
             minor_number: 0
             grace_cpu_pair: 0               # Paired with Grace CPU 0
             platform:
-              module_id: 1                  # ID of this GPU within the node
+              module_id: 2                  # ID of this GPU within the node
 
           - index: 1
             uuid: "GPU-b300b300-0000-0000-0000-000000000001"
-            serial: "1573041103701"
+            serial: "1573041103700"
             pci:
               bus_id: "0000:0B:00.0"
             minor_number: 1
             grace_cpu_pair: 0               # Same superchip as GPU 0
             platform:
-              module_id: 2
+              module_id: 1
 
           - index: 2
             uuid: "GPU-b300b300-0000-0000-0000-000000000002"
-            serial: "1573041103702"
+            serial: "1573041103701"         # second superchip, shared with GPU 3
             pci:
               bus_id: "0000:4A:00.0"
             minor_number: 2
             grace_cpu_pair: 1
             platform:
-              module_id: 3
+              module_id: 4
 
           - index: 3
             uuid: "GPU-b300b300-0000-0000-0000-000000000003"
-            serial: "1573041103703"
+            serial: "1573041103701"
             pci:
               bus_id: "0000:4B:00.0"
             minor_number: 3
             grace_cpu_pair: 1
             platform:
-              module_id: 4
-
-          - index: 4
-            uuid: "GPU-b300b300-0000-0000-0000-000000000004"
-            serial: "1573041103704"
-            pci:
-              bus_id: "0000:8A:00.0"
-            minor_number: 4
-            grace_cpu_pair: 2
-            platform:
-              module_id: 5
-
-          - index: 5
-            uuid: "GPU-b300b300-0000-0000-0000-000000000005"
-            serial: "1573041103705"
-            pci:
-              bus_id: "0000:8B:00.0"
-            minor_number: 5
-            grace_cpu_pair: 2
-            platform:
-              module_id: 6
-
-          - index: 6
-            uuid: "GPU-b300b300-0000-0000-0000-000000000006"
-            serial: "1573041103706"
-            pci:
-              bus_id: "0000:CA:00.0"
-            minor_number: 6
-            grace_cpu_pair: 3
-            platform:
-              module_id: 7
-
-          - index: 7
-            uuid: "GPU-b300b300-0000-0000-0000-000000000007"
-            serial: "1573041103707"
-            pci:
-              bus_id: "0000:CB:00.0"
-            minor_number: 7
-            grace_cpu_pair: 3
-            platform:
-              module_id: 8
+              module_id: 3
 
         # =============================================================================
         # NVLink topology - GB300 uses NVLink 5.0 (same fabric as GB200)
@@ -1497,7 +1466,7 @@ should match snapshot with default gb300 profile:
         # PCIe topology (consumed by render-pci-sysfs to materialize
         # /sys/bus/pci/devices/<bdf> -> ../../../devices/pciDDDD:BB/<bdf> symlinks
         # and per-device numa_node files). Mirrors the GB300 NVL superchip layout:
-        # one PCI root complex per Grace+2×B300 tray, NUMA-aligned per tray.
+        # one PCI root complex per Grace+2×B300 superchip, NUMA-aligned per superchip.
         # =============================================================================
         pcie_topology:
           root_complexes:
@@ -1511,16 +1480,6 @@ should match snapshot with default gb300 profile:
               devices:
                 - "0000:4A:00.0"
                 - "0000:4B:00.0"
-            - id: "pci0000:80"
-              numa_node: 2
-              devices:
-                - "0000:8A:00.0"
-                - "0000:8B:00.0"
-            - id: "pci0000:c0"
-              numa_node: 3
-              devices:
-                - "0000:CA:00.0"
-                - "0000:CB:00.0"
     kind: ConfigMap
     metadata:
       labels:
@@ -1614,7 +1573,7 @@ should match snapshot with gb200 profile:
             chassis_serial_number: "1822725100200"
             slot_number: 21
             tray_index: 11
-            host_id: 1                      # first of the tray's two OS domains
+            host_id: 1                      # the tray's OS domain; all its GPUs report it
             peer_type: "switch_connected"   # peers reached through the NVSwitch trays
 
           # ---------------------------------------------------------------------------
@@ -1935,89 +1894,58 @@ should match snapshot with gb200 profile:
 
         # =============================================================================
         # Device-specific overrides
-        # GB200 NVL72 has 72 GPUs, but we'll define 8 for testing
-        # In a real GB200 system, GPUs are paired in superchips with Grace CPUs
+        #
+        # Four GPUs, because that is what one GB200 NVL72 compute tray presents to one
+        # OS domain: two Grace-Blackwell superchips, so 2 Grace CPUs and 4 B200 GPUs.
+        # The rack's 72 GPUs are 18 such trays, and nvidia-smi runs per node — see
+        # tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-gb200.xml, which
+        # reports 4 attached GPUs sharing one tray, slot and chassis.
+        #
+        # Two properties of that capture are deliberately reproduced here, because a
+        # consumer that assumes them away breaks on real hardware: the two GPUs of a
+        # superchip report the SAME board serial, and module_id does not follow the
+        # device index (the capture reports 2, 1, 4, 3 across devices 0..3).
         # =============================================================================
         devices:
           - index: 0
             uuid: "GPU-b200b200-0000-0000-0000-000000000000"
-            serial: "1562849103700"
+            serial: "1562849103700"         # superchip board serial, shared with GPU 1
             pci:
               bus_id: "0000:0A:00.0"
             minor_number: 0
             grace_cpu_pair: 0               # Paired with Grace CPU 0
             platform:
-              module_id: 1                  # ID of this GPU within the node
+              module_id: 2                  # ID of this GPU within the node
 
           - index: 1
             uuid: "GPU-b200b200-0000-0000-0000-000000000001"
-            serial: "1562849103701"
+            serial: "1562849103700"
             pci:
               bus_id: "0000:0B:00.0"
             minor_number: 1
             grace_cpu_pair: 0               # Same superchip as GPU 0
             platform:
-              module_id: 2
+              module_id: 1
 
           - index: 2
             uuid: "GPU-b200b200-0000-0000-0000-000000000002"
-            serial: "1562849103702"
+            serial: "1562849103701"         # second superchip, shared with GPU 3
             pci:
               bus_id: "0000:4A:00.0"
             minor_number: 2
             grace_cpu_pair: 1
             platform:
-              module_id: 3
+              module_id: 4
 
           - index: 3
             uuid: "GPU-b200b200-0000-0000-0000-000000000003"
-            serial: "1562849103703"
+            serial: "1562849103701"
             pci:
               bus_id: "0000:4B:00.0"
             minor_number: 3
             grace_cpu_pair: 1
             platform:
-              module_id: 4
-
-          - index: 4
-            uuid: "GPU-b200b200-0000-0000-0000-000000000004"
-            serial: "1562849103704"
-            pci:
-              bus_id: "0000:8A:00.0"
-            minor_number: 4
-            grace_cpu_pair: 2
-            platform:
-              module_id: 5
-
-          - index: 5
-            uuid: "GPU-b200b200-0000-0000-0000-000000000005"
-            serial: "1562849103705"
-            pci:
-              bus_id: "0000:8B:00.0"
-            minor_number: 5
-            grace_cpu_pair: 2
-            platform:
-              module_id: 6
-
-          - index: 6
-            uuid: "GPU-b200b200-0000-0000-0000-000000000006"
-            serial: "1562849103706"
-            pci:
-              bus_id: "0000:CA:00.0"
-            minor_number: 6
-            grace_cpu_pair: 3
-            platform:
-              module_id: 7
-
-          - index: 7
-            uuid: "GPU-b200b200-0000-0000-0000-000000000007"
-            serial: "1562849103707"
-            pci:
-              bus_id: "0000:CB:00.0"
-            minor_number: 7
-            grace_cpu_pair: 3
-            platform:
-              module_id: 8
+              module_id: 3
 
         # =============================================================================
         # NVLink topology - GB200 uses NVLink 5.0
@@ -2061,7 +1989,7 @@ should match snapshot with gb200 profile:
           node_desc_template: "{node_name} mlx5_{idx}"
 
         # =============================================================================
-        # PCIe topology - GB200, 4 Grace CPU pairs -> 4 NUMA nodes, 2 GPUs each.
+        # PCIe topology - GB200, 2 Grace CPUs -> 2 NUMA nodes, 2 GPUs each.
         # Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
         # under MOCK_PCI_ROOT. C consumers such as `lspci` resolve the PCIe root
         # complex through these symlinks. The NVIDIA DRA driver does NOT: it is a
@@ -2081,16 +2009,6 @@ should match snapshot with gb200 profile:
               devices:
                 - "0000:4A:00.0"
                 - "0000:4B:00.0"
-            - id: "pci0000:80"
-              numa_node: 2
-              devices:
-                - "0000:8A:00.0"
-                - "0000:8B:00.0"
-            - id: "pci0000:c0"
-              numa_node: 3
-              devices:
-                - "0000:CA:00.0"
-                - "0000:CB:00.0"
     kind: ConfigMap
     metadata:
       labels:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -380,7 +380,7 @@ should match snapshot with default values:
       template:
         metadata:
           annotations:
-            checksum/config: b521d8084a13dcabcdfdfb3d91eeb60da163e980aab6db65779b7c7d9723cde9
+            checksum/config: e320e5ab85f89b9678ceb8681b040d2cfd84ad50190566425a8772fe4c916221
           labels:
             app.kubernetes.io/component: daemon
             app.kubernetes.io/instance: RELEASE-NAME
@@ -391,7 +391,7 @@ should match snapshot with default values:
                 - /scripts/entrypoint.sh
               env:
                 - name: GPU_COUNT
-                  value: "8"
+                  value: "4"
                 - name: DRIVER_VERSION
                   value: 570.124.06
                 - name: NODE_NAME
@@ -474,7 +474,7 @@ should match snapshot with default values:
                 - --shutdown-timeout=30s
               env:
                 - name: GPU_COUNT
-                  value: "8"
+                  value: "4"
                 - name: DRIVER_VERSION
                   value: 570.124.06
               image: ghcr.io/nvidia/nvml-mock:latest

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/notes_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/notes_test.yaml.snap
@@ -74,7 +74,7 @@ should match snapshot with default values:
       Mock GPU environment deployed on all nodes!
 
         Profile: gb300
-        GPUs per node: 8
+        GPUs per node: 4
         Available profiles: a100, h100, b200, gb200, gb300, l40s, t4
         Driver version: 570.124.06
         Mock driver root: /var/lib/nvml-mock/driver

--- a/deployments/nvml-mock/helm/nvml-mock/tests/configmap_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/configmap_test.yaml
@@ -40,7 +40,7 @@ tests:
     set:
       gpu:
         profile: gb200
-        count: 8
+        count: 4
     asserts:
       - matchSnapshot: {}
 
@@ -132,7 +132,7 @@ tests:
     set:
       gpu:
         profile: gb200
-        count: 8
+        count: 4
     asserts:
       - matchRegex:
           path: data["config.yaml"]

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -125,13 +125,14 @@ tests:
           path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
           value: ["/scripts/cleanup.sh"]
 
-  - it: should set default GPU_COUNT env var to 8
+  # The default profile is gb300, whose device list is one NVL72 compute tray.
+  - it: should set default GPU_COUNT env var to 4
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: GPU_COUNT
-            value: "8"
+            value: "4"
 
   - it: should set default DRIVER_VERSION for non-Blackwell profile
     set:
@@ -161,7 +162,7 @@ tests:
     set:
       gpu:
         profile: gb200
-        count: 8
+        count: 4
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -278,7 +279,7 @@ tests:
     set:
       gpu:
         profile: gb300
-        count: 8
+        count: 4
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -343,7 +344,7 @@ tests:
             name: GPU_COUNT
             value: "4"
 
-  - it: should derive GPU_COUNT from the gb200 profile devices list (8)
+  - it: should derive GPU_COUNT from the gb200 profile devices list (4)
     set:
       gpu:
         profile: gb200
@@ -353,7 +354,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: GPU_COUNT
-            value: "8"
+            value: "4"
 
   - it: should mount all required volumes
     asserts:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -332,6 +332,22 @@ tests:
             value: "4"
 
   # ── GPU_COUNT derived from the profile devices list (count unset) ──────
+  #
+  # One case per device-list length the shipped profiles carry, so a derivation
+  # replaced by any single constant fails here. The 4-GPU profiles alone would
+  # all agree with a hardcoded 4.
+  - it: should derive GPU_COUNT from the h100 profile devices list (8)
+    set:
+      gpu:
+        profile: h100
+        count: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GPU_COUNT
+            value: "8"
+
   - it: should derive GPU_COUNT from the t4 profile devices list (4)
     set:
       gpu:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/notes_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/notes_test.yaml
@@ -27,16 +27,17 @@ tests:
       - matchRegexRaw:
           pattern: "Driver version: 570.124.06"
 
+  # count left unset: the rendered figure is the h100 device list, so it differs
+  # from the default profile's above and neither can be satisfied by a constant.
   - it: should render NOTES with h100 profile
     set:
       gpu:
         profile: h100
-        count: 4
     asserts:
       - matchRegexRaw:
           pattern: "Profile: h100"
       - matchRegexRaw:
-          pattern: "GPUs per node: 4"
+          pattern: "GPUs per node: 8"
       - matchRegexRaw:
           pattern: "Driver version: 550.163.01"
 

--- a/deployments/nvml-mock/helm/nvml-mock/tests/notes_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/notes_test.yaml
@@ -23,7 +23,7 @@ tests:
       - matchRegexRaw:
           pattern: "Profile: gb300"
       - matchRegexRaw:
-          pattern: "GPUs per node: 8"
+          pattern: "GPUs per node: 4"
       - matchRegexRaw:
           pattern: "Driver version: 570.124.06"
 
@@ -53,7 +53,7 @@ tests:
     set:
       gpu:
         profile: gb300
-        count: 8
+        count: 4
     asserts:
       - matchRegexRaw:
           pattern: "Driver version: 570.124.06"

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -4,10 +4,10 @@
 gpu:
   profile: gb300          # any *.yaml basename under profiles/ (e.g. a100, h100, b200, gb200, gb300, l40s, t4)
   # Number of GPUs to expose. Empty (default) derives the count from the
-  # selected profile's `devices:` list (t4 -> 4, all NVSwitch baseboards/NVL
-  # slices -> 8), so the profile is the single source of truth. Set to a
-  # positive integer to force a smaller/larger slice; setup.sh caps it to the
-  # profile's device count at runtime.
+  # selected profile's `devices:` list (t4 and the Grace-Blackwell trays
+  # gb200/gb300 -> 4, the 8-GPU baseboards -> 8), so the profile is the single
+  # source of truth. Set to a positive integer to force a smaller/larger slice;
+  # setup.sh caps it to the profile's device count at runtime.
   count: ""
   customConfig: ""
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -645,7 +645,9 @@ Standalone configuration files are provided for each supported GPU model:
 | `pkg/gpu/mocknvml/configs/mock-nvml-config-l40s.yaml` | NVIDIA L40S | 48 GiB | Ada Lovelace |
 | `pkg/gpu/mocknvml/configs/mock-nvml-config-t4.yaml` | NVIDIA T4 | 16 GiB | Turing |
 
-Each file contains a complete configuration with all 8 devices configured.
+Each file contains a complete configuration with every device configured: 8 for
+the baseboard profiles, 4 for the Grace-Blackwell ones (`gb200`, `gb300`), which
+model one NVL72 compute tray, the unit a real node reports.
 
 ## Integration Values
 

--- a/docs/demo/compute-domain/README.md
+++ b/docs/demo/compute-domain/README.md
@@ -67,9 +67,9 @@ The demo expects the following tools on `$PATH`:
    That flag only sizes the host-side CDI spec produced by
    `scripts/setup.sh`; the in-pod ConfigMap at
    `/etc/nvml-mock/config.yaml` — which is what `check-fabric` loads
-   — always reflects the chosen profile's full device list (8 GPUs
-   for `gb200`). For ComputeDomain verification this is actually
-   *stronger* evidence: every one of the 8 GPUs on each node must
+   — always reflects the chosen profile's full device list (4 GPUs
+   for `gb200`, one NVL72 compute tray). For ComputeDomain verification
+   this is actually *stronger* evidence: every GPU on each node must
    report the same `cliqueId` / `clusterUuid`, exercising the
    topology overlay over the full device list rather than a subset.
 4. Recycles the staging and NRI DaemonSets in order, then creates a separate

--- a/docs/demo/node-wide-injection/run.sh
+++ b/docs/demo/node-wide-injection/run.sh
@@ -17,7 +17,10 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 # to rewrite per node. A non-fabric profile (t4/l40s) still demonstrates plain
 # node-wide injection; set WITH_COMPUTE_DOMAIN=false to skip the fabric checks.
 : "${GPU_PROFILE:=gb200}"
-: "${GPU_COUNT:=8}"
+# Default to the profile's own device list, the same count the chart derives
+# when gpu.count is empty, so switching GPU_PROFILE never asks for more GPUs
+# than the profile declares (setup.sh would cap it and warn).
+: "${GPU_COUNT:=$(grep -c "^[[:space:]]*- index:" "${REPO_ROOT}/${CHART_PATH}/profiles/${GPU_PROFILE}.yaml")}"
 : "${FORCE_RECREATE:=false}"
 : "${NVML_MOCK_NAMESPACE:=mokka}"
 : "${WORKLOAD_NAMESPACE:=default}"

--- a/docs/demo/standalone/demo.sh
+++ b/docs/demo/standalone/demo.sh
@@ -10,11 +10,14 @@ set -euo pipefail
 #
 # GPU_PROFILE / GPU_COUNT are env-overridable so the same demo can drive any
 # of the chart's built-in profiles, e.g.
-#   GPU_PROFILE=gb200 GPU_COUNT=8 ./demo.sh
-#   GPU_PROFILE=t4    GPU_COUNT=4 ./demo.sh
-# The PCI-sysfs assertions in step 9 derive their expected values from
-# GPU_COUNT and from the profile's `pcie_topology:` block, so switching
-# profile keeps the demo correct without further edits.
+#   GPU_PROFILE=gb200 ./demo.sh
+#   GPU_PROFILE=t4    ./demo.sh
+# GPU_COUNT defaults to the selected profile's device list, so profiles that
+# model fewer GPUs than an 8-GPU baseboard (t4, and the 4-GPU Grace-Blackwell
+# trays gb200/gb300) need no second override. The PCI-sysfs assertions in
+# step 9 derive their expected values from GPU_COUNT and from the profile's
+# `pcie_topology:` block, so switching profile keeps the demo correct without
+# further edits.
 ###############################################################################
 CLUSTER_NAME="nvml-mock-demo"
 # Kind creates a kubeconfig context named "kind-<cluster>". Pin every kubectl
@@ -25,7 +28,6 @@ IMAGE_NAME="nvml-mock:demo"
 CHART_PATH="deployments/nvml-mock/helm/nvml-mock"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 : "${GPU_PROFILE:=h100}"
-: "${GPU_COUNT:=8}"
 # Deploy into a dedicated namespace (env-overridable) instead of default, so the
 # mock stack is easy to isolate and clean up. The namespace is also set as the
 # current context's default so the validate-*.sh helpers (which exec into pods
@@ -41,6 +43,12 @@ if [[ ! -f "${PROFILE_YAML}" ]]; then
   echo "       set GPU_PROFILE to one of: $(ls "${REPO_ROOT}/${CHART_PATH}/profiles/" | sed 's/\.yaml$//' | tr '\n' ' ')" >&2
   exit 1
 fi
+
+# Default the GPU count to the profile's device list, matching what the chart
+# derives when gpu.count is empty. Asking for more than the profile declares
+# would leave the step 9 PCI-sysfs assertions expecting devices the renderer
+# never materializes.
+: "${GPU_COUNT:=$(grep -c "^[[:space:]]*- index:" "${PROFILE_YAML}")}"
 
 # Count the `- id: "pci...` rows under `pcie_topology.root_complexes`. The
 # renderer falls back to a flat single-root layout for profiles without an
@@ -233,8 +241,8 @@ info "${FIRST_DEV} numa_node=${NUMA_NODE}"
 
 # Count distinct root complexes the symlinks resolve to. The expected
 # count was derived from the profile's `pcie_topology.root_complexes`
-# block at the top of the script, so e.g. h100/a100/b200/l40s -> 2,
-# gb200 -> 4, t4 -> 1. A regression that collapsed all devices onto a
+# block at the top of the script, so e.g. h100/a100/b200/l40s/gb200 -> 2,
+# t4 -> 1. A regression that collapsed all devices onto a
 # single root would silently break NUMA-aware scheduling.
 # readlink target shape: "../../../devices/pciDDDD:BB/<bdf>"
 # Splitting on "/" yields: $1=.. $2=.. $3=.. $4=devices $5=pciDDDD:BB

--- a/docs/helm-chart.md
+++ b/docs/helm-chart.md
@@ -149,7 +149,7 @@ NODE=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
 kubectl get node "$NODE" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}'
 ```
 
-Expected: `8` (default gpu.count).
+Expected: `4` (default gpu.count, derived from the `gb300` profile's four devices).
 
 ### 7. Clean up
 
@@ -240,7 +240,7 @@ kubectl get resourceslices -o json | \
   jq '[.items[].spec.devices // [] | length] | add // 0'
 ```
 
-Expected: `8` (default gpu.count).
+Expected: `4` (default gpu.count, derived from the `gb300` profile's four devices).
 
 ### 7. Clean up
 
@@ -355,7 +355,7 @@ kubectl -n gpu-operator wait --for=condition=ready pod --all --timeout=180s
 kubectl get nodes -o jsonpath='{.items[0].status.allocatable.nvidia\.com/gpu}'
 ```
 
-Expected: `8` (default gpu.count).
+Expected: `4` (default gpu.count, derived from the `gb300` profile's four devices).
 
 ### 9. Clean up
 
@@ -675,7 +675,8 @@ $ cat /var/lib/nvml-mock/sys/devices/pci0000:00/0000:07:00.0/numa_node
 | `a100`  | 2 (`pci0000:00`, `pci0000:80`) | 2 (dual EPYC) | 4 |
 | `h100`  | 2 (`pci0000:00`, `pci0000:80`) | 2 (dual socket) | 4 |
 | `b200`  | 2 (`pci0000:00`, `pci0000:80`) | 2 (dual socket) | 4 |
-| `gb200` | 4 (`pci0000:00`, `:40`, `:80`, `:c0`) | 4 (per Grace pair) | 2 |
+| `gb200` | 2 (`pci0000:00`, `pci0000:40`) | 2 (one per Grace CPU) | 2 |
+| `gb300` | 2 (`pci0000:00`, `pci0000:40`) | 2 (one per Grace CPU) | 2 |
 | `l40s`  | 2 (`pci0000:00`, `pci0000:80`) | 2 (dual socket) | 4 |
 | `t4`    | 1 (`pci0000:00`) | 1 | 4 |
 
@@ -925,7 +926,7 @@ namespace, on the pod IP where the kubelet reaches it.
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `gpu.profile` | `gb300` | GPU profile: `a100`, `h100`, `b200`, `gb200`, `gb300`, `l40s`, or `t4` |
-| `gpu.count` | `8` | Number of mock GPUs per node |
+| `gpu.count` | `""` | Number of mock GPUs per node. Empty derives it from the profile's `devices:` list (8 for the baseboard profiles, 4 for `t4`, `gb200` and `gb300`); a larger value is capped to that list at runtime |
 | `gpu.customConfig` | `""` | Inline YAML to override profile config entirely |
 | `gpu.dynamicMetrics.enabled` | `false` | Make the mock return time-varying temperature / power / utilization readings instead of the static profile values. See [Dynamic Metrics](#dynamic-metrics) below. |
 | `gpu.dynamicMetrics.seed` | `0` (baseline) | RNG seed; `0` uses a time-based seed, non-zero produces reproducible sequences. |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -14,7 +14,8 @@ helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
     --set gpu.profile=gb300
 ```
 
-Every node now reports 8 mock GB300 GPUs. `gb300` is the chart default; swap in
+Every node now reports 4 mock GB300 GPUs, one NVL72 compute tray. `gb300` is the
+chart default; swap in
 `a100`, `h100`, `b200`, `gb200`, `l40s`, or `t4` for other hardware.
 
 Verify:

--- a/pkg/gpu/mocknvml/README.md
+++ b/pkg/gpu/mocknvml/README.md
@@ -118,7 +118,7 @@ YAML configs allow full control over GPU properties. See `configs/` for examples
 - `mock-nvml-config-gb200.yaml` - GB200 NVL (4x GB200 with 192 GiB HBM3e — one NVL72 compute tray)
 - `mock-nvml-config-gb300.yaml` - GB300 NVL (4x Blackwell Ultra with 288 GiB HBM3e, 1.4 kW TDP)
 - `mock-nvml-config-l40s.yaml` - L40S (8x L40S, 48 GiB)
-- `mock-nvml-config-t4.yaml` - T4 (8x T4, 16 GiB)
+- `mock-nvml-config-t4.yaml` - T4 (4x T4, 16 GiB)
 
 #### Configuration Structure
 

--- a/pkg/gpu/mocknvml/README.md
+++ b/pkg/gpu/mocknvml/README.md
@@ -30,10 +30,10 @@ LD_LIBRARY_PATH=. nvidia-smi
 # 2. A100 profile (8x A100-SXM4-40GB, 40GB, 400W)
 LD_LIBRARY_PATH=. MOCK_NVML_CONFIG=configs/mock-nvml-config-a100.yaml nvidia-smi
 
-# 3. GB200 profile (8x GB200 NVL, 192GB, 1000W)
+# 3. GB200 profile (4x GB200 NVL, 192GB, 1000W)
 LD_LIBRARY_PATH=. MOCK_NVML_CONFIG=configs/mock-nvml-config-gb200.yaml nvidia-smi
 
-# 4. GB300 profile (8x GB300 NVL Blackwell Ultra, 288GB, 1400W)
+# 4. GB300 profile (4x GB300 NVL Blackwell Ultra, 288GB, 1400W)
 LD_LIBRARY_PATH=. MOCK_NVML_CONFIG=configs/mock-nvml-config-gb300.yaml nvidia-smi
 ```
 
@@ -115,8 +115,8 @@ YAML configs allow full control over GPU properties. See `configs/` for examples
 - `mock-nvml-config-a100.yaml` - DGX A100 (8x A100-SXM4-40GB)
 - `mock-nvml-config-h100.yaml` - HGX H100 (8x H100 80GB HBM3)
 - `mock-nvml-config-b200.yaml` - B200 (8x B200, 192 GiB HBM3e)
-- `mock-nvml-config-gb200.yaml` - GB200 NVL (8x GB200 with 192 GiB HBM3e)
-- `mock-nvml-config-gb300.yaml` - GB300 NVL (8x Blackwell Ultra with 288 GiB HBM3e, 1.4 kW TDP)
+- `mock-nvml-config-gb200.yaml` - GB200 NVL (4x GB200 with 192 GiB HBM3e — one NVL72 compute tray)
+- `mock-nvml-config-gb300.yaml` - GB300 NVL (4x Blackwell Ultra with 288 GiB HBM3e, 1.4 kW TDP)
 - `mock-nvml-config-l40s.yaml` - L40S (8x L40S, 48 GiB)
 - `mock-nvml-config-t4.yaml` - T4 (8x T4, 16 GiB)
 

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml
@@ -335,13 +335,19 @@ device_defaults:
 
 # =============================================================================
 # Device-specific overrides
-# GB200 NVL72 has 72 GPUs, but we'll define 8 for testing
-# In a real GB200 system, GPUs are paired in superchips with Grace CPUs
+#
+# Four GPUs, because that is what one GB200 NVL72 compute tray presents to one
+# OS domain: two Grace-Blackwell superchips, so 2 Grace CPUs and 4 B200 GPUs.
+# The rack's 72 GPUs are 18 such trays, and nvidia-smi runs per node — see
+# tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-gb200.xml.
+#
+# The two GPUs of a superchip report the SAME board serial there, so they do
+# here: a consumer keying on serial must not assume it identifies one GPU.
 # =============================================================================
 devices:
   - index: 0
     uuid: "GPU-b200b200-0000-0000-0000-000000000000"
-    serial: "1562849103700"
+    serial: "1562849103700"         # superchip board serial, shared with GPU 1
     pci:
       bus_id: "0000:0A:00.0"
     minor_number: 0
@@ -349,7 +355,7 @@ devices:
 
   - index: 1
     uuid: "GPU-b200b200-0000-0000-0000-000000000001"
-    serial: "1562849103701"
+    serial: "1562849103700"
     pci:
       bus_id: "0000:0B:00.0"
     minor_number: 1
@@ -357,7 +363,7 @@ devices:
 
   - index: 2
     uuid: "GPU-b200b200-0000-0000-0000-000000000002"
-    serial: "1562849103702"
+    serial: "1562849103701"         # second superchip, shared with GPU 3
     pci:
       bus_id: "0000:4A:00.0"
     minor_number: 2
@@ -365,43 +371,11 @@ devices:
 
   - index: 3
     uuid: "GPU-b200b200-0000-0000-0000-000000000003"
-    serial: "1562849103703"
+    serial: "1562849103701"
     pci:
       bus_id: "0000:4B:00.0"
     minor_number: 3
     grace_cpu_pair: 1
-
-  - index: 4
-    uuid: "GPU-b200b200-0000-0000-0000-000000000004"
-    serial: "1562849103704"
-    pci:
-      bus_id: "0000:8A:00.0"
-    minor_number: 4
-    grace_cpu_pair: 2
-
-  - index: 5
-    uuid: "GPU-b200b200-0000-0000-0000-000000000005"
-    serial: "1562849103705"
-    pci:
-      bus_id: "0000:8B:00.0"
-    minor_number: 5
-    grace_cpu_pair: 2
-
-  - index: 6
-    uuid: "GPU-b200b200-0000-0000-0000-000000000006"
-    serial: "1562849103706"
-    pci:
-      bus_id: "0000:CA:00.0"
-    minor_number: 6
-    grace_cpu_pair: 3
-
-  - index: 7
-    uuid: "GPU-b200b200-0000-0000-0000-000000000007"
-    serial: "1562849103707"
-    pci:
-      bus_id: "0000:CB:00.0"
-    minor_number: 7
-    grace_cpu_pair: 3
 
 # =============================================================================
 # NVLink topology - GB200 uses NVLink 5.0
@@ -428,7 +402,7 @@ nvlink:
       uuid: "NVSwitch-GB200-0000-0000-0000-000000000003"
 
 # =============================================================================
-# PCIe topology - GB200, 4 Grace CPU pairs -> 4 NUMA nodes, 2 GPUs each.
+# PCIe topology - GB200, 2 Grace CPUs -> 2 NUMA nodes, 2 GPUs each.
 # Consumed by `render-pci-sysfs` to materialize a fake /sys/bus/pci tree
 # under MOCK_PCI_ROOT. C consumers such as `lspci` resolve the PCIe root
 # complex through these symlinks. The NVIDIA DRA driver does NOT: it is a
@@ -448,13 +422,3 @@ pcie_topology:
       devices:
         - "0000:4A:00.0"
         - "0000:4B:00.0"
-    - id: "pci0000:80"
-      numa_node: 2
-      devices:
-        - "0000:8A:00.0"
-        - "0000:8B:00.0"
-    - id: "pci0000:c0"
-      numa_node: 3
-      devices:
-        - "0000:CA:00.0"
-        - "0000:CB:00.0"

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-gb300.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-gb300.yaml
@@ -338,13 +338,19 @@ device_defaults:
 
 # =============================================================================
 # Device-specific overrides
-# GB300 NVL72 has 72 GPUs, but we define 8 for testing (4 superchip trays,
-# each with 1 Grace CPU + 2 B300 GPUs, matching the GB200 layout).
+#
+# Four GPUs, because that is what one GB300 NVL72 compute tray presents to one
+# OS domain: two Grace-Blackwell Ultra superchips, so 2 Grace CPUs and 4 B300
+# GPUs. The rack's 72 GPUs are 18 such trays, and nvidia-smi runs per node —
+# see tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-gb300.xml.
+#
+# The two GPUs of a superchip report the SAME board serial there, so they do
+# here: a consumer keying on serial must not assume it identifies one GPU.
 # =============================================================================
 devices:
   - index: 0
     uuid: "GPU-b300b300-0000-0000-0000-000000000000"
-    serial: "1573041103700"
+    serial: "1573041103700"         # superchip board serial, shared with GPU 1
     pci:
       bus_id: "0000:0A:00.0"
     minor_number: 0
@@ -352,7 +358,7 @@ devices:
 
   - index: 1
     uuid: "GPU-b300b300-0000-0000-0000-000000000001"
-    serial: "1573041103701"
+    serial: "1573041103700"
     pci:
       bus_id: "0000:0B:00.0"
     minor_number: 1
@@ -360,7 +366,7 @@ devices:
 
   - index: 2
     uuid: "GPU-b300b300-0000-0000-0000-000000000002"
-    serial: "1573041103702"
+    serial: "1573041103701"         # second superchip, shared with GPU 3
     pci:
       bus_id: "0000:4A:00.0"
     minor_number: 2
@@ -368,43 +374,11 @@ devices:
 
   - index: 3
     uuid: "GPU-b300b300-0000-0000-0000-000000000003"
-    serial: "1573041103703"
+    serial: "1573041103701"
     pci:
       bus_id: "0000:4B:00.0"
     minor_number: 3
     grace_cpu_pair: 1
-
-  - index: 4
-    uuid: "GPU-b300b300-0000-0000-0000-000000000004"
-    serial: "1573041103704"
-    pci:
-      bus_id: "0000:8A:00.0"
-    minor_number: 4
-    grace_cpu_pair: 2
-
-  - index: 5
-    uuid: "GPU-b300b300-0000-0000-0000-000000000005"
-    serial: "1573041103705"
-    pci:
-      bus_id: "0000:8B:00.0"
-    minor_number: 5
-    grace_cpu_pair: 2
-
-  - index: 6
-    uuid: "GPU-b300b300-0000-0000-0000-000000000006"
-    serial: "1573041103706"
-    pci:
-      bus_id: "0000:CA:00.0"
-    minor_number: 6
-    grace_cpu_pair: 3
-
-  - index: 7
-    uuid: "GPU-b300b300-0000-0000-0000-000000000007"
-    serial: "1573041103707"
-    pci:
-      bus_id: "0000:CB:00.0"
-    minor_number: 7
-    grace_cpu_pair: 3
 
 # =============================================================================
 # NVLink topology - GB300 uses NVLink 5.0 (same fabric as GB200)
@@ -434,7 +408,7 @@ nvlink:
 # PCIe topology (consumed by render-pci-sysfs to materialize
 # /sys/bus/pci/devices/<bdf> -> ../../../devices/pciDDDD:BB/<bdf> symlinks
 # and per-device numa_node files). Mirrors the GB300 NVL superchip layout:
-# one PCI root complex per Grace+2×B300 tray, NUMA-aligned per tray.
+# one PCI root complex per Grace+2×B300 superchip, NUMA-aligned per superchip.
 # =============================================================================
 pcie_topology:
   root_complexes:
@@ -448,13 +422,3 @@ pcie_topology:
       devices:
         - "0000:4A:00.0"
         - "0000:4B:00.0"
-    - id: "pci0000:80"
-      numa_node: 2
-      devices:
-        - "0000:8A:00.0"
-        - "0000:8B:00.0"
-    - id: "pci0000:c0"
-      numa_node: 3
-      devices:
-        - "0000:CA:00.0"
-        - "0000:CB:00.0"

--- a/pkg/gpu/mocknvml/engine/config_profiles_platform_test.go
+++ b/pkg/gpu/mocknvml/engine/config_profiles_platform_test.go
@@ -39,7 +39,7 @@ var gracePlatformProfiles = map[string]bool{
 // distinct per GPU so a physical location can be derived per device. Loading
 // through Config.GetDeviceConfig is what makes the distinctness meaningful —
 // that is the merge path a device's getters read, and a shared PlatformConfig
-// pointer would collapse all eight module ids onto whichever merged last.
+// pointer would collapse every module id onto whichever merged last.
 func TestProfilePlatformIdentity(t *testing.T) {
 	for file, grace := range gracePlatformProfiles {
 		t.Run(file, func(t *testing.T) {

--- a/pkg/gpu/mocknvml/engine/config_profiles_test.go
+++ b/pkg/gpu/mocknvml/engine/config_profiles_test.go
@@ -127,8 +127,10 @@ func TestLoadConfig_GB300Profile(t *testing.T) {
 	yamlCfg, err := LoadYAMLConfig(profilePath)
 	require.NoError(t, err, "Failed to load GB300 profile")
 
-	// 8 GPUs: 4 Grace-Blackwell Ultra superchips × 2 B300 GPUs each.
-	require.Len(t, yamlCfg.Devices, 8, "GB300 device count")
+	// 4 GPUs: one NVL72 compute tray, 2 Grace-Blackwell Ultra superchips × 2
+	// B300 GPUs each, which is what a real node reports (see
+	// tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-gb300.xml).
+	require.Len(t, yamlCfg.Devices, 4, "GB300 device count")
 
 	require.Equal(t, "NVIDIA GB300 NVL", yamlCfg.DeviceDefaults.Name, "GB300 name")
 
@@ -177,8 +179,8 @@ func TestLoadConfig_AllProfilesConsistent(t *testing.T) {
 		{"A100", "a100.yaml", "ampere", 8, 0, 40, 8},
 		{"H100", "h100.yaml", "hopper", 9, 0, 80, 8},
 		{"B200", "b200.yaml", "blackwell", 10, 0, 192, 8},
-		{"GB200", "gb200.yaml", "blackwell", 10, 0, 192, 8},
-		{"GB300", "gb300.yaml", "blackwell", 10, 0, 288, 8},
+		{"GB200", "gb200.yaml", "blackwell", 10, 0, 192, 4},
+		{"GB300", "gb300.yaml", "blackwell", 10, 0, 288, 4},
 		{"L40S", "l40s.yaml", "ada_lovelace", 8, 9, 48, 8},
 		{"T4", "t4.yaml", "turing", 7, 5, 16, 4},
 	}

--- a/tests/e2e/go/profile/gfd_test.go
+++ b/tests/e2e/go/profile/gfd_test.go
@@ -10,15 +10,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The expected values are the ones GPU Feature Discovery actually published on a
-// live gb200 Mokka cluster on 2026-07-25:
+// The product and memory values are the ones GPU Feature Discovery actually
+// published on a live gb200 Mokka cluster on 2026-07-25:
 //
 //	nvidia.com/gpu.product=NVIDIA-GB200
 //	nvidia.com/gpu.memory=196608
-//	nvidia.com/gpu.count=8
 //
 // Deriving them from the profile and comparing against those observed literals
-// is what makes the e2e GFD assertion discriminating.
+// is what makes the e2e GFD assertion discriminating. The count follows the
+// profile's device list rather than that capture, which was taken while the
+// profile still declared a node of eight GPUs; it now models the four an NVL72
+// compute tray actually reports.
 func TestGB200ProfileDerivesObservedGFDLabelValues(t *testing.T) {
 	t.Parallel()
 
@@ -27,7 +29,7 @@ func TestGB200ProfileDerivesObservedGFDLabelValues(t *testing.T) {
 
 	assert.Equal(t, "NVIDIA-GB200", p.GFDProductName())
 	assert.Equal(t, 196608, p.MemoryMiB())
-	assert.Equal(t, 8, p.ExpectedGPUs())
+	assert.Equal(t, 4, p.ExpectedGPUs())
 }
 
 func TestGFDProductNameReplacesSpacesWithDashes(t *testing.T) {

--- a/tests/e2e/go/profile/profile.go
+++ b/tests/e2e/go/profile/profile.go
@@ -309,7 +309,7 @@ func (p Profile) ExpectedNV() int {
 // ExpectedPCIRoots is the number of distinct PCIe root complexes the rendered
 // /sys/bus/pci tree should span (len of pcie_topology.root_complexes, or 1 for
 // profiles with no explicit block). Mirrors the demo's EXPECTED_ROOTS: e.g.
-// a100/h100/b200/l40s -> 2, gb200/gb300 -> 4, t4 -> 1. A regression that
+// a100/h100/b200/l40s/gb200/gb300 -> 2, t4 -> 1. A regression that
 // collapsed every device onto one root would break NUMA-aware scheduling.
 func (p Profile) ExpectedPCIRoots() int { return p.pciRoots }
 

--- a/tests/e2e/go/profile/profile_test.go
+++ b/tests/e2e/go/profile/profile_test.go
@@ -46,8 +46,8 @@ func TestDerivations(t *testing.T) {
 		{"a100", "NVIDIA A100-SXM4-40GB", 8, 8, 12, true, false, true, 2, "ampere", false, false, 92, 87, 83, 4}, // NVSwitch (FabricMgr) but no ComputeDomain fabric block
 		{"h100", "NVIDIA H100 80GB HBM3", 8, 8, 18, true, true, true, 2, "hopper", true, false, 92, 87, 83, 5},
 		{"b200", "NVIDIA B200", 8, 8, 0, false, false, true, 2, "blackwell", true, false, 95, 90, 85, 6}, // NVLink negative control, IB enabled
-		{"gb200", "NVIDIA GB200", 8, 8, 18, true, true, true, 4, "blackwell", true, true, 95, 90, 85, 6},
-		{"gb300", "NVIDIA GB300 NVL", 8, 8, 18, true, true, true, 4, "blackwell", true, true, 95, 90, 85, 6},
+		{"gb200", "NVIDIA GB200", 4, 4, 18, true, true, true, 2, "blackwell", true, true, 95, 90, 85, 6}, // one NVL72 compute tray: 2 superchips, 4 GPUs
+		{"gb300", "NVIDIA GB300 NVL", 4, 4, 18, true, true, true, 2, "blackwell", true, true, 95, 90, 85, 6},
 		{"l40s", "NVIDIA L40S", 8, 0, 0, false, false, false, 2, "ada_lovelace", true, false, 96, 93, 89, 4}, // IB + NVLink negative control
 		{"t4", "NVIDIA T4", 4, 0, 0, false, false, false, 1, "turing", false, false, 96, 93, 89, 3},
 	}


### PR DESCRIPTION
## Summary

The `gb200` and `gb300` profiles declared 8 GPUs over 4 PCI root complexes — the shape the 8-GPU baseboard profiles use. That is not what a Grace-Blackwell node reports. An NVL72 rack reaches 72 GPUs as 18 compute trays of 4, and `nvidia-smi` runs per node: the real captures added in #694 show 4 attached GPUs sharing one tray, one slot and one chassis, over 2 Grace CPUs.

```
$ rg '<attached_gpus>' tests/e2e/go/assertions/nvidiasmi/testdata/hardware/qx-gb300.xml
<attached_gpus>4</attached_gpus>
```

A node twice its real size inflates every count a consumer derives from it — allocatable GPUs, GFD's `nvidia.com/gpu.count`, ResourceSlice sizes — and invents a second pair of Grace CPUs and NUMA nodes that no such node has.

Both profiles now ship 4 devices over 2 root complexes (`pci0000:00`, `pci0000:40`), in the chart `profiles/` and the engine `configs/` copies. Two further properties of the captures come with the trim, because a consumer that assumes them away breaks on real hardware rather than here:

- the two GPUs of a superchip report the **same board serial**, so GPUs 0-1 share one and GPUs 2-3 share another;
- `module_id` does **not** follow the device index — the captures report 2, 1, 4, 3 across devices 0..3, and so do the profiles.

The BDFs stay synthetic (`0000:0A/0B/4A/4B`). Real hardware reports `0000:29/3F/9C/B2` on GB200 and per-GPU PCI domains on GB300; adopting those would ripple into the `render-pci-sysfs` domain handling and the fixtures keyed on `0000:0A:00.0`, which is a separate change from getting the node's shape right.

### User-visible

`gb300` is the chart default, so **a default install now exposes 4 GPUs per node rather than 8.** `gpu.count` left empty still derives from the profile's `devices:` list, so select an 8-GPU baseboard profile or set `gpu.count` explicitly for a larger node.

The standalone and node-wide demos now default `GPU_COUNT` from the selected profile's device list instead of a hardcoded 8. This was a latent bug, not just tidiness: `node-wide-injection/run.sh` defaults to the `gb200` profile, and `standalone/demo.sh` asserts the rendered PCI device count equals `GPU_COUNT`, so the hardcoded 8 would have failed its step 9 check.

Oracles and docs updated in lockstep: the `tests/e2e/go/profile` derivation table (4 GPUs, 4 HCAs, 2 PCI roots), the engine profile-consistency tests, the Helm unittests (including the two that pinned the default count at 8) and their snapshots, `docs/helm-chart.md`, `docs/quickstart.md`, `docs/configuration.md` and the top-level README.

## Test plan

- [x] `make test`
- [x] `make helm-tests` (173 tests, 15 snapshots)
- [x] `golangci-lint` clean via `make lint-fix` (its `govulncheck` step fails on pre-existing Go 1.26.5 stdlib advisories, unrelated to this change)
- [x] `bash -n` on both touched demo scripts, and the derived counts verified per profile: `gb200`/`gb300`/`t4` -> 4 devices, the baseboards -> 8
- [ ] e2e legs for the `gb200` and `gb300` profiles in CI

## Notes for reviewers

The mock-output fixtures under `tests/e2e/go/assertions/nvidiasmi/testdata/` (`qx-gb200-healthy.xml` and friends) are 2-GPU captures carrying unique serials, so they no longer match what the profile would emit. Nothing asserts on `serial`, so they remain valid parser fixtures, but they will drift further if regenerated.