### PR TITLE
fix(node-agent): serve the mock PCI tree at the kernel paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -370,6 +370,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   profile that declares no `bus_id`, where it previously left the last
   profile's devices in place — invisible until the tree started being served,
   and then a container enumerating GPUs the node no longer simulates. (#673)
+- node-agent: the rendered PCI tree now follows the devices NVML reports rather
+  than `pcie_topology` as the profile writes it. `gpu.count` (`GPU_COUNT`) caps
+  the device list without touching the layout, so a capped node used to render
+  BDFs with no NVML device behind them — phantom NVIDIA 3D controllers, every
+  attribute plausible, harmless only while nothing could read the tree. Declared
+  BDFs no device claims are dropped along with any root left empty, and a device
+  no root claims is adopted by the first one, since an unplaced GPU cannot be
+  resolved at all where a misplaced one only misreports its `pcieRoot`. (#673)
 - node-agent: `nvidia.com/gpu.machine` no longer reads `unknown`. GFD derives it
   from `--machine-type-file`, whose default `/sys/class/dmi/id/product_name` no
   mock can own under kind: the node image writes `kind` there and re-binds it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,6 +345,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   roll sequence continue across a re-init within one process rather than
   starting over. Handles issued before the shutdown remain invalid, and their
   addresses are never reused for new handles.
+- node-agent: the rendered PCI sysfs tree now reaches Go consumers. It was
+  readable only through `MOCK_PCI_ROOT` and the `libpcisysfs.so` `LD_PRELOAD`
+  shim, which covers libc consumers such as `lspci` but not Go: `os.Open` issues
+  `openat` directly, the shim never sees it, and the process reads the node's
+  real `/sys`, where the mock GPUs do not exist. GPU Feature Discovery and the
+  NVIDIA DRA driver are both Go, so GFD resolved each mock GPU's BDF from NVML,
+  failed to read its class, and labelled the node
+  `nvidia.com/gpu.mode=unknown`. The `nvidia.com/gpu` CDI spec the agent writes
+  now bind-mounts `sys/devices` and `sys/bus/pci/devices` read-only onto the
+  kernel paths. The two go together, because the PCI entries are relative
+  symlinks into `../../../devices/pciDDDD:BB`: mounting one alone yields entries
+  that list and whose every attribute read returns `ENOENT`, which is
+  indistinguishable from no mount at all. `/sys/devices` is mounted whole —
+  narrowing it to the profile's root complexes needs a mountpoint the runtime
+  cannot create on a read-only sysfs, and container creation fails outright
+  rather than degrading — so a served container does not see the host's other
+  device classes, CPU topology among them (#689). The `pcibus` simulator also
+  mirrors the node's `product_name` and an empty `product_uuid` stand-in into
+  `sys/devices/virtual/dmi/id`: that is where `/sys/class/dmi/id` resolves, and
+  kind bind-mounts the node's product files there for every container, so
+  without the mirror the shadowing removes a target `mount(8)` cannot recreate
+  and every served pod fails to start. This is not a machine-type mock, which
+  remains blocked under kind (#681). Rendering also empties the tree for a
+  profile that declares no `bus_id`, where it previously left the last
+  profile's devices in place — invisible until the tree started being served,
+  and then a container enumerating GPUs the node no longer simulates. (#673)
 - mocknvml: `nvmlPciInfo_t.busId` now reports the 8-digit PCI domain real NVML
   uses (`00000000:07:00.0`, `NVML_DEVICE_PCI_BUS_ID_FMT`) while `busIdLegacy`
   keeps the 4-digit one (`0000:07:00.0`). Both were filled with the profile's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -366,11 +366,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `sys/devices/virtual/dmi/id`: that is where `/sys/class/dmi/id` resolves, and
   kind bind-mounts the node's product files there for every container, so
   without the mirror the shadowing removes a target `mount(8)` cannot recreate
-  and every served pod fails to start. This is not a machine-type mock, which
-  remains blocked under kind (#681). Rendering also empties the tree for a
+  and every served pod fails to start. Rendering also empties the tree for a
   profile that declares no `bus_id`, where it previously left the last
   profile's devices in place — invisible until the tree started being served,
   and then a container enumerating GPUs the node no longer simulates. (#673)
+- node-agent: `nvidia.com/gpu.machine` no longer reads `unknown`. GFD derives it
+  from `--machine-type-file`, whose default `/sys/class/dmi/id/product_name` no
+  mock can own under kind: the node image writes `kind` there and re-binds it
+  into every container after the container's own mounts are set up, and hosts
+  without DMI (Docker Desktop) have no such path at all. The agent now writes
+  the machine type to `driver/config/machine-type`, served at
+  `/etc/nvml-mock/machine-type` by the CDI mount that already carries
+  `config.yaml`, and the chart's GPU Operator values point
+  `GFD_MACHINE_TYPE_FILE` at it. The value is the profile's GPU product name for
+  want of a platform name in the profiles, so the label reads
+  `NVIDIA-GB300-NVL`, matching `gpu.product`, rather than the
+  `NVIDIA-GB300-NVL72` a real compute tray reports. (#681)
 - mocknvml: `nvmlPciInfo_t.busId` now reports the 8-digit PCI domain real NVML
   uses (`00000000:07:00.0`, `NVML_DEVICE_PCI_BUS_ID_FMT`) while `busIdLegacy`
   keeps the 4-digit one (`0000:07:00.0`). Both were filled with the profile's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,49 +345,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   roll sequence continue across a re-init within one process rather than
   starting over. Handles issued before the shutdown remain invalid, and their
   addresses are never reused for new handles.
-- node-agent: the rendered PCI sysfs tree now reaches Go consumers. It was
-  readable only through `MOCK_PCI_ROOT` and the `libpcisysfs.so` `LD_PRELOAD`
-  shim, which covers libc consumers such as `lspci` but not Go: `os.Open` issues
-  `openat` directly, the shim never sees it, and the process reads the node's
-  real `/sys`, where the mock GPUs do not exist. GPU Feature Discovery and the
-  NVIDIA DRA driver are both Go, so GFD resolved each mock GPU's BDF from NVML,
-  failed to read its class, and labelled the node
-  `nvidia.com/gpu.mode=unknown`. The `nvidia.com/gpu` CDI spec the agent writes
-  now bind-mounts `sys/devices` and `sys/bus/pci/devices` read-only onto the
-  kernel paths. The two go together, because the PCI entries are relative
-  symlinks into `../../../devices/pciDDDD:BB`: mounting one alone yields entries
-  that list and whose every attribute read returns `ENOENT`, which is
-  indistinguishable from no mount at all. `/sys/devices` is mounted whole —
-  narrowing it to the profile's root complexes needs a mountpoint the runtime
-  cannot create on a read-only sysfs, and container creation fails outright
-  rather than degrading — so a served container does not see the host's other
-  device classes, CPU topology among them (#689). The `pcibus` simulator also
-  mirrors the node's `product_name` and an empty `product_uuid` stand-in into
-  `sys/devices/virtual/dmi/id`: that is where `/sys/class/dmi/id` resolves, and
-  kind bind-mounts the node's product files there for every container, so
-  without the mirror the shadowing removes a target `mount(8)` cannot recreate
-  and every served pod fails to start. Rendering also empties the tree for a
-  profile that declares no `bus_id`, where it previously left the last
-  profile's devices in place — invisible until the tree started being served,
-  and then a container enumerating GPUs the node no longer simulates. (#673)
-- node-agent: the rendered PCI tree now follows the devices NVML reports rather
-  than `pcie_topology` as the profile writes it. `gpu.count` (`GPU_COUNT`) caps
-  the device list without touching the layout, so a capped node used to render
-  BDFs with no NVML device behind them — phantom NVIDIA 3D controllers, every
-  attribute plausible, harmless only while nothing could read the tree. Declared
-  BDFs no device claims are dropped along with any root left empty, and a device
-  no root claims is adopted by the first one, since an unplaced GPU cannot be
-  resolved at all where a misplaced one only misreports its `pcieRoot`. (#673)
-- node-agent: `nvidia.com/gpu.machine` no longer reads `unknown`. GFD derives it
-  from `--machine-type-file`, whose default `/sys/class/dmi/id/product_name` no
-  mock can own under kind: the node image writes `kind` there and re-binds it
-  into every container after the container's own mounts are set up, and hosts
-  without DMI (Docker Desktop) have no such path at all. The agent now writes
-  the machine type to `driver/config/machine-type`, served at
-  `/etc/nvml-mock/machine-type` by the CDI mount that already carries
-  `config.yaml`, and the chart's GPU Operator values point
-  `GFD_MACHINE_TYPE_FILE` at it. The value is the profile's GPU product name for
-  want of a platform name in the profiles, so the label reads
+- node-agent: the rendered PCI sysfs tree now reaches Go consumers. Only the
+  `libpcisysfs.so` `LD_PRELOAD` shim redirected the kernel paths to it, and Go
+  bypasses the shim — `os.Open` issues `openat` directly — so GPU Feature
+  Discovery read the node's real `/sys`, found none of the mock GPUs, and
+  labelled the node `nvidia.com/gpu.mode=unknown`; the NVIDIA DRA driver omitted
+  `dra.k8s.io/pcieRoot` for the same reason. The agent's `nvidia.com/gpu` CDI
+  spec now bind-mounts `sys/devices` and `sys/bus/pci/devices` read-only over
+  the kernel paths, as a pair, since the PCI entries are relative symlinks into
+  `../../../devices/pciDDDD:BB`. `/sys/devices` is served whole, so a served
+  container no longer sees the host's other device classes, CPU topology among
+  them; #689 tracks narrowing it. The node's DMI attributes are reproduced
+  inside the tree, without which kind's product-file bind-mounts lose their
+  target and every served pod fails to start. (#673)
+- node-agent: the rendered tree now follows the devices NVML reports rather than
+  `pcie_topology` as the profile writes it. `gpu.count` caps the device list
+  without touching the layout, so a capped node rendered PCI entries that read
+  as GPUs — NVIDIA vendor ID, GPU device class — with no NVML device behind
+  them. Declared BDFs no device claims are dropped along with any root left
+  empty, and a device no root claims is adopted by the first. A profile
+  declaring no `bus_id` now empties the tree instead of leaving the previous
+  profile's GPUs served. (#673)
+- node-agent: `nvidia.com/gpu.machine` no longer reads `unknown`. GFD's default
+  source for it, `/sys/class/dmi/id/product_name`, is a path no mock can own
+  under kind — the node image writes `kind` there and re-binds it into every
+  container — and hosts without DMI have no such path at all. The agent now
+  writes the machine type to `driver/config/machine-type`, and the NRI plugin
+  points `GFD_MACHINE_TYPE_FILE` at it, so an install needs no GPU Operator
+  override. Deployments using the CDI path still need one, because the runtime
+  applies the spec's mounts but drops its env. The value is the GPU product name
+  for want of a platform name in the profiles, so the label reads
   `NVIDIA-GB300-NVL`, matching `gpu.product`, rather than the
   `NVIDIA-GB300-NVL72` a real compute tray reports. (#681)
 - mocknvml: `nvmlPciInfo_t.busId` now reports the 8-digit PCI domain real NVML

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -375,9 +375,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   container — and hosts without DMI have no such path at all. The agent now
   writes the machine type to `driver/config/machine-type`, and the NRI plugin
   points `GFD_MACHINE_TYPE_FILE` at it, so an install needs no GPU Operator
-  override. Deployments using the CDI path still need one, because the runtime
-  applies the spec's mounts but drops its env (#747). The value is the GPU product name
-  for want of a platform name in the profiles, so the label reads
+  override. Deployments using the CDI path still need one, because the toolkit
+  resolving `nvidia.com/gpu` applies the spec's mounts and drops its env (#747).
+  The value is the GPU product name for want of a platform name in the
+  profiles, so the label reads
   `NVIDIA-GB300-NVL`, matching `gpu.product`, rather than the
   `NVIDIA-GB300-NVL72` a real compute tray reports. (#681)
 - mocknvml: `nvmlPciInfo_t.busId` now reports the 8-digit PCI domain real NVML

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -373,7 +373,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   writes the machine type to `driver/config/machine-type`, and the NRI plugin
   points `GFD_MACHINE_TYPE_FILE` at it, so an install needs no GPU Operator
   override. Deployments using the CDI path still need one, because the runtime
-  applies the spec's mounts but drops its env. The value is the GPU product name
+  applies the spec's mounts but drops its env (#747). The value is the GPU product name
   for want of a platform name in the profiles, so the label reads
   `NVIDIA-GB300-NVL`, matching `gpu.product`, rather than the
   `NVIDIA-GB300-NVL72` a real compute tray reports. (#681)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -363,9 +363,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without touching the layout, so a capped node rendered PCI entries that read
   as GPUs — NVIDIA vendor ID, GPU device class — with no NVML device behind
   them. Declared BDFs no device claims are dropped along with any root left
-  empty, and a device no root claims is adopted by the first. A profile
-  declaring no `bus_id` now empties the tree instead of leaving the previous
-  profile's GPUs served. (#673)
+  empty. A device no root claims is still rendered, since one missing from the
+  tree is one no consumer can resolve, but under a root its own address implies
+  and reporting `numa_node` `-1` — the kernel's own "no proximity information" —
+  rather than borrowing the locality of a root the profile never put it in. A
+  profile declaring no `bus_id` now empties the tree instead of leaving the
+  previous profile's GPUs served. (#673)
 - node-agent: `nvidia.com/gpu.machine` no longer reads `unknown`. GFD's default
   source for it, `/sys/class/dmi/id/product_name`, is a path no mock can own
   under kind — the node image writes `kind` there and re-binds it into every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -353,7 +353,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `dra.k8s.io/pcieRoot` for the same reason. The agent's `nvidia.com/gpu` CDI
   spec now bind-mounts `sys/devices` and `sys/bus/pci/devices` read-only over
   the kernel paths, as a pair, since the PCI entries are relative symlinks into
-  `../../../devices/pciDDDD:BB`. `/sys/devices` is served whole, so a served
+  `../../../devices/pciDDDD:BB`. Tearing the tree down empties those two
+  directories in place rather than removing them, so a container already holding
+  the mount is not left on a replaced inode reading an empty tree.
+  `/sys/devices` is served whole, so a served
   container no longer sees the host's other device classes, CPU topology among
   them; #689 tracks narrowing it. The node's DMI attributes are reproduced
   inside the tree, without which kind's product-file bind-mounts lose their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -370,7 +370,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tree is one no consumer can resolve, but under a root its own address implies
   and reporting `numa_node` `-1` — the kernel's own "no proximity information" —
   rather than borrowing the locality of a root the profile never put it in. A
-  profile declaring no `bus_id` now empties the tree instead of leaving the
+  `bus_id` that is not an address in the kernel's `DDDD:BB:DD.F` form is dropped
+  rather than placed: it named the default root, which every shipped profile
+  declares, so the device inherited that root's NUMA node — and since a `bus_id`
+  becomes a directory name, one carrying `/` or `..` rendered outside the tree.
+  A profile declaring no `bus_id` now empties the tree instead of leaving the
   previous profile's GPUs served. (#673)
 - node-agent: `nvidia.com/gpu.machine` no longer reads `unknown`. GFD's default
   source for it, `/sys/class/dmi/id/product_name`, is a path no mock can own

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -255,6 +255,14 @@ spec:
             - name: host-fabric-state
               mountPath: {{ printf "/host%s" .Values.fabricmanager.stateDir }}
             {{- end }}
+            # Read-only, and read from rather than written to: serving the
+            # rendered tree at /sys/devices replaces the directory
+            # /sys/class/dmi/id resolves into, so the agent reproduces the
+            # node's DMI attributes inside the tree to keep the runtime's
+            # bind-mount targets alive.
+            - name: host-sys
+              mountPath: /host/sys
+              readOnly: true
           livenessProbe:
             httpGet:
               path: /healthz
@@ -329,6 +337,12 @@ spec:
           hostPath:
             path: {{ .Values.nodeLabels.featuresDir | quote }}
             type: DirectoryOrCreate
+        # Directory, not DirectoryOrCreate: every node has /sys, and a node that
+        # somehow does not should fail loudly rather than get an empty stand-in.
+        - name: host-sys
+          hostPath:
+            path: /sys
+            type: Directory
         {{- if .Values.topology.enabled }}
         - name: gpu-topology
           configMap:

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -255,11 +255,8 @@ spec:
             - name: host-fabric-state
               mountPath: {{ printf "/host%s" .Values.fabricmanager.stateDir }}
             {{- end }}
-            # Read-only, and read from rather than written to: serving the
-            # rendered tree at /sys/devices replaces the directory
-            # /sys/class/dmi/id resolves into, so the agent reproduces the
-            # node's DMI attributes inside the tree to keep the runtime's
-            # bind-mount targets alive.
+            # Read only: the agent copies the node's DMI attributes into the
+            # rendered tree, which shadows them once served at /sys/devices.
             - name: host-sys
               mountPath: /host/sys
               readOnly: true
@@ -337,8 +334,8 @@ spec:
           hostPath:
             path: {{ .Values.nodeLabels.featuresDir | quote }}
             type: DirectoryOrCreate
-        # Directory, not DirectoryOrCreate: every node has /sys, and a node that
-        # somehow does not should fail loudly rather than get an empty stand-in.
+        # Directory, not DirectoryOrCreate: a node without /sys should fail
+        # loudly rather than get an empty stand-in.
         - name: host-sys
           hostPath:
             path: /sys

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -152,6 +152,9 @@ should match snapshot with all overrides:
                   name: host-nfd-features
                 - mountPath: /host/var/lib/nvml-mock/fabric-state
                   name: host-fabric-state
+                - mountPath: /host/sys
+                  name: host-sys
+                  readOnly: true
           nodeSelector:
             nvidia.com/gpu.present: "true"
           serviceAccountName: nvml-mock-custom
@@ -180,6 +183,10 @@ should match snapshot with all overrides:
                 path: /etc/kubernetes/node-feature-discovery/features.d
                 type: DirectoryOrCreate
               name: host-nfd-features
+            - hostPath:
+                path: /sys
+                type: Directory
+              name: host-sys
             - hostPath:
                 path: /var/lib/nvml-mock/fabric-state
                 type: DirectoryOrCreate
@@ -329,6 +336,9 @@ should match snapshot with b200 profile:
                   readOnly: true
                 - mountPath: /host/etc/kubernetes/node-feature-discovery/features.d
                   name: host-nfd-features
+                - mountPath: /host/sys
+                  name: host-sys
+                  readOnly: true
           serviceAccountName: RELEASE-NAME-nvml-mock
           terminationGracePeriodSeconds: 2
           tolerations:
@@ -353,6 +363,10 @@ should match snapshot with b200 profile:
                 path: /etc/kubernetes/node-feature-discovery/features.d
                 type: DirectoryOrCreate
               name: host-nfd-features
+            - hostPath:
+                path: /sys
+                type: Directory
+              name: host-sys
       updateStrategy:
         rollingUpdate:
           maxUnavailable: 25%
@@ -504,6 +518,9 @@ should match snapshot with default values:
                   name: host-nfd-features
                 - mountPath: /host/var/lib/nvml-mock/fabric-state
                   name: host-fabric-state
+                - mountPath: /host/sys
+                  name: host-sys
+                  readOnly: true
           serviceAccountName: RELEASE-NAME-nvml-mock
           terminationGracePeriodSeconds: 2
           tolerations:
@@ -528,6 +545,10 @@ should match snapshot with default values:
                 path: /etc/kubernetes/node-feature-discovery/features.d
                 type: DirectoryOrCreate
               name: host-nfd-features
+            - hostPath:
+                path: /sys
+                type: Directory
+              name: host-sys
             - hostPath:
                 path: /var/lib/nvml-mock/fabric-state
                 type: DirectoryOrCreate

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -927,10 +927,18 @@ tests:
   # rendered PCI tree, because serving that tree at /sys/devices replaces the
   # directory /sys/class/dmi/id resolves into and the runtime's bind-mount
   # targets have to survive it. Read-only: the agent never writes to /sys.
-  - it: node-agent should mount the node's sysfs read-only
+  - it: should mount the node's sysfs read-only in the agent alone
     asserts:
       - contains:
           path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: host-sys
+            mountPath: /host/sys
+            readOnly: true
+      # Nothing in the mock container reads the node's sysfs, and the volume is
+      # the whole of /sys.
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
           content:
             name: host-sys
             mountPath: /host/sys

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -923,6 +923,26 @@ tests:
             name: host-cdi
             mountPath: /host/run/cdi
 
+  # The agent reads the node's DMI attributes and reproduces them inside the
+  # rendered PCI tree, because serving that tree at /sys/devices replaces the
+  # directory /sys/class/dmi/id resolves into and the runtime's bind-mount
+  # targets have to survive it. Read-only: the agent never writes to /sys.
+  - it: node-agent should mount the node's sysfs read-only
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: host-sys
+            mountPath: /host/sys
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: host-sys
+            hostPath:
+              path: /sys
+              type: Directory
+
   - it: should honour node-agent logging and timeout overrides
     set:
       nodeAgent:

--- a/docs/helm-chart.md
+++ b/docs/helm-chart.md
@@ -19,12 +19,11 @@ Deploys a DaemonSet that creates on every node:
   paired with `libibmocksys.so` (`LD_PRELOAD`) so real `ibstat`, `ibstatus`,
   `iblinkinfo`, ... read mock HCAs
 - A fake PCI sysfs tree at `/var/lib/nvml-mock/sys/bus/pci/devices/...` (symlinks
-  into `/var/lib/nvml-mock/sys/devices/pciDDDD:BB/...`) so C consumers of the
-  PCI sysfs — `lspci` and anything else reaching it through libc — resolve the
-  PCIe root complex via a standard `readlink()`. The NVIDIA DRA driver is a Go
-  binary and does not see this tree, so `dra.k8s.io/pcieRoot` is still absent
-  from its ResourceSlices; see [Known Limitations](#known-limitations) and
-  issue [#265](https://github.com/NVIDIA/k8s-test-infra/issues/265)
+  into `/var/lib/nvml-mock/sys/devices/pciDDDD:BB/...`) so consumers resolve the
+  PCIe root complex via a standard `readlink()`. `lspci` and anything else
+  reaching it through libc read it via `libpcisysfs.so`; containers served the
+  `nvidia.com/gpu` CDI spec get it bind-mounted at the kernel paths, which is
+  what Go consumers need — see [PCI sysfs in containers](#pci-sysfs-in-containers)
 
 Consumers (DRA driver, device plugin) point at `/var/lib/nvml-mock/driver`
 as the NVIDIA driver root and discover GPUs through standard NVML APIs.
@@ -653,12 +652,11 @@ Two options, depending on intent:
 ## PCIe topology mocking
 
 Each profile carries a `pcie_topology:` block describing the host's PCI
-root-complex layout. When the DaemonSet starts, `render-pci-sysfs` reads
-it and writes a fake sysfs tree at `/var/lib/nvml-mock/sys/...` matching
-what real Linux kernels expose. Topology-aware consumers (NVIDIA DRA
-driver, device plugins computing NUMA hints) resolve "which PCIe root
-complex a GPU lives on" via a standard `readlink()` + path parse against
-the rendered tree:
+root-complex layout. The node agent's `pcibus` simulator reads it and writes a
+fake sysfs tree at `/var/lib/nvml-mock/sys/...` matching what real Linux kernels
+expose. Topology-aware consumers (NVIDIA DRA driver, device plugins computing
+NUMA hints) resolve "which PCIe root complex a GPU lives on" via a standard
+`readlink()` + path parse against the rendered tree:
 
 ```bash
 $ readlink /var/lib/nvml-mock/sys/bus/pci/devices/0000:07:00.0
@@ -697,8 +695,8 @@ pcie_topology:
         - "0000:90:00.0"
 ```
 
-`render-pci-sysfs` validates the block at startup and fails the
-DaemonSet under `set -e` if it finds a typo:
+The simulator validates the block and reports a staging failure through the
+agent's `/healthz` if it finds a typo:
 
 - Every BDF listed under a root complex must also appear in `devices[]`.
 - Each BDF may belong to at most one root complex.
@@ -707,7 +705,41 @@ DaemonSet under `set -e` if it finds a typo:
   `busIdLegacy` 8-digit form is rejected.
 
 If a profile omits `pcie_topology:` entirely the renderer falls back to
-a flat single-root layout (every device under `pci0000:00`, NUMA 0).
+a flat single-root layout (every device under `pci0000:00`, NUMA 0). A profile
+whose devices declare no `bus_id` at all renders nothing, and the simulator
+empties any tree a previous profile left behind.
+
+### PCI sysfs in containers
+
+Reaching the tree through `MOCK_PCI_ROOT` requires the `libpcisysfs.so`
+`LD_PRELOAD` shim, which only works for libc consumers: Go's `os` package issues
+`openat` directly, so the shim never sees the open and the process reads the
+node's real `/sys`, where the mock GPUs do not exist. GPU Feature Discovery and
+the NVIDIA DRA driver are both Go.
+
+So the `nvidia.com/gpu` CDI spec the node agent writes bind-mounts the tree
+read-only at the kernel paths:
+
+| Host | Container |
+|---|---|
+| `/var/lib/nvml-mock/sys/devices` | `/sys/devices` |
+| `/var/lib/nvml-mock/sys/bus/pci/devices` | `/sys/bus/pci/devices` |
+
+Both, always together. The entries under `sys/bus/pci/devices` are relative
+symlinks into `../../../devices/pciDDDD:BB`, so mounting that directory alone
+yields entries that list but whose every attribute read fails with `ENOENT`.
+
+**Trade-off:** `/sys/devices` is mounted whole, which hides the host's other
+device classes — CPU topology among them — from served containers. Narrowing it
+to the profile's root complexes is not possible: the runtime would have to create
+the mountpoint, and sysfs is read-only in a container, so container creation
+fails outright rather than degrading. Profiles routinely declare root complexes
+the node does not have. [#689](https://github.com/NVIDIA/k8s-test-infra/issues/689)
+tracks removing the trade-off.
+
+A workload that needs the node's real device tree belongs in
+`nri.excludedNamespaces`, or should not request a GPU through the
+`nvidia.com/gpu` CDI spec.
 
 ### Cross-node `ibping`
 
@@ -1355,8 +1387,9 @@ discovery and monitoring. Some host-level subsystems are not mocked:
 
 | What's Missing | Affected Consumer | Impact |
 |----------------|-------------------|--------|
-| `/sys/bus/pci/devices/{busID}` sysfs entries **as a Go program reads them** | DRA driver | The tree is rendered and `lspci` reads it, but the driver is a Go binary: Go's `os` package issues raw syscalls that the `LD_PRELOAD` shim cannot intercept, so it reads the host's real sysfs instead. `dra.k8s.io/pcieRoot` stays absent from ResourceSlices — **blocks topology-aware scheduling demos** (e.g., GPU + SR-IOV VF alignment). Tracked in [#265](https://github.com/NVIDIA/k8s-test-infra/issues/265) |
-| `/sys/bus/pci/devices/{busID}/numa_node` | Device plugin | NUMA-aware topology hints unavailable; scheduling works but NUMA affinity not enforced |
+| `/sys/bus/pci/devices/{busID}` sysfs entries **in a container the mock does not serve** | Any Go consumer | Go's `os` package issues raw syscalls that the `LD_PRELOAD` shim cannot intercept, so a Go binary reads the host's real sysfs. Containers served the `nvidia.com/gpu` CDI spec get the tree bind-mounted at the kernel paths instead; ones reached only by the NRI plugin still see the host's — see [PCI sysfs in containers](#pci-sysfs-in-containers) |
+| The host's other device classes **in a container the mock does serve** | Anything reading `/sys/devices` | `/sys/devices` is replaced wholesale, so CPU topology and the container's namespaced sysfs are not visible there. Tracked in [#689](https://github.com/NVIDIA/k8s-test-infra/issues/689) |
+| `/sys/bus/pci/devices/{busID}/numa_node` **in a container the mock does not serve** | Device plugin | NUMA-aware topology hints unavailable there; scheduling works but NUMA affinity not enforced. A served device plugin does get the hints — the renderer writes `numa_node` for every device |
 | `/sys/bus/pci/devices/*/vendor,device,class` **as NFD reads them** (`/host-sys/…`, fixed at link time) | NFD (Node Feature Discovery) | PCI feature labels not auto-detected. `nvidia.com/gpu.present` is written directly by nvml-mock; `pci-10de.present` is created by NFD from a feature file nvml-mock drops in `nodeLabels.featuresDir` — see [Node Labels](#node-labels) |
 
 ### PCIe Root Complex (DRA driver)
@@ -1370,20 +1403,25 @@ W0319 11:41:21.314205       1 nvlib.go:491] error getting PCIe root for device 0
   readlink /sys/bus/pci/devices/0000:07:00.0: no such file or directory
 ```
 
-**This warning is expected** but has real impact. The DRA driver resolves PCIe
-root complex topology by reading sysfs symlinks. Since nvml-mock provides a mock
-NVML library (not a full kernel driver), these sysfs entries don't exist. GPUs
-appear in ResourceSlices and are fully allocatable, but the
-`dra.k8s.io/pcieRoot` topology attribute is absent.
+The driver resolves PCIe root complex topology by `readlink()`-ing
+`/sys/bus/pci/devices/{busID}`, and it is a Go binary, so `libpcisysfs.so` cannot
+redirect that read to the rendered tree. A container served the `nvidia.com/gpu`
+CDI spec gets the tree at that path and resolves the root; one the mock does not
+serve reads the node's real sysfs and logs the warning above. GPUs are fully
+allocatable either way — only the `dra.k8s.io/pcieRoot` attribute is affected.
 
-**What this blocks:** DRA topology-aware scheduling that uses `pcieRoot` to
-align devices on the same PCIe root complex — for example, co-scheduling a GPU
+**What its absence blocks:** DRA topology-aware scheduling that uses `pcieRoot`
+to align devices on the same PCIe root complex — for example, co-scheduling a GPU
 with an SR-IOV virtual function (VF) from the same root for optimal data path
 locality. Without `pcieRoot`, ResourceClaims that express cross-device topology
 constraints cannot be validated.
 
-We are actively working on PCIe sysfs simulation to address this gap — see
-[#265](https://github.com/NVIDIA/k8s-test-infra/issues/265) for progress.
+Confirming the attribute end-to-end against the pinned driver version is tracked
+in [#265](https://github.com/NVIDIA/k8s-test-infra/issues/265). Note the upstream
+constraint the shape of the tree has to satisfy: `deviceattribute` rejects a
+symlink whose resolved target does not start with `devices/pci`, so the mock's
+entries have to stay canonical relative symlinks and be served at the kernel
+path rather than redirected elsewhere.
 
 ## Troubleshooting
 

--- a/docs/helm-chart.md
+++ b/docs/helm-chart.md
@@ -756,8 +756,9 @@ container wins, for a cluster pinning a file of its own.
 
 Without NRI the file is still served, at `/etc/nvml-mock/machine-type` by the
 CDI mount that carries `config.yaml`, but the value has to be set by hand — the
-runtime applies the spec's mounts and drops its env, so the plugin's channel is
-the only automatic one:
+runtime applies the spec's mounts and drops its env
+([#747](https://github.com/NVIDIA/k8s-test-infra/issues/747)), so the plugin's
+channel is the only automatic one:
 
 ```yaml
 gfd:

--- a/docs/helm-chart.md
+++ b/docs/helm-chart.md
@@ -741,6 +741,29 @@ A workload that needs the node's real device tree belongs in
 `nri.excludedNamespaces`, or should not request a GPU through the
 `nvidia.com/gpu` CDI spec.
 
+### Machine type (`nvidia.com/gpu.machine`)
+
+GFD derives the label from `--machine-type-file`, which defaults to
+`/sys/class/dmi/id/product_name` — a path no mock can own under `kind`: the node
+image writes `kind` there and re-binds it into every container after the
+container's own mounts are set up, and on hosts without DMI (Docker Desktop) it
+does not exist at all.
+
+The agent therefore writes the machine type to `driver/config/machine-type`,
+served at `/etc/nvml-mock/machine-type` by the same CDI mount that carries
+`config.yaml`. Point GFD at it in the GPU Operator values:
+
+```yaml
+gfd:
+  env:
+    - name: GFD_MACHINE_TYPE_FILE
+      value: "/etc/nvml-mock/machine-type"
+```
+
+The value is the profile's GPU product name, so `gpu.machine` matches
+`gpu.product` (`NVIDIA-GB300-NVL`) rather than the `NVIDIA-GB300-NVL72` a real
+tray reports; the profiles carry no platform name to use instead.
+
 ### Cross-node `ibping`
 
 Sysfs mocking alone lets `ibstat` / `iblinkinfo` work, but real `ibping`

--- a/docs/helm-chart.md
+++ b/docs/helm-chart.md
@@ -756,7 +756,7 @@ container wins, for a cluster pinning a file of its own.
 
 Without NRI the file is still served, at `/etc/nvml-mock/machine-type` by the
 CDI mount that carries `config.yaml`, but the value has to be set by hand — the
-runtime applies the spec's mounts and drops its env
+toolkit resolving `nvidia.com/gpu` applies the spec's mounts and drops its env
 ([#747](https://github.com/NVIDIA/k8s-test-infra/issues/747)), so the plugin's
 channel is the only automatic one:
 

--- a/docs/helm-chart.md
+++ b/docs/helm-chart.md
@@ -749,9 +749,15 @@ image writes `kind` there and re-binds it into every container after the
 container's own mounts are set up, and on hosts without DMI (Docker Desktop) it
 does not exist at all.
 
-The agent therefore writes the machine type to `driver/config/machine-type`,
-served at `/etc/nvml-mock/machine-type` by the same CDI mount that carries
-`config.yaml`. Point GFD at it in the GPU Operator values:
+The agent therefore writes the machine type to `driver/config/machine-type`. The
+NRI plugin points `GFD_MACHINE_TYPE_FILE` at it, so with `nri.enabled` the label
+needs nothing from the operator's own configuration. A value authored on the
+container wins, for a cluster pinning a file of its own.
+
+Without NRI the file is still served, at `/etc/nvml-mock/machine-type` by the
+CDI mount that carries `config.yaml`, but the value has to be set by hand — the
+runtime applies the spec's mounts and drops its env, so the plugin's channel is
+the only automatic one:
 
 ```yaml
 gfd:

--- a/docs/helm-chart.md
+++ b/docs/helm-chart.md
@@ -699,6 +699,11 @@ Nothing validates the block, so a typo is not reported anywhere — not through
 the agent's `/healthz`. What the agent renders is the block reconciled against
 the devices NVML reports, which silently absorbs most mistakes:
 
+- A `bus_id` that is not an address in the kernel's `DDDD:BB:DD.F` form is
+  dropped, and the device is left out of the tree. This includes the 8-digit
+  domain NVML reports through `nvmlPciInfo_t.busId`; `bus_id` carries the
+  4-digit form, as `busIdLegacy` does. A value that is not an address is one no
+  consumer can look up, and it would otherwise become a directory name.
 - A BDF listed under a root complex that no entry in `devices[]` claims is
   dropped, along with any root complex it leaves empty. This is also how
   `gpu.count` works: capping the device list leaves the layout untouched, and

--- a/docs/helm-chart.md
+++ b/docs/helm-chart.md
@@ -695,14 +695,20 @@ pcie_topology:
         - "0000:90:00.0"
 ```
 
-The simulator validates the block and reports a staging failure through the
-agent's `/healthz` if it finds a typo:
+Nothing validates the block, so a typo is not reported anywhere — not through
+the agent's `/healthz`. What the agent renders is the block reconciled against
+the devices NVML reports, which silently absorbs most mistakes:
 
-- Every BDF listed under a root complex must also appear in `devices[]`.
-- Each BDF may belong to at most one root complex.
-- Root complex IDs must match `pciDDDD:BB`.
-- BDFs must use 4-digit-domain form (`DDDD:BB:DD.F`); the legacy NVML
-  `busIdLegacy` 8-digit form is rejected.
+- A BDF listed under a root complex that no entry in `devices[]` claims is
+  dropped, along with any root complex it leaves empty. This is also how
+  `gpu.count` works: capping the device list leaves the layout untouched, and
+  the uncapped BDFs disappear from the tree rather than rendering as GPUs NVML
+  denies exist.
+- A BDF listed under two root complexes stays under the first and is dropped
+  from the second.
+- A device in `devices[]` whose BDF no root complex lists is still rendered,
+  under the root its own address implies (`pciDDDD:BB`) and reporting
+  `numa_node` `-1`. A GPU missing from the tree is one no consumer can resolve.
 
 If a profile omits `pcie_topology:` entirely the renderer falls back to
 a flat single-root layout (every device under `pci0000:00`, NUMA 0). A profile
@@ -737,9 +743,11 @@ fails outright rather than degrading. Profiles routinely declare root complexes
 the node does not have. [#689](https://github.com/NVIDIA/k8s-test-infra/issues/689)
 tracks removing the trade-off.
 
-A workload that needs the node's real device tree belongs in
-`nri.excludedNamespaces`, or should not request a GPU through the
-`nvidia.com/gpu` CDI spec.
+A workload that needs the node's real device tree must not request
+`nvidia.com/gpu`, since the mount rides the CDI spec the container toolkit
+resolves for that resource. `nri.excludedNamespaces` is not an escape: it only
+reaches the NRI plugin, whose own `nvml-mock.nvidia.com/gpu` spec carries no
+sysfs mounts.
 
 ### Machine type (`nvidia.com/gpu.machine`)
 

--- a/internal/agent/cdi/spec.go
+++ b/internal/agent/cdi/spec.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/NVIDIA/k8s-test-infra/internal/agent"
+	"github.com/NVIDIA/k8s-test-infra/internal/pcisysfs"
 )
 
 // overlayHostRoot is the path containerd sees for the mock overlay on the host.
@@ -110,6 +111,8 @@ func buildNvidiaSpec(state *agent.State) cdiSpec {
 		},
 	}
 
+	edits.Mounts = append(edits.Mounts, pciSysfsMounts(state)...)
+
 	// The .so resolving fabric.state:auto runs in the consumer container, so the
 	// marker dir mounts there — but only where it exists, else creation fails.
 	if stateDir := state.Fabric.ManagerStateDir; stateDir != "" {
@@ -153,6 +156,48 @@ func buildNvidiaSpec(state *agent.State) cdiSpec {
 		ContainerEdits: edits,
 		Devices:        devices,
 	}
+}
+
+// pciSysfsMounts serves the tree the pcibus simulator renders at the kernel
+// paths a Go consumer reads.
+//
+// libpcisysfs.so already redirects those paths for libc consumers such as lspci,
+// but Go's os package issues openat directly, so the shim never sees the open
+// and the process reads the node's real /sys — where the mock GPUs do not
+// exist. GPU Feature Discovery resolves each GPU's BDF from NVML and then reads
+// its class from sysfs, so it labelled the node nvidia.com/gpu.mode=unknown
+// (#673). The NVIDIA DRA driver resolves dra.k8s.io/pcieRoot the same way.
+//
+// Both entries go together: the lookup directory holds relative symlinks into
+// ../../../devices/pciDDDD:BB, so serving it alone yields entries that list and
+// whose every attribute read returns ENOENT.
+//
+// /sys/devices is served whole. Narrowing it to the profile's root complexes
+// would need mountpoints the runtime cannot create on a read-only sysfs, and it
+// fails container creation rather than degrading — profiles routinely declare
+// root complexes the node does not have. A served container therefore does not
+// see the host's other device classes, CPU topology among them; #689 tracks
+// removing that trade-off.
+//
+// Emitted only when the state declares a topology, because pcibus renders on
+// exactly that condition and a mount with a missing source fails container
+// creation for the whole pod.
+func pciSysfsMounts(state *agent.State) []cdiMount {
+	if !state.HasPCITopology() {
+		return nil
+	}
+
+	mounts := make([]cdiMount, 0, 2)
+	// The renderer's rel-paths are the kernel paths without the leading slash,
+	// because it renders a fake root rather than a private layout.
+	for _, relPath := range []string{pcisysfs.SysDevicesRelPath, pcisysfs.PCIDevicesRelPath} {
+		mounts = append(mounts, cdiMount{
+			HostPath:      overlayHostRoot + "/" + relPath,
+			ContainerPath: "/" + relPath,
+			Options:       []string{"ro", "nosuid", "nodev", "bind"},
+		})
+	}
+	return mounts
 }
 
 // buildNRISpec returns the nvml-mock.nvidia.com/gpu CDI spec consumed by the NRI plugin's

--- a/internal/agent/cdi/spec.go
+++ b/internal/agent/cdi/spec.go
@@ -158,38 +158,28 @@ func buildNvidiaSpec(state *agent.State) cdiSpec {
 	}
 }
 
-// pciSysfsMounts serves the tree the pcibus simulator renders at the kernel
-// paths a Go consumer reads.
+// pciSysfsMounts serves the rendered PCI tree at the kernel paths, which is the
+// only way it reaches a Go consumer: libpcisysfs.so redirects those paths for
+// libc callers, but Go's os package issues openat directly, so GFD and the DRA
+// driver read the node's real /sys and find no mock GPUs (#673).
 //
-// libpcisysfs.so already redirects those paths for libc consumers such as lspci,
-// but Go's os package issues openat directly, so the shim never sees the open
-// and the process reads the node's real /sys — where the mock GPUs do not
-// exist. GPU Feature Discovery resolves each GPU's BDF from NVML and then reads
-// its class from sysfs, so it labelled the node nvidia.com/gpu.mode=unknown
-// (#673). The NVIDIA DRA driver resolves dra.k8s.io/pcieRoot the same way.
+// The pair is indivisible — the lookup directory holds relative symlinks into
+// ../../../devices/pciDDDD:BB, so serving it alone yields entries whose every
+// attribute read returns ENOENT.
 //
-// Both entries go together: the lookup directory holds relative symlinks into
-// ../../../devices/pciDDDD:BB, so serving it alone yields entries that list and
-// whose every attribute read returns ENOENT.
+// /sys/devices goes whole, hiding the host's other device classes from served
+// containers (#689): narrowing it needs mountpoints the runtime cannot create
+// on a read-only sysfs, and profiles declare root complexes the node lacks.
 //
-// /sys/devices is served whole. Narrowing it to the profile's root complexes
-// would need mountpoints the runtime cannot create on a read-only sysfs, and it
-// fails container creation rather than degrading — profiles routinely declare
-// root complexes the node does not have. A served container therefore does not
-// see the host's other device classes, CPU topology among them; #689 tracks
-// removing that trade-off.
-//
-// Emitted only when the state declares a topology, because pcibus renders on
-// exactly that condition and a mount with a missing source fails container
-// creation for the whole pod.
+// Gated on the same condition pcibus renders under, since a mount with a
+// missing source fails container creation for the whole pod.
 func pciSysfsMounts(state *agent.State) []cdiMount {
 	if !state.HasPCITopology() {
 		return nil
 	}
 
 	mounts := make([]cdiMount, 0, 2)
-	// The renderer's rel-paths are the kernel paths without the leading slash,
-	// because it renders a fake root rather than a private layout.
+	// The renderer's rel-paths are the kernel paths minus the leading slash.
 	for _, relPath := range []string{pcisysfs.SysDevicesRelPath, pcisysfs.PCIDevicesRelPath} {
 		mounts = append(mounts, cdiMount{
 			HostPath:      overlayHostRoot + "/" + relPath,

--- a/internal/agent/cdi/spec.go
+++ b/internal/agent/cdi/spec.go
@@ -102,10 +102,12 @@ func buildNvidiaSpec(state *agent.State) cdiSpec {
 				Args:     []string{"nvidia-cdi-hook", "update-ldcache", "--folder", "/usr/lib64"},
 			},
 		},
-		// None of this currently reaches a container: the runtime applies the
-		// mounts from this same block and drops its env (#747). Kept because the
-		// values are correct and the mock's compiled-in defaults match them, so
-		// nothing depends on the channel working — do not add a key that would.
+		// None of this currently reaches a container. The toolkit resolving this
+		// spec applies the mounts from the same block and drops its env (#747) —
+		// unlike buildNRISpec's, which containerd resolves natively and whose env
+		// does arrive. Kept because the values are correct and the mock's
+		// compiled-in defaults match them, so nothing depends on the channel
+		// working — do not add a key that would.
 		Env: []string{
 			// void tells the container toolkit to skip its own device enumeration;
 			// without it the toolkit would override our mock nodes with an empty set.

--- a/internal/agent/cdi/spec.go
+++ b/internal/agent/cdi/spec.go
@@ -102,6 +102,10 @@ func buildNvidiaSpec(state *agent.State) cdiSpec {
 				Args:     []string{"nvidia-cdi-hook", "update-ldcache", "--folder", "/usr/lib64"},
 			},
 		},
+		// None of this currently reaches a container: the runtime applies the
+		// mounts from this same block and drops its env (#747). Kept because the
+		// values are correct and the mock's compiled-in defaults match them, so
+		// nothing depends on the channel working — do not add a key that would.
 		Env: []string{
 			// void tells the container toolkit to skip its own device enumeration;
 			// without it the toolkit would override our mock nodes with an empty set.

--- a/internal/agent/cdi/spec_test.go
+++ b/internal/agent/cdi/spec_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/NVIDIA/k8s-test-infra/internal/agent"
 	"github.com/NVIDIA/k8s-test-infra/internal/fabricmanager"
+	"github.com/NVIDIA/k8s-test-infra/internal/pcisysfs"
 )
 
 func twoGPUState() *agent.State {
@@ -158,6 +159,66 @@ func TestNvidiaSpecFabricManagerDisabled(t *testing.T) {
 	for _, e := range spec.ContainerEdits.Env {
 		require.NotContains(t, e, "MOCK_FABRICMANAGER_STATE_DIR")
 	}
+}
+
+// --- PCI sysfs mounts ---
+
+// pciState carries what a profile with a pcie_topology block compiles to.
+func pciState() *agent.State {
+	state := twoGPUState()
+	state.Devices[0].PCIBusID = "0000:07:00.0"
+	state.Devices[1].PCIBusID = "0000:0f:00.0"
+	return state
+}
+
+func mountByContainerPath(spec cdiSpec, path string) (cdiMount, bool) {
+	for _, m := range spec.ContainerEdits.Mounts {
+		if m.ContainerPath == path {
+			return m, true
+		}
+	}
+	return cdiMount{}, false
+}
+
+// The mock renders the tree and libpcisysfs.so redirects reads of the kernel
+// paths to it, but Go's os package issues openat directly, so the shim never
+// sees the open. GPU Feature Discovery and the DRA driver are both Go. Only a
+// real mount at the kernel path reaches them.
+func TestNvidiaSpecServesPCISysfsAtKernelPaths(t *testing.T) {
+	spec := buildNvidiaSpec(pciState())
+
+	devices, ok := mountByContainerPath(spec, "/sys/bus/pci/devices")
+	require.True(t, ok, "/sys/bus/pci/devices must be served")
+	require.Equal(t, overlayHostRoot+"/"+pcisysfs.PCIDevicesRelPath, devices.HostPath)
+	require.Contains(t, devices.Options, "ro")
+
+	sysDevices, ok := mountByContainerPath(spec, "/sys/devices")
+	require.True(t, ok, "/sys/devices must be served")
+	require.Equal(t, overlayHostRoot+"/"+pcisysfs.SysDevicesRelPath, sysDevices.HostPath)
+	require.Contains(t, sysDevices.Options, "ro")
+}
+
+// The two mounts are one feature. The PCI entries are relative symlinks into
+// ../../../devices/pciDDDD:BB, so serving the lookup directory alone yields
+// entries that list and whose every attribute read returns ENOENT — which looks
+// exactly like no mount at all, and is why they must never drift apart.
+func TestNvidiaSpecPCISysfsMountsAreEmittedAsAPair(t *testing.T) {
+	spec := buildNvidiaSpec(pciState())
+
+	_, devices := mountByContainerPath(spec, "/sys/bus/pci/devices")
+	_, sysDevices := mountByContainerPath(spec, "/sys/devices")
+	require.Equal(t, devices, sysDevices, "one half of the pair without the other")
+}
+
+// A profile whose devices declare no bus_id renders no tree, and a CDI mount
+// whose source does not exist fails container creation for the whole pod.
+func TestNvidiaSpecOmitsPCISysfsWithoutTopology(t *testing.T) {
+	spec := buildNvidiaSpec(twoGPUState())
+
+	_, ok := mountByContainerPath(spec, "/sys/bus/pci/devices")
+	require.False(t, ok, "nothing may be served when no tree is rendered")
+	_, ok = mountByContainerPath(spec, "/sys/devices")
+	require.False(t, ok, "nothing may be served when no tree is rendered")
 }
 
 // --- buildNRISpec ---

--- a/internal/agent/cdi/spec_test.go
+++ b/internal/agent/cdi/spec_test.go
@@ -183,6 +183,8 @@ func mountByContainerPath(spec cdiSpec, path string) (cdiMount, bool) {
 // GFD and the DRA driver are Go, so libpcisysfs.so never sees their openat
 // calls: only a real mount at the kernel path reaches them.
 func TestNvidiaSpecServesPCISysfsAtKernelPaths(t *testing.T) {
+	t.Parallel()
+
 	spec := buildNvidiaSpec(pciState())
 
 	devices, ok := mountByContainerPath(spec, "/sys/bus/pci/devices")
@@ -199,6 +201,8 @@ func TestNvidiaSpecServesPCISysfsAtKernelPaths(t *testing.T) {
 // The two mounts are one feature: the entries are relative symlinks into
 // ../../../devices/pciDDDD:BB, so half the pair reads like no mount at all.
 func TestNvidiaSpecPCISysfsMountsAreEmittedAsAPair(t *testing.T) {
+	t.Parallel()
+
 	spec := buildNvidiaSpec(pciState())
 
 	_, devices := mountByContainerPath(spec, "/sys/bus/pci/devices")
@@ -209,6 +213,8 @@ func TestNvidiaSpecPCISysfsMountsAreEmittedAsAPair(t *testing.T) {
 // A profile whose devices declare no bus_id renders no tree, and a CDI mount
 // whose source does not exist fails container creation for the whole pod.
 func TestNvidiaSpecOmitsPCISysfsWithoutTopology(t *testing.T) {
+	t.Parallel()
+
 	spec := buildNvidiaSpec(twoGPUState())
 
 	_, ok := mountByContainerPath(spec, "/sys/bus/pci/devices")

--- a/internal/agent/cdi/spec_test.go
+++ b/internal/agent/cdi/spec_test.go
@@ -180,10 +180,8 @@ func mountByContainerPath(spec cdiSpec, path string) (cdiMount, bool) {
 	return cdiMount{}, false
 }
 
-// The mock renders the tree and libpcisysfs.so redirects reads of the kernel
-// paths to it, but Go's os package issues openat directly, so the shim never
-// sees the open. GPU Feature Discovery and the DRA driver are both Go. Only a
-// real mount at the kernel path reaches them.
+// GFD and the DRA driver are Go, so libpcisysfs.so never sees their openat
+// calls: only a real mount at the kernel path reaches them.
 func TestNvidiaSpecServesPCISysfsAtKernelPaths(t *testing.T) {
 	spec := buildNvidiaSpec(pciState())
 
@@ -198,10 +196,8 @@ func TestNvidiaSpecServesPCISysfsAtKernelPaths(t *testing.T) {
 	require.Contains(t, sysDevices.Options, "ro")
 }
 
-// The two mounts are one feature. The PCI entries are relative symlinks into
-// ../../../devices/pciDDDD:BB, so serving the lookup directory alone yields
-// entries that list and whose every attribute read returns ENOENT — which looks
-// exactly like no mount at all, and is why they must never drift apart.
+// The two mounts are one feature: the entries are relative symlinks into
+// ../../../devices/pciDDDD:BB, so half the pair reads like no mount at all.
 func TestNvidiaSpecPCISysfsMountsAreEmittedAsAPair(t *testing.T) {
 	spec := buildNvidiaSpec(pciState())
 

--- a/internal/agent/cdi/spec_test.go
+++ b/internal/agent/cdi/spec_test.go
@@ -203,11 +203,25 @@ func TestNvidiaSpecServesPCISysfsAtKernelPaths(t *testing.T) {
 func TestNvidiaSpecPCISysfsMountsAreEmittedAsAPair(t *testing.T) {
 	t.Parallel()
 
-	spec := buildNvidiaSpec(pciState())
+	for name, tc := range map[string]struct {
+		state  *agent.State
+		served bool
+	}{
+		"a rendered tree serves both":     {state: pciState(), served: true},
+		"no rendered tree serves neither": {state: twoGPUState(), served: false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	_, devices := mountByContainerPath(spec, "/sys/bus/pci/devices")
-	_, sysDevices := mountByContainerPath(spec, "/sys/devices")
-	require.Equal(t, devices, sysDevices, "one half of the pair without the other")
+			spec := buildNvidiaSpec(tc.state)
+
+			_, servesLookup := mountByContainerPath(spec, "/sys/bus/pci/devices")
+			require.Equal(t, tc.served, servesLookup, "the lookup directory of BDF symlinks")
+
+			_, servesHierarchy := mountByContainerPath(spec, "/sys/devices")
+			require.Equal(t, tc.served, servesHierarchy, "the hierarchy those symlinks point into")
+		})
+	}
 }
 
 // A profile whose devices declare no bus_id renders no tree, and a CDI mount

--- a/internal/agent/gpudriver/gpudriver.go
+++ b/internal/agent/gpudriver/gpudriver.go
@@ -55,6 +55,7 @@ func (s *Simulator) Stage(ctx context.Context, h *host.Host, state *agent.State)
 	g.Go(func() error { return stageNvidiaSMI(gctx, h, state) })
 	g.Go(func() error { return writeProcFS(gctx, h, state) })
 	g.Go(func() error { return writeEngineConfig(gctx, h, state) })
+	g.Go(func() error { return writeMachineType(gctx, h, state) })
 
 	if err := g.Wait(); err != nil {
 		return err
@@ -73,6 +74,7 @@ var stagedPaths = []string{
 	"driver/usr/bin/nvidia-smi.sh",
 	"driver/proc/driver/nvidia",
 	"driver/config/config.yaml",
+	machineTypeRel,
 	"config/config.yaml",
 }
 

--- a/internal/agent/gpudriver/gpudriver_test.go
+++ b/internal/agent/gpudriver/gpudriver_test.go
@@ -108,7 +108,7 @@ func TestWriteMachineType_ServesTheProductName(t *testing.T) {
 	state := testState(t)
 	state.Devices[0].Name = "NVIDIA GB300 NVL"
 
-	require.NoError(t, writeMachineType(context.Background(), h, state))
+	require.NoError(t, writeMachineType(t.Context(), h, state))
 
 	data, err := os.ReadFile(filepath.Join(h.Root, machineTypeRel))
 	require.NoError(t, err)
@@ -123,7 +123,7 @@ func TestWriteMachineType_NoFileWithoutAProductName(t *testing.T) {
 	state := testState(t)
 	state.Devices[0].Name = ""
 
-	require.NoError(t, writeMachineType(context.Background(), h, state))
+	require.NoError(t, writeMachineType(t.Context(), h, state))
 
 	_, err := os.Stat(filepath.Join(h.Root, machineTypeRel))
 	require.True(t, os.IsNotExist(err), "no product name means no file")
@@ -134,7 +134,7 @@ func TestWriteMachineType_NoFileWithoutDevices(t *testing.T) {
 	state := testState(t)
 	state.Devices = nil
 
-	require.NoError(t, writeMachineType(context.Background(), h, state))
+	require.NoError(t, writeMachineType(t.Context(), h, state))
 
 	_, err := os.Stat(filepath.Join(h.Root, machineTypeRel))
 	require.True(t, os.IsNotExist(err))

--- a/internal/agent/gpudriver/gpudriver_test.go
+++ b/internal/agent/gpudriver/gpudriver_test.go
@@ -101,6 +101,51 @@ func TestWriteEngineConfig_EmptyConfigRawErrors(t *testing.T) {
 	require.Error(t, err)
 }
 
+// GFD reads its machine type from a file, so the mock has to serve one: under
+// kind the DMI path it defaults to is either absent or owned by the node image.
+func TestWriteMachineType_ServesTheProductName(t *testing.T) {
+	h := testHost(t)
+	state := testState(t)
+	state.Devices[0].Name = "NVIDIA GB300 NVL"
+
+	require.NoError(t, writeMachineType(context.Background(), h, state))
+
+	data, err := os.ReadFile(filepath.Join(h.Root, machineTypeRel))
+	require.NoError(t, err)
+	require.Equal(t, "NVIDIA GB300 NVL\n", string(data),
+		"trailing newline mirrors how the kernel renders product_name")
+}
+
+// A missing file leaves GFD on its own default, which is the better failure:
+// an empty one would label the node with the empty string.
+func TestWriteMachineType_NoFileWithoutAProductName(t *testing.T) {
+	h := testHost(t)
+	state := testState(t)
+	state.Devices[0].Name = ""
+
+	require.NoError(t, writeMachineType(context.Background(), h, state))
+
+	_, err := os.Stat(filepath.Join(h.Root, machineTypeRel))
+	require.True(t, os.IsNotExist(err), "no product name means no file")
+}
+
+func TestWriteMachineType_NoFileWithoutDevices(t *testing.T) {
+	h := testHost(t)
+	state := testState(t)
+	state.Devices = nil
+
+	require.NoError(t, writeMachineType(context.Background(), h, state))
+
+	_, err := os.Stat(filepath.Join(h.Root, machineTypeRel))
+	require.True(t, os.IsNotExist(err))
+}
+
+// The file is served through the same mount as config.yaml, so it has to sit
+// beside it — a path outside driver/config would never reach a container.
+func TestWriteMachineType_LandsInTheServedConfigDir(t *testing.T) {
+	require.Equal(t, "driver/config", filepath.Dir(machineTypeRel))
+}
+
 func TestStageNvidiaSMI_WritesSMIScript(t *testing.T) {
 	h := testHost(t)
 	state := testState(t)

--- a/internal/agent/gpudriver/stage.go
+++ b/internal/agent/gpudriver/stage.go
@@ -203,6 +203,33 @@ func writeProcFS(ctx context.Context, h *host.Host, state *agent.State) error {
 	return fsutil.Write(filepath.Join(procDir, "params"), []byte(params), 0o644)
 }
 
+// machineTypeRel is the machine type served to containers at
+// /etc/nvml-mock/machine-type, alongside config.yaml under the same CDI mount.
+const machineTypeRel = "driver/config/machine-type"
+
+// writeMachineType serves the string GFD turns into nvidia.com/gpu.machine,
+// pointed at by GFD_MACHINE_TYPE_FILE in the chart's GPU Operator values.
+//
+// GFD defaults to /sys/class/dmi/id/product_name, which cannot carry a mocked
+// value under kind: the node image writes "kind" there and re-binds it into
+// every container after the container's own mounts are set up, and on hosts
+// without DMI (Docker Desktop) the path does not exist at all (#681). A file of
+// our own sidesteps both.
+//
+// The value is the GPU's product name for want of a platform field in the
+// profiles, so gpu.machine reads NVIDIA-GB300-NVL rather than the
+// NVIDIA-GB300-NVL72 a real tray reports.
+func writeMachineType(ctx context.Context, h *host.Host, state *agent.State) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(state.Devices) == 0 || state.Devices[0].Name == "" {
+		return nil
+	}
+	return fsutil.Write(filepath.Join(h.Root, machineTypeRel),
+		[]byte(state.Devices[0].Name+"\n"), 0o644)
+}
+
 // writeEngineConfig writes the GPU profile so the mock NVML shim knows how many
 // GPUs to expose and their properties at dlopen time.
 // Written to two locations: h.Root/config/ (device-plugin) and

--- a/internal/agent/pcibus/pcibus.go
+++ b/internal/agent/pcibus/pcibus.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/NVIDIA/k8s-test-infra/internal/agent"
 	"github.com/NVIDIA/k8s-test-infra/internal/agent/host"
+	"github.com/NVIDIA/k8s-test-infra/internal/pcisysfs"
 )
 
 const (
@@ -63,18 +64,18 @@ func (s *Simulator) Stage(_ context.Context, h *host.Host, state *agent.State) e
 	return nil
 }
 
-// Discard removes the rendered PCI sysfs tree and staged shim. It is a no-op
-// when Stage never completed successfully.
+// Discard empties the rendered PCI sysfs tree and removes the staged shim. It
+// is a no-op when Stage never completed successfully.
 func (s *Simulator) Discard(_ context.Context, h *host.Host) error {
 	if !s.ready.Load() {
 		return nil
 	}
 
 	var errs []error
-	// Remove the entire sys/ subtree; pcibus is its only writer.
-	sysRoot := filepath.Join(h.Root, "sys")
-	if err := os.RemoveAll(sysRoot); err != nil && !os.IsNotExist(err) {
-		errs = append(errs, fmt.Errorf("remove %s: %w", sysRoot, err))
+	// Emptied rather than removed: the CDI spec mounts these directories, and a
+	// container holding one keeps the inode it started with.
+	if err := pcisysfs.Clear(h.Root); err != nil {
+		errs = append(errs, fmt.Errorf("clear pci sysfs: %w", err))
 	}
 
 	// Remove staged shim files.

--- a/internal/agent/pcibus/pcibus_test.go
+++ b/internal/agent/pcibus/pcibus_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/NVIDIA/k8s-test-infra/internal/agent"
 	"github.com/NVIDIA/k8s-test-infra/internal/agent/host"
+	"github.com/NVIDIA/k8s-test-infra/internal/pcisysfs"
 )
 
 func testHost(t *testing.T) *host.Host {
@@ -89,16 +90,41 @@ func TestDiscard_NopWhenNotReady(t *testing.T) {
 	require.NoError(t, sim.Discard(context.Background(), h))
 }
 
-func TestDiscard_RemovesSysTree(t *testing.T) {
+func TestDiscard_EmptiesSysTree(t *testing.T) {
 	h := testHost(t)
 	sim := New()
 
 	require.NoError(t, sim.Stage(context.Background(), h, stateWithTopology()))
 	require.NoError(t, sim.Discard(context.Background(), h))
 
-	sysDir := filepath.Join(h.Root, "sys")
-	_, err := os.Stat(sysDir)
-	require.True(t, os.IsNotExist(err), "sys/ must be removed after Discard")
+	for _, rel := range []string{pcisysfs.SysDevicesRelPath, pcisysfs.PCIDevicesRelPath} {
+		entries, err := os.ReadDir(filepath.Join(h.Root, rel))
+		require.NoError(t, err)
+		require.Empty(t, entries, "%s still carries a discarded profile", rel)
+	}
+}
+
+// The CDI spec names the two served directories as mount sources, so a consumer
+// container that outlives an agent restart reads whatever those inodes hold. If
+// Discard replaces them the container is left on the removed ones, reading an
+// empty tree no restage can reach.
+func TestDiscard_KeepsTheDirectoriesTheCDISpecMounts(t *testing.T) {
+	h := testHost(t)
+	sim := New()
+
+	require.NoError(t, sim.Stage(context.Background(), h, stateWithTopology()))
+
+	for _, rel := range []string{pcisysfs.SysDevicesRelPath, pcisysfs.PCIDevicesRelPath} {
+		path := filepath.Join(h.Root, rel)
+		before, err := os.Stat(path)
+		require.NoError(t, err)
+
+		require.NoError(t, sim.Discard(context.Background(), h))
+
+		after, err := os.Stat(path)
+		require.NoError(t, err, "%s must outlive the teardown", rel)
+		require.True(t, os.SameFile(before, after), "%s was replaced rather than emptied", rel)
+	}
 }
 
 func TestDiscard_SysGoneIsNotError(t *testing.T) {
@@ -107,8 +133,8 @@ func TestDiscard_SysGoneIsNotError(t *testing.T) {
 
 	require.NoError(t, sim.Stage(context.Background(), h, stateWithTopology()))
 
-	// Manually remove sys/ before calling Discard; RemoveAll on a missing path is
-	// a no-op so Discard must still succeed.
+	// Removing sys/ before Discard: a teardown with nothing left to tear down
+	// must still succeed.
 	require.NoError(t, os.RemoveAll(filepath.Join(h.Root, "sys")))
 	require.NoError(t, sim.Discard(context.Background(), h))
 }

--- a/internal/agent/pcibus/stage.go
+++ b/internal/agent/pcibus/stage.go
@@ -24,10 +24,9 @@ const (
 	mockDMIRelPath = pcisysfs.SysDevicesRelPath + "/virtual/dmi/id"
 )
 
-// dmiMountTargets are the attributes kind's mount-product-files.sh hook
-// bind-mounts into every container. product_uuid identifies the node and the
-// kernel shows it to root alone, so it is staged empty — it exists only to be
-// mounted over.
+// dmiMountTargets are the DMI attributes a container reads through
+// /sys/class/dmi/id. product_uuid identifies the node and the kernel shows it
+// to root alone, so it is staged empty — a target to mount over, not a value.
 var dmiMountTargets = []struct {
 	name     string
 	byValue  bool
@@ -37,10 +36,14 @@ var dmiMountTargets = []struct {
 	{name: "product_uuid", byValue: false, fileMode: 0o400},
 }
 
-// stageDMI keeps kind's bind-mount targets alive: serving the tree at
-// /sys/devices replaces the directory /sys/class/dmi/id resolves into, and
-// mount(8) cannot create a target on a read-only sysfs, so without these files
-// every served pod dies on "mount point does not exist".
+// stageDMI reproduces the node's DMI attributes inside the rendered tree.
+// Serving the tree at /sys/devices replaces the directory /sys/class/dmi/id
+// resolves into, so on any cluster a served container would otherwise read
+// ENOENT where the node has values.
+//
+// Under kind it is worse than a missing value: the node image bind-mounts its
+// own product files into every container, mount(8) cannot create a target on a
+// read-only sysfs, and every served pod dies on "mount point does not exist".
 //
 // Deliberately not a machine-type mock — that is writeMachineType's job (#681).
 func stageDMI(h *host.Host) error {

--- a/internal/agent/pcibus/stage.go
+++ b/internal/agent/pcibus/stage.go
@@ -21,18 +21,17 @@ import (
 const defaultRootComplexID = "pci0000:00"
 
 const (
-	// kernelDMIRelPath is where the kernel keeps DMI attributes, relative to
-	// /sys. /sys/class/dmi/id is a symlink to it.
+	// kernelDMIRelPath is the kernel's DMI directory relative to /sys;
+	// /sys/class/dmi/id is a symlink to it.
 	kernelDMIRelPath = "devices/virtual/dmi/id"
-	// mockDMIRelPath is the same directory inside the rendered tree, relative
-	// to the overlay root.
+	// mockDMIRelPath is the same directory inside the rendered tree.
 	mockDMIRelPath = pcisysfs.SysDevicesRelPath + "/virtual/dmi/id"
 )
 
 // dmiMountTargets are the attributes kind's mount-product-files.sh hook
-// bind-mounts into every container. Only product_name travels by value:
-// product_uuid identifies the node and the kernel exposes it to root alone, so
-// it is staged as an empty file that exists purely to be mounted over.
+// bind-mounts into every container. product_uuid identifies the node and the
+// kernel shows it to root alone, so it is staged empty — it exists only to be
+// mounted over.
 var dmiMountTargets = []struct {
 	name     string
 	byValue  bool
@@ -42,23 +41,16 @@ var dmiMountTargets = []struct {
 	{name: "product_uuid", byValue: false, fileMode: 0o400},
 }
 
-// stageDMI reproduces, inside the rendered tree, the DMI attributes kind's
-// createContainer hook bind-mounts into every container.
+// stageDMI keeps kind's bind-mount targets alive: serving the tree at
+// /sys/devices replaces the directory /sys/class/dmi/id resolves into, and
+// mount(8) cannot create a target on a read-only sysfs, so without these files
+// every served pod dies on "mount point does not exist".
 //
-// This is mount-target compatibility, not a machine-type mock (#681). Serving
-// the tree at /sys/devices replaces the directory /sys/class/dmi/id resolves
-// into, and mount(8) cannot create a target on a read-only sysfs — so without
-// these files every served pod dies with
-//
-//	mount: .../sys/class/dmi/id/product_uuid: mount point does not exist
-//
-// on Linux, while passing on Docker Desktop, whose linuxkit VM exposes no DMI
-// and where kind's hook therefore does not fire either.
+// Deliberately not a machine-type mock — that is writeMachineType's job (#681).
 func stageDMI(h *host.Host) error {
 	kernelDir := filepath.Join(h.Sys, kernelDMIRelPath)
 	if _, err := os.Stat(kernelDir); err != nil {
-		// No DMI on this kernel means no /sys/class/dmi to resolve through and
-		// no hook to satisfy, so there is nothing to stand in for.
+		// No kernel DMI means no hook to satisfy either: both test the host.
 		return nil
 	}
 
@@ -70,8 +62,7 @@ func stageDMI(h *host.Host) error {
 	for _, attr := range dmiMountTargets {
 		var value []byte
 		if attr.byValue {
-			// Unreadable is not fatal: the file's job as a mount target does
-			// not depend on carrying the node's value.
+			// Unreadable is not fatal: a mount target need not carry a value.
 			value, _ = os.ReadFile(filepath.Join(kernelDir, attr.name))
 		}
 		if err := fsutil.Write(filepath.Join(mockDir, attr.name), value, attr.fileMode); err != nil {
@@ -82,10 +73,9 @@ func stageDMI(h *host.Host) error {
 	return nil
 }
 
-// stageSysfs renders the PCI sysfs tree under h.Root, together with the DMI
-// mount targets a container served that tree needs. When the state declares no
-// PCI topology the tree is emptied instead and no DMI is staged, since nothing
-// is served.
+// stageSysfs renders the PCI sysfs tree under h.Root, plus the DMI mount
+// targets a container served that tree needs. A state with no PCI topology
+// empties the tree and stages no DMI, since nothing is served.
 func stageSysfs(h *host.Host, state *agent.State) error {
 	if err := pcisysfs.Render(pcisysfs.Options{
 		Topology:   buildTopology(state),

--- a/internal/agent/pcibus/stage.go
+++ b/internal/agent/pcibus/stage.go
@@ -16,10 +16,6 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/internal/pcisysfs"
 )
 
-// defaultRootComplexID is the host bridge a flat fallback topology hangs every
-// device off, matching what a single-socket profile declares explicitly.
-const defaultRootComplexID = "pci0000:00"
-
 const (
 	// kernelDMIRelPath is the kernel's DMI directory relative to /sys;
 	// /sys/class/dmi/id is a symlink to it.
@@ -122,18 +118,15 @@ func stagePCIShim(h *host.Host) error {
 	return nil
 }
 
-// buildTopology converts the agent's PCIeTopology to the pcisysfs type, falling
-// back to a flat single-root layout when the state declares no root complexes.
-// Returns nil only when no device carries a BDF (Render treats nil as no-op).
+// buildTopology maps the state's reconciled layout onto the renderer's type.
+// Returns nil when there is nothing to render, which Render treats as a no-op.
 func buildTopology(state *agent.State) *pcisysfs.PCIeTopology {
-	rcs := state.NodeShape.Topology.RootComplexes
-
+	rcs := state.PCITopology()
 	if len(rcs) == 0 {
-		return flatTopology(state)
+		return nil
 	}
 
 	topo := &pcisysfs.PCIeTopology{RootComplexes: make([]pcisysfs.RootComplex, 0, len(rcs))}
-
 	for _, rc := range rcs {
 		topo.RootComplexes = append(topo.RootComplexes, pcisysfs.RootComplex{
 			ID:       rc.ID,
@@ -143,27 +136,6 @@ func buildTopology(state *agent.State) *pcisysfs.PCIeTopology {
 	}
 
 	return topo
-}
-
-// flatTopology synthesizes one root complex covering every device that declares
-// a BDF. A config with devices but no pcie_topology block is a single-socket
-// node, so rendering nothing at all would leave lspci with no devices to find.
-func flatTopology(state *agent.State) *pcisysfs.PCIeTopology {
-	rc := pcisysfs.RootComplex{ID: defaultRootComplexID}
-
-	for _, d := range state.Devices {
-		if d.PCIBusID == "" {
-			continue
-		}
-
-		rc.Devices = append(rc.Devices, strings.ToLower(d.PCIBusID))
-	}
-
-	if len(rc.Devices) == 0 {
-		return nil
-	}
-
-	return &pcisysfs.PCIeTopology{RootComplexes: []pcisysfs.RootComplex{rc}}
 }
 
 // buildIdentities maps each device's lowercased BDF to its PCI identity for

--- a/internal/agent/pcibus/stage.go
+++ b/internal/agent/pcibus/stage.go
@@ -20,14 +20,86 @@ import (
 // device off, matching what a single-socket profile declares explicitly.
 const defaultRootComplexID = "pci0000:00"
 
-// stageSysfs renders the PCI sysfs tree under h.Root.
-// When the state carries no root complexes Render is a no-op.
+const (
+	// kernelDMIRelPath is where the kernel keeps DMI attributes, relative to
+	// /sys. /sys/class/dmi/id is a symlink to it.
+	kernelDMIRelPath = "devices/virtual/dmi/id"
+	// mockDMIRelPath is the same directory inside the rendered tree, relative
+	// to the overlay root.
+	mockDMIRelPath = pcisysfs.SysDevicesRelPath + "/virtual/dmi/id"
+)
+
+// dmiMountTargets are the attributes kind's mount-product-files.sh hook
+// bind-mounts into every container. Only product_name travels by value:
+// product_uuid identifies the node and the kernel exposes it to root alone, so
+// it is staged as an empty file that exists purely to be mounted over.
+var dmiMountTargets = []struct {
+	name     string
+	byValue  bool
+	fileMode os.FileMode
+}{
+	{name: "product_name", byValue: true, fileMode: 0o444},
+	{name: "product_uuid", byValue: false, fileMode: 0o400},
+}
+
+// stageDMI reproduces, inside the rendered tree, the DMI attributes kind's
+// createContainer hook bind-mounts into every container.
+//
+// This is mount-target compatibility, not a machine-type mock (#681). Serving
+// the tree at /sys/devices replaces the directory /sys/class/dmi/id resolves
+// into, and mount(8) cannot create a target on a read-only sysfs — so without
+// these files every served pod dies with
+//
+//	mount: .../sys/class/dmi/id/product_uuid: mount point does not exist
+//
+// on Linux, while passing on Docker Desktop, whose linuxkit VM exposes no DMI
+// and where kind's hook therefore does not fire either.
+func stageDMI(h *host.Host) error {
+	kernelDir := filepath.Join(h.Sys, kernelDMIRelPath)
+	if _, err := os.Stat(kernelDir); err != nil {
+		// No DMI on this kernel means no /sys/class/dmi to resolve through and
+		// no hook to satisfy, so there is nothing to stand in for.
+		return nil
+	}
+
+	mockDir := filepath.Join(h.Root, mockDMIRelPath)
+	if err := os.MkdirAll(mockDir, 0o755); err != nil {
+		return err
+	}
+
+	for _, attr := range dmiMountTargets {
+		var value []byte
+		if attr.byValue {
+			// Unreadable is not fatal: the file's job as a mount target does
+			// not depend on carrying the node's value.
+			value, _ = os.ReadFile(filepath.Join(kernelDir, attr.name))
+		}
+		if err := fsutil.Write(filepath.Join(mockDir, attr.name), value, attr.fileMode); err != nil {
+			return fmt.Errorf("stage dmi %s: %w", attr.name, err)
+		}
+	}
+
+	return nil
+}
+
+// stageSysfs renders the PCI sysfs tree under h.Root, together with the DMI
+// mount targets a container served that tree needs. When the state declares no
+// PCI topology the tree is emptied instead and no DMI is staged, since nothing
+// is served.
 func stageSysfs(h *host.Host, state *agent.State) error {
-	return pcisysfs.Render(pcisysfs.Options{
+	if err := pcisysfs.Render(pcisysfs.Options{
 		Topology:   buildTopology(state),
 		Identities: buildIdentities(state),
 		Output:     h.Root,
-	})
+	}); err != nil {
+		return err
+	}
+
+	if !state.HasPCITopology() {
+		return nil
+	}
+
+	return stageDMI(h)
 }
 
 // shimGlob locates the shim in the container image. A package var so tests can

--- a/internal/agent/pcibus/stage_test.go
+++ b/internal/agent/pcibus/stage_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/k8s-test-infra/internal/agent"
+	"github.com/NVIDIA/k8s-test-infra/internal/agent/host"
 	"github.com/NVIDIA/k8s-test-infra/internal/pcisysfs"
 )
 
@@ -85,6 +86,29 @@ func TestBuildTopology_MultipleRCs(t *testing.T) {
 	require.Len(t, topo.RootComplexes, 2)
 	require.Equal(t, "pci0000:00", topo.RootComplexes[0].ID)
 	require.Equal(t, "pci0001:00", topo.RootComplexes[1].ID)
+}
+
+// TestHasPCITopology_AgreesWithBuildTopology pins the invariant the CDI
+// simulator relies on. It gates the sysfs mounts it publishes on
+// HasPCITopology, so that predicate has to answer exactly "will a tree be
+// rendered": a false positive publishes a bind mount with no source, which
+// fails container creation for every pod that requests a GPU.
+func TestHasPCITopology_AgreesWithBuildTopology(t *testing.T) {
+	states := map[string]*agent.State{
+		"empty":              {},
+		"device without bdf": {Devices: []agent.DeviceSpec{{Index: 0}}},
+		"device with bdf":    {Devices: []agent.DeviceSpec{{Index: 0, PCIBusID: "0000:07:00.0"}}},
+		"explicit topology":  stateWithTopology(),
+		"root complex, no devices": {NodeShape: agent.NodeShape{Topology: agent.PCIeTopology{
+			RootComplexes: []agent.RootComplex{{ID: "pci0000:00"}},
+		}}},
+	}
+
+	for name, state := range states {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, buildTopology(state) != nil, state.HasPCITopology())
+		})
+	}
 }
 
 // ─── buildIdentities ─────────────────────────────────────────────────────────
@@ -197,6 +221,114 @@ func TestStageSysfs_RendersFlatDefault(t *testing.T) {
 	target, err := os.Readlink(filepath.Join(h.Root, "sys/bus/pci/devices/0000:1a:00.0"))
 	require.NoError(t, err, "device must be rendered under the synthesized root")
 	require.Contains(t, target, defaultRootComplexID)
+}
+
+// ─── stageDMI ────────────────────────────────────────────────────────────────
+
+// writeKernelDMI fakes a kernel that exposes DMI, at the path
+// /sys/class/dmi/id resolves into.
+func writeKernelDMI(t *testing.T, h *host.Host, attrs map[string]string) string {
+	t.Helper()
+	dir := filepath.Join(h.Sys, kernelDMIRelPath)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	for name, val := range attrs {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(val), 0o444))
+	}
+	return dir
+}
+
+func TestStageDMI_MirrorsProductName(t *testing.T) {
+	h := testHost(t)
+	writeKernelDMI(t, h, map[string]string{"product_name": "NVIDIA DGX A100\n"})
+
+	require.NoError(t, stageDMI(h))
+
+	data, err := os.ReadFile(filepath.Join(h.Root, mockDMIRelPath, "product_name"))
+	require.NoError(t, err, "product_name must be mirrored into the served tree")
+	require.Equal(t, "NVIDIA DGX A100\n", string(data))
+}
+
+// product_uuid is a node identifier the kernel exposes to root alone. Only the
+// file's existence matters here — kind bind-mounts the node's own copy over it
+// — so mirroring the value would republish it into every served container for
+// no gain.
+func TestStageDMI_ProductUUIDIsEmptyStandIn(t *testing.T) {
+	h := testHost(t)
+	writeKernelDMI(t, h, map[string]string{
+		"product_name": "NVIDIA DGX A100\n",
+		"product_uuid": "4c4c4544-0037-5710-8058-b7c04f503432\n",
+	})
+
+	require.NoError(t, stageDMI(h))
+
+	path := filepath.Join(h.Root, mockDMIRelPath, "product_uuid")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "product_uuid must exist as a mount target")
+	require.Empty(t, data, "the node's UUID must not travel into served containers")
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o400), info.Mode().Perm(), "mirror the kernel's own permissions")
+}
+
+// A kernel with no DMI at all (Docker Desktop's linuxkit VM) has no
+// /sys/class/dmi for anything to resolve through, and kind's hook guards on the
+// same condition — so there is no mount target to keep alive and nothing to write.
+func TestStageDMI_NothingWithoutKernelDMI(t *testing.T) {
+	h := testHost(t)
+
+	require.NoError(t, stageDMI(h))
+
+	_, err := os.Stat(filepath.Join(h.Root, mockDMIRelPath))
+	require.True(t, os.IsNotExist(err), "no DMI directory without a kernel one")
+}
+
+// An attribute the renderer cannot read still has to exist, because it is
+// kind's bind-mount target and mount(8) cannot create one on a read-only sysfs.
+func TestStageDMI_StandsInForUnreadableProductName(t *testing.T) {
+	h := testHost(t)
+	dir := writeKernelDMI(t, h, map[string]string{"product_name": "NVIDIA DGX A100\n"})
+	require.NoError(t, os.Chmod(filepath.Join(dir, "product_name"), 0o000))
+
+	require.NoError(t, stageDMI(h), "an unreadable attribute is not a staging failure")
+
+	data, err := os.ReadFile(filepath.Join(h.Root, mockDMIRelPath, "product_name"))
+	require.NoError(t, err, "product_name must exist even when its value is unreadable")
+	require.Empty(t, data)
+}
+
+// The DMI mirror exists only to keep bind-mount targets alive in containers the
+// tree is served to, and nothing is served when no tree is rendered.
+func TestStageSysfs_NoDMIWithoutTopology(t *testing.T) {
+	h := testHost(t)
+	writeKernelDMI(t, h, map[string]string{"product_name": "NVIDIA DGX A100\n"})
+
+	require.NoError(t, stageSysfs(h, &agent.State{}))
+
+	_, err := os.Stat(filepath.Join(h.Root, "sys"))
+	require.True(t, os.IsNotExist(err), "sys/ must not be created when state has no root complexes")
+}
+
+func TestStageSysfs_StagesDMIAlongsideTheTree(t *testing.T) {
+	h := testHost(t)
+	writeKernelDMI(t, h, map[string]string{"product_name": "NVIDIA DGX A100\n"})
+
+	require.NoError(t, stageSysfs(h, stateWithTopology()))
+
+	require.FileExists(t, filepath.Join(h.Root, mockDMIRelPath, "product_name"))
+}
+
+// A re-render must not take the DMI directory with it: a CDI-served container
+// cannot wait for the next render, and the runtime applies the spec's mounts
+// unconditionally.
+func TestStageSysfs_DMISurvivesARerender(t *testing.T) {
+	h := testHost(t)
+	writeKernelDMI(t, h, map[string]string{"product_name": "NVIDIA DGX A100\n"})
+
+	require.NoError(t, stageSysfs(h, stateWithTopology()))
+	require.NoError(t, stageSysfs(h, stateWithTopology()))
+
+	require.FileExists(t, filepath.Join(h.Root, mockDMIRelPath, "product_name"))
 }
 
 // ─── stagePCIShim ────────────────────────────────────────────────────────────

--- a/internal/agent/pcibus/stage_test.go
+++ b/internal/agent/pcibus/stage_test.go
@@ -88,11 +88,9 @@ func TestBuildTopology_MultipleRCs(t *testing.T) {
 	require.Equal(t, "pci0001:00", topo.RootComplexes[1].ID)
 }
 
-// TestHasPCITopology_AgreesWithBuildTopology pins the invariant the CDI
-// simulator relies on. It gates the sysfs mounts it publishes on
-// HasPCITopology, so that predicate has to answer exactly "will a tree be
-// rendered": a false positive publishes a bind mount with no source, which
-// fails container creation for every pod that requests a GPU.
+// The CDI simulator gates its sysfs mounts on HasPCITopology, so the predicate
+// has to answer exactly "will a tree be rendered": a false positive publishes a
+// bind mount with no source, failing every pod that requests a GPU.
 func TestHasPCITopology_AgreesWithBuildTopology(t *testing.T) {
 	states := map[string]*agent.State{
 		"empty":              {},
@@ -248,10 +246,8 @@ func TestStageDMI_MirrorsProductName(t *testing.T) {
 	require.Equal(t, "NVIDIA DGX A100\n", string(data))
 }
 
-// product_uuid is a node identifier the kernel exposes to root alone. Only the
-// file's existence matters here — kind bind-mounts the node's own copy over it
-// — so mirroring the value would republish it into every served container for
-// no gain.
+// product_uuid identifies the node and kind mounts its own copy over ours, so
+// mirroring the value would republish it into every served container for no gain.
 func TestStageDMI_ProductUUIDIsEmptyStandIn(t *testing.T) {
 	h := testHost(t)
 	writeKernelDMI(t, h, map[string]string{
@@ -271,9 +267,8 @@ func TestStageDMI_ProductUUIDIsEmptyStandIn(t *testing.T) {
 	require.Equal(t, os.FileMode(0o400), info.Mode().Perm(), "mirror the kernel's own permissions")
 }
 
-// A kernel with no DMI at all (Docker Desktop's linuxkit VM) has no
-// /sys/class/dmi for anything to resolve through, and kind's hook guards on the
-// same condition — so there is no mount target to keep alive and nothing to write.
+// A kernel with no DMI (Docker Desktop's linuxkit VM) is also one where kind's
+// hook does not fire, so there is no mount target to keep alive.
 func TestStageDMI_NothingWithoutKernelDMI(t *testing.T) {
 	h := testHost(t)
 
@@ -318,9 +313,8 @@ func TestStageSysfs_StagesDMIAlongsideTheTree(t *testing.T) {
 	require.FileExists(t, filepath.Join(h.Root, mockDMIRelPath, "product_name"))
 }
 
-// A re-render must not take the DMI directory with it: a CDI-served container
-// cannot wait for the next render, and the runtime applies the spec's mounts
-// unconditionally.
+// A re-render must not take the DMI directory with it: the runtime applies the
+// spec's mounts unconditionally, and a container cannot wait for the next pass.
 func TestStageSysfs_DMISurvivesARerender(t *testing.T) {
 	h := testHost(t)
 	writeKernelDMI(t, h, map[string]string{"product_name": "NVIDIA DGX A100\n"})

--- a/internal/agent/pcibus/stage_test.go
+++ b/internal/agent/pcibus/stage_test.go
@@ -41,7 +41,7 @@ func TestBuildTopology_FlatDefaultWhenNoRootComplexes(t *testing.T) {
 	require.Len(t, topo.RootComplexes, 1)
 
 	rc := topo.RootComplexes[0]
-	require.Equal(t, defaultRootComplexID, rc.ID)
+	require.Equal(t, agent.DefaultRootComplexID, rc.ID)
 	require.Equal(t, 0, rc.NUMANode)
 	// BDFs are lowercased to match the keys buildIdentities emits; the device
 	// without one is skipped rather than rendered as an empty entry.
@@ -56,6 +56,10 @@ func TestBuildTopology_SingleRC(t *testing.T) {
 					{ID: "pci0000:00", NUMANode: 2, DeviceBDFs: []string{"0000:07:00.0", "0000:07:00.1"}},
 				},
 			},
+		},
+		Devices: []agent.DeviceSpec{
+			{Index: 0, PCIBusID: "0000:07:00.0"},
+			{Index: 1, PCIBusID: "0000:07:00.1"},
 		},
 	}
 
@@ -79,6 +83,11 @@ func TestBuildTopology_MultipleRCs(t *testing.T) {
 				},
 			},
 		},
+		Devices: []agent.DeviceSpec{
+			{Index: 0, PCIBusID: "0000:03:00.0"},
+			{Index: 1, PCIBusID: "0001:05:00.0"},
+			{Index: 2, PCIBusID: "0001:05:00.1"},
+		},
 	}
 
 	topo := buildTopology(state)
@@ -88,25 +97,15 @@ func TestBuildTopology_MultipleRCs(t *testing.T) {
 	require.Equal(t, "pci0001:00", topo.RootComplexes[1].ID)
 }
 
-// The CDI simulator gates its sysfs mounts on HasPCITopology, so the predicate
-// has to answer exactly "will a tree be rendered": a false positive publishes a
-// bind mount with no source, failing every pod that requests a GPU.
-func TestHasPCITopology_AgreesWithBuildTopology(t *testing.T) {
-	states := map[string]*agent.State{
-		"empty":              {},
-		"device without bdf": {Devices: []agent.DeviceSpec{{Index: 0}}},
-		"device with bdf":    {Devices: []agent.DeviceSpec{{Index: 0, PCIBusID: "0000:07:00.0"}}},
-		"explicit topology":  stateWithTopology(),
-		"root complex, no devices": {NodeShape: agent.NodeShape{Topology: agent.PCIeTopology{
-			RootComplexes: []agent.RootComplex{{ID: "pci0000:00"}},
-		}}},
-	}
+// A layout no device backs renders nothing, so nothing is served either. The
+// reconciliation itself is covered in internal/agent.
+func TestBuildTopology_NilWhenNoDeviceBacksTheLayout(t *testing.T) {
+	state := &agent.State{NodeShape: agent.NodeShape{Topology: agent.PCIeTopology{
+		RootComplexes: []agent.RootComplex{{ID: "pci0000:00", DeviceBDFs: []string{"0000:07:00.0"}}},
+	}}}
 
-	for name, state := range states {
-		t.Run(name, func(t *testing.T) {
-			require.Equal(t, buildTopology(state) != nil, state.HasPCITopology())
-		})
-	}
+	require.Nil(t, buildTopology(state))
+	require.False(t, state.HasPCITopology())
 }
 
 // ─── buildIdentities ─────────────────────────────────────────────────────────
@@ -218,7 +217,7 @@ func TestStageSysfs_RendersFlatDefault(t *testing.T) {
 
 	target, err := os.Readlink(filepath.Join(h.Root, "sys/bus/pci/devices/0000:1a:00.0"))
 	require.NoError(t, err, "device must be rendered under the synthesized root")
-	require.Contains(t, target, defaultRootComplexID)
+	require.Contains(t, target, agent.DefaultRootComplexID)
 }
 
 // ─── stageDMI ────────────────────────────────────────────────────────────────

--- a/internal/agent/pcibus/stage_test.go
+++ b/internal/agent/pcibus/stage_test.go
@@ -205,6 +205,22 @@ func TestStageSysfs_RendersSubsystemAttrs(t *testing.T) {
 	}
 }
 
+// A device its profile's pcie_topology forgot still reaches the tree, and
+// reports -1 — what Linux writes for a device it has no proximity information
+// for — rather than the NUMA node of a root it was never put in.
+func TestStageSysfs_UnplacedDeviceRendersUnknownNUMA(t *testing.T) {
+	h := testHost(t)
+	state := stateWithTopology()
+	state.Devices = append(state.Devices,
+		agent.DeviceSpec{Index: 1, PCIBusID: "0000:8A:00.0", PCIDeviceID: 0x233010DE})
+
+	require.NoError(t, stageSysfs(h, state))
+
+	numa, err := os.ReadFile(filepath.Join(h.Root, "sys/bus/pci/devices/0000:8a:00.0/numa_node"))
+	require.NoError(t, err, "the forgotten device must still be rendered")
+	require.Equal(t, "-1\n", string(numa))
+}
+
 func TestStageSysfs_RendersFlatDefault(t *testing.T) {
 	h := testHost(t)
 	state := &agent.State{

--- a/internal/agent/source/file_test.go
+++ b/internal/agent/source/file_test.go
@@ -126,6 +126,29 @@ func TestCompileState_EverySKUCarriesPCIIdentity(t *testing.T) {
 	}
 }
 
+// GPU_COUNT truncates the device list while pcie_topology is compiled from the
+// profile whole, so the two disagree on any capped node. The rendered tree is
+// served at the kernel paths now, so a BDF left over from the profile would
+// show a consumer an NVIDIA 3D controller that NVML denies exists.
+func TestCompileState_TopologyTracksACappedDeviceCount(t *testing.T) {
+	t.Setenv("GPU_COUNT", "2")
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", "pkg", "gpu", "mocknvml",
+		"configs", "mock-nvml-config-gb300.yaml"))
+	require.NoError(t, err)
+
+	state, err := compileState(data)
+	require.NoError(t, err)
+	require.Len(t, state.Devices, 2, "GPU_COUNT caps the devices NVML reports")
+	require.Len(t, state.NodeShape.Topology.RootComplexes, 2,
+		"the profile's own layout is compiled whole, both roots and all four BDFs")
+
+	rendered := state.PCITopology()
+
+	require.Len(t, rendered, 1, "the root whose GPUs were capped away is dropped")
+	require.Equal(t, "pci0000:00", rendered[0].ID)
+	require.Equal(t, []string{"0000:0a:00.0", "0000:0b:00.0"}, rendered[0].DeviceBDFs)
+}
+
 func TestCompileState_PerDevicePCIOverride(t *testing.T) {
 	t.Setenv("GPU_COUNT", "")
 

--- a/internal/agent/state.go
+++ b/internal/agent/state.go
@@ -31,6 +31,27 @@ type State struct {
 	TopologyRaw []byte
 }
 
+// HasPCITopology reports whether the state describes a PCI layout to render:
+// either explicit root complexes, or devices carrying a BDF for a flat one to
+// be synthesized from.
+//
+// It is the condition under which a PCI sysfs tree exists on the node, so
+// anything that serves that tree to a container gates on it. A bind mount whose
+// source is missing fails container creation for the whole pod, which is why
+// the answer has to come from the same state the renderer reads rather than
+// from a filesystem probe.
+func (s *State) HasPCITopology() bool {
+	if len(s.NodeShape.Topology.RootComplexes) > 0 {
+		return true
+	}
+	for _, d := range s.Devices {
+		if d.PCIBusID != "" {
+			return true
+		}
+	}
+	return false
+}
+
 // NodeMeta carries node identity fields.
 type NodeMeta struct {
 	NodeName string

--- a/internal/agent/state.go
+++ b/internal/agent/state.go
@@ -44,9 +44,11 @@ const DefaultRootComplexID = "pci0000:00"
 //
 // The profile's pcie_topology outlives its device list — GPU_COUNT truncates
 // Devices and leaves the layout whole — so declared BDFs no device claims are
-// dropped, along with any root that empties out. Conversely a device no root
-// claims is adopted by the first one, since an unplaced GPU cannot be resolved
-// at all while a misplaced one only misreports its pcieRoot.
+// dropped, along with any root that empties out. A device no root claims is
+// rendered under a root its own address implies, never folded into a declared
+// one: locality is what a consumer reads this tree for, so a GPU carrying the
+// NUMA node of a root the profile never put it in is worse than one carrying
+// none. See adopt.
 //
 // Returns nil when no device carries a BDF, which is the signal to render
 // nothing.
@@ -69,16 +71,69 @@ func (s *State) PCITopology() []RootComplex {
 			orphans = append(orphans, bdf)
 		}
 	}
-
-	switch {
-	case len(orphans) == 0:
-		return roots
-	case len(roots) == 0:
-		return []RootComplex{{ID: DefaultRootComplexID, DeviceBDFs: orphans}}
-	default:
-		roots[0].DeviceBDFs = append(roots[0].DeviceBDFs, orphans...)
+	if len(orphans) == 0 {
 		return roots
 	}
+
+	return adopt(roots, orphans)
+}
+
+// numaNodeUnknown is what Linux writes to numa_node for a device it has no
+// proximity information for. Rendering it says "unknown" in the encoding every
+// consumer already handles, rather than asserting a node we do not know.
+const numaNodeUnknown = -1
+
+// adopt renders the devices no declared root claims — a profile whose
+// pcie_topology omits a BDF its device list carries.
+//
+// Each lands under the root its own address implies (pciDDDD:BB), joining a
+// declared root only when that root is the one the address names, where
+// membership is the profile's own arithmetic rather than our guess. Anything
+// else gets a root of its own with an unknown NUMA node: the alternative,
+// appending to whichever declared root came first, hands a topology-aware
+// consumer a specific and wrong answer for something it cannot re-derive.
+//
+// Rendering them at all is deliberate. A GPU missing from the tree is one no
+// consumer can resolve from the BDF NVML hands it, which is the failure this
+// whole path exists to fix.
+func adopt(roots []RootComplex, orphans []string) []RootComplex {
+	index := make(map[string]int, len(roots)+len(orphans))
+	for i, rc := range roots {
+		index[rc.ID] = i
+	}
+
+	for _, bdf := range orphans {
+		id := rootIDForBDF(bdf)
+		if i, ok := index[id]; ok {
+			roots[i].DeviceBDFs = append(roots[i].DeviceBDFs, bdf)
+			continue
+		}
+
+		index[id] = len(roots)
+		roots = append(roots, RootComplex{
+			ID:         id,
+			NUMANode:   numaNodeUnknown,
+			DeviceBDFs: []string{bdf},
+		})
+	}
+
+	return roots
+}
+
+// rootIDForBDF names the root complex a device's address implies, in the
+// kernel's pciDDDD:BB form. A BDF too malformed to split is left to the default
+// root, since the renderer needs somewhere to put it either way.
+func rootIDForBDF(bdf string) string {
+	domain, rest, ok := strings.Cut(bdf, ":")
+	if !ok {
+		return DefaultRootComplexID
+	}
+	bus, _, ok := strings.Cut(rest, ":")
+	if !ok {
+		return DefaultRootComplexID
+	}
+
+	return "pci" + domain + ":" + bus
 }
 
 // activeBDFs returns the BDFs of the devices that exist at runtime, lowercased

--- a/internal/agent/state.go
+++ b/internal/agent/state.go
@@ -121,32 +121,65 @@ func adopt(roots []RootComplex, orphans []string) []RootComplex {
 }
 
 // rootIDForBDF names the root complex a device's address implies, in the
-// kernel's pciDDDD:BB form. A BDF too malformed to split is left to the default
-// root, since the renderer needs somewhere to put it either way.
+// kernel's pciDDDD:BB form. Requires a BDF validBDF accepted, which is why it
+// needs no fallback: guessing the default root here would hand the device that
+// root's NUMA node, which every shipped profile declares.
 func rootIDForBDF(bdf string) string {
-	domain, rest, ok := strings.Cut(bdf, ":")
-	if !ok {
-		return DefaultRootComplexID
-	}
-	bus, _, ok := strings.Cut(rest, ":")
-	if !ok {
-		return DefaultRootComplexID
-	}
+	domain, rest, _ := strings.Cut(bdf, ":")
+	bus, _, _ := strings.Cut(rest, ":")
 
 	return "pci" + domain + ":" + bus
 }
 
+// validBDF reports whether s is a PCI address in the form the kernel names
+// sysfs entries with, DDDD:BB:DD.F, lowercase hex.
+//
+// The check is a boundary, not a nicety: gpu.customConfig authors bus_id by
+// hand, and the value becomes both a path component under the rendered tree and
+// the basis for a root-complex ID. Anything else is dropped rather than placed
+// somewhere it does not belong — a string that is not an address is one no
+// consumer can look up either. The 8-digit domain NVML reports through
+// nvmlPciInfo_t.busId is not this form; the profile field carries the 4-digit
+// one, as busIdLegacy does.
+func validBDF(s string) bool {
+	const form = "dddd:bb:dd.f"
+	if len(s) != len(form) {
+		return false
+	}
+
+	for i, want := range form {
+		got := s[i]
+		switch want {
+		case ':', '.':
+			if got != byte(want) {
+				return false
+			}
+		default:
+			if !isLowerHex(got) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func isLowerHex(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')
+}
+
 // activeBDFs returns the BDFs of the devices that exist at runtime, lowercased
 // to match the paths the renderer writes, in device order and deduplicated.
+// A device whose bus_id is absent or not an address is left out entirely.
 func (s *State) activeBDFs() []string {
 	seen := make(map[string]bool, len(s.Devices))
 	out := make([]string, 0, len(s.Devices))
 
 	for _, d := range s.Devices {
-		if d.PCIBusID == "" {
+		bdf := strings.ToLower(d.PCIBusID)
+		if !validBDF(bdf) {
 			continue
 		}
-		bdf := strings.ToLower(d.PCIBusID)
 		if seen[bdf] {
 			continue
 		}

--- a/internal/agent/state.go
+++ b/internal/agent/state.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"context"
+	"strings"
 	"time"
 )
 
@@ -31,20 +32,113 @@ type State struct {
 	TopologyRaw []byte
 }
 
-// HasPCITopology reports whether the state describes a PCI layout to render:
-// explicit root complexes, or devices carrying a BDF to synthesize a flat one
-// from. Whoever serves that tree gates on this rather than probing the
-// filesystem, so the answer comes from the same state the renderer reads.
-func (s *State) HasPCITopology() bool {
-	if len(s.NodeShape.Topology.RootComplexes) > 0 {
-		return true
+// DefaultRootComplexID is the host bridge a synthesized layout hangs every
+// device off, matching what a single-socket profile declares explicitly.
+const DefaultRootComplexID = "pci0000:00"
+
+// PCITopology returns the root complexes to render, reconciled against the
+// devices that exist at runtime rather than taken from the profile as written.
+// Devices are the authority because they are what NVML reports, and a served
+// tree that disagrees with NVML is worse than no tree: a consumer resolves a
+// GPU in one and not the other.
+//
+// The profile's pcie_topology outlives its device list — GPU_COUNT truncates
+// Devices and leaves the layout whole — so declared BDFs no device claims are
+// dropped, along with any root that empties out. Conversely a device no root
+// claims is adopted by the first one, since an unplaced GPU cannot be resolved
+// at all while a misplaced one only misreports its pcieRoot.
+//
+// Returns nil when no device carries a BDF, which is the signal to render
+// nothing.
+func (s *State) PCITopology() []RootComplex {
+	active := s.activeBDFs()
+	if len(active) == 0 {
+		return nil
 	}
-	for _, d := range s.Devices {
-		if d.PCIBusID != "" {
-			return true
+
+	declared := s.NodeShape.Topology.RootComplexes
+	if len(declared) == 0 {
+		return []RootComplex{{ID: DefaultRootComplexID, DeviceBDFs: active}}
+	}
+
+	roots, placed := placeDeclared(declared, active)
+
+	var orphans []string
+	for _, bdf := range active {
+		if !placed[bdf] {
+			orphans = append(orphans, bdf)
 		}
 	}
-	return false
+
+	switch {
+	case len(orphans) == 0:
+		return roots
+	case len(roots) == 0:
+		return []RootComplex{{ID: DefaultRootComplexID, DeviceBDFs: orphans}}
+	default:
+		roots[0].DeviceBDFs = append(roots[0].DeviceBDFs, orphans...)
+		return roots
+	}
+}
+
+// activeBDFs returns the BDFs of the devices that exist at runtime, lowercased
+// to match the paths the renderer writes, in device order and deduplicated.
+func (s *State) activeBDFs() []string {
+	seen := make(map[string]bool, len(s.Devices))
+	out := make([]string, 0, len(s.Devices))
+
+	for _, d := range s.Devices {
+		if d.PCIBusID == "" {
+			continue
+		}
+		bdf := strings.ToLower(d.PCIBusID)
+		if seen[bdf] {
+			continue
+		}
+		seen[bdf] = true
+		out = append(out, bdf)
+	}
+
+	return out
+}
+
+// placeDeclared keeps the BDFs of each declared root that an active device
+// claims, dropping any root left with none. It reports which BDFs it placed so
+// the caller can find the devices no root accounts for.
+func placeDeclared(declared []RootComplex, active []string) ([]RootComplex, map[string]bool) {
+	wanted := make(map[string]bool, len(active))
+	for _, bdf := range active {
+		wanted[bdf] = true
+	}
+
+	placed := make(map[string]bool, len(active))
+	out := make([]RootComplex, 0, len(declared))
+
+	for _, rc := range declared {
+		kept := make([]string, 0, len(rc.DeviceBDFs))
+		for _, bdf := range rc.DeviceBDFs {
+			bdf = strings.ToLower(bdf)
+			if wanted[bdf] && !placed[bdf] {
+				placed[bdf] = true
+				kept = append(kept, bdf)
+			}
+		}
+		if len(kept) == 0 {
+			continue
+		}
+		rc.DeviceBDFs = kept
+		out = append(out, rc)
+	}
+
+	return out, placed
+}
+
+// HasPCITopology reports whether a PCI sysfs tree will be rendered for this
+// state. Whoever serves that tree gates on this, so it answers from the same
+// reconciliation the renderer reads rather than from a filesystem probe: a bind
+// mount whose source is missing fails container creation for the whole pod.
+func (s *State) HasPCITopology() bool {
+	return len(s.PCITopology()) > 0
 }
 
 // NodeMeta carries node identity fields.

--- a/internal/agent/state.go
+++ b/internal/agent/state.go
@@ -32,14 +32,9 @@ type State struct {
 }
 
 // HasPCITopology reports whether the state describes a PCI layout to render:
-// either explicit root complexes, or devices carrying a BDF for a flat one to
-// be synthesized from.
-//
-// It is the condition under which a PCI sysfs tree exists on the node, so
-// anything that serves that tree to a container gates on it. A bind mount whose
-// source is missing fails container creation for the whole pod, which is why
-// the answer has to come from the same state the renderer reads rather than
-// from a filesystem probe.
+// explicit root complexes, or devices carrying a BDF to synthesize a flat one
+// from. Whoever serves that tree gates on this rather than probing the
+// filesystem, so the answer comes from the same state the renderer reads.
 func (s *State) HasPCITopology() bool {
 	if len(s.NodeShape.Topology.RootComplexes) > 0 {
 		return true

--- a/internal/agent/state_test.go
+++ b/internal/agent/state_test.go
@@ -120,6 +120,40 @@ func TestPCITopology_SynthesizesARootWhenNoneDeclared(t *testing.T) {
 		"lowercased, and the device without a BDF is skipped")
 }
 
+// gpu.customConfig can put anything in bus_id. A value that is not an address
+// cannot be placed, and every shipped profile declares pci0000:00, so treating
+// it as the default root would hand it that root's real NUMA node.
+func TestPCITopology_DropsAMalformedBDF(t *testing.T) {
+	state := twoRootState()
+	state.Devices = append(state.Devices, DeviceSpec{Index: 4, PCIBusID: "not-a-bdf"})
+
+	rcs := state.PCITopology()
+
+	require.Equal(t, map[string][]string{
+		"pci0000:00": {"0000:0a:00.0", "0000:0b:00.0"},
+		"pci0000:40": {"0000:4a:00.0", "0000:4b:00.0"},
+	}, bdfsOf(rcs), "the declared roots keep exactly what the profile put in them")
+}
+
+// A bus_id is joined into a filesystem path, so one carrying separators or
+// parent references would render outside the tree it belongs to.
+func TestPCITopology_DropsABDFThatWouldEscapeTheTree(t *testing.T) {
+	for _, busID := range []string{
+		"../../../../escaped",
+		"0000:0a:00.0/../../etc",
+		"..",
+		".",
+		"0000:0a:00.g",
+		"00000000:07:00.0", // the 8-digit NVML form, not the kernel's
+	} {
+		t.Run(busID, func(t *testing.T) {
+			state := &State{Devices: []DeviceSpec{{Index: 0, PCIBusID: busID}}}
+
+			require.Nil(t, state.PCITopology(), "%q is not a BDF", busID)
+		})
+	}
+}
+
 func TestPCITopology_NilWithoutADeviceBDF(t *testing.T) {
 	require.Nil(t, (&State{}).PCITopology())
 	require.Nil(t, (&State{Devices: []DeviceSpec{{Index: 0}}}).PCITopology())

--- a/internal/agent/state_test.go
+++ b/internal/agent/state_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// twoRootState is a gb300-shaped node: two host bridges, two GPUs each.
+func twoRootState() *State {
+	return &State{
+		NodeShape: NodeShape{Topology: PCIeTopology{RootComplexes: []RootComplex{
+			{ID: "pci0000:00", NUMANode: 0, DeviceBDFs: []string{"0000:0a:00.0", "0000:0b:00.0"}},
+			{ID: "pci0000:40", NUMANode: 1, DeviceBDFs: []string{"0000:4a:00.0", "0000:4b:00.0"}},
+		}}},
+		Devices: []DeviceSpec{
+			{Index: 0, PCIBusID: "0000:0A:00.0"},
+			{Index: 1, PCIBusID: "0000:0B:00.0"},
+			{Index: 2, PCIBusID: "0000:4A:00.0"},
+			{Index: 3, PCIBusID: "0000:4B:00.0"},
+		},
+	}
+}
+
+func bdfsOf(rcs []RootComplex) map[string][]string {
+	out := make(map[string][]string, len(rcs))
+	for _, rc := range rcs {
+		out[rc.ID] = rc.DeviceBDFs
+	}
+	return out
+}
+
+func TestPCITopology_KeepsADeclaredLayout(t *testing.T) {
+	rcs := twoRootState().PCITopology()
+
+	require.Equal(t, map[string][]string{
+		"pci0000:00": {"0000:0a:00.0", "0000:0b:00.0"},
+		"pci0000:40": {"0000:4a:00.0", "0000:4b:00.0"},
+	}, bdfsOf(rcs))
+}
+
+// GPU_COUNT truncates State.Devices while pcie_topology is copied from the
+// profile whole, so the profile's BDFs outlive the GPUs NVML reports. Rendering
+// them would put phantom NVIDIA 3D controllers in the tree now served at the
+// kernel paths — every attribute plausible, no NVML device behind them.
+func TestPCITopology_DropsBDFsNoDeviceClaims(t *testing.T) {
+	state := twoRootState()
+	state.Devices = state.Devices[:2]
+
+	rcs := state.PCITopology()
+
+	require.Equal(t, map[string][]string{
+		"pci0000:00": {"0000:0a:00.0", "0000:0b:00.0"},
+	}, bdfsOf(rcs), "the emptied root goes with its devices")
+}
+
+// The mirror case: a hand-written pcie_topology that forgets a device. Coverage
+// beats placement here — an unplaced GPU is one a consumer cannot resolve at
+// all, where a misplaced one only reports the wrong pcieRoot.
+func TestPCITopology_AdoptsADeviceNoRootClaims(t *testing.T) {
+	state := twoRootState()
+	state.Devices = append(state.Devices, DeviceSpec{Index: 4, PCIBusID: "0000:8a:00.0"})
+
+	rcs := state.PCITopology()
+
+	require.Equal(t, []string{"0000:0a:00.0", "0000:0b:00.0", "0000:8a:00.0"},
+		bdfsOf(rcs)["pci0000:00"], "adopted by the first declared root")
+}
+
+func TestPCITopology_SynthesizesARootWhenNoneDeclared(t *testing.T) {
+	state := &State{Devices: []DeviceSpec{
+		{Index: 0, PCIBusID: "0000:1A:00.0"},
+		{Index: 1},
+		{Index: 2, PCIBusID: "0000:1B:00.0"},
+	}}
+
+	rcs := state.PCITopology()
+
+	require.Len(t, rcs, 1)
+	require.Equal(t, DefaultRootComplexID, rcs[0].ID)
+	require.Equal(t, 0, rcs[0].NUMANode)
+	require.Equal(t, []string{"0000:1a:00.0", "0000:1b:00.0"}, rcs[0].DeviceBDFs,
+		"lowercased, and the device without a BDF is skipped")
+}
+
+func TestPCITopology_NilWithoutADeviceBDF(t *testing.T) {
+	require.Nil(t, (&State{}).PCITopology())
+	require.Nil(t, (&State{Devices: []DeviceSpec{{Index: 0}}}).PCITopology())
+	require.Nil(t, (&State{NodeShape: NodeShape{Topology: PCIeTopology{
+		RootComplexes: []RootComplex{{ID: "pci0000:00", DeviceBDFs: []string{"0000:0a:00.0"}}},
+	}}}).PCITopology(), "a topology no device backs renders nothing")
+}
+
+// The CDI simulator gates the sysfs mounts it publishes on the predicate while
+// pcibus renders from PCITopology, so the two must not be able to disagree: a
+// false positive publishes a bind mount over /sys/devices for an empty tree.
+func TestHasPCITopology_TracksPCITopology(t *testing.T) {
+	noBackingDevice := &State{NodeShape: NodeShape{Topology: PCIeTopology{
+		RootComplexes: []RootComplex{{ID: "pci0000:00", DeviceBDFs: []string{"0000:0a:00.0"}}},
+	}}}
+	truncated := twoRootState()
+	truncated.Devices = truncated.Devices[:1]
+
+	for name, state := range map[string]*State{
+		"empty":              {},
+		"device without bdf": {Devices: []DeviceSpec{{Index: 0}}},
+		"device with bdf":    {Devices: []DeviceSpec{{Index: 0, PCIBusID: "0000:07:00.0"}}},
+		"declared layout":    twoRootState(),
+		"truncated by count": truncated,
+		"no backing device":  noBackingDevice,
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, len(state.PCITopology()) > 0, state.HasPCITopology())
+		})
+	}
+}

--- a/internal/agent/state_test.go
+++ b/internal/agent/state_test.go
@@ -57,17 +57,51 @@ func TestPCITopology_DropsBDFsNoDeviceClaims(t *testing.T) {
 	}, bdfsOf(rcs), "the emptied root goes with its devices")
 }
 
-// The mirror case: a hand-written pcie_topology that forgets a device. Coverage
-// beats placement here — an unplaced GPU is one a consumer cannot resolve at
-// all, where a misplaced one only reports the wrong pcieRoot.
-func TestPCITopology_AdoptsADeviceNoRootClaims(t *testing.T) {
+// The mirror case: a hand-written pcie_topology that forgets a device. It is
+// still rendered, since a GPU absent from the tree is one no consumer can
+// resolve from the BDF NVML reports.
+func TestPCITopology_RendersADeviceNoRootClaims(t *testing.T) {
 	state := twoRootState()
 	state.Devices = append(state.Devices, DeviceSpec{Index: 4, PCIBusID: "0000:8a:00.0"})
 
 	rcs := state.PCITopology()
 
-	require.Equal(t, []string{"0000:0a:00.0", "0000:0b:00.0", "0000:8a:00.0"},
-		bdfsOf(rcs)["pci0000:00"], "adopted by the first declared root")
+	require.Equal(t, []string{"0000:8a:00.0"}, bdfsOf(rcs)["pci0000:8a"],
+		"under the root its own address implies")
+	require.Equal(t, []string{"0000:0a:00.0", "0000:0b:00.0"}, bdfsOf(rcs)["pci0000:00"],
+		"the declared roots keep exactly what the profile put in them")
+}
+
+// Locality is what this tree gets read for, so an unplaced device reports no
+// NUMA node rather than one borrowed from a root the profile never put it in:
+// -1 is what Linux itself writes when it has no proximity information.
+func TestPCITopology_UnplacedDeviceHasUnknownNUMA(t *testing.T) {
+	state := twoRootState()
+	state.Devices = append(state.Devices, DeviceSpec{Index: 4, PCIBusID: "0000:8a:00.0"})
+
+	for _, rc := range state.PCITopology() {
+		if rc.ID == "pci0000:8a" {
+			require.Equal(t, -1, rc.NUMANode)
+			return
+		}
+	}
+
+	t.Fatal("the unplaced device was not rendered")
+}
+
+// When the address names a root the profile did declare, membership is the
+// profile's own arithmetic rather than a guess, so the device joins it and
+// inherits a NUMA node that is genuinely its own.
+func TestPCITopology_UnplacedDeviceJoinsTheRootItsAddressNames(t *testing.T) {
+	state := twoRootState()
+	state.NodeShape.Topology.RootComplexes[1].ID = "pci0000:8a"
+	state.Devices = append(state.Devices, DeviceSpec{Index: 4, PCIBusID: "0000:8a:00.0"})
+
+	rcs := state.PCITopology()
+
+	require.Equal(t, []string{"0000:4a:00.0", "0000:4b:00.0", "0000:8a:00.0"},
+		bdfsOf(rcs)["pci0000:8a"])
+	require.Len(t, rcs, 2, "no root invented next to the one that fits")
 }
 
 func TestPCITopology_SynthesizesARootWhenNoneDeclared(t *testing.T) {

--- a/internal/nri/inject/env.go
+++ b/internal/nri/inject/env.go
@@ -22,6 +22,13 @@ func setEnvironment(cfg Config, container Container, adjustment *Adjustment) {
 	env.setDefault("MOCK_IB_ROOT", filepath.Join(cfg.ContainerOverlayPath, "ib"))
 	env.setDefault("MOCK_IB_PING_SOCKET", filepath.Join(cfg.ContainerOverlayPath, "run/mock-ib.sock"))
 	env.setDefault("MOCK_PCI_ROOT", cfg.ContainerOverlayPath)
+	// GFD derives nvidia.com/gpu.machine from this file. Its own default,
+	// /sys/class/dmi/id/product_name, is a path no mock can own: kind's node
+	// image writes "kind" there and re-binds it into every container, and hosts
+	// without DMI have no such path. Injecting it here means a mokka install
+	// labels the node correctly with no GPU Operator values override (#681).
+	env.setDefault("GFD_MACHINE_TYPE_FILE",
+		filepath.Join(cfg.ContainerOverlayPath, configRelPath, "machine-type"))
 
 	// ComputeDomain topology overlay: point the mock NVML engine at the staged
 	// topology document and tell it which node this container runs on, so every

--- a/internal/nri/inject/env_test.go
+++ b/internal/nri/inject/env_test.go
@@ -55,10 +55,27 @@ func TestAdjustPointsTheLoaderAtTheOverlay(t *testing.T) {
 	require.Contains(t, adjustment.Env, "MOCK_IB_ROOT=/opt/nvml-mock/ib")
 	require.Contains(t, adjustment.Env, "MOCK_IB_PING_SOCKET=/opt/nvml-mock/run/mock-ib.sock")
 	require.Contains(t, adjustment.Env, "MOCK_PCI_ROOT=/opt/nvml-mock")
+	require.Contains(t, adjustment.Env, "GFD_MACHINE_TYPE_FILE=/opt/nvml-mock/driver/config/machine-type")
 	// MOCK_IB=off is authored by the container and left unchanged, so the
 	// plugin must NOT re-emit it — emitting untouched vars would claim NRI
 	// ownership and conflict with other plugins.
 	requireNoEnvKey(t, adjustment.Env, "MOCK_IB")
+}
+
+// The machine type reaches GFD as a default, so a cluster that pins its own
+// file keeps it: overriding would silently retarget a deliberate choice.
+func TestAdjustLeavesAnAuthoredMachineTypeFile(t *testing.T) {
+	t.Parallel()
+
+	container := Container{
+		Namespace: "default",
+		Env:       []string{"GFD_MACHINE_TYPE_FILE=/etc/machine-type"},
+	}
+
+	adjustment, ok := Adjust(DefaultConfig(), container)
+	require.True(t, ok)
+
+	requireNoEnvKey(t, adjustment.Env, "GFD_MACHINE_TYPE_FILE")
 }
 
 func TestAdjustEmitsOnlyAddedOrChangedEnv(t *testing.T) {

--- a/internal/pcisysfs/render.go
+++ b/internal/pcisysfs/render.go
@@ -12,6 +12,17 @@ import (
 	"strings"
 )
 
+// The two directories that together make the tree readable. Exported because
+// whoever serves them to a container has to name the same paths the renderer
+// writes, and a silent drift there fails open: the entries list and every
+// attribute read returns ENOENT, which is indistinguishable from no tree at all.
+const (
+	// PCIDevicesRelPath is the flat lookup directory of BDF symlinks.
+	PCIDevicesRelPath = "sys/bus/pci/devices"
+	// SysDevicesRelPath is the hierarchy those symlinks point into.
+	SysDevicesRelPath = "sys/devices"
+)
+
 // Options controls a single rendering pass.
 type Options struct {
 	// Topology is the resolved layout to render. When nil or empty, Render
@@ -26,7 +37,8 @@ type Options struct {
 
 	// Output is the fake-root directory. The renderer writes under
 	// <Output>/sys/... — Output itself is created if missing. Required when
-	// Topology is non-empty; otherwise Render returns an error.
+	// Topology is non-empty; otherwise Render returns an error. An empty
+	// Topology empties the tree under Output rather than leaving it alone.
 	Output string
 }
 
@@ -35,18 +47,28 @@ type Options struct {
 // symlinks are removed and recreated so a stale relative target does not linger,
 // and entries the new topology no longer declares are pruned.
 func Render(o Options) error {
-	if o.Topology == nil || len(o.Topology.RootComplexes) == 0 {
-		return nil
-	}
+	empty := o.Topology == nil || len(o.Topology.RootComplexes) == 0
 	if o.Output == "" {
+		if empty {
+			return nil
+		}
 		return errors.New("pcisysfs render: Output is required")
 	}
 
+	// A profile that declares no PCI devices means an empty tree, not the
+	// previous profile's. Pruning rather than returning is what makes the
+	// rendered tree describe this generation, which matters most for whoever
+	// serves it: an a100 tree left behind by a config change would go on being
+	// mounted at the kernel paths as if the node still simulated those GPUs.
+	if empty {
+		return prune(o.Output, &PCIeTopology{})
+	}
+
 	root := o.Output
-	if err := mkdirAll(root, "sys/bus/pci/devices"); err != nil {
+	if err := mkdirAll(root, PCIDevicesRelPath); err != nil {
 		return err
 	}
-	if err := mkdirAll(root, "sys/devices"); err != nil {
+	if err := mkdirAll(root, SysDevicesRelPath); err != nil {
 		return err
 	}
 
@@ -80,11 +102,11 @@ func prune(root string, topo *PCIeTopology) error {
 
 	errs := []error{
 		// The flat lookup directory holds only BDF symlinks.
-		pruneDir(filepath.Join(root, "sys/bus/pci/devices"),
+		pruneDir(filepath.Join(root, PCIDevicesRelPath),
 			func(name string) bool { return allBDFs[name] }),
 	}
 
-	devicesDir := filepath.Join(root, "sys/devices")
+	devicesDir := filepath.Join(root, SysDevicesRelPath)
 	entries, err := os.ReadDir(devicesDir)
 	if err != nil && !os.IsNotExist(err) {
 		errs = append(errs, fmt.Errorf("read %s: %w", devicesDir, err))
@@ -140,7 +162,7 @@ func pruneDir(dir string, keep func(string) bool) error {
 }
 
 func renderRootComplex(root string, rc RootComplex, ids map[string]PCI) error {
-	rcDir := filepath.Join("sys/devices", rc.ID)
+	rcDir := filepath.Join(SysDevicesRelPath, rc.ID)
 	if err := mkdirAll(root, rcDir); err != nil {
 		return err
 	}
@@ -167,11 +189,11 @@ func renderRootComplex(root string, rc RootComplex, ids map[string]PCI) error {
 		// Relative target matches what the kernel emits, so readlink()
 		// consumers (realpath, deviceattribute) resolve to the same
 		// canonical path they would on real Linux.
-		linkPath := filepath.Join(root, "sys/bus/pci/devices", bdfLC)
+		linkPath := filepath.Join(root, PCIDevicesRelPath, bdfLC)
 		linkTarget := filepath.Join("..", "..", "..", "devices", rc.ID, bdfLC)
 		if err := replaceSymlink(linkPath, linkTarget); err != nil {
 			return fmt.Errorf("symlink %s -> %s: %w",
-				filepath.Join("sys/bus/pci/devices", bdfLC), linkTarget, err)
+				filepath.Join(PCIDevicesRelPath, bdfLC), linkTarget, err)
 		}
 	}
 	return nil

--- a/internal/pcisysfs/render.go
+++ b/internal/pcisysfs/render.go
@@ -12,10 +12,9 @@ import (
 	"strings"
 )
 
-// The two directories that together make the tree readable. Exported because
-// whoever serves them to a container has to name the same paths the renderer
-// writes, and a silent drift there fails open: the entries list and every
-// attribute read returns ENOENT, which is indistinguishable from no tree at all.
+// The two directories that together make the tree readable. Exported because a
+// server naming different paths fails open: entries list, every attribute read
+// returns ENOENT, and the result is indistinguishable from no tree at all.
 const (
 	// PCIDevicesRelPath is the flat lookup directory of BDF symlinks.
 	PCIDevicesRelPath = "sys/bus/pci/devices"
@@ -55,11 +54,9 @@ func Render(o Options) error {
 		return errors.New("pcisysfs render: Output is required")
 	}
 
-	// A profile that declares no PCI devices means an empty tree, not the
-	// previous profile's. Pruning rather than returning is what makes the
-	// rendered tree describe this generation, which matters most for whoever
-	// serves it: an a100 tree left behind by a config change would go on being
-	// mounted at the kernel paths as if the node still simulated those GPUs.
+	// A profile declaring no PCI devices means an empty tree, not the previous
+	// profile's: leftovers would go on being served at the kernel paths as if
+	// the node still simulated those GPUs.
 	if empty {
 		return prune(o.Output, &PCIeTopology{})
 	}

--- a/internal/pcisysfs/render.go
+++ b/internal/pcisysfs/render.go
@@ -24,8 +24,8 @@ const (
 
 // Options controls a single rendering pass.
 type Options struct {
-	// Topology is the resolved layout to render. When nil or empty, Render
-	// is a no-op.
+	// Topology is the resolved layout to render. Nil or empty renders an
+	// empty tree rather than leaving the previous one served.
 	Topology *PCIeTopology
 
 	// Identities carries the per-device PCI identity (device_id /
@@ -78,6 +78,22 @@ func Render(o Options) error {
 	// Pruning last means a wanted device is never briefly absent: the window
 	// holds the union of the old and new trees rather than a gap.
 	return prune(root, o.Topology)
+}
+
+// Clear tears the tree down for good, emptying the two served directories
+// without replacing them.
+//
+// The distinction matters because those directories are CDI mount sources: a
+// consumer container binds their inodes when it starts and keeps them across an
+// agent restart, so removing and re-rendering leaves it reading an empty tree
+// until something recreates the pod. Everything below them goes, DMI included,
+// which is what separates this from rendering an empty topology.
+func Clear(root string) error {
+	return errors.Join(
+		prune(root, &PCIeTopology{}),
+		// prune spares what the renderer does not own; a teardown owns all of it.
+		pruneDir(filepath.Join(root, SysDevicesRelPath), func(string) bool { return false }),
+	)
 }
 
 // prune removes entries the topology no longer declares. Rendering alone is

--- a/internal/pcisysfs/render.go
+++ b/internal/pcisysfs/render.go
@@ -96,6 +96,16 @@ func Clear(root string) error {
 	)
 }
 
+// safeName reports whether name can be joined under Output as a single
+// directory. Every root-complex ID and BDF becomes a path component, so one
+// carrying a separator or a parent reference writes outside the tree. Callers
+// are expected to have validated their input; this is the backstop that keeps a
+// hand-authored bus_id from reaching the host filesystem.
+func safeName(name string) bool {
+	return name != "" && name != "." && name != ".." &&
+		!strings.ContainsAny(name, `/\`)
+}
+
 // prune removes entries the topology no longer declares. Rendering alone is
 // additive, so a device set that shrinks or is re-addressed would otherwise
 // leave orphans that lspci keeps enumerating and NVML no longer reports.
@@ -175,12 +185,20 @@ func pruneDir(dir string, keep func(string) bool) error {
 }
 
 func renderRootComplex(root string, rc RootComplex, ids map[string]PCI) error {
+	if !safeName(rc.ID) {
+		return fmt.Errorf("root complex id %q is not a path component", rc.ID)
+	}
+
 	rcDir := filepath.Join(SysDevicesRelPath, rc.ID)
 	if err := mkdirAll(root, rcDir); err != nil {
 		return err
 	}
 
 	for _, bdf := range rc.Devices {
+		if !safeName(bdf) {
+			return fmt.Errorf("device %q is not a path component", bdf)
+		}
+
 		// Normalize once: sysfs paths are case-insensitive on most
 		// filesystems but tooling (libpciaccess, lspci) compares
 		// strings literally, so render lowercase to match the kernel.

--- a/internal/pcisysfs/render_test.go
+++ b/internal/pcisysfs/render_test.go
@@ -316,3 +316,55 @@ func TestRender_PruneLeavesForeignEntriesAlone(t *testing.T) {
 
 	require.DirExists(t, foreign, "non-pci entries are not this renderer's to remove")
 }
+
+// A consumer container holds its bind-mounts on the inodes these two
+// directories had when it started, so replacing them leaves it reading an empty
+// tree until it is recreated.
+func TestClear_EmptiesTheServedDirectoriesInPlace(t *testing.T) {
+	dir := t.TempDir()
+	topo := &PCIeTopology{RootComplexes: []RootComplex{
+		{ID: "pci0000:00", NUMANode: 0, Devices: []string{"0000:07:00.0"}},
+	}}
+	require.NoError(t, Render(Options{Topology: topo, Output: dir}))
+
+	served := []string{filepath.Join(dir, SysDevicesRelPath), filepath.Join(dir, PCIDevicesRelPath)}
+	before := make([]os.FileInfo, len(served))
+	for i, p := range served {
+		fi, err := os.Stat(p)
+		require.NoError(t, err)
+		before[i] = fi
+	}
+
+	require.NoError(t, Clear(dir))
+
+	for i, p := range served {
+		after, err := os.Stat(p)
+		require.NoError(t, err, "the mount source must outlive the teardown")
+		require.True(t, os.SameFile(before[i], after), "%s was replaced rather than emptied", p)
+
+		entries, err := os.ReadDir(p)
+		require.NoError(t, err)
+		require.Empty(t, entries, "%s still carries a discarded profile", p)
+	}
+}
+
+// Clear tears the simulator down, so unlike an empty Render it takes the DMI
+// attributes with it rather than leaving them for the next profile.
+func TestClear_RemovesTheStagedDMI(t *testing.T) {
+	dir := t.TempDir()
+	topo := &PCIeTopology{RootComplexes: []RootComplex{
+		{ID: "pci0000:00", NUMANode: 0, Devices: []string{"0000:07:00.0"}},
+	}}
+	require.NoError(t, Render(Options{Topology: topo, Output: dir}))
+	dmi := filepath.Join(dir, SysDevicesRelPath, "virtual/dmi/id")
+	require.NoError(t, os.MkdirAll(dmi, 0o755))
+
+	require.NoError(t, Clear(dir))
+
+	require.NoDirExists(t, filepath.Join(dir, SysDevicesRelPath, "virtual"))
+}
+
+// Nothing rendered is not a failure to tear down.
+func TestClear_ToleratesAnUnrenderedRoot(t *testing.T) {
+	require.NoError(t, Clear(t.TempDir()))
+}

--- a/internal/pcisysfs/render_test.go
+++ b/internal/pcisysfs/render_test.go
@@ -263,6 +263,46 @@ func TestRender_PrunesRemovedRootComplex(t *testing.T) {
 	require.True(t, os.IsNotExist(err), "symlink into the dropped root must be pruned")
 }
 
+// TestRender_ClearsTreeWhenTopologyEmpty covers re-profiling a node onto a
+// config whose devices declare no bus_id, which gpu.customConfig makes
+// reachable. Leaving the previous profile's devices behind is not a cosmetic
+// leak now that the tree is mounted at the kernel paths: a consumer would
+// enumerate GPUs the node no longer simulates, under a root complex no profile
+// declares.
+func TestRender_ClearsTreeWhenTopologyEmpty(t *testing.T) {
+	dir := t.TempDir()
+	topo := &PCIeTopology{RootComplexes: []RootComplex{
+		{ID: "pci0000:00", NUMANode: 0, Devices: []string{"0000:07:00.0"}},
+	}}
+	require.NoError(t, Render(Options{Topology: topo, Output: dir}))
+
+	require.NoError(t, Render(Options{Output: dir}), "Render(empty topology)")
+
+	require.NoDirExists(t, filepath.Join(dir, "sys/devices/pci0000:00"))
+	entries, err := os.ReadDir(filepath.Join(dir, PCIDevicesRelPath))
+	require.NoError(t, err)
+	require.Empty(t, entries, "no device may survive a profile that declares none")
+}
+
+// TestRender_EmptyTopologyKeepsForeignEntries pins the ownership boundary on
+// the clearing path too. virtual/dmi/id is staged by the same simulator for a
+// different reason and must outlive a topology change, or a container served
+// the tree loses a bind-mount target it needs to start.
+func TestRender_EmptyTopologyKeepsForeignEntries(t *testing.T) {
+	dir := t.TempDir()
+	topo := &PCIeTopology{RootComplexes: []RootComplex{
+		{ID: "pci0000:00", NUMANode: 0, Devices: []string{"0000:07:00.0"}},
+	}}
+	require.NoError(t, Render(Options{Topology: topo, Output: dir}))
+
+	foreign := filepath.Join(dir, SysDevicesRelPath, "virtual/dmi/id")
+	require.NoError(t, os.MkdirAll(foreign, 0o755))
+
+	require.NoError(t, Render(Options{Output: dir}), "Render(empty topology)")
+
+	require.DirExists(t, foreign)
+}
+
 // TestRender_PruneLeavesForeignEntriesAlone guards the ownership boundary:
 // libpcisysfs rewrites only /sys/devices/pci*, so the renderer must not delete
 // anything else a sibling component staged in the same fake root.

--- a/internal/pcisysfs/render_test.go
+++ b/internal/pcisysfs/render_test.go
@@ -263,12 +263,10 @@ func TestRender_PrunesRemovedRootComplex(t *testing.T) {
 	require.True(t, os.IsNotExist(err), "symlink into the dropped root must be pruned")
 }
 
-// TestRender_ClearsTreeWhenTopologyEmpty covers re-profiling a node onto a
-// config whose devices declare no bus_id, which gpu.customConfig makes
-// reachable. Leaving the previous profile's devices behind is not a cosmetic
-// leak now that the tree is mounted at the kernel paths: a consumer would
-// enumerate GPUs the node no longer simulates, under a root complex no profile
-// declares.
+// Re-profiling onto a config whose devices declare no bus_id, which
+// gpu.customConfig makes reachable. Now that the tree is served at the kernel
+// paths, leftovers would have a consumer enumerate GPUs the node no longer
+// simulates.
 func TestRender_ClearsTreeWhenTopologyEmpty(t *testing.T) {
 	dir := t.TempDir()
 	topo := &PCIeTopology{RootComplexes: []RootComplex{
@@ -284,10 +282,9 @@ func TestRender_ClearsTreeWhenTopologyEmpty(t *testing.T) {
 	require.Empty(t, entries, "no device may survive a profile that declares none")
 }
 
-// TestRender_EmptyTopologyKeepsForeignEntries pins the ownership boundary on
-// the clearing path too. virtual/dmi/id is staged by the same simulator for a
-// different reason and must outlive a topology change, or a container served
-// the tree loses a bind-mount target it needs to start.
+// The ownership boundary holds on the clearing path too: virtual/dmi/id is
+// staged by the same simulator for another reason, and a served container needs
+// it to start.
 func TestRender_EmptyTopologyKeepsForeignEntries(t *testing.T) {
 	dir := t.TempDir()
 	topo := &PCIeTopology{RootComplexes: []RootComplex{

--- a/internal/pcisysfs/render_test.go
+++ b/internal/pcisysfs/render_test.go
@@ -368,3 +368,28 @@ func TestClear_RemovesTheStagedDMI(t *testing.T) {
 func TestClear_ToleratesAnUnrenderedRoot(t *testing.T) {
 	require.NoError(t, Clear(t.TempDir()))
 }
+
+// Every BDF and root-complex ID becomes a path component under Output, so one
+// carrying separators or parent references writes outside the tree. The agent
+// filters these already; failing here keeps that from being the only thing
+// standing between a profile's bus_id and the host filesystem.
+func TestRender_RejectsANameThatEscapesOutput(t *testing.T) {
+	for name, topo := range map[string]*PCIeTopology{
+		"device": {RootComplexes: []RootComplex{
+			{ID: "pci0000:00", Devices: []string{"../../../../escaped"}},
+		}},
+		"root complex": {RootComplexes: []RootComplex{
+			{ID: "../../../../escaped", Devices: []string{"0000:07:00.0"}},
+		}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			base := t.TempDir()
+			out := filepath.Join(base, "overlay")
+			require.NoError(t, os.MkdirAll(out, 0o755))
+
+			require.Error(t, Render(Options{Topology: topo, Output: out}))
+			require.NoDirExists(t, filepath.Join(base, "escaped"),
+				"the render escaped Output")
+		})
+	}
+}

--- a/local/gpu-operator/gpu-operator.values.yaml
+++ b/local/gpu-operator/gpu-operator.values.yaml
@@ -58,11 +58,17 @@ devicePlugin:
       value: "/var/lib/nvml-mock/driver"
 
 # GFD reads GPU attributes via mock NVML and labels the node.
+#
+# The machine type has to come from a file of the mock's own: GFD's default,
+# /sys/class/dmi/id/product_name, reads "kind" under kind and does not exist on
+# hosts without DMI. The agent writes this one, served by the CDI config mount.
 gfd:
   enabled: true
   env:
     - name: NVIDIA_DRIVER_ROOT
       value: "/var/lib/nvml-mock/driver"
+    - name: GFD_MACHINE_TYPE_FILE
+      value: "/etc/nvml-mock/machine-type"
 
 # Validator checks that the GPU stack is functional.
 #

--- a/local/gpu-operator/gpu-operator.values.yaml
+++ b/local/gpu-operator/gpu-operator.values.yaml
@@ -63,10 +63,10 @@ devicePlugin:
 # /sys/class/dmi/id/product_name, reads "kind" under kind and does not exist on
 # hosts without DMI. The agent writes this one, served by the CDI config mount.
 #
-# Set here only because this overlay drives the CDI path, where the runtime
-# applies the spec's mounts but drops its env (#747). With nri.enabled the
-# plugin
-# injects GFD_MACHINE_TYPE_FILE itself and no override is needed.
+# Set here only because this overlay drives the CDI path, where the toolkit
+# resolving nvidia.com/gpu applies the spec's mounts and drops its env (#747).
+# With nri.enabled the plugin injects GFD_MACHINE_TYPE_FILE itself and no
+# override is needed.
 gfd:
   enabled: true
   env:

--- a/local/gpu-operator/gpu-operator.values.yaml
+++ b/local/gpu-operator/gpu-operator.values.yaml
@@ -62,6 +62,10 @@ devicePlugin:
 # The machine type has to come from a file of the mock's own: GFD's default,
 # /sys/class/dmi/id/product_name, reads "kind" under kind and does not exist on
 # hosts without DMI. The agent writes this one, served by the CDI config mount.
+#
+# Set here only because this overlay drives the CDI path, where the runtime
+# applies the spec's mounts but drops its env. With nri.enabled the plugin
+# injects GFD_MACHINE_TYPE_FILE itself and no override is needed.
 gfd:
   enabled: true
   env:

--- a/local/gpu-operator/gpu-operator.values.yaml
+++ b/local/gpu-operator/gpu-operator.values.yaml
@@ -64,7 +64,8 @@ devicePlugin:
 # hosts without DMI. The agent writes this one, served by the CDI config mount.
 #
 # Set here only because this overlay drives the CDI path, where the runtime
-# applies the spec's mounts but drops its env. With nri.enabled the plugin
+# applies the spec's mounts but drops its env (#747). With nri.enabled the
+# plugin
 # injects GFD_MACHINE_TYPE_FILE itself and no override is needed.
 gfd:
   enabled: true

--- a/tests/e2e/go/assertions/gfd_labels.go
+++ b/tests/e2e/go/assertions/gfd_labels.go
@@ -22,7 +22,16 @@ const (
 	GFDLabelProduct = "nvidia.com/gpu.product"
 	GFDLabelMemory  = "nvidia.com/gpu.memory"
 	GFDLabelCount   = "nvidia.com/gpu.count"
+	// GFDLabelMode is derived from each GPU's PCI class rather than from NVML,
+	// so it is the one GFD label that reports whether the mock's PCI sysfs tree
+	// reaches a consumer. It is asserted separately from the labels above for
+	// that reason: they fail together when NVML is wrong, this one when sysfs is.
+	GFDLabelMode = "nvidia.com/gpu.mode"
 )
+
+// GFDModeCompute is the mode GFD derives from the 3D-controller PCI class every
+// profile renders. A node whose GPUs it cannot resolve in sysfs reads "unknown".
+const GFDModeCompute = "compute"
 
 // ExpectedGFDLabels derives the GFD labels a node must carry from the profile,
 // rather than from the node itself. Deriving them independently is what makes

--- a/tests/e2e/go/assertions/gfd_labels.go
+++ b/tests/e2e/go/assertions/gfd_labels.go
@@ -27,6 +27,10 @@ const (
 	// reaches a consumer. It is asserted separately from the labels above for
 	// that reason: they fail together when NVML is wrong, this one when sysfs is.
 	GFDLabelMode = "nvidia.com/gpu.mode"
+	// GFDLabelMachine comes from the machine-type file the agent serves, not
+	// from GFD's DMI default: under kind that path reads "kind", and on hosts
+	// without DMI it does not exist (#681).
+	GFDLabelMachine = "nvidia.com/gpu.machine"
 )
 
 // GFDModeCompute is the mode GFD derives from the 3D-controller PCI class every

--- a/tests/e2e/go/assertions/pcisysfs.go
+++ b/tests/e2e/go/assertions/pcisysfs.go
@@ -79,6 +79,59 @@ func PCISysfs(ctx context.Context, k *kube.Client, pod kube.PodRef, gpuCount, ex
 		"distinct PCI root complexes\n%s", roots.Combined())
 }
 
+// KernelPCIDevicesDir is where the kernel keeps the flat PCI lookup directory,
+// and so where a consumer that reads sysfs directly looks. Unlike PCIDevicesDir
+// this path owes nothing to the mock's layout: it is what has to be true inside
+// a container for a Go consumer to see the mock GPUs at all.
+const KernelPCIDevicesDir = "/sys/bus/pci/devices"
+
+// PCISysfsAtKernelPaths asserts, from inside a container the mock serves, that
+// the rendered tree is readable at the kernel paths.
+//
+// The overlay path the standalone scenario checks proves the renderer ran; it
+// says nothing about whether anything reaches a consumer. libpcisysfs.so covers
+// libc consumers such as lspci, but Go's os package issues openat directly, so
+// the shim never sees the open and the process reads the node's real /sys —
+// which is how GPU Feature Discovery came to label a mock node
+// nvidia.com/gpu.mode=unknown (#673).
+func PCISysfsAtKernelPaths(ctx context.Context, k *kube.Client, pod kube.PodRef, gpuCount int) {
+	ginkgo.GinkgoHelper()
+
+	ginkgo.By(fmt.Sprintf("%d mock GPUs visible at %s", gpuCount, KernelPCIDevicesDir))
+	// Exact, not "at least": the mount replaces the directory outright, so a
+	// higher count means the host's real devices are showing through or a
+	// previous profile's render was never pruned.
+	res, err := k.ExecSh(ctx, pod, "ls "+KernelPCIDevicesDir+" 2>/dev/null | wc -l")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "listing %s: %s", KernelPCIDevicesDir, res.Combined())
+	gomega.Expect(atoiTrim(res.Stdout)).To(gomega.Equal(gpuCount),
+		"mock GPUs served at the kernel path\n%s", res.Combined())
+
+	first, err := k.ExecSh(ctx, pod, "ls "+KernelPCIDevicesDir+" | sort | head -1")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	dev := strings.TrimSpace(first.Stdout)
+	gomega.Expect(dev).NotTo(gomega.BeEmpty(), "no PCI devices under %s", KernelPCIDevicesDir)
+
+	ginkgo.By("vendor resolves through the symlink into the served /sys/devices")
+	// This is what separates delivery from coincidence, and why the two mounts
+	// are one feature. The entries are relative symlinks into
+	// ../../../devices/pciDDDD:BB, so this read succeeds only when that half is
+	// served too — with the lookup directory alone the listing above still
+	// passes and every attribute read returns ENOENT.
+	vendor, err := k.ExecSh(ctx, pod, "cat "+KernelPCIDevicesDir+"/"+dev+"/vendor")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "reading vendor for %s: %s", dev, vendor.Combined())
+	gomega.Expect(strings.TrimSpace(vendor.Stdout)).To(gomega.Equal("0x10de"),
+		"vendor for %s did not resolve to the mock tree", dev)
+
+	ginkgo.By("class is the 3D-controller value gpu.mode is derived from")
+	// Naming the value here is what makes the gpu.mode assertion elsewhere
+	// attributable: the label reads "compute" because GFD read this class out
+	// of the served tree, not because it defaulted to it.
+	class, err := k.ExecSh(ctx, pod, "cat "+KernelPCIDevicesDir+"/"+dev+"/class")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "reading class for %s", dev)
+	gomega.Expect(strings.TrimSpace(class.Stdout)).To(gomega.Equal("0x030200"),
+		"class for %s", dev)
+}
+
 func atoiTrim(s string) int {
 	n, _ := strconv.Atoi(strings.TrimSpace(s))
 	return n

--- a/tests/e2e/go/framework/kube/kube.go
+++ b/tests/e2e/go/framework/kube/kube.go
@@ -79,6 +79,9 @@ type objectMeta struct {
 	Name        string            `json:"name"`
 	Labels      map[string]string `json:"labels"`
 	Annotations map[string]string `json:"annotations"`
+	// A terminating pod reports phase Running until its containers exit, so the
+	// phase alone does not distinguish one an exec can reach.
+	DeletionTimestamp string `json:"deletionTimestamp"`
 }
 
 type nodeCondition struct {
@@ -283,6 +286,27 @@ func (c *Client) RunningPodNames(ctx context.Context, ns, selector string) ([]st
 		}
 	}
 	return out, nil
+}
+
+// RunningPodOnNode returns a pod matching the selector that is on node and that
+// an exec can reach: Running and not terminating.
+//
+// FirstPodName is the wrong tool for a DaemonSet whose pod a caller means to
+// exec into. It returns Items[0] with no filter, so a Terminating or Pending pod
+// matches as readily as the Running one, and Items[0] is not necessarily on the
+// node the surrounding specs assert labels about — the spec could report about
+// hardware it never checked.
+func (c *Client) RunningPodOnNode(ctx context.Context, ns, selector, node string) (string, error) {
+	var pl podList
+	if err := c.getJSON(ctx, &pl, "pods", "-n", ns, "-l", selector, "--field-selector", "spec.nodeName="+node); err != nil {
+		return "", err
+	}
+	for _, p := range pl.Items {
+		if p.Status.Phase == "Running" && p.Metadata.DeletionTimestamp == "" {
+			return p.Metadata.Name, nil
+		}
+	}
+	return "", fmt.Errorf("no running pod in ns %q matching %q on node %q", ns, selector, node)
 }
 
 // PodNode returns the Kubernetes node a pod is scheduled on.

--- a/tests/e2e/go/scenario_gpu_operator_test.go
+++ b/tests/e2e/go/scenario_gpu_operator_test.go
@@ -91,6 +91,14 @@ var _ = Describe("nvml-mock GPU Operator", Label("gpu-operator"), Ordered, func(
 					config.ReadyTimeout(), config.PollInterval())
 			})
 
+			It("labels gpu.machine from the served machine-type file", Label("device-plugin"), func(ctx SpecContext) {
+				// The same string as gpu.product, for want of a platform field
+				// in the profiles: both are the GPU's product name.
+				assertions.WaitGFDLabels(ctx, h.Kube, node,
+					map[string]string{assertions.GFDLabelMachine: p.GFDProductName()},
+					config.ReadyTimeout(), config.PollInterval())
+			})
+
 			It("exports DCGM device metrics that vary over time", Label("dcgm"), func(ctx SpecContext) {
 				assertions.DCGMDeviceMetrics(ctx, h.Kube, gpuOperatorNamespace,
 					p.DisplayName, p.ExpectedGPUs(), gpmProfiles[name],

--- a/tests/e2e/go/scenario_gpu_operator_test.go
+++ b/tests/e2e/go/scenario_gpu_operator_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/config"
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/harness"
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/helm"
+	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/kube"
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/framework/runner"
 	"github.com/NVIDIA/k8s-test-infra/tests/e2e/go/profile"
 )
@@ -69,6 +70,25 @@ var _ = Describe("nvml-mock GPU Operator", Label("gpu-operator"), Ordered, func(
 					assertions.ExpectedGFDLabels(p.GFDProductName(), p.MemoryMiB(), p.ExpectedGPUs()),
 					config.ReadyTimeout(), config.PollInterval())
 				assertions.WaitAllocatableGPU(ctx, h.Kube, node, p.ExpectedGPUs(), config.ReadyTimeout(), config.PollInterval())
+			})
+
+			It("serves the mock PCI tree to a Go consumer at the kernel paths", Label("pcisysfs"), func(ctx SpecContext) {
+				// GFD is the consumer the bug was found in, and it is Go: it
+				// resolves each GPU's BDF from NVML and then reads that device's
+				// class from sysfs. Reading the tree from inside its own
+				// container is what pins delivery, independently of the label
+				// below, which the operator could publish for other reasons.
+				assertions.PCISysfsAtKernelPaths(ctx, h.Kube,
+					gfdPodRef(ctx, h, node), p.ExpectedGPUs())
+			})
+
+			It("labels gpu.mode from the served PCI class", Label("device-plugin"), func(ctx SpecContext) {
+				// Separate from the GFD labels above: those come from NVML and
+				// fail together, this one reads "unknown" precisely when the
+				// tree does not reach GFD (#673).
+				assertions.WaitGFDLabels(ctx, h.Kube, node,
+					map[string]string{assertions.GFDLabelMode: assertions.GFDModeCompute},
+					config.ReadyTimeout(), config.PollInterval())
 			})
 
 			It("exports DCGM device metrics that vary over time", Label("dcgm"), func(ctx SpecContext) {
@@ -244,6 +264,27 @@ func verifyGPUOperatorNodeSetup(ctx context.Context, container string) {
 	GinkgoHelper()
 	Expect(dockerExec(ctx, container, "test", "-f", "/var/run/cdi/nvidia.yaml")).To(Succeed(), "CDI spec exists")
 	Expect(dockerExec(ctx, container, "bash", "-c", "LD_LIBRARY_PATH=/run/nvidia/driver/usr/lib64 /run/nvidia/driver/usr/bin/nvidia-smi")).To(Succeed(), "nvidia-smi works via /run/nvidia/driver")
+}
+
+// gfdPodRef resolves the GPU Feature Discovery pod on node, polling for the
+// same reason waitOperatorValidatorRunning does: the operator replaces its
+// operands a reconcile after nvml-mock rolls, so resolving the pod once can land
+// in the gap where none is ready.
+func gfdPodRef(ctx SpecContext, h *harness.Harness, node string) kube.PodRef {
+	GinkgoHelper()
+	var pod string
+	Eventually(func() (string, error) {
+		p, err := h.Kube.RunningPodOnNode(ctx, gpuOperatorNamespace, "app=gpu-feature-discovery", node)
+		pod = p
+		return p, err
+	}).WithContext(ctx).WithTimeout(config.ReadyTimeout()).WithPolling(config.PollInterval()).
+		ShouldNot(BeEmpty(), "no running gpu-feature-discovery pod on node %s", node)
+
+	return kube.PodRef{
+		Namespace: gpuOperatorNamespace,
+		Pod:       pod,
+		Container: "gpu-feature-discovery",
+	}
 }
 
 func waitOperatorValidatorRunning(ctx SpecContext, h *harness.Harness) {

--- a/tests/e2e/gpu-operator-values.yaml
+++ b/tests/e2e/gpu-operator-values.yaml
@@ -78,7 +78,8 @@ devicePlugin:
 # hosts without DMI. The agent writes this one, served by the CDI config mount.
 #
 # Set here only because this suite drives the CDI path, where the runtime
-# applies the spec's mounts but drops its env. With nri.enabled the plugin
+# applies the spec's mounts but drops its env (#747). With nri.enabled the
+# plugin
 # injects GFD_MACHINE_TYPE_FILE itself and no override is needed.
 gfd:
   enabled: true

--- a/tests/e2e/gpu-operator-values.yaml
+++ b/tests/e2e/gpu-operator-values.yaml
@@ -76,6 +76,10 @@ devicePlugin:
 # The machine type has to come from a file of the mock's own: GFD's default,
 # /sys/class/dmi/id/product_name, reads "kind" under kind and does not exist on
 # hosts without DMI. The agent writes this one, served by the CDI config mount.
+#
+# Set here only because this suite drives the CDI path, where the runtime
+# applies the spec's mounts but drops its env. With nri.enabled the plugin
+# injects GFD_MACHINE_TYPE_FILE itself and no override is needed.
 gfd:
   enabled: true
   env:

--- a/tests/e2e/gpu-operator-values.yaml
+++ b/tests/e2e/gpu-operator-values.yaml
@@ -77,10 +77,10 @@ devicePlugin:
 # /sys/class/dmi/id/product_name, reads "kind" under kind and does not exist on
 # hosts without DMI. The agent writes this one, served by the CDI config mount.
 #
-# Set here only because this suite drives the CDI path, where the runtime
-# applies the spec's mounts but drops its env (#747). With nri.enabled the
-# plugin
-# injects GFD_MACHINE_TYPE_FILE itself and no override is needed.
+# Set here only because this suite drives the CDI path, where the toolkit
+# resolving nvidia.com/gpu applies the spec's mounts and drops its env (#747).
+# With nri.enabled the plugin injects GFD_MACHINE_TYPE_FILE itself and no
+# override is needed.
 gfd:
   enabled: true
   env:

--- a/tests/e2e/gpu-operator-values.yaml
+++ b/tests/e2e/gpu-operator-values.yaml
@@ -72,11 +72,17 @@ devicePlugin:
       value: "/var/lib/nvml-mock/driver"
 
 # GFD reads GPU attributes via mock NVML and labels the node.
+#
+# The machine type has to come from a file of the mock's own: GFD's default,
+# /sys/class/dmi/id/product_name, reads "kind" under kind and does not exist on
+# hosts without DMI. The agent writes this one, served by the CDI config mount.
 gfd:
   enabled: true
   env:
     - name: NVIDIA_DRIVER_ROOT
       value: "/var/lib/nvml-mock/driver"
+    - name: GFD_MACHINE_TYPE_FILE
+      value: "/etc/nvml-mock/machine-type"
 
 # Validator checks that the GPU stack is functional.
 # driver-validation: mounts hostPath /run/nvidia/driver → our mock (via symlink).


### PR DESCRIPTION
## What This PR Does

Makes the simulated PCI tree and machine type visible to Go consumers, so a mock node labels itself the way a real one does.

- **Serves the rendered PCI tree at the kernel paths.** The agent's `nvidia.com/gpu` CDI spec bind-mounts `sys/devices` and `sys/bus/pci/devices` read-only, as a pair. Fixes `nvidia.com/gpu.mode=unknown`.
- **Reproduces the node's DMI attributes inside the tree.** Serving `/sys/devices` replaces what `/sys/class/dmi/id` resolves into, so without this a container reads `ENOENT` where the node has values — and under `kind`, whose node image bind-mounts its product files into every container, the pod fails to start outright.
- **Renders only the GPUs NVML reports.** `gpu.count` caps the device list without touching `pcie_topology`, so a capped node used to render PCI entries that read as GPUs with no NVML device behind them.
- **Serves a machine-type file and points GFD at it via NRI.** Fixes `nvidia.com/gpu.machine=unknown`.

Trade-off: `/sys/devices` is served whole, so a served container no longer sees the host's other device classes, CPU topology among them. Narrowing it needs mountpoints the runtime cannot create on a read-only sysfs; #689 tracks removing it.

Known gap: the CDI path still needs `GFD_MACHINE_TYPE_FILE` in the operator's values, because the runtime applies the spec's mounts but drops its env — filed as #747. NRI needs no override.

## Why

Fixes #673. `pcibus` rendered the tree into the agent's overlay, reachable only through the `libpcisysfs.so` `LD_PRELOAD` shim. That covers libc consumers like `lspci`, but Go bypasses it — `os.Open` issues `openat` directly — so GPU Feature Discovery and the NVIDIA DRA driver read the node's real `/sys` and found no mock GPUs. GFD resolved each GPU's BDF from NVML, failed to read its class, and labelled the node `nvidia.com/gpu.mode=unknown`; the DRA driver omitted `dra.k8s.io/pcieRoot` for the same reason.

Fixes #681. `nvidia.com/gpu.machine` read `unknown` for a separate reason: GFD's default source for it is a DMI path no mock can own under `kind`, and one that does not exist at all on hosts without DMI.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`go test -v -race ./...`) — plus `make helm-tests` (175 tests, 15 snapshots) and `go vet` including under the e2e build tag
- [x] Linter passes (`make lint-fix`) — `golangci-lint` reports 0 issues; the target's `govulncheck` stage fails on Go 1.26.5 stdlib advisories fixed in 1.26.6, pre-existing and reached only through code this PR does not touch
- [x] New code has SPDX license headers
- [x] Documentation updated (if applicable) — `docs/helm-chart.md`
- [x] CHANGELOG.md updated (if user-facing change)

Verified with `tilt ci -- --gpu-operator --gpu-profile gb300` on `kind`: both workers reach `gpu.mode=compute` and `gpu.machine=NVIDIA-GB300-NVL`, and all four GPUs resolve at the kernel paths from inside a served container. Not verified locally: `kind`'s DMI mount-target hook, which cannot fire on Docker Desktop (no DMI) and is covered by Linux CI; and `dra.k8s.io/pcieRoot`, which needs a `--dra` run.
