### PR TITLE
fix(tilt): send shims/ in the nvml-mock build context

### DIFF
--- a/local/compute-domain/compute_domain.tiltfile
+++ b/local/compute-domain/compute_domain.tiltfile
@@ -50,6 +50,8 @@ def build_images(with_dra):
     # Base nvml-mock image. Locally tagged (nvml-mock:compute-domain)
     # rather than the ghcr.io ref used by local/nvml_mock.tiltfile — the
     # demo overlay's NVML_MOCK_IMAGE build-arg targets this exact ref.
+    # Same Dockerfile as local/nvml_mock.tiltfile, so this list has to carry
+    # the same trees.
     docker_build(
         _BASE_IMAGE,
         context='.',
@@ -60,6 +62,9 @@ def build_images(with_dra):
             'vendor/',
             'cmd/',
             'pkg/',
+            'internal/',
+            'shims/',
+            'Makefile',
             'deployments/nvml-mock/',
         ],
     )

--- a/local/nvml_mock.tiltfile
+++ b/local/nvml_mock.tiltfile
@@ -61,7 +61,8 @@ def build_nvml_mock_image(nvmlmock_image=''):
     # only= is intentionally coarse (top-level dirs): the Dockerfile's
     # per-subpath COPYs drive layer-cache invalidation, so listing whole
     # trees here avoids drift when new cmd/pkg subdirs are added without
-    # forcing extra rebuilds.
+    # forcing extra rebuilds. A new top-level tree in the Dockerfile does
+    # need an entry here, or its COPY fails on a path the context omits.
     docker_build(
         _IMAGE,
         context='.',
@@ -73,6 +74,7 @@ def build_nvml_mock_image(nvmlmock_image=''):
             'cmd/',
             'pkg/',
             'internal/',
+            'shims/',
             'Makefile',
             'deployments/nvml-mock/',
         ],


### PR DESCRIPTION
## Summary

Local Tilt has been broken since #719: it added `COPY shims/ shims/` to the nvml-mock Dockerfile, but Tilt builds that Dockerfile through an `only=` allowlist that still ends at `internal/`. The tree never reaches the daemon, so every `tilt ci` fails before compiling anything:

```
ERROR IN: [builder  8/14] COPY shims/ shims/
ERROR: Build Failed: ImageBuild: failed to compute cache key: "/shims": not found
```

CI never saw it — the `build-nvmlmock-image` job builds with the full context, so the allowlist only exists on the local path.

`local/compute-domain/compute_domain.tiltfile` drives the same Dockerfile from a second list that had also fallen behind on `internal/` and `Makefile`, so it gains all three rather than trading one missing `COPY` for the next. The remaining `only=` lists (control-plane, the compute-domain daemon overlay) already match their Dockerfiles.

The comment above the list now says that a new top-level tree in the Dockerfile needs an entry here, since that is the drift the coarse-list convention invites.

## Test plan

- [x] `tilt alpha tiltfile-result -- --gpu-operator --gpu-profile gb300 --dra` resolves the context filter to `['**', '!go.mod', '!go.sum', '!vendor/', '!cmd/', '!pkg/', '!internal/', '!shims/', '!Makefile', '!deployments/nvml-mock/']`
- [x] Reproduced the failure on `main` and confirmed a plain `docker build` of the same context copies `shims/` fine, isolating the allowlist as the cause
- [ ] `tilt ci -- --gpu-operator --gpu-profile gb300 --dra` runs to completion
- [ ] `tilt ci -- --compute-domain` covers the second list