### PR TITLE
fix(mocknvml): deliver injected Xid events the way real NVML does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rejected. (#719)
 
 ### Fixed
+- mocknvml: Xid critical-error events are now attributed to the whole GPU the
+  way real NVML does — `nvmlEventData_t.gpuInstanceId`/`computeInstanceId`
+  carry the `0xFFFFFFFF` "not a MIG instance" sentinel instead of `0`/`0`,
+  which consumers (e.g. the DRA driver's health monitor) treat as MIG GI 0 /
+  CI 0 and drop on a GPU without MIG enabled.
+- mocknvml: device state (tripped failure injection, ECC counters, undelivered
+  Xid events) now survives a full `nvmlShutdown()`/`nvmlInit()` cycle, as it
+  does on real hardware. Previously the devices were recreated on re-init, so
+  a failure tripped during one init cycle was silently forgotten before a
+  client that inits NVML again (e.g. for an event-set wait loop) could observe
+  it. This also means the `after_calls` counter and the seeded `probability`
+  roll sequence continue across a re-init within one process rather than
+  starting over. Handles issued before the shutdown remain invalid, and their
+  addresses are never reused for new handles.
 - mocknvml: `nvmlPciInfo_t.busId` now reports the 8-digit PCI domain real NVML
   uses (`00000000:07:00.0`, `NVML_DEVICE_PCI_BUS_ID_FMT`) while `busIdLegacy`
   keeps the 4-digit one (`0000:07:00.0`). Both were filled with the profile's

--- a/docs/helm-chart.md
+++ b/docs/helm-chart.md
@@ -1281,7 +1281,9 @@ recover.
 
 Each `nvidia-smi` invocation is a fresh process whose call counter starts at
 0, so a narrow query like `--query-gpu=ecc.errors.uncorrected.aggregate.total`
-will only ever issue **one** guarded call per GPU per invocation. To see the
+will only ever issue **one** guarded call per GPU per invocation. (Within a
+single process the counter, like the rest of the device state, also survives
+`nvmlShutdown()` followed by `nvmlInit()`.) To see the
 failure surface from a single short command set `after_calls: 1`, or use a
 richer query that issues several guarded calls per GPU (e.g. `nvidia-smi -q`)
 so the trigger fires within one process.

--- a/pkg/gpu/mocknvml/bridge/events.go
+++ b/pkg/gpu/mocknvml/bridge/events.go
@@ -112,8 +112,13 @@ func pollPendingXid(data *C.nvmlEventData_t) bool {
 	data.device.handle = (*C.struct_nvmlDevice_st)(handle)
 	data.eventType = C.NVML_EVENT_TYPE_XID_CRITICAL_ERROR
 	data.eventData = C.ulonglong(xid)
-	data.gpuInstanceId = 0
-	data.computeInstanceId = 0
+	// Real NVML reports 0xFFFFFFFF for both instance ids on events that are
+	// not scoped to a MIG instance. Consumers such as the DRA driver and the
+	// device plugin key off that sentinel to attribute the Xid to the whole
+	// GPU; (0, 0) would name MIG GI 0 / CI 0 instead and be dropped on a GPU
+	// without MIG enabled.
+	data.gpuInstanceId = C.uint(nvmlNoMIGInstanceID)
+	data.computeInstanceId = C.uint(nvmlNoMIGInstanceID)
 	return true
 }
 
@@ -217,11 +222,13 @@ func eventSetWaitForTest(
 
 // xidDelivery is what the bridge wrote into the caller's nvmlEventData_t.
 type xidDelivery struct {
-	status     uint32
-	eventType  uint64
-	eventData  uint64
-	deviceSet  bool
-	claimCount int
+	status            uint32
+	eventType         uint64
+	eventData         uint64
+	gpuInstanceID     uint32
+	computeInstanceID uint32
+	deviceSet         bool
+	claimCount        int
 }
 
 // eventSetWaitWithPendingXidForTest stubs the engine claim with one pending Xid
@@ -259,6 +266,8 @@ func eventSetWaitWithPendingXidForTest(xid uint64, timeoutms uint32, availableAf
 	out.status = uint32(nvmlEventSetWait_v2(set, &data, C.uint(timeoutms)))
 	out.eventType = uint64(data.eventType)
 	out.eventData = uint64(data.eventData)
+	out.gpuInstanceID = uint32(data.gpuInstanceId)
+	out.computeInstanceID = uint32(data.computeInstanceId)
 	out.deviceSet = unsafe.Pointer(data.device.handle) == handle
 	return out
 }

--- a/pkg/gpu/mocknvml/bridge/events_test.go
+++ b/pkg/gpu/mocknvml/bridge/events_test.go
@@ -188,6 +188,10 @@ func TestEventSetWait_DeliversPendingXid(t *testing.T) {
 		"clients filter on eventType; a wrong class is an undelivered event")
 	require.Equal(t, uint64(xid), got.eventData, "the configured Xid code must reach the caller")
 	require.True(t, got.deviceSet, "the event must name the device the Xid came from")
+	require.Equal(t, nvmlNoMIGInstanceID, got.gpuInstanceID,
+		"a non-MIG Xid must carry NVML's 0xFFFFFFFF gpuInstanceId sentinel, not GI 0")
+	require.Equal(t, nvmlNoMIGInstanceID, got.computeInstanceID,
+		"a non-MIG Xid must carry NVML's 0xFFFFFFFF computeInstanceId sentinel, not CI 0")
 }
 
 // An Xid pending while the caller is parked must arrive within one poll

--- a/pkg/gpu/mocknvml/bridge/internal.go
+++ b/pkg/gpu/mocknvml/bridge/internal.go
@@ -274,13 +274,18 @@ func mockInternalFillProcessList(handle unsafe.Pointer, buf unsafe.Pointer, capa
 // writeProcessEntry writes one process into the caller's array at index, using
 // the layout documented above. The name is truncated to fit and always
 // NUL-terminated.
+// nvmlNoMIGInstanceID is the gpuInstanceId / computeInstanceId value NVML
+// reports for anything not attributed to a MIG instance: process entries and
+// nvmlEventData_t alike ("0xFFFFFFFF otherwise" in the NVML docs).
+const nvmlNoMIGInstanceID uint32 = 0xFFFFFFFF
+
 func writeProcessEntry(buf unsafe.Pointer, index int, pid uint32, usedGpuMemory uint64, name string) {
 	e := unsafe.Add(buf, index*procEntrySize)
 	*(*uint32)(e) = pid
 	*(*uint64)(unsafe.Add(e, 8)) = usedGpuMemory
-	*(*uint32)(unsafe.Add(e, 16)) = 0xFFFFFFFF // gpuInstanceId = N/A (non-MIG)
-	*(*uint32)(unsafe.Add(e, 20)) = 0xFFFFFFFF // computeInstanceId = N/A
-	*(*uint64)(unsafe.Add(e, 24)) = 0          // usedGpuCcProtectedMemory
+	*(*uint32)(unsafe.Add(e, 16)) = nvmlNoMIGInstanceID // gpuInstanceId = N/A (non-MIG)
+	*(*uint32)(unsafe.Add(e, 20)) = nvmlNoMIGInstanceID // computeInstanceId = N/A
+	*(*uint64)(unsafe.Add(e, 24)) = 0                   // usedGpuCcProtectedMemory
 
 	if len(name) > procEntryNameMax-1 {
 		name = name[:procEntryNameMax-1]

--- a/pkg/gpu/mocknvml/bridge/process_layout_test.go
+++ b/pkg/gpu/mocknvml/bridge/process_layout_test.go
@@ -55,8 +55,8 @@ func TestWriteProcessEntry_StrideAndFields(t *testing.T) {
 		e := unsafe.Add(base, i*procEntrySize)
 		require.Equal(t, want.pid, *(*uint32)(e), "entry %d pid", i)
 		require.Equal(t, want.mem, *(*uint64)(unsafe.Add(e, 8)), "entry %d usedGpuMemory", i)
-		require.Equal(t, uint32(0xFFFFFFFF), *(*uint32)(unsafe.Add(e, 16)), "entry %d gpuInstanceId", i)
-		require.Equal(t, uint32(0xFFFFFFFF), *(*uint32)(unsafe.Add(e, 20)), "entry %d computeInstanceId", i)
+		require.Equal(t, nvmlNoMIGInstanceID, *(*uint32)(unsafe.Add(e, 16)), "entry %d gpuInstanceId", i)
+		require.Equal(t, nvmlNoMIGInstanceID, *(*uint32)(unsafe.Add(e, 20)), "entry %d computeInstanceId", i)
 
 		nameBuf := unsafe.Slice((*byte)(unsafe.Add(e, procEntryNameOffset)), procEntryNameMax)
 		got, _, found := bytes.Cut(nameBuf, []byte{0})

--- a/pkg/gpu/mocknvml/engine/engine.go
+++ b/pkg/gpu/mocknvml/engine/engine.go
@@ -75,11 +75,23 @@ func (e *Engine) Init() nvml.Return {
 		return nvml.SUCCESS
 	}
 
-	// Create server on first init
-	server, err := e.createServer()
-	if err != nil {
-		debugLog("[ENGINE] Failed to create mock server: %v\n", err)
-		return nvml.ERROR_UNKNOWN
+	// Create the server on the first init only. After a full shutdown the
+	// existing one is reused: injected failures, ECC counters, call counters
+	// and undelivered Xid events model hardware state, which survives
+	// nvmlShutdown()/nvmlInit() on a real GPU. Clients such as the DRA driver
+	// init/shutdown NVML around each discovery step and then again for their
+	// health monitor; recreating the devices here would silently drop a
+	// failure tripped in between.
+	server := e.server
+	if server == nil {
+		var err error
+		server, err = e.createServer()
+		if err != nil {
+			debugLog("[ENGINE] Failed to create mock server: %v\n", err)
+			return nvml.ERROR_UNKNOWN
+		}
+	} else {
+		debugLog("[ENGINE] Re-initializing, reusing existing device state\n")
 	}
 
 	// Detect which GPU device nodes exist. In containers where CDI injects
@@ -262,7 +274,8 @@ func (e *Engine) Shutdown() nvml.Return {
 		return nvml.SUCCESS
 	}
 
-	e.server = nil
+	// Handles become invalid (and their addresses are never reused, see
+	// HandleTable.Clear), but the device state is kept for a later Init.
 	e.handles.Clear()
 
 	debugLog("[ENGINE] Shutdown complete\n")

--- a/pkg/gpu/mocknvml/engine/engine_test.go
+++ b/pkg/gpu/mocknvml/engine/engine_test.go
@@ -66,8 +66,10 @@ func TestEngine_InitShutdown(t *testing.T) {
 	// Shutdown
 	ret = e.Shutdown()
 	require.Equal(t, nvml.SUCCESS, ret, "Shutdown failed")
-	require.Nil(t, e.server, "Server should be nil after shutdown")
+	require.NotNil(t, e.server, "Device state must be kept across shutdown")
 	require.Equal(t, 0, e.initCount, "Expected initCount 0")
+	_, ret = e.DeviceGetCount()
+	require.Equal(t, nvml.ERROR_UNINITIALIZED, ret, "API must report uninitialized after shutdown")
 }
 
 func TestEngine_MultipleInit(t *testing.T) {
@@ -95,8 +97,79 @@ func TestEngine_MultipleInit(t *testing.T) {
 	// Second shutdown (should uninitialize)
 	ret = e.Shutdown()
 	require.Equal(t, nvml.SUCCESS, ret, "Second shutdown failed")
-	require.Nil(t, e.server, "Server should be nil after final shutdown")
+	require.NotNil(t, e.server, "Device state must be kept across final shutdown")
 	require.Equal(t, 0, e.initCount, "Expected initCount 0")
+}
+
+// A full Shutdown followed by Init must keep the device objects (and with
+// them failure-injection state) while invalidating previously issued
+// handles, mirroring hardware state surviving nvmlShutdown/nvmlInit.
+func TestEngine_DeviceStatePersistsAcrossShutdownInit(t *testing.T) {
+	config := &Config{
+		NumDevices:    2,
+		DriverVersion: "550.54.15",
+	}
+	e := NewEngine(config)
+	require.Equal(t, nvml.SUCCESS, e.Init())
+
+	handle, ret := e.DeviceGetHandleByIndex(0)
+	require.Equal(t, nvml.SUCCESS, ret)
+	server := e.server
+	dev := e.LookupDevice(handle)
+	require.NotNil(t, dev)
+
+	require.Equal(t, nvml.SUCCESS, e.Shutdown())
+	require.Equal(t, 0, e.initCount)
+	require.Equal(t, InvalidDeviceInstance, e.LookupDevice(handle), "handles must not survive shutdown")
+
+	require.Equal(t, nvml.SUCCESS, e.Init())
+	defer func() { _ = e.Shutdown() }()
+	require.Equal(t, 1, e.initCount)
+	require.Same(t, server, e.server, "the same device set must be reused after re-init")
+
+	handle2, ret := e.DeviceGetHandleByIndex(0)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Same(t, dev, e.LookupDevice(handle2), "device 0 must be the same object across Shutdown/Init")
+	require.NotEqual(t, handle, handle2, "a retired handle address must not be reissued")
+	require.Equal(t, InvalidDeviceInstance, e.LookupDevice(handle), "the pre-shutdown handle must stay invalid after re-init")
+}
+
+// The behaviour the persistence buys: a failure tripped in one init cycle
+// (as during a client's device discovery) must still deliver its Xid in the
+// next one (the client's event-wait loop).
+func TestEngine_TrippedFailureSurvivesShutdownInit(t *testing.T) {
+	config := &Config{
+		NumDevices:    1,
+		DriverVersion: "550.54.15",
+	}
+	e := NewEngine(config)
+	require.Equal(t, nvml.SUCCESS, e.Init())
+
+	dev := e.server.configurableDevices[0]
+	// Apply any pending override generation first so the injector installed
+	// below is not reconciled away by the first guarded call.
+	dev.refresh()
+	dev.failure.Store(newFailureInjector(&FailureInjectionConfig{
+		Mode: FailureModeECCUncorrectable,
+		Xid:  &XidErrorConfig{Code: 79},
+	}))
+
+	_, ret := dev.GetMemoryInfo() // guarded call: trips the injector
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.True(t, dev.failureInjector().Triggered(), "guarded call must trip the injector")
+
+	require.Equal(t, nvml.SUCCESS, e.Shutdown())
+	require.Equal(t, nvml.SUCCESS, e.Init())
+	defer func() { _ = e.Shutdown() }()
+
+	require.True(t, e.server.configurableDevices[0].failureInjector().Triggered(),
+		"tripped state must survive Shutdown/Init")
+	handle, xid, ok := e.PendingXidEvent()
+	require.True(t, ok, "the Xid tripped before shutdown must still be deliverable after re-init")
+	require.Equal(t, uint64(79), xid)
+	require.Same(t, dev, e.LookupDevice(handle))
+	_, _, ok = e.PendingXidEvent()
+	require.False(t, ok, "each Xid is delivered once")
 }
 
 func TestEngine_ShutdownWithoutInit(t *testing.T) {

--- a/pkg/gpu/mocknvml/engine/handles.go
+++ b/pkg/gpu/mocknvml/engine/handles.go
@@ -37,6 +37,14 @@ static void freeHandle(void* handle) {
     free(handle);
 }
 
+// retireHandle invalidates a handle block without freeing it, so its
+// address can never be handed out again for a later registration.
+static void retireHandle(void* handle) {
+    if (handle) {
+        ((HandleBlock*)handle)->magic = 0;
+    }
+}
+
 // isValidHandle checks if the handle has the correct magic number.
 // Returns 1 if valid, 0 otherwise.
 static int isValidHandle(void* handle) {
@@ -85,6 +93,13 @@ import (
 type HandleTable struct {
 	devices map[unsafe.Pointer]nvml.Device
 	reverse map[nvml.Device]unsafe.Pointer
+	// retired holds blocks handed out before a Clear. They are kept
+	// allocated (with the magic cleared) instead of freed so that a later
+	// Register can never reuse their address: a client holding a handle from
+	// before nvmlShutdown must keep getting ERROR_INVALID_ARGUMENT, not
+	// alias whichever device happened to get the recycled block. Blocks are
+	// tiny and only accumulate once per Shutdown/Init cycle.
+	retired []unsafe.Pointer
 	mu      sync.RWMutex
 }
 
@@ -176,16 +191,35 @@ func (ht *HandleTable) HandleFor(dev nvml.Device) unsafe.Pointer {
 	return ht.reverse[dev]
 }
 
-// Clear removes all entries from the handle table and frees allocated memory.
+// Clear invalidates every registered handle. The C blocks are retired, not
+// freed (see HandleTable.retired), so handles issued before the Clear stay
+// invalid for the lifetime of the table even after new registrations.
 func (ht *HandleTable) Clear() {
 	ht.mu.Lock()
 	defer ht.mu.Unlock()
 
-	// Free all allocated C handle blocks
+	for handle := range ht.devices {
+		C.retireHandle(handle)
+		ht.retired = append(ht.retired, handle)
+	}
+
+	ht.devices = make(map[unsafe.Pointer]nvml.Device)
+	ht.reverse = make(map[nvml.Device]unsafe.Pointer)
+}
+
+// Free releases every block, live and retired. Only for tests and teardown;
+// any handle a client still holds becomes a dangling pointer afterwards.
+func (ht *HandleTable) Free() {
+	ht.mu.Lock()
+	defer ht.mu.Unlock()
+
 	for handle := range ht.devices {
 		C.freeHandle(handle)
 	}
-
+	for _, handle := range ht.retired {
+		C.freeHandle(handle)
+	}
+	ht.retired = nil
 	ht.devices = make(map[unsafe.Pointer]nvml.Device)
 	ht.reverse = make(map[nvml.Device]unsafe.Pointer)
 }


### PR DESCRIPTION
## What This PR Does

Fixes two places where the mock NVML behaves differently from a real GPU, which made injected Xid errors invisible to health monitors such as the DRA driver's.

1. Xid events now say "this is the whole GPU, not a MIG slice". Real NVML fills `gpuInstanceId` and `computeInstanceId` in `nvmlEventData_t` with `0xFFFFFFFF` when the event is not tied to a MIG instance. The mock wrote `0` and `0`. Clients read that as MIG instance 0 on compute instance 0, which does not exist on a GPU without MIG, so they dropped the event.

2. Device state now survives `nvmlShutdown()` followed by `nvmlInit()`. The mock used to throw away its devices on shutdown and build new ones on the next init, which also reset the failure injector. On real hardware a tripped Xid or ECC fault does not disappear because a process reinitializes NVML. Many clients call init and shutdown around device discovery and then call init again for their event loop, so the failure tripped during discovery was lost before the event loop could see it. The devices are now kept; old handles are still invalid and the API still returns `ERROR_UNINITIALIZED` after shutdown.

Also:
* The bridge test hook (`xidDelivery`) now exposes the instance ids so the sentinel is covered by a test.
* New engine test for state persistence, and the two existing tests that expected the server to be dropped on shutdown are updated.
* CHANGELOG entry under Unreleased / Fixed.

## Why

I found this while writing bats e2e tests for the GPU DRA driver health reporting (kubernetes-sigs/dra-driver-nvidia-gpu#1243) on top of the mock NVML kind setup. With `nvml-mock-ctl fail --mode ecc_uncorrectable --xid 79` the driver never tainted the device or reported it as Unhealthy. The event was either never raised (state lost across the driver's init, shutdown, init sequence) or raised with instance ids the driver treats as an invalid MIG address.

With this change the driver's health path works end to end on the mock: the ResourceSlice gets `gpu.nvidia.com/xid=79:NoSchedule` and the pod's `allocatedResourcesStatus` shows `Unhealthy`.

Note for existing users: an injected failure now stays in effect across NVML reinitialization inside the same process, matching the documented sticky behavior of the injector. Restarting the pod still resets everything, as before.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`go test -v -race ./...`)
- [x] Linter passes (`make lint-fix`)
- [x] New code has SPDX license headers
- [ ] Documentation updated (if applicable)
- [x] CHANGELOG.md updated (if user-facing change)

## AI Usage

Claude Code assisted with the investigation, code, tests and this write up; I reviewed the changes and verified the results myself.
