### PR TITLE
feat(node-agent): Node Agent CDI Simulator

### DIFF
--- a/cmd/node-agent/main.go
+++ b/cmd/node-agent/main.go
@@ -93,6 +93,7 @@ func runStart(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return err
 	}
+
 	log := logging.NewLogger(logging.Config{Level: level, Format: format})
 
 	configPath := cmd.String("config")

--- a/cmd/node-agent/main.go
+++ b/cmd/node-agent/main.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/NVIDIA/k8s-test-infra/internal/agent"
+	"github.com/NVIDIA/k8s-test-infra/internal/agent/cdi"
 	"github.com/NVIDIA/k8s-test-infra/internal/agent/gpudriver"
 	"github.com/NVIDIA/k8s-test-infra/internal/agent/health"
 	"github.com/NVIDIA/k8s-test-infra/internal/agent/host"
@@ -107,7 +108,7 @@ func runStart(ctx context.Context, cmd *cli.Command) error {
 	healthSrv := health.NewServer(cmd.String("health-addr"), log, shutdownTimeout)
 
 	a := agent.New(agent.Config{
-		Simulators:      []agent.Simulator{gpudriver.New(), pcibus.New()},
+		Simulators:      []agent.Simulator{gpudriver.New(), pcibus.New(), cdi.New()},
 		Source:          source.NewFileSource(configPath, log),
 		Host:            host.New(cmd.String("host-root")),
 		Log:             log,

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -221,6 +221,10 @@ spec:
             - --log-format={{ .Values.nodeAgent.logging.format }}
             - --shutdown-timeout={{ .Values.nodeAgent.shutdownTimeout }}
           env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: GPU_COUNT
               value: "{{ include "nvml-mock.gpuCount" . }}"
             - name: DRIVER_VERSION
@@ -235,6 +239,8 @@ spec:
               mountPath: /host/var/lib/nvml-mock
             - name: host-run-nvidia
               mountPath: /host/run/nvidia
+            - name: host-cdi
+              mountPath: /host/run/cdi
             - name: gpu-config
               mountPath: /etc/nvml-mock
               readOnly: true

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -229,6 +229,13 @@ spec:
               value: "{{ include "nvml-mock.gpuCount" . }}"
             - name: DRIVER_VERSION
               value: "{{ include "nvml-mock.driverVersion" . }}"
+            {{- if $fmEnabled }}
+            # Gates the fabric-state mount in the CDI spec this agent writes.
+            # Same guard as the host-fabric-state volume, so the mount and the
+            # directory it binds always appear together.
+            - name: MOCK_FABRICMANAGER_STATE_DIR
+              value: {{ .Values.fabricmanager.stateDir }}
+            {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -125,6 +125,8 @@ should match snapshot with all overrides:
                   value: "2"
                 - name: DRIVER_VERSION
                   value: 555.55.55
+                - name: MOCK_FABRICMANAGER_STATE_DIR
+                  value: /var/lib/nvml-mock/fabric-state
               image: custom-registry/nvml-mock:v2.0.0
               imagePullPolicy: Always
               livenessProbe:
@@ -491,6 +493,8 @@ should match snapshot with default values:
                   value: "4"
                 - name: DRIVER_VERSION
                   value: 570.124.06
+                - name: MOCK_FABRICMANAGER_STATE_DIR
+                  value: /var/lib/nvml-mock/fabric-state
               image: ghcr.io/nvidia/nvml-mock:latest
               imagePullPolicy: IfNotPresent
               livenessProbe:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -117,6 +117,10 @@ should match snapshot with all overrides:
                 - --log-format=json
                 - --shutdown-timeout=30s
               env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
                 - name: GPU_COUNT
                   value: "2"
                 - name: DRIVER_VERSION
@@ -148,6 +152,8 @@ should match snapshot with all overrides:
                   name: host-nvml-mock
                 - mountPath: /host/run/nvidia
                   name: host-run-nvidia
+                - mountPath: /host/run/cdi
+                  name: host-cdi
                 - mountPath: /etc/nvml-mock
                   name: gpu-config
                   readOnly: true
@@ -295,6 +301,10 @@ should match snapshot with b200 profile:
                 - --log-format=json
                 - --shutdown-timeout=30s
               env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
                 - name: GPU_COUNT
                   value: "4"
                 - name: DRIVER_VERSION
@@ -326,6 +336,8 @@ should match snapshot with b200 profile:
                   name: host-nvml-mock
                 - mountPath: /host/run/nvidia
                   name: host-run-nvidia
+                - mountPath: /host/run/cdi
+                  name: host-cdi
                 - mountPath: /etc/nvml-mock
                   name: gpu-config
                   readOnly: true
@@ -471,6 +483,10 @@ should match snapshot with default values:
                 - --log-format=json
                 - --shutdown-timeout=30s
               env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
                 - name: GPU_COUNT
                   value: "4"
                 - name: DRIVER_VERSION
@@ -502,6 +518,8 @@ should match snapshot with default values:
                   name: host-nvml-mock
                 - mountPath: /host/run/nvidia
                   name: host-run-nvidia
+                - mountPath: /host/run/cdi
+                  name: host-cdi
                 - mountPath: /etc/nvml-mock
                   name: gpu-config
                   readOnly: true

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -756,6 +756,27 @@ tests:
               path: /var/lib/nvml-mock/fabric-state
               type: DirectoryOrCreate
 
+  # b200 declares NVLink but no NVSwitches, so no state dir is created on the
+  # node. Leaving node-agent's env unset keeps that mount out of its CDI spec;
+  # emitting it would fail creation of every CDI consumer on the node.
+  - it: should not wire fabricmanager for an NVLink profile without NVSwitches (b200)
+    set:
+      gpu:
+        profile: b200
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: MOCK_FABRICMANAGER_STATE_DIR
+            value: /var/lib/nvml-mock/fabric-state
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: host-fabric-state
+            hostPath:
+              path: /var/lib/nvml-mock/fabric-state
+              type: DirectoryOrCreate
+
   - it: should wire fabricmanager env, mount, and volume when enabled
     set:
       fabricmanager:
@@ -768,6 +789,13 @@ tests:
             value: "on"
       - contains:
           path: spec.template.spec.containers[0].env
+          content:
+            name: MOCK_FABRICMANAGER_STATE_DIR
+            value: /var/lib/nvml-mock/fabric-state
+      # node-agent gates its CDI fabric-state mount on this env, so it must be
+      # set wherever the host-fabric-state volume below is.
+      - contains:
+          path: spec.template.spec.containers[1].env
           content:
             name: MOCK_FABRICMANAGER_STATE_DIR
             value: /var/lib/nvml-mock/fabric-state
@@ -792,6 +820,11 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
+          content:
+            name: MOCK_FABRICMANAGER_STATE_DIR
+            value: /run/nvidia-fabricmanager
+      - contains:
+          path: spec.template.spec.containers[1].env
           content:
             name: MOCK_FABRICMANAGER_STATE_DIR
             value: /run/nvidia-fabricmanager

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -812,6 +812,16 @@ tests:
           path: spec.template.spec.containers[1].command
           content: --shutdown-timeout=30s
 
+  # CDI specs are written to h.Run/cdi/ = /host/run/cdi/. Without this mount the
+  # writes land in the container overlayfs and containerd never sees the specs.
+  - it: node-agent should mount the CDI spec directory
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: host-cdi
+            mountPath: /host/run/cdi
+
   - it: should honour node-agent logging and timeout overrides
     set:
       nodeAgent:

--- a/deployments/nvml-mock/scripts/cleanup.sh
+++ b/deployments/nvml-mock/scripts/cleanup.sh
@@ -8,11 +8,6 @@ MOCK_GPU_DIR="/host/var/lib/nvml-mock"
 if [ -d "$MOCK_GPU_DIR" ] && [ "$MOCK_GPU_DIR" = "/host/var/lib/nvml-mock" ]; then
   rm -rf "$MOCK_GPU_DIR"/*
 fi
-# Remove GPU Operator compatibility symlink
-if [ -L "/host/run/nvidia/driver" ]; then
-  rm -f "/host/run/nvidia/driver"
-  echo "GPU Operator driver symlink removed"
-fi
 # NOTE: /run/nvidia/validations/toolkit-ready is deliberately NOT removed here.
 # setup.sh no longer creates it (see setup.sh step 8b); its owner is GPU
 # Operator's nvidia-validator. This hook is nvml-mock's preStop, so removing the
@@ -22,19 +17,6 @@ fi
 # us, and it rewrites the marker within seconds (observed live). The rm is dead
 # code either way, and the hazard is real wherever the validator does not
 # happen to restart.
-# Remove the CDI specs setup.sh staged. Both live in the same directory setup.sh
-# writes to (CDI_DIR at setup.sh:120), and both name device nodes under
-# $MOCK_GPU_DIR, which the rm -rf above has just deleted. Leaving either behind
-# hands the runtime a spec whose hostPaths no longer exist: containerd fails
-# container creation with "failed to stat CDI host device", the kubelet retries
-# it forever, and the NRI plugin keeps emitting the reference because its
-# staged-spec check (cdiSpecStaged, adjust.go) is a bare stat of the spec file.
-for CDI_FILE in /host/var/run/cdi/nvidia.yaml /host/var/run/cdi/nvml-mock-nri.yaml; do
-  if [ -f "$CDI_FILE" ]; then
-    rm -f "$CDI_FILE"
-    echo "CDI spec removed: $CDI_FILE"
-  fi
-done
 if command -v kubectl >/dev/null 2>&1; then
   kubectl label node "$NODE_NAME" nvidia.com/gpu.present- || true
 fi

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -78,251 +78,6 @@ CAPS_EOF
   echo "Mock IMEX surface ready: $IMEX_CHANNELS channels, major $IMEX_MAJOR, proc-devices at $IMEX_DIR/proc-devices"
 fi
 
-# 3b. Generate CDI spec for nvidia-container-runtime CDI mode.
-#     This allows the toolkit to inject our mock libs into containers without
-#     needing libnvidia-container or kernel modules.
-#
-#     Wait for node-agent to stage the driver footprint before writing either
-#     CDI spec (3b and 3c). node-agent runs as a sibling container with no
-#     ordering guarantee. nvidiactl is the last file stageCharDevs creates, so
-#     its presence implies the full Stage wave (libs, smi, chardevs, config) is
-#     complete. Without this guard the specs would reference hostPaths that do
-#     not yet exist, and any container created in the interim would fail the
-#     bind-mount silently from setup.sh's perspective.
-#     TODO: remove this wait once setup.sh is fully replaced by the node-agent.
-_wait_secs=0
-until [ -e "$DEV_ROOT/nvidiactl" ] || [ "$_wait_secs" -ge 60 ]; do
-  sleep 1
-  _wait_secs=$((_wait_secs + 1))
-done
-if [ ! -e "$DEV_ROOT/nvidiactl" ]; then
-  echo "ERROR: timed out waiting for node-agent to stage driver footprint" >&2
-  exit 1
-fi
-
-CDI_DIR=/host/var/run/cdi
-mkdir -p "$CDI_DIR"
-
-# Resolve fabricmanager enablement once, here, because it influences both the
-# CDI spec (below) and the daemon launch (step 11). Validate early so a typo
-# fails the pod with a clear message rather than silently disabling the gate.
-MOCK_FM_MODE=$(printf '%s' "${MOCK_FABRICMANAGER:-off}" | tr '[:upper:]' '[:lower:]')
-case "$MOCK_FM_MODE" in
-  off | on) ;;
-  *)
-    echo "ERROR: MOCK_FABRICMANAGER='$MOCK_FABRICMANAGER' is invalid; expected off or on" >&2
-    exit 1
-    ;;
-esac
-FM_STATE_DIR="${MOCK_FABRICMANAGER_STATE_DIR:-/var/lib/nvml-mock/fabric-state}"
-
-cat > "$CDI_DIR/nvidia.yaml" << 'CDI_HEADER'
-cdiVersion: "0.6.0"
-kind: "nvidia.com/gpu"
-containerEdits:
-  deviceNodes:
-    - path: /dev/nvidiactl
-      hostPath: /var/lib/nvml-mock/driver/dev/nvidiactl
-    - path: /dev/nvidia-uvm
-      hostPath: /var/lib/nvml-mock/driver/dev/nvidia-uvm
-    - path: /dev/nvidia-uvm-tools
-      hostPath: /var/lib/nvml-mock/driver/dev/nvidia-uvm-tools
-  mounts:
-    - hostPath: /var/lib/nvml-mock/driver/usr/lib64/libnvidia-ml.so.1
-      containerPath: /usr/lib64/libnvidia-ml.so.1
-      options: [ro, nosuid, nodev, bind]
-    - hostPath: /var/lib/nvml-mock/driver/usr/bin/nvidia-smi
-      containerPath: /usr/bin/nvidia-smi
-      options: [ro, nosuid, nodev, bind]
-    # Bind-mount the GPU profile config DIRECTORY (not just config.yaml) so the
-    # mock NVML library finds config.yaml via MOCK_NVML_CONFIG below AND sees
-    # overrides.yaml when nvml-mock-ctl writes it at runtime. The CLI creates
-    # the config override via temp-file+rename in this same dir; a directory bind makes
-    # that atomic rename observable to CDI-injected consumers (a single-file
-    # bind would pin the original inode and hide the replacement). Without the
-    # config the mock .so falls back to "no-YAML" defaults — temperature, power
-    # and similar metrics surface as N/A in nvidia-smi.
-    - hostPath: /var/lib/nvml-mock/driver/config
-      containerPath: /etc/nvml-mock
-      options: [ro, nosuid, nodev, bind]
-CDI_HEADER
-
-# When fabricmanager is enabled, bind-mount the node-local readiness marker
-# directory into CDI-injected workloads and point the mock NVML library at it.
-# Without this, the mock .so loaded inside user pods sees an empty
-# MOCK_FABRICMANAGER_STATE_DIR and resolves `fabric.state: auto` straight to
-# COMPLETED, silently bypassing the fabricmanager readiness gate (the mock .so
-# is loaded by nvidia-smi *inside the workload container*, not by this pod).
-if [ "$MOCK_FM_MODE" != "off" ]; then
-  cat >> "$CDI_DIR/nvidia.yaml" << FM_MOUNT_EOF
-    - hostPath: $FM_STATE_DIR
-      containerPath: $FM_STATE_DIR
-      options: [ro, nosuid, nodev, bind]
-FM_MOUNT_EOF
-fi
-
-cat >> "$CDI_DIR/nvidia.yaml" << 'CDI_HOOKS_ENV'
-  hooks:
-    - hookName: createContainer
-      path: /usr/bin/nvidia-cdi-hook
-      args: [nvidia-cdi-hook, update-ldcache, --folder, /usr/lib64]
-  env:
-    - NVIDIA_VISIBLE_DEVICES=void
-    - MOCK_NVML_CONFIG=/etc/nvml-mock/config.yaml
-    - MOCK_NVML_OVERRIDES=/etc/nvml-mock/overrides.yaml
-CDI_HOOKS_ENV
-
-if [ "$MOCK_FM_MODE" != "off" ]; then
-  cat >> "$CDI_DIR/nvidia.yaml" << FM_ENV_EOF
-    - MOCK_FABRICMANAGER_STATE_DIR=$FM_STATE_DIR
-FM_ENV_EOF
-fi
-
-cat >> "$CDI_DIR/nvidia.yaml" << 'CDI_DEVICES'
-devices:
-CDI_DEVICES
-
-# Build an "index uuid" map from the profile config so each device node's CDI
-# entry uses the UUID for its declared `index:`, not for its list position.
-# Profiles are conventionally in ascending order, but the mock's NVML shim
-# resolves overrides by explicit index — an out-of-order profile would make
-# CDI and NVML disagree about which GPU a UUID names, and pods would land on
-# the wrong /dev/nvidia<n>. Devices are exposed under BOTH the index
-# shorthand ("0".."N-1") — how the nvidia-container-runtime CLI addresses
-# them — and the fully-qualified UUID — how the k8s device plugin allocates
-# and how containerd resolves CDI device references by name. Without the UUID
-# entries, any pod requesting `nvidia.com/gpu` on a containerd with
-# `enable_cdi = true` (the kind-nvidia-cdi image default) fails with
-# `unresolvable CDI devices nvidia.com/gpu=<uuid>`.
-INDEX_UUID_MAP=$(awk '
-    /^[[:space:]]*- index:/ {
-        cur_index = $3
-        gsub(/"/, "", cur_index)
-        pending = 1
-        next
-    }
-    pending && /^[[:space:]]*uuid:/ {
-        sub(/^[[:space:]]*uuid:[[:space:]]*/, "")
-        gsub(/"/, "")
-        print cur_index " " $0
-        pending = 0
-    }
-' /etc/nvml-mock/config.yaml)
-
-# Per-GPU device entries (index and UUID names point at the same device node).
-for i in $(seq 0 $((GPU_COUNT - 1))); do
-  UUID=$(echo "$INDEX_UUID_MAP" | awk -v idx="$i" '$1 == idx { print $2; exit }')
-  for NAME in "$i" "$UUID"; do
-    [ -z "$NAME" ] && continue
-    cat >> "$CDI_DIR/nvidia.yaml" << DEVICE_EOF
-  - name: "$NAME"
-    containerEdits:
-      deviceNodes:
-        - path: /dev/nvidia$i
-          hostPath: /var/lib/nvml-mock/driver/dev/nvidia$i
-DEVICE_EOF
-  done
-done
-
-# "all" device — aggregates all GPUs
-echo '  - name: "all"' >> "$CDI_DIR/nvidia.yaml"
-echo '    containerEdits:' >> "$CDI_DIR/nvidia.yaml"
-echo '      deviceNodes:' >> "$CDI_DIR/nvidia.yaml"
-for i in $(seq 0 $((GPU_COUNT - 1))); do
-  echo "        - path: /dev/nvidia$i" >> "$CDI_DIR/nvidia.yaml"
-  echo "          hostPath: /var/lib/nvml-mock/driver/dev/nvidia$i" >> "$CDI_DIR/nvidia.yaml"
-done
-
-echo "CDI spec generated at $CDI_DIR/nvidia.yaml ($GPU_COUNT devices, index + UUID keyed)"
-
-# 3c. Generate the CDI spec the NRI plugin injects (issue #436).
-#
-#     This is deliberately a SECOND spec, not a reuse of nvidia.yaml above:
-#
-#     - Vendor. nvidia.com/gpu belongs to the device plugin and the container
-#       toolkit. MEP-0002 requires that exactly one component emit CDI device
-#       references for a given container; a distinct vendor makes that
-#       observable instead of merely asserted.
-#     - No hooks. nvidia.yaml runs /usr/bin/nvidia-cdi-hook, which only exists
-#       on a toolkit-bearing node. The NRI path has to work on stock
-#       kindest/node, where containerd enables CDI by default but no toolkit is
-#       installed.
-#     - Device nodes only. The NRI plugin already delivers the libraries and the
-#       environment through its overlay bind mount and LD_PRELOAD, so repeating
-#       nvidia.yaml's library mounts here would inject them twice by two
-#       different mechanisms.
-#
-#     Per-GPU entries plus "all" keep MEP-0002's detectVisibleDevices oracle
-#     intact: the correct SUBSET stays expressible, so a future per-device
-#     caller does not have to widen the container to use CDI.
-NRI_CDI_SPEC=$CDI_DIR/nvml-mock-nri.yaml
-
-# hostPath in a CDI spec is resolved by the RUNTIME, on the real host — not by
-# this container, which sees the host root under /host. $DEV_ROOT is this
-# container's view, so strip the prefix. Getting this wrong does not fail here:
-# the spec is written happily and containerd then refuses to create any
-# container that references it, which surfaces as a pod stuck out of Running
-# with no obvious link back to this file.
-HOST_DEV_ROOT=${DEV_ROOT#/host}
-
-# NVML_MOCK_DEVICE_SOURCE records which mechanism delivered the device nodes.
-# The raw NRI path injects device nodes only and has no way to set an
-# environment variable on the device opt-in, so this is present if and only if
-# the runtime resolved this spec. That makes "did CDI actually take effect"
-# observable from inside the container: the two modes are otherwise identical by
-# design, and a silent fallback to raw would look exactly like a working CDI
-# deployment.
-cat > "$NRI_CDI_SPEC" << 'NRI_CDI_HEADER'
-cdiVersion: "0.6.0"
-kind: "nvml-mock.nvidia.com/gpu"
-containerEdits:
-  env:
-    - NVML_MOCK_DEVICE_SOURCE=cdi
-devices:
-NRI_CDI_HEADER
-
-# nri_cdi_device_nodes emits the deviceNodes block for one GPU index, or for
-# every mock node when passed "all". The set MUST match what discoverDevices
-# stages on the raw path (every non-directory nvidia* node under $DEV_ROOT):
-# cdi mode replaces the mechanism, not the contract, and a narrower set here
-# would be a silent regression for a workload that opens /dev/nvidia-uvm.
-nri_cdi_device_nodes() {
-  _which=$1
-  if [ "$_which" = "all" ]; then
-    for _i in $(seq 0 $((GPU_COUNT - 1))); do
-      echo "        - path: /dev/nvidia$_i"
-      echo "          hostPath: $HOST_DEV_ROOT/nvidia$_i"
-    done
-    for _extra in nvidiactl nvidia-uvm nvidia-uvm-tools; do
-      if [ -e "$DEV_ROOT/$_extra" ]; then
-        echo "        - path: /dev/$_extra"
-        echo "          hostPath: $HOST_DEV_ROOT/$_extra"
-      fi
-    done
-  else
-    echo "        - path: /dev/nvidia$_which"
-    echo "          hostPath: $HOST_DEV_ROOT/nvidia$_which"
-  fi
-}
-
-for i in $(seq 0 $((GPU_COUNT - 1))); do
-  {
-    echo "  - name: \"$i\""
-    echo '    containerEdits:'
-    echo '      deviceNodes:'
-    nri_cdi_device_nodes "$i"
-  } >> "$NRI_CDI_SPEC"
-done
-
-{
-  echo '  - name: "all"'
-  echo '    containerEdits:'
-  echo '      deviceNodes:'
-  nri_cdi_device_nodes all
-} >> "$NRI_CDI_SPEC"
-
-echo "NRI CDI spec generated at $NRI_CDI_SPEC ($GPU_COUNT devices + all)"
-
 # 4b. Stage InfiniBand tools and preload shims for node-wide NRI injection.
 #     The NRI plugin mounts /var/lib/nvml-mock at /opt/nvml-mock in each
 #     workload, then prepends driver/usr/bin and driver/usr/lib64 and appends
@@ -495,12 +250,21 @@ fi
 #     /proc/stat btime (stable across nvidia-smi invocations), so no epoch
 #     export is needed here for counters to grow.
 #
-#     MOCK_FM_MODE / FM_STATE_DIR were resolved + validated earlier (near the
-#     CDI block). The readiness marker lives on a DirectoryOrCreate hostPath
+#     The readiness marker lives on a DirectoryOrCreate hostPath
 #     that survives pod restarts, and the daemon re-asserts it every 2s — so a
 #     stale marker from a prior pod could make a fresh pod report COMPLETED
 #     before its own daemon is ready. Clear it here so every pod starts in a
 #     clean IN_PROGRESS state until *this* daemon writes the marker.
+MOCK_FM_MODE=$(printf '%s' "${MOCK_FABRICMANAGER:-off}" | tr '[:upper:]' '[:lower:]')
+case "$MOCK_FM_MODE" in
+  off | on) ;;
+  *)
+    echo "ERROR: MOCK_FABRICMANAGER='$MOCK_FABRICMANAGER' is invalid; expected off or on" >&2
+    exit 1
+    ;;
+esac
+FM_STATE_DIR="${MOCK_FABRICMANAGER_STATE_DIR:-/var/lib/nvml-mock/fabric-state}"
+
 if [ "$MOCK_FM_MODE" != "off" ]; then
   if [ -x /usr/bin/nv-fabricmanager ]; then
     mkdir -p "$FM_STATE_DIR"

--- a/internal/agent/cdi/cdi.go
+++ b/internal/agent/cdi/cdi.go
@@ -1,0 +1,88 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cdi implements the CDI spec applier: it writes two CDI YAML specs
+// that containerd uses to inject mock GPU devices into workload containers.
+package cdi
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync/atomic"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/NVIDIA/k8s-test-infra/internal/agent"
+	"github.com/NVIDIA/k8s-test-infra/internal/agent/host"
+)
+
+const (
+	name = "cdi"
+	// Paths are relative to h.Run (/run on the host; /var/run is a symlink to /run).
+	nvidiaSpecFile = "cdi/nvidia.yaml"
+	nriSpecFile    = "cdi/nvml-mock-nri.yaml"
+)
+
+var (
+	_ agent.Simulator = (*Simulator)(nil)
+	_ agent.Applier   = (*Simulator)(nil)
+)
+
+// Simulator owns the CDI specs containerd needs to inject mock GPUs:
+// nvidia.yaml (nvidia-container-runtime path) and nvml-mock-nri.yaml (NRI CDI path).
+type Simulator struct {
+	ready atomic.Bool
+}
+
+// New returns a CDI Simulator.
+func New() *Simulator { return &Simulator{} }
+
+// Name returns the stable simulator identifier.
+func (s *Simulator) Name() string { return name }
+
+// Ready reports whether Stage succeeded (always true; Stage is a no-op).
+func (s *Simulator) Ready() bool { return s.ready.Load() }
+
+// Stage is a no-op. Writing a CDI spec before the Stage barrier means the spec's
+// hostPaths (chardevs, shims) may not exist yet; containerd fails every container
+// creation that references an unresolvable spec. The write is deferred to Apply.
+func (s *Simulator) Stage(_ context.Context, _ *host.Host, _ *agent.State) error {
+	s.ready.Store(true)
+	return nil
+}
+
+// Discard is a no-op. Stage wrote nothing, so there is nothing to undo here.
+// The specs are published artifacts visible to containerd and are cleaned up in Revoke.
+func (s *Simulator) Discard(_ context.Context, _ *host.Host) error { return nil }
+
+// Apply writes /run/cdi/nvidia.yaml and /run/cdi/nvml-mock-nri.yaml.
+func (s *Simulator) Apply(_ context.Context, h *host.Host, state *agent.State) error {
+	if err := writeSpec(h, filepath.Join(h.Run, nvidiaSpecFile), buildNvidiaSpec(state)); err != nil {
+		return fmt.Errorf("nvidia.yaml: %w", err)
+	}
+	if err := writeSpec(h, filepath.Join(h.Run, nriSpecFile), buildNRISpec(state)); err != nil {
+		return fmt.Errorf("nvml-mock-nri.yaml: %w", err)
+	}
+	return nil
+}
+
+// Revoke removes both CDI specs.
+func (s *Simulator) Revoke(_ context.Context, h *host.Host) error {
+	err1 := h.Remove(filepath.Join(h.Run, nvidiaSpecFile))
+	err2 := h.Remove(filepath.Join(h.Run, nriSpecFile))
+
+	if err1 != nil {
+		return err1
+	}
+
+	return err2
+}
+
+func writeSpec(h *host.Host, path string, spec cdiSpec) error {
+	data, err := yaml.Marshal(spec)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	return h.WriteFile(path, data, 0o644)
+}

--- a/internal/agent/cdi/cdi_test.go
+++ b/internal/agent/cdi/cdi_test.go
@@ -115,7 +115,7 @@ func TestNRISpec(t *testing.T) {
 func TestFabricStateMount(t *testing.T) {
 	h := host.New(t.TempDir())
 	state := testState()
-	state.Fabric.Enabled = true
+	state.Fabric.ManagerStateDir = "/var/lib/nvml-mock/fabric-state"
 	s := New()
 	ctx := context.Background()
 	require.NoError(t, s.Stage(ctx, h, state))
@@ -143,9 +143,12 @@ func TestFabricStateMount(t *testing.T) {
 	require.True(t, hasFabricEnv, "expected MOCK_FABRICMANAGER_STATE_DIR in nvidia.yaml env")
 }
 
+// A profile can declare NVLink without running fabricmanager, in which case
+// the marker directory does not exist on the node and must not be mounted.
 func TestFabricMountAbsentWhenDisabled(t *testing.T) {
 	h := host.New(t.TempDir())
-	state := testState() // Fabric.Enabled is false by default
+	state := testState()
+	state.Fabric.Enabled = true // NVLink, but ManagerStateDir is empty
 	s := New()
 	ctx := context.Background()
 	require.NoError(t, s.Stage(ctx, h, state))

--- a/internal/agent/cdi/cdi_test.go
+++ b/internal/agent/cdi/cdi_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package cdi
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+
+	"github.com/NVIDIA/k8s-test-infra/internal/agent"
+	"github.com/NVIDIA/k8s-test-infra/internal/agent/host"
+)
+
+func testState() *agent.State {
+	return &agent.State{
+		Software: agent.SoftwareVersions{DriverVersion: "550.163.01"},
+		Devices: []agent.DeviceSpec{
+			{Index: 0, UUID: "GPU-abc123", MinorNumber: 0},
+			{Index: 1, UUID: "GPU-def456", MinorNumber: 1},
+		},
+	}
+}
+
+func TestApplyWritesSpecs(t *testing.T) {
+	h := host.New(t.TempDir())
+	state := testState()
+	s := New()
+	ctx := context.Background()
+
+	require.NoError(t, s.Stage(ctx, h, state))
+	require.True(t, s.Ready())
+	require.NoError(t, s.Apply(ctx, h, state))
+
+	require.FileExists(t, filepath.Join(h.Run, nvidiaSpecFile))
+	require.FileExists(t, filepath.Join(h.Run, nriSpecFile))
+}
+
+func TestNvidiaSpec(t *testing.T) {
+	h := host.New(t.TempDir())
+	state := testState()
+	s := New()
+	ctx := context.Background()
+	require.NoError(t, s.Stage(ctx, h, state))
+	require.NoError(t, s.Apply(ctx, h, state))
+
+	data, err := os.ReadFile(filepath.Join(h.Run, nvidiaSpecFile))
+	require.NoError(t, err)
+
+	var spec cdiSpec
+	require.NoError(t, yaml.Unmarshal(data, &spec))
+
+	require.Equal(t, "0.6.0", spec.CDIVersion)
+	require.Equal(t, "nvidia.com/gpu", spec.Kind)
+	require.NotNil(t, spec.ContainerEdits)
+
+	// 2 GPUs × (index + UUID) + "all" = 5 devices
+	require.Len(t, spec.Devices, 5)
+	require.Equal(t, "0", spec.Devices[0].Name)
+	require.Equal(t, "GPU-abc123", spec.Devices[1].Name)
+	require.Equal(t, "1", spec.Devices[2].Name)
+	require.Equal(t, "GPU-def456", spec.Devices[3].Name)
+	require.Equal(t, "all", spec.Devices[4].Name)
+
+	// "all" has 2 per-GPU device nodes
+	require.Len(t, spec.Devices[4].ContainerEdits.DeviceNodes, 2)
+
+	// Shared device nodes must include control devices
+	paths := make([]string, 0, len(spec.ContainerEdits.DeviceNodes))
+	for _, dn := range spec.ContainerEdits.DeviceNodes {
+		paths = append(paths, dn.Path)
+	}
+	require.Contains(t, paths, "/dev/nvidiactl")
+	require.Contains(t, paths, "/dev/nvidia-uvm")
+	require.Contains(t, paths, "/dev/nvidia-uvm-tools")
+}
+
+func TestNRISpec(t *testing.T) {
+	h := host.New(t.TempDir())
+	state := testState()
+	s := New()
+	ctx := context.Background()
+	require.NoError(t, s.Stage(ctx, h, state))
+	require.NoError(t, s.Apply(ctx, h, state))
+
+	data, err := os.ReadFile(filepath.Join(h.Run, nriSpecFile))
+	require.NoError(t, err)
+
+	var spec cdiSpec
+	require.NoError(t, yaml.Unmarshal(data, &spec))
+
+	require.Equal(t, "0.6.0", spec.CDIVersion)
+	require.Equal(t, "nvml-mock.nvidia.com/gpu", spec.Kind)
+	require.NotNil(t, spec.ContainerEdits)
+	require.Contains(t, spec.ContainerEdits.Env, "NVML_MOCK_DEVICE_SOURCE=cdi")
+
+	// No library mounts or hooks — the NRI overlay bind-mount delivers those.
+	require.Empty(t, spec.ContainerEdits.Mounts)
+	require.Empty(t, spec.ContainerEdits.Hooks)
+
+	// 2 GPUs (index only, no UUID) + "all" = 3 devices
+	require.Len(t, spec.Devices, 3)
+	require.Equal(t, "0", spec.Devices[0].Name)
+	require.Equal(t, "1", spec.Devices[1].Name)
+	require.Equal(t, "all", spec.Devices[2].Name)
+
+	// "all" has 2 per-GPU + 3 control nodes = 5
+	require.Len(t, spec.Devices[2].ContainerEdits.DeviceNodes, 5)
+}
+
+func TestFabricStateMount(t *testing.T) {
+	h := host.New(t.TempDir())
+	state := testState()
+	state.Fabric.Enabled = true
+	s := New()
+	ctx := context.Background()
+	require.NoError(t, s.Stage(ctx, h, state))
+	require.NoError(t, s.Apply(ctx, h, state))
+
+	data, err := os.ReadFile(filepath.Join(h.Run, nvidiaSpecFile))
+	require.NoError(t, err)
+	var spec cdiSpec
+	require.NoError(t, yaml.Unmarshal(data, &spec))
+
+	var hasFabricMount bool
+	for _, m := range spec.ContainerEdits.Mounts {
+		if m.HostPath == "/var/lib/nvml-mock/fabric-state" {
+			hasFabricMount = true
+		}
+	}
+	require.True(t, hasFabricMount, "expected fabric-state mount in nvidia.yaml")
+
+	var hasFabricEnv bool
+	for _, e := range spec.ContainerEdits.Env {
+		if e == "MOCK_FABRICMANAGER_STATE_DIR=/var/lib/nvml-mock/fabric-state" {
+			hasFabricEnv = true
+		}
+	}
+	require.True(t, hasFabricEnv, "expected MOCK_FABRICMANAGER_STATE_DIR in nvidia.yaml env")
+}
+
+func TestFabricMountAbsentWhenDisabled(t *testing.T) {
+	h := host.New(t.TempDir())
+	state := testState() // Fabric.Enabled is false by default
+	s := New()
+	ctx := context.Background()
+	require.NoError(t, s.Stage(ctx, h, state))
+	require.NoError(t, s.Apply(ctx, h, state))
+
+	data, err := os.ReadFile(filepath.Join(h.Run, nvidiaSpecFile))
+	require.NoError(t, err)
+	var spec cdiSpec
+	require.NoError(t, yaml.Unmarshal(data, &spec))
+
+	for _, m := range spec.ContainerEdits.Mounts {
+		require.NotEqual(t, "/var/lib/nvml-mock/fabric-state", m.HostPath)
+	}
+	for _, e := range spec.ContainerEdits.Env {
+		require.NotContains(t, e, "MOCK_FABRICMANAGER_STATE_DIR")
+	}
+}
+
+func TestRevoke(t *testing.T) {
+	h := host.New(t.TempDir())
+	state := testState()
+	s := New()
+	ctx := context.Background()
+
+	require.NoError(t, s.Stage(ctx, h, state))
+	require.NoError(t, s.Apply(ctx, h, state))
+
+	require.FileExists(t, filepath.Join(h.Run, nvidiaSpecFile))
+	require.FileExists(t, filepath.Join(h.Run, nriSpecFile))
+
+	require.NoError(t, s.Revoke(ctx, h))
+
+	_, err := os.Stat(filepath.Join(h.Run, nvidiaSpecFile))
+	require.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(filepath.Join(h.Run, nriSpecFile))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestRevokeBeforeApplyIsNoop(t *testing.T) {
+	h := host.New(t.TempDir())
+	s := New()
+	require.NoError(t, s.Revoke(context.Background(), h))
+}
+
+func TestApplyIsIdempotent(t *testing.T) {
+	h := host.New(t.TempDir())
+	state := testState()
+	s := New()
+	ctx := context.Background()
+
+	require.NoError(t, s.Stage(ctx, h, state))
+	require.NoError(t, s.Apply(ctx, h, state))
+	require.NoError(t, s.Apply(ctx, h, state))
+
+	require.FileExists(t, filepath.Join(h.Run, nvidiaSpecFile))
+	require.FileExists(t, filepath.Join(h.Run, nriSpecFile))
+}

--- a/internal/agent/cdi/spec.go
+++ b/internal/agent/cdi/spec.go
@@ -1,0 +1,184 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package cdi
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/NVIDIA/k8s-test-infra/internal/agent"
+	"github.com/NVIDIA/k8s-test-infra/pkg/fmcoord"
+)
+
+// overlayHostRoot is the path containerd sees for the mock overlay on the host.
+// CDI hostPaths are resolved by the runtime on the node itself, not by the agent container.
+const overlayHostRoot = "/var/lib/nvml-mock"
+
+// cdiSpec is the structure of a CDI 0.6.0 spec file.
+type cdiSpec struct {
+	CDIVersion     string      `json:"cdiVersion"`
+	Kind           string      `json:"kind"`
+	ContainerEdits *cdiEdits   `json:"containerEdits,omitempty"`
+	Devices        []cdiDevice `json:"devices,omitempty"`
+}
+
+type cdiEdits struct {
+	DeviceNodes []cdiDeviceNode `json:"deviceNodes,omitempty"`
+	Mounts      []cdiMount      `json:"mounts,omitempty"`
+	Hooks       []cdiHook       `json:"hooks,omitempty"`
+	Env         []string        `json:"env,omitempty"`
+}
+
+type cdiDeviceNode struct {
+	Path     string `json:"path"`
+	HostPath string `json:"hostPath,omitempty"`
+}
+
+type cdiMount struct {
+	HostPath      string   `json:"hostPath"`
+	ContainerPath string   `json:"containerPath"`
+	Options       []string `json:"options,omitempty"`
+}
+
+type cdiHook struct {
+	HookName string   `json:"hookName"`
+	Path     string   `json:"path"`
+	Args     []string `json:"args,omitempty"`
+}
+
+type cdiDevice struct {
+	Name           string   `json:"name"`
+	ContainerEdits cdiEdits `json:"containerEdits"`
+}
+
+// buildNvidiaSpec returns the nvidia.com/gpu CDI spec consumed by nvidia-container-runtime.
+// It includes library mounts, an ldcache hook, and per-GPU + "all" device entries.
+func buildNvidiaSpec(state *agent.State) cdiSpec {
+	devRoot := overlayHostRoot + "/driver/dev"
+
+	edits := &cdiEdits{
+		DeviceNodes: []cdiDeviceNode{
+			{Path: "/dev/nvidiactl", HostPath: devRoot + "/nvidiactl"},
+			{Path: "/dev/nvidia-uvm", HostPath: devRoot + "/nvidia-uvm"},
+			{Path: "/dev/nvidia-uvm-tools", HostPath: devRoot + "/nvidia-uvm-tools"},
+		},
+		Mounts: []cdiMount{
+			{
+				HostPath:      overlayHostRoot + "/driver/usr/lib64/libnvidia-ml.so.1",
+				ContainerPath: "/usr/lib64/libnvidia-ml.so.1",
+				Options:       []string{"ro", "nosuid", "nodev", "bind"},
+			},
+			{
+				HostPath:      overlayHostRoot + "/driver/usr/bin/nvidia-smi",
+				ContainerPath: "/usr/bin/nvidia-smi",
+				Options:       []string{"ro", "nosuid", "nodev", "bind"},
+			},
+			// Bind the config directory (not just config.yaml) so atomic renames
+			// by nvml-mock-ctl's overrides.yaml writes are visible inside the container.
+			{
+				HostPath:      overlayHostRoot + "/driver/config",
+				ContainerPath: "/etc/nvml-mock",
+				Options:       []string{"ro", "nosuid", "nodev", "bind"},
+			},
+		},
+		Hooks: []cdiHook{
+			{
+				HookName: "createContainer",
+				Path:     "/usr/bin/nvidia-cdi-hook",
+				Args:     []string{"nvidia-cdi-hook", "update-ldcache", "--folder", "/usr/lib64"},
+			},
+		},
+		Env: []string{
+			"NVIDIA_VISIBLE_DEVICES=void",
+			"MOCK_NVML_CONFIG=/etc/nvml-mock/config.yaml",
+			"MOCK_NVML_OVERRIDES=/etc/nvml-mock/overrides.yaml",
+		},
+	}
+
+	// Fabric state dir: the mock NVML .so inside the container must see the
+	// fabricmanager readiness marker for fabric.state:auto to work correctly.
+	if state.Fabric.Enabled {
+		stateDir := fmcoord.DefaultStateDir
+		edits.Mounts = append(edits.Mounts, cdiMount{
+			HostPath:      stateDir,
+			ContainerPath: stateDir,
+			Options:       []string{"ro", "nosuid", "nodev", "bind"},
+		})
+		edits.Env = append(edits.Env, "MOCK_FABRICMANAGER_STATE_DIR="+stateDir)
+	}
+
+	allNodes := make([]cdiDeviceNode, 0, len(state.Devices))
+	devices := make([]cdiDevice, 0, len(state.Devices)*2+1)
+	for _, d := range state.Devices {
+		node := cdiDeviceNode{
+			Path:     fmt.Sprintf("/dev/nvidia%d", d.Index),
+			HostPath: fmt.Sprintf("%s/nvidia%d", devRoot, d.Index),
+		}
+		allNodes = append(allNodes, node)
+		// Index shorthand ("0".."N-1"): addressed by nvidia-container-runtime CLI.
+		devices = append(devices, cdiDevice{
+			Name:           strconv.Itoa(d.Index),
+			ContainerEdits: cdiEdits{DeviceNodes: []cdiDeviceNode{node}},
+		})
+		// UUID entry: addressed by containerd and the device plugin allocator.
+		if d.UUID != "" {
+			devices = append(devices, cdiDevice{
+				Name:           d.UUID,
+				ContainerEdits: cdiEdits{DeviceNodes: []cdiDeviceNode{node}},
+			})
+		}
+	}
+	devices = append(devices, cdiDevice{
+		Name:           "all",
+		ContainerEdits: cdiEdits{DeviceNodes: allNodes},
+	})
+
+	return cdiSpec{
+		CDIVersion:     "0.6.0",
+		Kind:           "nvidia.com/gpu",
+		ContainerEdits: edits,
+		Devices:        devices,
+	}
+}
+
+// buildNRISpec returns the nvml-mock.nvidia.com/gpu CDI spec consumed by the NRI plugin's
+// cdi injection mode. No hooks or library mounts: the NRI plugin already delivers those via
+// the overlay bind-mount. The distinct vendor (nvml-mock.nvidia.com vs nvidia.com) keeps
+// MEP-0002's "exactly one source of CDI references per container" invariant observable.
+func buildNRISpec(state *agent.State) cdiSpec {
+	devRoot := overlayHostRoot + "/driver/dev"
+
+	allNodes := make([]cdiDeviceNode, 0, len(state.Devices)+3)
+	devices := make([]cdiDevice, 0, len(state.Devices)+1)
+	for _, d := range state.Devices {
+		node := cdiDeviceNode{
+			Path:     fmt.Sprintf("/dev/nvidia%d", d.Index),
+			HostPath: fmt.Sprintf("%s/nvidia%d", devRoot, d.Index),
+		}
+		devices = append(devices, cdiDevice{
+			Name:           strconv.Itoa(d.Index),
+			ContainerEdits: cdiEdits{DeviceNodes: []cdiDeviceNode{node}},
+		})
+		allNodes = append(allNodes, node)
+	}
+	// "all" also covers the control devices so a workload that only requests
+	// "all" still gets the UVM and nvidiactl nodes it needs.
+	for _, extra := range []string{"nvidiactl", "nvidia-uvm", "nvidia-uvm-tools"} {
+		allNodes = append(allNodes, cdiDeviceNode{
+			Path:     "/dev/" + extra,
+			HostPath: devRoot + "/" + extra,
+		})
+	}
+	devices = append(devices, cdiDevice{
+		Name:           "all",
+		ContainerEdits: cdiEdits{DeviceNodes: allNodes},
+	})
+
+	return cdiSpec{
+		CDIVersion:     "0.6.0",
+		Kind:           "nvml-mock.nvidia.com/gpu",
+		ContainerEdits: &cdiEdits{Env: []string{"NVML_MOCK_DEVICE_SOURCE=cdi"}},
+		Devices:        devices,
+	}
+}

--- a/internal/agent/cdi/spec.go
+++ b/internal/agent/cdi/spec.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 
 	"github.com/NVIDIA/k8s-test-infra/internal/agent"
-	"github.com/NVIDIA/k8s-test-infra/pkg/fmcoord"
 )
 
 // overlayHostRoot is the path containerd sees for the mock overlay on the host.
@@ -103,10 +102,9 @@ func buildNvidiaSpec(state *agent.State) cdiSpec {
 		},
 	}
 
-	// Fabric state dir: the mock NVML .so inside the container must see the
-	// fabricmanager readiness marker for fabric.state:auto to work correctly.
-	if state.Fabric.Enabled {
-		stateDir := fmcoord.DefaultStateDir
+	// The .so resolving fabric.state:auto runs in the consumer container, so the
+	// marker dir mounts there — but only where it exists, else creation fails.
+	if stateDir := state.Fabric.ManagerStateDir; stateDir != "" {
 		edits.Mounts = append(edits.Mounts, cdiMount{
 			HostPath:      stateDir,
 			ContainerPath: stateDir,

--- a/internal/agent/cdi/spec.go
+++ b/internal/agent/cdi/spec.go
@@ -58,6 +58,8 @@ func buildNvidiaSpec(state *agent.State) cdiSpec {
 	devRoot := overlayHostRoot + "/driver/dev"
 
 	edits := &cdiEdits{
+		// Control devices are shared by every named GPU entry (per-GPU nvidia<N>
+		// nodes live under devices[*].containerEdits, not here).
 		DeviceNodes: []cdiDeviceNode{
 			{Path: "/dev/nvidiactl", HostPath: devRoot + "/nvidiactl"},
 			{Path: "/dev/nvidia-uvm", HostPath: devRoot + "/nvidia-uvm"},
@@ -82,6 +84,9 @@ func buildNvidiaSpec(state *agent.State) cdiSpec {
 				Options:       []string{"ro", "nosuid", "nodev", "bind"},
 			},
 		},
+		// update-ldcache rebuilds the dynamic linker cache inside the container
+		// namespace so dlopen finds the bind-mounted libnvidia-ml.so.1 without
+		// modifying the container image's own ld.so.conf.
 		Hooks: []cdiHook{
 			{
 				HookName: "createContainer",
@@ -90,6 +95,8 @@ func buildNvidiaSpec(state *agent.State) cdiSpec {
 			},
 		},
 		Env: []string{
+			// void tells the container toolkit to skip its own device enumeration;
+			// without it the toolkit would override our mock nodes with an empty set.
 			"NVIDIA_VISIBLE_DEVICES=void",
 			"MOCK_NVML_CONFIG=/etc/nvml-mock/config.yaml",
 			"MOCK_NVML_OVERRIDES=/etc/nvml-mock/overrides.yaml",
@@ -151,6 +158,7 @@ func buildNRISpec(state *agent.State) cdiSpec {
 
 	allNodes := make([]cdiDeviceNode, 0, len(state.Devices)+3)
 	devices := make([]cdiDevice, 0, len(state.Devices)+1)
+
 	for _, d := range state.Devices {
 		node := cdiDeviceNode{
 			Path:     fmt.Sprintf("/dev/nvidia%d", d.Index),
@@ -162,6 +170,7 @@ func buildNRISpec(state *agent.State) cdiSpec {
 		})
 		allNodes = append(allNodes, node)
 	}
+
 	// "all" also covers the control devices so a workload that only requests
 	// "all" still gets the UVM and nvidiactl nodes it needs.
 	for _, extra := range []string{"nvidiactl", "nvidia-uvm", "nvidia-uvm-tools"} {
@@ -176,8 +185,10 @@ func buildNRISpec(state *agent.State) cdiSpec {
 	})
 
 	return cdiSpec{
-		CDIVersion:     "0.6.0",
-		Kind:           "nvml-mock.nvidia.com/gpu",
+		CDIVersion: "0.6.0",
+		Kind:       "nvml-mock.nvidia.com/gpu",
+		// NVML_MOCK_DEVICE_SOURCE makes the injection path (CDI vs raw NRI) observable
+		// from inside the container — the two modes are otherwise indistinguishable.
 		ContainerEdits: &cdiEdits{Env: []string{"NVML_MOCK_DEVICE_SOURCE=cdi"}},
 		Devices:        devices,
 	}

--- a/internal/agent/cdi/spec_test.go
+++ b/internal/agent/cdi/spec_test.go
@@ -106,24 +106,31 @@ func TestNvidiaSpecNoUUIDEntry(t *testing.T) {
 	require.Equal(t, "all", spec.Devices[1].Name)
 }
 
-func TestNvidiaSpecFabricEnabled(t *testing.T) {
+// The mounted path follows the configured state dir, which the chart allows to
+// differ from the default.
+func TestNvidiaSpecFabricManagerEnabled(t *testing.T) {
+	const stateDir = "/var/lib/custom/fabric-state"
 	state := twoGPUState()
-	state.Fabric.Enabled = true
+	state.Fabric.ManagerStateDir = stateDir
 	spec := buildNvidiaSpec(state)
 
 	var hasFabricMount bool
 	for _, m := range spec.ContainerEdits.Mounts {
-		if m.HostPath == fmcoord.DefaultStateDir {
+		if m.HostPath == stateDir {
 			hasFabricMount = true
-			require.Equal(t, fmcoord.DefaultStateDir, m.ContainerPath)
+			require.Equal(t, stateDir, m.ContainerPath)
 		}
 	}
 	require.True(t, hasFabricMount, "fabric-state mount missing")
-	require.Contains(t, spec.ContainerEdits.Env, "MOCK_FABRICMANAGER_STATE_DIR="+fmcoord.DefaultStateDir)
+	require.Contains(t, spec.ContainerEdits.Env, "MOCK_FABRICMANAGER_STATE_DIR="+stateDir)
 }
 
-func TestNvidiaSpecFabricDisabled(t *testing.T) {
-	spec := buildNvidiaSpec(twoGPUState()) // Fabric.Enabled is false
+// NVLink alone leaves no marker directory on the node, so nothing is mounted.
+func TestNvidiaSpecFabricManagerDisabled(t *testing.T) {
+	state := twoGPUState()
+	state.Fabric.Enabled = true
+	spec := buildNvidiaSpec(state)
+
 	for _, m := range spec.ContainerEdits.Mounts {
 		require.NotEqual(t, fmcoord.DefaultStateDir, m.HostPath)
 	}

--- a/internal/agent/cdi/spec_test.go
+++ b/internal/agent/cdi/spec_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package cdi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/k8s-test-infra/internal/agent"
+	"github.com/NVIDIA/k8s-test-infra/pkg/fmcoord"
+)
+
+func twoGPUState() *agent.State {
+	return &agent.State{
+		Devices: []agent.DeviceSpec{
+			{Index: 0, UUID: "GPU-aaa"},
+			{Index: 1, UUID: "GPU-bbb"},
+		},
+	}
+}
+
+// --- buildNvidiaSpec ---
+
+func TestNvidiaSpecHeader(t *testing.T) {
+	spec := buildNvidiaSpec(twoGPUState())
+	require.Equal(t, "0.6.0", spec.CDIVersion)
+	require.Equal(t, "nvidia.com/gpu", spec.Kind)
+}
+
+func TestNvidiaSpecSharedDeviceNodes(t *testing.T) {
+	spec := buildNvidiaSpec(twoGPUState())
+	require.NotNil(t, spec.ContainerEdits)
+
+	paths := make([]string, 0, len(spec.ContainerEdits.DeviceNodes))
+	for _, dn := range spec.ContainerEdits.DeviceNodes {
+		paths = append(paths, dn.Path)
+		// hostPath must point at the overlay root, not the agent container's /host prefix.
+		require.Contains(t, dn.HostPath, overlayHostRoot)
+	}
+	require.ElementsMatch(t, []string{"/dev/nvidiactl", "/dev/nvidia-uvm", "/dev/nvidia-uvm-tools"}, paths)
+}
+
+func TestNvidiaSpecMounts(t *testing.T) {
+	spec := buildNvidiaSpec(twoGPUState())
+	require.NotNil(t, spec.ContainerEdits)
+
+	containerPaths := make([]string, 0, len(spec.ContainerEdits.Mounts))
+	for _, m := range spec.ContainerEdits.Mounts {
+		containerPaths = append(containerPaths, m.ContainerPath)
+		require.Contains(t, m.HostPath, overlayHostRoot)
+	}
+	require.ElementsMatch(t, []string{
+		"/usr/lib64/libnvidia-ml.so.1",
+		"/usr/bin/nvidia-smi",
+		"/etc/nvml-mock",
+	}, containerPaths)
+}
+
+func TestNvidiaSpecHookAndEnv(t *testing.T) {
+	spec := buildNvidiaSpec(twoGPUState())
+	require.NotNil(t, spec.ContainerEdits)
+
+	require.Len(t, spec.ContainerEdits.Hooks, 1)
+	require.Equal(t, "createContainer", spec.ContainerEdits.Hooks[0].HookName)
+
+	require.Contains(t, spec.ContainerEdits.Env, "NVIDIA_VISIBLE_DEVICES=void")
+	require.Contains(t, spec.ContainerEdits.Env, "MOCK_NVML_CONFIG=/etc/nvml-mock/config.yaml")
+	require.Contains(t, spec.ContainerEdits.Env, "MOCK_NVML_OVERRIDES=/etc/nvml-mock/overrides.yaml")
+}
+
+func TestNvidiaSpecPerGPUDevices(t *testing.T) {
+	// 2 GPUs × (index + UUID) + "all" = 5
+	spec := buildNvidiaSpec(twoGPUState())
+	require.Len(t, spec.Devices, 5)
+	require.Equal(t, "0", spec.Devices[0].Name)
+	require.Equal(t, "GPU-aaa", spec.Devices[1].Name)
+	require.Equal(t, "1", spec.Devices[2].Name)
+	require.Equal(t, "GPU-bbb", spec.Devices[3].Name)
+	require.Equal(t, "all", spec.Devices[4].Name)
+
+	// Each per-GPU entry has exactly one device node pointing at the right index.
+	require.Equal(t, "/dev/nvidia0", spec.Devices[0].ContainerEdits.DeviceNodes[0].Path)
+	require.Equal(t, "/dev/nvidia1", spec.Devices[2].ContainerEdits.DeviceNodes[0].Path)
+
+	// Index and UUID entries for the same GPU share the same device node.
+	require.Equal(t, spec.Devices[0].ContainerEdits.DeviceNodes, spec.Devices[1].ContainerEdits.DeviceNodes)
+	require.Equal(t, spec.Devices[2].ContainerEdits.DeviceNodes, spec.Devices[3].ContainerEdits.DeviceNodes)
+}
+
+func TestNvidiaSpecAllDevice(t *testing.T) {
+	spec := buildNvidiaSpec(twoGPUState())
+	all := spec.Devices[len(spec.Devices)-1]
+	require.Equal(t, "all", all.Name)
+	// "all" aggregates the per-GPU nodes only (control nodes are in containerEdits).
+	require.Len(t, all.ContainerEdits.DeviceNodes, 2)
+}
+
+func TestNvidiaSpecNoUUIDEntry(t *testing.T) {
+	state := &agent.State{Devices: []agent.DeviceSpec{{Index: 0, UUID: ""}}}
+	spec := buildNvidiaSpec(state)
+	// Only index entry + "all" — no UUID entry when UUID is empty.
+	require.Len(t, spec.Devices, 2)
+	require.Equal(t, "0", spec.Devices[0].Name)
+	require.Equal(t, "all", spec.Devices[1].Name)
+}
+
+func TestNvidiaSpecFabricEnabled(t *testing.T) {
+	state := twoGPUState()
+	state.Fabric.Enabled = true
+	spec := buildNvidiaSpec(state)
+
+	var hasFabricMount bool
+	for _, m := range spec.ContainerEdits.Mounts {
+		if m.HostPath == fmcoord.DefaultStateDir {
+			hasFabricMount = true
+			require.Equal(t, fmcoord.DefaultStateDir, m.ContainerPath)
+		}
+	}
+	require.True(t, hasFabricMount, "fabric-state mount missing")
+	require.Contains(t, spec.ContainerEdits.Env, "MOCK_FABRICMANAGER_STATE_DIR="+fmcoord.DefaultStateDir)
+}
+
+func TestNvidiaSpecFabricDisabled(t *testing.T) {
+	spec := buildNvidiaSpec(twoGPUState()) // Fabric.Enabled is false
+	for _, m := range spec.ContainerEdits.Mounts {
+		require.NotEqual(t, fmcoord.DefaultStateDir, m.HostPath)
+	}
+	for _, e := range spec.ContainerEdits.Env {
+		require.NotContains(t, e, "MOCK_FABRICMANAGER_STATE_DIR")
+	}
+}
+
+// --- buildNRISpec ---
+
+func TestNRISpecHeader(t *testing.T) {
+	spec := buildNRISpec(twoGPUState())
+	require.Equal(t, "0.6.0", spec.CDIVersion)
+	require.Equal(t, "nvml-mock.nvidia.com/gpu", spec.Kind)
+}
+
+func TestNRISpecEnv(t *testing.T) {
+	spec := buildNRISpec(twoGPUState())
+	require.NotNil(t, spec.ContainerEdits)
+	require.Contains(t, spec.ContainerEdits.Env, "NVML_MOCK_DEVICE_SOURCE=cdi")
+	// No library mounts or hooks — the NRI overlay bind-mount delivers those.
+	require.Empty(t, spec.ContainerEdits.Mounts)
+	require.Empty(t, spec.ContainerEdits.Hooks)
+}
+
+func TestNRISpecPerGPUDevices(t *testing.T) {
+	// Index entries only (no UUID) + "all" = 3.
+	spec := buildNRISpec(twoGPUState())
+	require.Len(t, spec.Devices, 3)
+	require.Equal(t, "0", spec.Devices[0].Name)
+	require.Equal(t, "1", spec.Devices[1].Name)
+	require.Equal(t, "all", spec.Devices[2].Name)
+}
+
+func TestNRISpecAllDeviceIncludesControlNodes(t *testing.T) {
+	spec := buildNRISpec(twoGPUState())
+	all := spec.Devices[len(spec.Devices)-1]
+	require.Equal(t, "all", all.Name)
+
+	// 2 per-GPU + nvidiactl + nvidia-uvm + nvidia-uvm-tools = 5
+	require.Len(t, all.ContainerEdits.DeviceNodes, 5)
+
+	paths := make([]string, 0, len(all.ContainerEdits.DeviceNodes))
+	for _, dn := range all.ContainerEdits.DeviceNodes {
+		paths = append(paths, dn.Path)
+	}
+	require.Contains(t, paths, "/dev/nvidia0")
+	require.Contains(t, paths, "/dev/nvidia1")
+	require.Contains(t, paths, "/dev/nvidiactl")
+	require.Contains(t, paths, "/dev/nvidia-uvm")
+	require.Contains(t, paths, "/dev/nvidia-uvm-tools")
+}
+
+func TestNRISpecHostPathsUseOverlayRoot(t *testing.T) {
+	spec := buildNRISpec(twoGPUState())
+	for _, d := range spec.Devices {
+		for _, dn := range d.ContainerEdits.DeviceNodes {
+			require.Contains(t, dn.HostPath, overlayHostRoot,
+				"hostPath %q must be rooted at overlayHostRoot", dn.HostPath)
+		}
+	}
+}

--- a/internal/agent/source/file.go
+++ b/internal/agent/source/file.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"sigs.k8s.io/yaml"
@@ -162,6 +163,9 @@ func compileState(data []byte) (*agent.State, error) {
 		state.Fabric.ClusterUUID = defaults.Fabric.ClusterUUID
 		state.Fabric.CliqueID = defaults.Fabric.CliqueID
 	}
+	// Set by the chart only where it also creates the marker directory and
+	// starts the daemon, so it is the one signal that both exist on this node.
+	state.Fabric.ManagerStateDir = strings.TrimSpace(os.Getenv(engine.EnvFabricStateDir))
 
 	return state, nil
 }

--- a/internal/agent/source/file_test.go
+++ b/internal/agent/source/file_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
 )
 
 func TestCompileState_AllSKUs(t *testing.T) {
@@ -47,6 +49,22 @@ func TestCompileState_FabricState(t *testing.T) {
 
 	require.True(t, state.Fabric.Enabled, "gb200 fabric should be enabled")
 	require.Positive(t, state.Fabric.LinksPerGPU)
+}
+
+// The state dir comes from the environment, not the profile: NVLink in the
+// config says nothing about whether fabricmanager runs on the node.
+func TestCompileState_ManagerStateDir(t *testing.T) {
+	data, err := os.ReadFile("../../../pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml")
+	require.NoError(t, err)
+
+	state, err := compileState(data)
+	require.NoError(t, err)
+	require.Empty(t, state.Fabric.ManagerStateDir)
+
+	t.Setenv(engine.EnvFabricStateDir, " /var/lib/nvml-mock/fabric-state ")
+	state, err = compileState(data)
+	require.NoError(t, err)
+	require.Equal(t, "/var/lib/nvml-mock/fabric-state", state.Fabric.ManagerStateDir)
 }
 
 func TestFileSource_EmitsInitialState(t *testing.T) {

--- a/internal/agent/state.go
+++ b/internal/agent/state.go
@@ -77,7 +77,10 @@ type DeviceSpec struct {
 
 // FabricState describes the NVLink / NVSwitch fabric configuration.
 type FabricState struct {
-	Enabled              bool
+	// Profile declares NVLink; does not imply fabricmanager runs.
+	Enabled bool
+	// Fabricmanager readiness marker directory; empty when the daemon is off.
+	ManagerStateDir      string
 	ClusterUUID          string
 	CliqueID             uint32
 	LinksPerGPU          int

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -67,24 +67,31 @@ type Config struct {
 
 // NewLogger returns a slog.Logger writing to stdout.
 func NewLogger(cfg Config) *slog.Logger {
-	var slogLevel slog.Level
+	var lvl slog.Level
+
 	switch cfg.Level {
 	case LevelDebug:
-		slogLevel = slog.LevelDebug
+		lvl = slog.LevelDebug
 	case LevelWarn:
-		slogLevel = slog.LevelWarn
+		lvl = slog.LevelWarn
 	case LevelError:
-		slogLevel = slog.LevelError
+		lvl = slog.LevelError
 	default:
-		slogLevel = slog.LevelInfo
+		lvl = slog.LevelInfo
 	}
 
-	opts := &slog.HandlerOptions{Level: slogLevel}
-	var handler slog.Handler
+	opts := &slog.HandlerOptions{Level: lvl}
+	var h slog.Handler
+
 	if cfg.Format == FormatPlain {
-		handler = slog.NewTextHandler(os.Stdout, opts)
+		h = slog.NewTextHandler(os.Stdout, opts)
 	} else {
-		handler = slog.NewJSONHandler(os.Stdout, opts)
+		h = slog.NewJSONHandler(os.Stdout, opts)
 	}
-	return slog.New(handler)
+
+	l := slog.New(h)
+
+	slog.SetDefault(l)
+
+	return l
 }


### PR DESCRIPTION
## What This PR Does

Ported the CDI logic as a new node agent Simulator.
Cleaned up nvml-mock scripts from ported logic.

## Why

<!-- Link to issue or explain motivation -->

A part of MEP0003.
## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`go test -v -race ./...`)
- [x] Linter passes (`make lint-fix`)
- [x] New code has SPDX license headers
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (if user-facing change)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>