### PR TITLE
poc: Mokka + AICR pre-silicon coverage sweep, measured twice

### DIFF
--- a/docs/aicr-preflight/README.md
+++ b/docs/aicr-preflight/README.md
@@ -1,0 +1,131 @@
+# AICR pre-silicon preflight, on a simulated GPU fleet
+
+You have bought a GPU cluster. It lands in about three months. Your engineers are here now, and there
+is nothing for them to integrate against. Whatever breaks when the hardware arrives, you find out
+then, on the clock, at scale, with everyone watching.
+
+This page explains a way to move part of that work earlier, what it covers, and what it does not.
+
+## The two pieces
+
+**AICR** (AI Cloud Ready) codifies configurations that have been validated and optimized on real
+hardware. It gives a cloud provider a known-good baseline instead of each one rediscovering the stack
+independently. It ships recipes (what to deploy) and a validation suite (21 checks across deployment,
+performance and conformance phases).
+
+**Mokka** (`nvml-mock`) presents ordinary CPU nodes to Kubernetes as a faithful GPU and fabric fleet.
+It intercepts at the NVML and driver line, so the real GPU Operator, the real device plugin, the real
+DRA driver, real NFD and GFD, and a real dcgm-exporter all run and see GPUs that are not there.
+
+They compose in one direction, and the direction matters:
+
+**AICR runs unmodified on a Mokka-enabled cluster.** AICR is the workload. Mokka is the substrate
+underneath it. Simulation does not live "inside" AICR.
+
+![Stack layering](diagrams/stack-layering.svg)
+
+```mermaid
+flowchart TB
+    subgraph L5["AICR: the workload on top"]
+        R["Recipes (14 components)"]
+        V["validate: deployment, performance, conformance"]
+    end
+    subgraph L4["Cluster software AICR deploys and checks"]
+        OP["GPU Operator"]
+        DRA["NVIDIA DRA driver"]
+        NFD["NFD + GFD"]
+        DCGM["dcgm-exporter"]
+    end
+    subgraph L3["Kubernetes"]
+        KUBELET["kubelet + containerd (NRI enabled)"]
+    end
+    subgraph L2["Mokka: the substrate (nvml-mock v0.3.0)"]
+        NRI["NRI plugin: node-wide injection"]
+        NVML["mock libnvidia-ml.so.1 at the NVML/driver line"]
+        FAB["mock fabric management: NVSwitch, fabricmanager, IB SM, IMEX channels"]
+    end
+    subgraph L1["Real nodes, no GPU"]
+        NODE["CPU nodes"]
+    end
+    L5 --> L4 --> L3 --> L2 --> L1
+```
+
+## What this is
+
+A **pre-silicon integration preflight**. It finds integration failures before the hardware lands, so
+the hardware time is spent on the things that genuinely need hardware.
+
+**AICR validation on real silicon remains the final readiness gate.** Preflight does not replace it
+and cannot.
+
+The defensible claim is that this **reduces** time to first token, by moving integration failures
+earlier. It is not a claim that you **hit** first token on day one. Simulation cannot prove that,
+because the path that determines first token is exactly the path simulation does not exercise.
+
+## What preflight covers
+
+From a real sweep on 2026-08-03 (kind, Kubernetes 1.36.1, Mokka v0.3.0 `gb200`, AICR `0752ea14`):
+
+- The GPU Operator installs and reconciles against the mock driver surface.
+- The device plugin advertises `nvidia.com/gpu` (8 per worker, from the profile).
+- `nvidia-smi` works inside a CUDA base-image pod on every GPU node: device-plugin allocation, device
+  injection and `dlopen` of `libnvidia-ml.so.1`, end to end.
+- A real dcgm-exporter serves `DCGM_FI_DEV_*` telemetry read off the mock NVML.
+- The NVIDIA DRA driver publishes ResourceSlices (16 devices across 2 nodes) derived from the mock.
+- Ordinary pods see GPUs with **no** resource request, **no** hostPath and **no** pod-spec change,
+  through node-wide NRI injection.
+- Recipe-level constraints are enforced: the sweep caught a GPU Operator version that violated the
+  gb200 recipe's own `>= v25.10.0` floor.
+
+## What preflight does NOT cover
+
+This list is not a disclaimer. It is the reason the final gate stays where it is.
+
+- **CUDA execution.** The mock runs no kernel. `cudaLaunchKernel` is a no-op.
+- **Firmware and driver compatibility.** Every version string is configuration text.
+- **NCCL, NVLink and NVLS data-plane throughput.** Mokka simulates fabric *management* (NVSwitch
+  topology, fabricmanager, InfiniBand subnet manager, IMEX channels). It does not move bytes. NVLink
+  counters advance with the clock, not with traffic.
+- **Workload time-to-first-token and throughput.** There is no inference to measure.
+- **Anything reading GPU memory utilization as evidence of real work.** With the allocation watcher
+  enabled, `memory.used` reflects that a claim *exists*. The bytes are synthetic by construction.
+
+In AICR's 21-check suite, 4 checks (three NCCL variants and `inference-perf`) fall entirely in this
+category and cannot be judged without hardware.
+
+## What this sweep does NOT tell you
+
+**Nothing about scale.** The sweep ran on three containers on one laptop with a 7.75 GiB budget. Deep
+GPU-stack fidelity at large node counts is unproven and is not claimed here.
+
+**No bring-up-time number.** Measuring that needs a real bring-up's failure history to back-test
+against. That data was not available, so no time saving is quoted. Treat any such number attributed
+to this work as unsupported.
+
+## Mokka and KWOK are orthogonal
+
+The common question is whether this competes with KWOK. It does not.
+
+![Vertical versus horizontal](diagrams/vertical-vs-horizontal.svg)
+
+| | KWOK (horizontal) | Mokka (vertical) |
+|---|---|---|
+| Layer | API and control plane; no kubelet | Real kubelet and runtime on real CPU nodes; GPU faked at the NVML/driver line |
+| Nodes | Hollow; pods reach Running as status only | Real device plugin, DRA driver, GPU Operator, NFD/GFD, dcgm-exporter all run |
+| Cost | Very cheap per node | One CPU node per simulated GPU node |
+| Good for | Scheduler, API server and etcd at scale | GPU-stack depth: the layer AICR's checks actually read |
+| Blind spot | No GPU stack exists, so AICR has nothing to validate | Not the cheapest way to push node count |
+
+AICR already ships a KWOK lane, and its own README draws the line: KWOK validates scheduling, not
+runtime, and explicitly not container execution or GPU functionality. `aicr validate` cannot run under
+KWOK at all, because every validator is a containerized Job that needs a real pod on a real kubelet.
+
+That is the whole argument for combining them, in AICR's own words rather than ours: KWOK gives
+recipe and scheduling breadth cheaply; Mokka is what lets the 21 validator checks run at all before
+silicon.
+
+## Where to go next
+
+- [how-it-works.md](how-it-works.md): bring-up order, what runs where, what the mock intercepts.
+- [coverage.md](coverage.md): the measured matrix, what needs silicon, and the gap backlog.
+- The harness that produced these numbers: [`tests/aicr-sweep/`](../../tests/aicr-sweep/).

--- a/docs/aicr-preflight/coverage.md
+++ b/docs/aicr-preflight/coverage.md
@@ -1,9 +1,9 @@
 # Coverage: what preflight validates, and what needs silicon
 
 Every number on this page comes from the sweep run on 2026-08-03. The raw results are
-[`tests/aicr-sweep/results/report.json`](../../tests/aicr-sweep/results/report.json); the per-check
+[`tests/aicr-sweep/results/report.json`](https://github.com/NVIDIA/k8s-test-infra/blob/main/tests/aicr-sweep/results/report.json); the per-check
 reasoning with source citations is
-[`tests/aicr-sweep/catalog.yaml`](../../tests/aicr-sweep/catalog.yaml).
+[`tests/aicr-sweep/catalog.yaml`](https://github.com/NVIDIA/k8s-test-infra/blob/main/tests/aicr-sweep/catalog.yaml).
 
 **All evidence is simulation provenance (`sim`).** None of it was run on silicon.
 
@@ -87,7 +87,7 @@ One gap found. It is closable and it is small.
 | PCI bus ID reaches NVML consumers without its domain prefix (`:0a:00.0` instead of `0000:0a:00.0`), breaking `dra.k8s.io/pcieRoot` on the DRA driver and crashing `gpu-feature-discovery` | the `pcieRoot` topology attribute; indirectly `gpu-operator-health` via ClusterPolicy | 1 check moves from fail to testable, plus the topology attribute | S | open |
 
 Two consumers, one symptom, all 8 devices. Evidence:
-[`results/pci-busid-evidence.log`](../../tests/aicr-sweep/results/pci-busid-evidence.log).
+[`results/pci-busid-evidence.log`](https://github.com/NVIDIA/k8s-test-infra/blob/main/tests/aicr-sweep/results/pci-busid-evidence.log).
 
 This also bears on issue #265, which records `dra.k8s.io/pcieRoot` as unavailable and attributes it to
 Go's `os` package bypassing the `LD_PRELOAD` shim. The DRA driver log shows the failure happening

--- a/docs/aicr-preflight/coverage.md
+++ b/docs/aicr-preflight/coverage.md
@@ -1,0 +1,107 @@
+# Coverage: what preflight validates, and what needs silicon
+
+Every number on this page comes from the sweep run on 2026-08-03. The raw results are
+[`tests/aicr-sweep/results/report.json`](../../tests/aicr-sweep/results/report.json); the per-check
+reasoning with source citations is
+[`tests/aicr-sweep/catalog.yaml`](../../tests/aicr-sweep/catalog.yaml).
+
+**All evidence is simulation provenance (`sim`).** None of it was run on silicon.
+
+## The suite, split
+
+AICR ships 21 validator checks: 4 deployment, 4 performance, 13 conformance.
+
+| Bucket | Count | Share | What it means for you |
+|---|---|---|---|
+| **A meaningful** | 16 | 76% | integration work that can move earlier, before silicon |
+| **B trivial** | 1 | 5% | preflight does **not** cover this; it would pass either way |
+| **C hardware-dependent** | 4 | 19% | why AICR-on-silicon remains the final gate |
+| **G closable Mokka gap** | 0 | 0% | none at v0.3.0 |
+
+![Coverage map](diagrams/coverage-map.svg)
+
+## Two numbers, and the difference between them
+
+- **Analytical ceiling: 76%** (A / total). What would carry real pre-silicon signal if the full
+  14-component recipe stack is deployed. **This is not a measured result.**
+- **Reachable once tracked gaps close: 76%** ((A + G) / total). Identical, because no catalogued check
+  is blocked by a missing Mokka capability at v0.3.0.
+- **Measured in this run: 14%.** AICR dispatched 9 of 21 checks and 3 reached a meaningful pass.
+
+The distance between 14% and 76% is almost entirely the host memory budget: 7.75 GiB held 2 of the 14
+recipe components. It is not a Mokka limitation. Re-running on a 32 GiB host is the single highest
+value next step, and nothing about Mokka has to change first.
+
+Of the 16 A-bucket checks, **10 are GPU-dependent**. The other 6 (`gpu-operator-version`,
+`gang-scheduling`, `inference-gateway`, `cluster-autoscaling`, `robust-controller`, `platform-health`)
+run on any cluster at all, so Mokka is not what unlocks them and they should not be counted as GPU
+coverage.
+
+## What passed, and what that proves
+
+| Check | What the pass demonstrates |
+|---|---|
+| `check-nvidia-smi` | device-plugin allocation, device injection and `dlopen` of `libnvidia-ml.so.1`, end to end, inside a real CUDA base image on every GPU node |
+| `operator-health` | the real GPU Operator reconciles against the mock driver surface and its operands reach healthy |
+| `accelerator-metrics` | a real dcgm-exporter serves `DCGM_FI_DEV_GPU_UTIL`, `FB_USED`, `GPU_TEMP` and `POWER_USAGE` read off the mock NVML |
+
+Alongside those, verified directly rather than through a check: the device plugin advertised
+`nvidia.com/gpu: 8` per worker, the DRA driver published 16 devices across 2 ResourceSlices, and a
+plain pod with `resources: {}` listed 8 GB200s.
+
+## What failed, and whose problem each one is
+
+![Break matrix](diagrams/break-matrix.svg)
+
+| Check | Cause | Attribution |
+|---|---|---|
+| `gpu-operator-version` | v25.3.4 installed; gb200 recipe requires `>= v25.10.0` | operator config. **The check worked**: this is a version-skew catch, pre-silicon. |
+| `dra-support` | ComputeDomain controller absent; enabling it crashes on `/proc/devices` | **U**, upstream. The DRA driver needs `altProcDevices`, on main, in no release including v25.12.0. |
+| `ai-service-metrics` | Prometheus not deployed | scope. 2 of 14 recipe components deployed. |
+| `platform-health` | 9 recipe namespaces absent | scope, same reason. |
+| `gpu-operator-health` | `ClusterPolicy notReady` because GFD crashed | **K**, provisionally. See the gap backlog. |
+
+**None of the five is a Mokka capability gap.**
+
+## What needs silicon, permanently
+
+These four checks are bucket C by construction. No amount of simulation work moves them.
+
+| Check | Why |
+|---|---|
+| `nccl-all-reduce-bw` | measures collective bus bandwidth; Mokka moves no bytes |
+| `nccl-all-reduce-bw-net` | additionally asserts the NET transport carried traffic |
+| `nccl-all-reduce-bw-nvls` | additionally asserts NVLS multicast across an NVL72 IMEX domain |
+| `inference-perf` | throughput and p99 time-to-first-token from a real vLLM workload |
+
+Note the boundary carefully: Mokka **does** simulate fabric *management*, so NVSwitch topology,
+fabricmanager state, the InfiniBand subnet manager and IMEX channel assignment are all reachable and
+can be bucket A. Collective *throughput* is not. Those two must never be blurred.
+
+## Gap backlog
+
+One gap found. It is closable and it is small.
+
+| Gap | Blocks | Coverage unlocked | Size | Status |
+|---|---|---|---|---|
+| PCI bus ID reaches NVML consumers without its domain prefix (`:0a:00.0` instead of `0000:0a:00.0`), breaking `dra.k8s.io/pcieRoot` on the DRA driver and crashing `gpu-feature-discovery` | the `pcieRoot` topology attribute; indirectly `gpu-operator-health` via ClusterPolicy | 1 check moves from fail to testable, plus the topology attribute | S | open |
+
+Two consumers, one symptom, all 8 devices. Evidence:
+[`results/pci-busid-evidence.log`](../../tests/aicr-sweep/results/pci-busid-evidence.log).
+
+This also bears on issue #265, which records `dra.k8s.io/pcieRoot` as unavailable and attributes it to
+Go's `os` package bypassing the `LD_PRELOAD` shim. The DRA driver log shows the failure happening
+earlier, at bus-ID string parsing, before any sysfs read. That diagnosis is at least incomplete, and
+the fix may be considerably smaller than the docs imply.
+
+## Not covered by this sweep, and not claimed
+
+- **Scale.** Three containers on one laptop. Nothing here speaks to node counts.
+- **Bring-up time saved.** Measuring it needs a real bring-up's failure history to back-test against.
+  That data was not available, so no number is given. Any time saving attributed to this work is
+  unsupported.
+- **11 of the 21 checks** were never dispatched in this run, including `secure-accelerator-access`,
+  which is the highest-value one still outstanding: it directly exercises the MEP-0002 device
+  isolation contract.
+- **`gb300`.** AICR's catalog has no gb300 accelerator, so there is nothing to run against Mokka's
+  gb300 profile. That is an AICR-side decision, not a Mokka gap.

--- a/docs/aicr-preflight/diagrams/README.md
+++ b/docs/aicr-preflight/diagrams/README.md
@@ -21,18 +21,22 @@ colour alone to carry meaning.
 
 `coverage-map` and `preflight-timeline` carry counts from a real run. **If the catalog changes, these
 must be regenerated.** The source of truth is
-[`tests/aicr-preflight/catalog.yaml`](../../../tests/aicr-preflight/catalog.yaml) and the generated
-[report](../../../tests/aicr-preflight/results/2026-07-25-gb200-kind/coverage.md).
+[`tests/aicr-sweep/catalog.yaml`](https://github.com/NVIDIA/k8s-test-infra/blob/main/tests/aicr-sweep/catalog.yaml), and the reports are generated
+from it by the harness in the same directory.
 
-Current values, from the 2026-07-25 run (provenance `sim`):
+Bucket split, from the catalog (21 checks):
 
-- 21 checks total: A 14, B 0, C 4, G 3
-- Today 66.7% (A / total), Mokka-specific 42.9% (9 / 21), reachable 81.0% ((A + G) / total)
-- Executed 9 of 21: 6 pass, 3 fail, 12 not run
-- Proxy back-test: 2 of 4 caught
+- A meaningful 16, B trivial 1, C hardware-dependent 4, G closable Mokka gap 0
+- **76% is the analytical ceiling** (A / total) if the full 14-component recipe stack deploys. It is
+  not a measured result, and the diagrams say so on their face.
+- **Measured on 2026-08-03: 14%**, three of 21 reaching a meaningful pass.
 
-Verify with:
+A second run against Mokka `57ef01659` on 2026-08-26 did not change the bucket split, because the
+catalog did not change. It moved the measured side: 53 of 210 check-results reached a verdict against
+13 in the first run. See `tests/aicr-sweep/FINDINGS-57ef016.md`.
+
+Verify the bucket counts with:
 
 ```bash
-grep -c 'bucket: A' ../../../tests/aicr-preflight/catalog.yaml
+grep -c 'bucket: A' tests/aicr-sweep/catalog.yaml
 ```

--- a/docs/aicr-preflight/diagrams/README.md
+++ b/docs/aicr-preflight/diagrams/README.md
@@ -1,0 +1,38 @@
+# Diagrams
+
+Each diagram exists twice: a `.mmd` mermaid source that renders inline on GitHub, and a committed
+`.svg` for reuse in email, slides, and docs. Mermaid does not render in mail clients, so use the SVG
+there.
+
+The SVGs are hand-authored. Text is real text, not paths, so it stays selectable and searchable. Each
+carries a `prefers-color-scheme: dark` block so it reads in both GitHub themes, and none relies on
+colour alone to carry meaning.
+
+| Diagram | What it is for |
+|---|---|
+| `stack-layering` | Kills the common misreading that simulation lives inside AICR. AICR is the workload, Mokka is the substrate. |
+| `vertical-vs-horizontal` | KWOK is node-count breadth, Mokka is GPU-stack depth. Orthogonal, and they compose. |
+| `preflight-timeline` | The customer value: where integration failures get found, with and without preflight. |
+| `coverage-map` | The A/B/C/G split with the final-gate boundary drawn. |
+| `break-matrix` | Where the base cell actually broke, and who owns each failure. Attribution, not the pass/fail split. |
+| `preflight-workflow` | The operational sequence, including how to triage a failing check. |
+
+## Keeping the numbers honest
+
+`coverage-map` and `preflight-timeline` carry counts from a real run. **If the catalog changes, these
+must be regenerated.** The source of truth is
+[`tests/aicr-preflight/catalog.yaml`](../../../tests/aicr-preflight/catalog.yaml) and the generated
+[report](../../../tests/aicr-preflight/results/2026-07-25-gb200-kind/coverage.md).
+
+Current values, from the 2026-07-25 run (provenance `sim`):
+
+- 21 checks total: A 14, B 0, C 4, G 3
+- Today 66.7% (A / total), Mokka-specific 42.9% (9 / 21), reachable 81.0% ((A + G) / total)
+- Executed 9 of 21: 6 pass, 3 fail, 12 not run
+- Proxy back-test: 2 of 4 caught
+
+Verify with:
+
+```bash
+grep -c 'bucket: A' ../../../tests/aicr-preflight/catalog.yaml
+```

--- a/docs/aicr-preflight/diagrams/break-matrix.mmd
+++ b/docs/aicr-preflight/diagrams/break-matrix.mmd
@@ -1,0 +1,14 @@
+%% Where it actually broke. Base cell, 2026-08-03. 9 of 21 checks dispatched.
+%% Attribution matters more than the pass/fail split: none of the 5 failures is a Mokka gap.
+flowchart TB
+    R["base-gb200-kind-inference-stack<br/>AICR dispatched 9 of 21 checks"]
+    R --> P["PASS: 3"]
+    R --> F["FAIL: 5"]
+    R --> I["INCONCLUSIVE: 1"]
+    R --> N["NOT DISPATCHED: 12"]
+    P --> P1["operator-health (A)<br/>check-nvidia-smi (A)<br/>accelerator-metrics (A)"]
+    F --> F1["gpu-operator-version<br/>cause: operator version violates<br/>the recipe's own >= v25.10.0 floor.<br/>The check WORKED."]
+    F --> F2["dra-support<br/>cause U: upstream altProcDevices unreleased"]
+    F --> F3["ai-service-metrics, platform-health<br/>cause: 2 of 14 recipe components deployed"]
+    F --> F4["gpu-operator-health<br/>cause K (provisional): GFD, no-toolkit config"]
+    I --> I1["expected-resources<br/>Job pod vanished; recorded not-run, never a pass"]

--- a/docs/aicr-preflight/diagrams/break-matrix.svg
+++ b/docs/aicr-preflight/diagrams/break-matrix.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" width="900" height="560" role="img" aria-label="Break matrix: AICR checks by outcome and attribution on the base sweep cell">
+  <title>Break matrix: where it actually broke, and whose problem each failure is</title>
+  <style>
+    .box{fill:none;stroke:#57606a;stroke-width:2}
+    .thick{fill:none;stroke:#57606a;stroke-width:4}
+    .dash{fill:none;stroke:#57606a;stroke-width:2;stroke-dasharray:7 4}
+    .t{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;fill:#57606a}
+    .hd{font-size:14px;font-weight:700}
+    .bd{font-size:12px}
+    .sm{font-size:10.5px;font-style:italic}
+    .mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11.5px;fill:#57606a}
+  </style>
+  <text class="t hd" x="16" y="24">Break matrix: base-gb200-kind-inference-stack, 2026-08-03</text>
+  <text class="t sm" x="16" y="42">AICR dispatched 9 of 21 checks. Outcome is the row; attribution is the column that matters.</text>
+
+  <text class="t hd" x="20" y="72">Check</text>
+  <text class="t hd" x="270" y="72">Bucket</text>
+  <text class="t hd" x="340" y="72">Outcome</text>
+  <text class="t hd" x="470" y="72">Attribution</text>
+  <line x1="16" y1="80" x2="884" y2="80" stroke="#57606a" stroke-width="2"/>
+
+  <text class="mono" x="20" y="102">operator-health</text><text class="t bd" x="270" y="102">A</text><text class="t hd" x="340" y="102">PASS</text><text class="t bd" x="470" y="102">real integration: operator reconciled on the mock</text>
+  <text class="mono" x="20" y="124">check-nvidia-smi</text><text class="t bd" x="270" y="124">A</text><text class="t hd" x="340" y="124">PASS</text><text class="t bd" x="470" y="124">real integration: alloc + inject + dlopen, end to end</text>
+  <text class="mono" x="20" y="146">accelerator-metrics</text><text class="t bd" x="270" y="146">A</text><text class="t hd" x="340" y="146">PASS</text><text class="t bd" x="470" y="146">real integration: dcgm-exporter on the mock NVML</text>
+  <line x1="16" y1="158" x2="884" y2="158" stroke="#57606a" stroke-width="1"/>
+
+  <text class="mono" x="20" y="182">gpu-operator-version</text><text class="t bd" x="270" y="182">A</text><text class="t hd" x="340" y="182">FAIL</text><text class="t bd" x="470" y="182">operator config. THE CHECK WORKED: caught v25.3.4</text>
+  <text class="t bd" x="470" y="198">against the recipe's own &gt;= v25.10.0 floor.</text>
+  <text class="mono" x="20" y="222">dra-support</text><text class="t bd" x="270" y="222">A</text><text class="t hd" x="340" y="222">FAIL</text><text class="t hd" x="470" y="222">cause U: upstream</text><text class="t bd" x="600" y="222">altProcDevices unreleased</text>
+  <text class="mono" x="20" y="246">ai-service-metrics</text><text class="t bd" x="270" y="246">A</text><text class="t hd" x="340" y="246">FAIL</text><text class="t bd" x="470" y="246">scope: 2 of 14 recipe components deployed</text>
+  <text class="mono" x="20" y="270">platform-health</text><text class="t bd" x="270" y="270">A</text><text class="t hd" x="340" y="270">FAIL</text><text class="t bd" x="470" y="270">scope: 9 recipe namespaces absent</text>
+  <text class="mono" x="20" y="294">gpu-operator-health</text><text class="t bd" x="270" y="294">A</text><text class="t hd" x="340" y="294">FAIL</text><text class="t hd" x="470" y="294">cause K (provisional)</text><text class="t bd" x="612" y="294">GFD, no-toolkit config</text>
+  <line x1="16" y1="306" x2="884" y2="306" stroke="#57606a" stroke-width="1"/>
+
+  <text class="mono" x="20" y="330">expected-resources</text><text class="t bd" x="270" y="330">A</text><text class="t bd" x="340" y="330">INCONCLUSIVE</text><text class="t bd" x="470" y="330">Job pod vanished. Recorded not-run, NEVER a pass.</text>
+  <line x1="16" y1="342" x2="884" y2="342" stroke="#57606a" stroke-width="1"/>
+
+  <text class="mono" x="20" y="366">12 further checks</text><text class="t bd" x="270" y="366">A/B/C</text><text class="t bd" x="340" y="366">NOT DISPATCHED</text><text class="t bd" x="470" y="366">AICR did not select them for this recipe + cluster</text>
+  <text class="t sm" x="20" y="384">includes secure-accelerator-access, the highest-value one outstanding (MEP-0002 device isolation)</text>
+
+  <rect class="thick" x="16" y="404" width="868" height="62" rx="6"/>
+  <text class="t hd" x="30" y="426">The line that matters</text>
+  <text class="t bd" x="30" y="448">NONE of the five failures is a Mokka capability gap. Two are this run's scope, one is the operator version</text>
+  <text class="t bd" x="30" y="464">the check correctly rejected, one is upstream (U), and one is provisionally the kind configuration (K).</text>
+
+  <text class="t sm" x="16" y="492">Buckets: A meaningful, B trivial, C hardware-dependent, G closable Mokka gap. Causes: K kind artifact,</text>
+  <text class="t sm" x="16" y="508">U upstream unreleased, X AICR catalog gap, BUDGET host memory. Bucket and cause are independent axes.</text>
+  <text class="t sm" x="16" y="532">Separate gap found outside the check outcomes: PCI bus ID loses its domain prefix (bucket G, size S).</text>
+  <text class="t sm" x="16" y="548">All evidence is sim provenance. Counts match tests/aicr-sweep/results/report.json exactly.</text>
+</svg>

--- a/docs/aicr-preflight/diagrams/coverage-map.mmd
+++ b/docs/aicr-preflight/diagrams/coverage-map.mmd
@@ -1,0 +1,13 @@
+%% AICR's 21 validator checks, split by bucket. Counts match tests/aicr-sweep/catalog.yaml.
+%% The final-gate boundary is drawn between what preflight can reach and what it cannot.
+flowchart TB
+    T["AICR validator suite: 21 checks"]
+    T --> A["A meaningful: 16<br/>(10 GPU-dependent, 6 run on any cluster)"]
+    T --> B["B trivial: 1<br/>pod-autoscaling"]
+    T --> C["C hardware-dependent: 4<br/>nccl-all-reduce-bw, -net, -nvls, inference-perf"]
+    T --> G["G closable Mokka gap: 0"]
+    A --> M["Reachable pre-silicon on Mokka"]
+    B --> M
+    G --> M
+    C --> S["FINAL GATE: requires real silicon"]
+    M -.->|"preflight ends here"| S

--- a/docs/aicr-preflight/diagrams/coverage-map.svg
+++ b/docs/aicr-preflight/diagrams/coverage-map.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 470" width="820" height="470" role="img" aria-label="Coverage map: AICR's 21 validator checks split by bucket, with the final-gate boundary">
+  <title>Coverage map: AICR's 21 validator checks split by bucket, with the final-gate boundary</title>
+  <style>
+    .box{fill:none;stroke:#57606a;stroke-width:2}
+    .dash{fill:none;stroke:#57606a;stroke-width:2;stroke-dasharray:7 4}
+    .thick{fill:none;stroke:#57606a;stroke-width:4}
+    .t{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;fill:#57606a}
+    .hd{font-size:14px;font-weight:700}
+    .bd{font-size:12px}
+    .sm{font-size:10.5px;font-style:italic}
+    .arw{stroke:#57606a;stroke-width:2;fill:none}
+  </style>
+  <defs><marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#57606a"/></marker></defs>
+  <text class="t hd" x="16" y="24">AICR validator suite: 21 checks, sized by real counts</text>
+
+  <!-- proportional bar: 21 units over 760px => ~36.2px per check -->
+  <rect class="box" x="16" y="40" width="580" height="46"/>
+  <text class="t hd" x="26" y="60">A meaningful</text><text class="t hd" x="26" y="78">16  (76%)</text>
+  <rect class="box" x="596" y="40" width="36" height="46"/>
+  <text class="t sm" x="600" y="62">B</text><text class="t sm" x="600" y="78">1</text>
+  <rect class="thick" x="632" y="40" width="145" height="46"/>
+  <text class="t hd" x="642" y="60">C hardware</text><text class="t hd" x="642" y="78">4  (19%)</text>
+  <rect class="dash" x="777" y="40" width="27" height="46"/>
+  <text class="t sm" x="781" y="62">G</text><text class="t sm" x="781" y="78">0</text>
+
+  <text class="t sm" x="16" y="104">Widths are proportional to the counts. C carries a thick border and G a dashed one, so the split reads without colour.</text>
+
+  <rect class="box" x="16" y="124" width="380" height="150" rx="6"/>
+  <text class="t hd" x="30" y="146">Reachable pre-silicon on Mokka</text>
+  <text class="t bd" x="30" y="170">A meaningful: 16</text>
+  <text class="t bd" x="30" y="188">   10 GPU-dependent (Mokka unlocks these)</text>
+  <text class="t bd" x="30" y="206">   6 run on any cluster (Mokka is not the reason)</text>
+  <text class="t bd" x="30" y="230">B trivial: 1  (pod-autoscaling)</text>
+  <text class="t bd" x="30" y="248">G closable Mokka gap: 0</text>
+  <text class="t sm" x="30" y="266">Measured this run: 9 dispatched, 3 passed.</text>
+
+  <rect class="thick" x="424" y="124" width="380" height="150" rx="6"/>
+  <text class="t hd" x="438" y="146">FINAL GATE: requires real silicon</text>
+  <text class="t bd" x="438" y="170">C hardware-dependent: 4</text>
+  <text class="t bd" x="438" y="192">   nccl-all-reduce-bw</text>
+  <text class="t bd" x="438" y="210">   nccl-all-reduce-bw-net</text>
+  <text class="t bd" x="438" y="228">   nccl-all-reduce-bw-nvls</text>
+  <text class="t bd" x="438" y="246">   inference-perf</text>
+  <text class="t sm" x="438" y="266">No simulation work moves these.</text>
+
+  <path class="arw" d="M 400 199 L 420 199" marker-end="url(#a)"/>
+  <text class="t sm" x="330" y="292">preflight ends here</text>
+
+  <rect class="box" x="16" y="298" width="788" height="70" rx="6"/>
+  <text class="t hd" x="30" y="320">The boundary that must not blur</text>
+  <text class="t bd" x="30" y="342">Mokka DOES simulate fabric MANAGEMENT: NVSwitch topology, fabricmanager, IB subnet manager, IMEX channels.</text>
+  <text class="t bd" x="30" y="358">Those can be bucket A. Collective THROUGHPUT (NCCL, NVLink, NVLS) and TTFT stay bucket C. Never blur the two.</text>
+
+  <text class="t sm" x="16" y="392">Counts from tests/aicr-sweep/catalog.yaml, derived from NVIDIA/aicr recipes/validators/catalog.yaml @0752ea14.</text>
+  <text class="t sm" x="16" y="410">76% is the analytical ceiling if the full 14-component recipe stack deploys. It is NOT a measured result.</text>
+  <text class="t sm" x="16" y="428">Measured on 2026-08-03: 14% (3 of 21 reached a meaningful pass). The gap is host memory, not Mokka.</text>
+  <text class="t sm" x="16" y="452">All evidence is sim provenance. None of it was run on silicon.</text>
+</svg>

--- a/docs/aicr-preflight/diagrams/preflight-timeline.mmd
+++ b/docs/aicr-preflight/diagrams/preflight-timeline.mmd
@@ -1,0 +1,21 @@
+%% The ~3-month procurement-to-silicon window.
+%% Numbers are from the 2026-08-03 sweep. No "day-one first token" is drawn:
+%% simulation does not prove it.
+flowchart LR
+    subgraph WITHOUT["WITHOUT preflight"]
+        direction TB
+        W1["Months 1-3: hardware in procurement.<br/>Engineers idle on integration."]
+        W2["Silicon lands"]
+        W3["Integration failures found HERE:<br/>operator install, resource advertisement,<br/>DRA, telemetry, version constraints"]
+        W4["Then: hardware-dependent validation<br/>(CUDA, NCCL, TTFT)"]
+        W1 --> W2 --> W3 --> W4
+    end
+    subgraph WITH["WITH preflight"]
+        direction TB
+        P1["Months 1-3: AICR runs unmodified<br/>on a Mokka fleet.<br/>16 of 21 checks are analytically<br/>capable of real signal."]
+        P2["Integration failures found and fixed HERE.<br/>Measured in this sweep: 3 real passes,<br/>1 real version-constraint catch."]
+        P3["Silicon lands"]
+        P4["Silicon time spent on the 4 checks<br/>that REQUIRE it:<br/>3x NCCL + inference-perf"]
+        P1 --> P2 --> P3 --> P4
+    end
+    WITHOUT -.-> WITH

--- a/docs/aicr-preflight/diagrams/preflight-timeline.svg
+++ b/docs/aicr-preflight/diagrams/preflight-timeline.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 420" width="860" height="420" role="img" aria-label="Preflight timeline: the procurement-to-silicon window with and without preflight">
+  <title>Preflight timeline: the procurement-to-silicon window with and without preflight</title>
+  <style>
+    .box{fill:none;stroke:#57606a;stroke-width:2}
+    .dash{fill:none;stroke:#57606a;stroke-width:2;stroke-dasharray:7 4}
+    .thick{fill:none;stroke:#57606a;stroke-width:4}
+    .t{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;fill:#57606a}
+    .hd{font-size:14px;font-weight:700}
+    .bd{font-size:12px}
+    .sm{font-size:10.5px;font-style:italic}
+    .arw{stroke:#57606a;stroke-width:2;fill:none}
+  </style>
+  <defs><marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#57606a"/></marker></defs>
+  <text class="t hd" x="16" y="24">The ~3 month procurement-to-silicon window</text>
+
+  <rect class="box" x="16" y="40" width="400" height="170" rx="6"/>
+  <text class="t hd" x="30" y="62">WITHOUT preflight</text>
+  <text class="t bd" x="30" y="86">Months 1-3: hardware in procurement.</text>
+  <text class="t bd" x="30" y="104">Engineers idle on integration.</text>
+  <text class="t bd" x="30" y="130">Silicon lands.</text>
+  <text class="t bd" x="30" y="154">Integration failures found HERE: operator install,</text>
+  <text class="t bd" x="30" y="170">resource advertisement, DRA, telemetry, versions.</text>
+  <text class="t bd" x="30" y="194">Then the hardware-dependent validation begins.</text>
+
+  <rect class="dash" x="444" y="40" width="400" height="170" rx="6"/>
+  <text class="t hd" x="458" y="62">WITH preflight  [dashed border]</text>
+  <text class="t bd" x="458" y="86">Months 1-3: AICR runs UNMODIFIED on a Mokka fleet.</text>
+  <text class="t bd" x="458" y="104">16 of 21 checks are analytically capable of real signal.</text>
+  <text class="t bd" x="458" y="128">Integration failures found and fixed HERE.</text>
+  <text class="t bd" x="458" y="144">Measured in this sweep: 3 real passes, and 1 genuine</text>
+  <text class="t bd" x="458" y="160">catch of a version-constraint violation.</text>
+  <text class="t bd" x="458" y="184">Silicon lands. Hardware time goes to the 4 checks that</text>
+  <text class="t bd" x="458" y="200">REQUIRE it: 3x NCCL plus inference-perf.</text>
+
+  <path class="arw" d="M 420 125 L 440 125" marker-end="url(#a)"/>
+
+  <rect class="box" x="16" y="232" width="828" height="76" rx="6"/>
+  <text class="t hd" x="30" y="254">What this diagram deliberately does NOT show</text>
+  <text class="t bd" x="30" y="276">No "day-one first token". Simulation does not prove it: the path that determines first token</text>
+  <text class="t bd" x="30" y="292">(CUDA execution, NCCL data plane, TTFT) is exactly the path preflight cannot exercise.</text>
+
+  <text class="t sm" x="16" y="332">Measured 2026-08-03. AICR dispatched 9 of 21 checks on this cluster; 3 passed. The distance to the 16-check</text>
+  <text class="t sm" x="16" y="348">ceiling is host memory (7.75 GiB held 2 of 14 recipe components), not a Mokka limitation.</text>
+  <text class="t sm" x="16" y="372">No bring-up-time saving is drawn or claimed: that needs a real bring-up failure history to back-test against,</text>
+  <text class="t sm" x="16" y="388">and that data was not available. AICR-on-silicon remains the final readiness gate.</text>
+</svg>

--- a/docs/aicr-preflight/diagrams/preflight-workflow.mmd
+++ b/docs/aicr-preflight/diagrams/preflight-workflow.mmd
@@ -1,0 +1,22 @@
+%% The operational sequence. Note the triage step: a failing check is not
+%% automatically a simulation limit.
+flowchart TB
+  S1["1. Stand up cluster<br/>real CPU nodes, containerd CDI enabled"]
+  S2["2. Install Mokka (nvml-mock)<br/>gb200 profile, driver overlay + device nodes + CDI spec"]
+  S3["3. Install GPU stack<br/>GPU Operator (driver.enabled=false) + DRA driver"]
+  S4["4. Generate recipe<br/>aicr recipe --service kind --accelerator gb200"]
+  S5["5. Run AICR<br/>aicr validate --phase deployment --phase conformance<br/>--fail-on-error=false"]
+  S6["6. Classify<br/>go run ./tests/aicr-preflight -ctrf ctrf<br/>emits provenance-labelled JSON + catalog table"]
+
+  S1 --> S2 --> S3 --> S4 --> S5 --> S6 --> T{"7. Triage each failure"}
+
+  T -->|"missing prerequisite<br/>component"| R1["harness scoping.<br/>Deploy it, re-run."]
+  T -->|"version or contract<br/>skew"| R2["REAL FINDING.<br/>Fix pre-silicon.<br/>This is the value."]
+  T -->|"Mokka capability<br/>missing"| R3["bucket G.<br/>File a tracked issue.<br/>Close if small."]
+
+  R1 --> S5
+  R2 --> FIX["8. Fix integration issues<br/>months before hardware lands"]
+  R3 --> FIX
+
+  FIX --> SIL["9. Silicon arrives"]
+  SIL --> GATE["10. AICR on real hardware<br/><b>FINAL READINESS GATE</b><br/>CUDA · firmware/driver · NCCL/NVLink/NVLS · TTFT"]

--- a/docs/aicr-preflight/diagrams/preflight-workflow.svg
+++ b/docs/aicr-preflight/diagrams/preflight-workflow.svg
@@ -1,0 +1,109 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 470" width="760" height="470" role="img" aria-label="Operational workflow: stand up cluster, install Mokka, install GPU stack, generate recipe, run AICR, classify, triage failures into three causes, fix integration issues pre-silicon, then AICR on real hardware as the final gate.">
+  <title>Preflight workflow: from cluster bring-up to the final gate</title>
+  <style>
+    .t   { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .hd  { font-size: 15px; font-weight: 600; fill: #1f2328; }
+    .lb  { font-size: 12px; fill: #1f2328; }
+    .sm  { font-size: 10.5px; fill: #1f2328; }
+    .cap { font-size: 10.5px; fill: #57606a; }
+    .box { fill: #ffffff; stroke: #57606a; stroke-width: 1.5; }
+    .tri { fill: #f6f8fa; stroke: #57606a; stroke-width: 2; }
+    .good{ fill: #dafbe1; stroke: #1a7f37; stroke-width: 2.5; }
+    .goodtx { fill: #0f5323; }
+    .gap { fill: #fff8e6; stroke: #9a6700; stroke-width: 2; }
+    .gaptx { fill: #7d4e00; }
+    .gate{ fill: #ddf4ff; stroke: #0969da; stroke-width: 2.5; }
+    .gatetx { fill: #0a3069; }
+    .arw { stroke: #57606a; stroke-width: 1.5; fill: none; }
+    @media (prefers-color-scheme: dark) {
+      .hd, .lb, .sm { fill: #e6edf3; }
+      .cap { fill: #9198a1; }
+      .box { fill: #161b22; stroke: #8b949e; }
+      .tri { fill: #21262d; stroke: #8b949e; }
+      .good{ fill: #12261a; stroke: #3fb950; } .goodtx { fill: #7ee787; }
+      .gap { fill: #2b2411; stroke: #d29922; } .gaptx { fill: #e3b341; }
+      .gate{ fill: #121d2f; stroke: #58a6ff; } .gatetx { fill: #79c0ff; }
+      .arw { stroke: #8b949e; }
+    }
+  </style>
+  <g class="t">
+    <text x="16" y="22" class="hd">Preflight workflow</text>
+
+    <rect x="16" y="38" width="200" height="40" rx="5" class="box"/>
+    <text x="26" y="56" class="sm" font-weight="600">1. Stand up cluster</text>
+    <text x="26" y="71" class="cap">real CPU nodes, containerd CDI</text>
+
+    <rect x="16" y="88" width="200" height="42" rx="5" class="box"/>
+    <text x="26" y="106" class="sm" font-weight="600">2. Install Mokka (gb200)</text>
+    <text x="26" y="121" class="cap">driver overlay, device nodes, CDI</text>
+
+    <rect x="16" y="140" width="200" height="42" rx="5" class="box"/>
+    <text x="26" y="158" class="sm" font-weight="600">3. Install GPU stack</text>
+    <text x="26" y="173" class="cap">GPU Operator + DRA driver</text>
+
+    <rect x="16" y="192" width="200" height="40" rx="5" class="box"/>
+    <text x="26" y="210" class="sm" font-weight="600">4. Generate recipe</text>
+    <text x="26" y="225" class="cap">aicr recipe --accelerator gb200</text>
+
+    <rect x="16" y="242" width="200" height="42" rx="5" class="box"/>
+    <text x="26" y="260" class="sm" font-weight="600">5. Run aicr validate</text>
+    <text x="26" y="275" class="cap">--fail-on-error=false</text>
+
+    <rect x="16" y="294" width="200" height="42" rx="5" class="box"/>
+    <text x="26" y="312" class="sm" font-weight="600">6. Classify</text>
+    <text x="26" y="327" class="cap">provenance-labelled JSON + table</text>
+
+    <rect x="16" y="346" width="200" height="34" rx="5" class="tri"/>
+    <text x="26" y="368" class="sm" font-weight="600">7. Triage each failure</text>
+
+    <path d="M116 78 L116 88"   class="arw" marker-end="url(#w)"/>
+    <path d="M116 130 L116 140" class="arw" marker-end="url(#w)"/>
+    <path d="M116 182 L116 192" class="arw" marker-end="url(#w)"/>
+    <path d="M116 232 L116 242" class="arw" marker-end="url(#w)"/>
+    <path d="M116 284 L116 294" class="arw" marker-end="url(#w)"/>
+    <path d="M116 336 L116 346" class="arw" marker-end="url(#w)"/>
+
+    <path d="M216 363 L252 363" class="arw" marker-end="url(#w)"/>
+
+    <rect x="256" y="228" width="228" height="46" rx="5" class="box"/>
+    <text x="266" y="246" class="sm" font-weight="600">missing prerequisite component</text>
+    <text x="266" y="263" class="cap">harness scoping. Deploy it and re-run.</text>
+
+    <rect x="256" y="286" width="228" height="60" rx="5" class="good"/>
+    <text x="266" y="305" class="sm goodtx" font-weight="600">version or contract skew</text>
+    <text x="266" y="322" class="cap goodtx">REAL FINDING. Fix pre-silicon.</text>
+    <text x="266" y="337" class="cap goodtx">This is the value of preflight.</text>
+
+    <rect x="256" y="358" width="228" height="60" rx="5" class="gap"/>
+    <text x="266" y="377" class="sm gaptx" font-weight="600">Mokka capability missing</text>
+    <text x="266" y="394" class="cap gaptx">bucket G. File a tracked issue.</text>
+    <text x="266" y="409" class="cap gaptx">Close it if small.</text>
+
+    <path d="M252 360 L256 274" class="arw" marker-end="url(#w)"/>
+    <path d="M252 363 L256 316" class="arw" marker-end="url(#w)"/>
+    <path d="M252 366 L256 388" class="arw" marker-end="url(#w)"/>
+
+    <rect x="516" y="286" width="230" height="52" rx="5" class="box"/>
+    <text x="526" y="306" class="sm" font-weight="600">8. Fix integration issues</text>
+    <text x="526" y="323" class="cap">months before hardware lands</text>
+
+    <path d="M484 316 L516 314" class="arw" marker-end="url(#w)"/>
+    <path d="M484 388 L516 330" class="arw" marker-end="url(#w)"/>
+
+    <rect x="516" y="222" width="230" height="34" rx="5" class="box"/>
+    <text x="526" y="244" class="sm" font-weight="600">9. Silicon arrives</text>
+    <path d="M631 286 L631 256" class="arw" marker-end="url(#w)"/>
+
+    <rect x="516" y="110" width="230" height="94" rx="5" class="gate"/>
+    <text x="526" y="132" class="lb gatetx" font-weight="600">10. AICR on real hardware</text>
+    <text x="526" y="151" class="sm gatetx" font-weight="600">FINAL READINESS GATE</text>
+    <text x="526" y="170" class="cap gatetx">CUDA · firmware and driver</text>
+    <text x="526" y="186" class="cap gatetx">NCCL / NVLink / NVLS · TTFT</text>
+    <path d="M631 222 L631 204" class="arw" marker-end="url(#w)"/>
+  </g>
+  <defs>
+    <marker id="w" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#57606a"/>
+    </marker>
+  </defs>
+</svg>

--- a/docs/aicr-preflight/diagrams/stack-layering.mmd
+++ b/docs/aicr-preflight/diagrams/stack-layering.mmd
@@ -1,0 +1,26 @@
+%% AICR is the workload. Mokka is the substrate underneath it.
+%% This diagram exists to kill the misreading that simulation lives "inside" AICR.
+flowchart TB
+    subgraph L5["AICR: the workload on top"]
+        R["Recipes (14 components)"]
+        V["validate: deployment, performance, conformance"]
+    end
+    subgraph L4["Cluster software AICR deploys and checks"]
+        OP["GPU Operator"]
+        DRA["NVIDIA DRA driver"]
+        NFD["NFD + GFD"]
+        DCGM["dcgm-exporter"]
+    end
+    subgraph L3["Kubernetes"]
+        KUBELET["kubelet + containerd (NRI enabled)"]
+    end
+    subgraph L2["Mokka: the substrate (nvml-mock v0.3.0)"]
+        NRI["NRI plugin: node-wide injection"]
+        NVML["mock libnvidia-ml.so.1 at the NVML/driver line"]
+        FAB["mock fabric management: NVSwitch, fabricmanager, IB SM, IMEX channels"]
+    end
+    subgraph L1["Real nodes, no GPU"]
+        NODE["CPU nodes (here: kind containers)"]
+    end
+    L5 --> L4 --> L3 --> L2 --> L1
+    NVML -. "answers every NVML call the layers above make" .-> L4

--- a/docs/aicr-preflight/diagrams/stack-layering.svg
+++ b/docs/aicr-preflight/diagrams/stack-layering.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 520" width="760" height="520" role="img" aria-label="Stack layering: AICR runs as the workload on top of a Mokka substrate">
+  <title>Stack layering: AICR is the workload, Mokka is the substrate</title>
+  <desc>Five layers bottom to top: real CPU nodes; Mokka nvml-mock v0.3.0 providing the NRI plugin, mock libnvidia-ml.so.1 and mock fabric management; Kubernetes kubelet and containerd with NRI enabled; cluster software comprising GPU Operator, NVIDIA DRA driver, NFD with GFD and dcgm-exporter; and AICR recipes and validate phases on top.</desc>
+  <style>
+    .box  { fill: none; stroke: #57606a; stroke-width: 2; }
+    .mok  { fill: none; stroke: #57606a; stroke-width: 3; stroke-dasharray: 8 4; }
+    .t    { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; fill: #57606a; }
+    .hd   { font-size: 15px; font-weight: 700; }
+    .bd   { font-size: 12.5px; }
+    .sm   { font-size: 11.5px; font-style: italic; }
+    .arw  { stroke: #57606a; stroke-width: 2; fill: none; }
+  </style>
+  <defs>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#57606a"/>
+    </marker>
+  </defs>
+
+  <!-- L5 AICR -->
+  <rect class="box" x="20" y="16" width="720" height="76" rx="6"/>
+  <text class="t hd" x="34" y="38">AICR: the workload on top</text>
+  <text class="t bd" x="34" y="60">Recipes (14 components for kind + gb200 + inference)</text>
+  <text class="t bd" x="34" y="80">validate: deployment · performance · conformance  (21 checks)</text>
+
+  <!-- L4 cluster software -->
+  <rect class="box" x="20" y="112" width="720" height="80" rx="6"/>
+  <text class="t hd" x="34" y="134">Cluster software AICR deploys and checks</text>
+  <text class="t bd" x="34" y="156">GPU Operator · NVIDIA DRA driver · NFD + GFD · dcgm-exporter</text>
+  <text class="t sm" x="34" y="177">these are the real components, unmodified</text>
+
+  <!-- L3 kubernetes -->
+  <rect class="box" x="20" y="212" width="720" height="58" rx="6"/>
+  <text class="t hd" x="34" y="234">Kubernetes</text>
+  <text class="t bd" x="34" y="256">kubelet + containerd, NRI enabled</text>
+
+  <!-- L2 Mokka -->
+  <rect class="mok" x="20" y="290" width="720" height="112" rx="6"/>
+  <text class="t hd" x="34" y="313">Mokka: the substrate (nvml-mock v0.3.0)  [dashed border]</text>
+  <text class="t bd" x="34" y="335">NRI plugin: node-wide injection, no pod-spec change</text>
+  <text class="t bd" x="34" y="355">mock libnvidia-ml.so.1, intercepting at the NVML / driver line</text>
+  <text class="t bd" x="34" y="375">mock fabric management: NVSwitch topology, fabricmanager, IB subnet manager, IMEX channels</text>
+  <text class="t sm" x="34" y="394">simulates fabric MANAGEMENT, not the collective data plane</text>
+
+  <!-- L1 nodes -->
+  <rect class="box" x="20" y="422" width="720" height="58" rx="6"/>
+  <text class="t hd" x="34" y="444">Real nodes, no GPU present</text>
+  <text class="t bd" x="34" y="466">CPU nodes. In this sweep: kind containers on one host.</text>
+
+  <!-- direction arrow: AICR runs ON Mokka -->
+  <path class="arw" d="M 752 54 L 752 451" marker-end="url(#a)" transform="translate(-4,0)"/>
+  <text class="t sm" x="700" y="255" transform="rotate(90 700 255)">runs on</text>
+
+  <text class="t sm" x="20" y="502">Direction matters: AICR is the workload, Mokka is the substrate. Simulation does not live inside AICR.</text>
+</svg>

--- a/docs/aicr-preflight/diagrams/vertical-vs-horizontal.mmd
+++ b/docs/aicr-preflight/diagrams/vertical-vs-horizontal.mmd
@@ -1,0 +1,15 @@
+%% KWOK and Mokka are orthogonal axes, not competitors. They compose.
+flowchart LR
+    subgraph H["KWOK: horizontal (node-count breadth)"]
+        H1["Hollow nodes, no kubelet"]
+        H2["Very cheap per node"]
+        H3["Good for: scheduler, API server, etcd at scale"]
+        H4["Blind spot: no GPU stack exists,<br/>so AICR has nothing to validate"]
+    end
+    subgraph V["Mokka: vertical (GPU-stack depth per node)"]
+        V1["Real kubelet + containerd on real CPU nodes"]
+        V2["GPU faked at the NVML/driver line"]
+        V3["Good for: operator + DRA install, resource<br/>advertisement, scheduling, telemetry"]
+        V4["Blind spot: not the cheapest way to push node count"]
+    end
+    H -. "compose: KWOK nodes for breadth,<br/>Mokka nodes for depth" .- V

--- a/docs/aicr-preflight/diagrams/vertical-vs-horizontal.svg
+++ b/docs/aicr-preflight/diagrams/vertical-vs-horizontal.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 340" width="820" height="340" role="img" aria-label="Vertical versus horizontal: Mokka and KWOK are orthogonal and compose">
+  <title>Mokka is vertical, KWOK is horizontal. Orthogonal axes, so they compose.</title>
+  <style>
+    .box{fill:none;stroke:#57606a;stroke-width:2}
+    .dash{fill:none;stroke:#57606a;stroke-width:2;stroke-dasharray:7 4}
+    .t{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;fill:#57606a}
+    .hd{font-size:14px;font-weight:700}
+    .bd{font-size:12px}
+    .sm{font-size:10.5px;font-style:italic}
+    .arw{stroke:#57606a;stroke-width:2;fill:none}
+  </style>
+  <defs><marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#57606a"/></marker></defs>
+  <path class="arw" d="M 60 250 L 470 250" marker-end="url(#a)"/>
+  <text class="t bd" x="180" y="272">horizontal: node-count breadth</text>
+  <path class="arw" d="M 60 250 L 60 40" marker-end="url(#a)"/>
+  <text class="t bd" x="16" y="150" transform="rotate(-90 16 150)">vertical: GPU-stack depth</text>
+
+  <rect class="box" x="80" y="196" width="380" height="46" rx="6"/>
+  <text class="t hd" x="92" y="216">KWOK (horizontal)</text>
+  <text class="t sm" x="92" y="234">hollow nodes, no kubelet, very cheap per node</text>
+
+  <rect class="dash" x="500" y="40" width="300" height="202" rx="6"/>
+  <text class="t hd" x="514" y="62">Mokka (vertical)  [dashed]</text>
+  <text class="t bd" x="514" y="86">real kubelet + containerd on real CPU nodes</text>
+  <text class="t bd" x="514" y="106">GPU faked at the NVML / driver line</text>
+  <text class="t bd" x="514" y="130">runs for real: GPU Operator, device plugin,</text>
+  <text class="t bd" x="514" y="146">DRA driver, NFD + GFD, dcgm-exporter</text>
+  <text class="t sm" x="514" y="172">blind spot: not the cheapest way to add nodes</text>
+  <text class="t bd" x="514" y="198">Good for: the layer AICR's 21 checks read</text>
+  <text class="t sm" x="514" y="220">KWOK blind spot: no GPU stack exists, so AICR</text>
+  <text class="t sm" x="514" y="234">has nothing to validate</text>
+
+  <text class="t hd" x="80" y="300">They compose. They do not compete.</text>
+  <text class="t sm" x="80" y="320">AICR ships a KWOK lane covering 90 recipes, but `aicr validate` cannot run under KWOK: every validator is a Job needing a real pod.</text>
+</svg>

--- a/docs/aicr-preflight/how-it-works.md
+++ b/docs/aicr-preflight/how-it-works.md
@@ -1,0 +1,134 @@
+# How the preflight works
+
+The mechanism, in the order things come up. Every command here is one this sweep actually ran; the
+harness that ran them is [`tests/aicr-sweep/`](../../tests/aicr-sweep/).
+
+## Where the mock intercepts
+
+Mokka replaces `libnvidia-ml.so.1`, the NVML library, on the node. Everything above that line is the
+real software:
+
+```text
+real:   GPU Operator · device plugin · GFD · dcgm-exporter · DRA driver · AICR validators
+        ---------------------------------------------------------------- NVML / driver line
+mock:   libnvidia-ml.so.1 · nvidia-smi · fabricmanager · ibstat/ibnetdiscover · IMEX channels
+        ---------------------------------------------------------------- 
+real:   kubelet · containerd · CPU node
+```
+
+A consumer calls `nvmlDeviceGetCount`, `nvmlDeviceGetPciInfo`, `nvmlDeviceGetFieldValues` and so on,
+and the mock answers from a YAML profile (`gb200`, `gb300`, `h100`, `b200`, `a100`, `l40s`, `t4`). The
+consumer cannot tell, because the C ABI is the same: v0.3.0 exports 417 NVML entry points, 135
+hand-written and engine-backed, 282 stubs returning `NOT_SUPPORTED` so an `RTLD_NOW` `dlopen`
+resolves.
+
+## Bring-up order
+
+1. **Cluster.** kind with containerd NRI enabled. On kind 0.32.0's node image (containerd 2.2.0+) NRI
+   is on by default; the config patch is kept because it is load-bearing on containerd 1.7.x.
+2. **Mokka.** The chart installs a DaemonSet that stages the mock driver root under
+   `/var/lib/nvml-mock`, plus an NRI plugin DaemonSet that registers with containerd.
+3. **Injection.** The NRI plugin subscribes to `CreateContainer`. For every container not excluded, it
+   bind-mounts the overlay at `/opt/nvml-mock`, prepends `PATH` and `LD_LIBRARY_PATH`, and sets the
+   `MOCK_*` environment. Device nodes are added only for containers that opt in.
+4. **GPU stack.** The real GPU Operator installs with `driver.enabled=false` and `toolkit.enabled=false`,
+   pointed at `NVIDIA_DRIVER_ROOT=/var/lib/nvml-mock/driver`. The device plugin, GFD and dcgm-exporter
+   load the mock NVML like any other consumer.
+5. **DRA.** The NVIDIA DRA driver's kubelet plugin enumerates through the mock and publishes
+   ResourceSlices.
+6. **AICR.** `aicr recipe` resolves criteria to a component list; `aicr validate` launches one
+   containerized Job per selected check and merges the results into a CTRF report.
+
+## What node-wide injection means in practice
+
+This is the part that surprises people. A pod with no GPU request, no volumes and no runtime class:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata: {name: probe}
+spec:
+  containers:
+    - name: probe
+      image: debian:bookworm-slim
+      command: ["sh","-c","sleep 300"]
+```
+
+```console
+$ kubectl exec probe -- nvidia-smi -L
+GPU 0: NVIDIA GB200 (UUID: GPU-b200b200-0000-0000-0000-000000000000)
+...
+GPU 7: NVIDIA GB200 (UUID: GPU-b200b200-0000-0000-0000-000000000007)
+$ kubectl get pod probe -o jsonpath='{.spec.containers[0].resources}'
+{}
+```
+
+No pod-spec change. That is what makes AICR run *unmodified*: nothing in the recipe or the checks has
+to know it is on a simulated fleet.
+
+When the device plugin also serves a node, MEP-0002 governs the composition: the resource request
+wins, and the NRI plugin suppresses its own device injection for any container that already carries
+`/dev/nvidia*` nodes or an `nvidia.com/` CDI device. Exactly one component serves a given container.
+
+## How AICR executes against it
+
+```bash
+aicr recipe --service kind --accelerator gb200 --intent inference -o recipe.yaml
+```
+
+resolves to a 14-component recipe over 5 overlays. Then:
+
+```bash
+aicr validate --recipe recipe.yaml --phase deployment --phase conformance --phase performance --fail-on-error=false --output ctrf/validate.json
+```
+
+Two things matter here. `--fail-on-error=false`, because the point is to record every outcome rather
+than stop at the first failure. And **read the CTRF report, never the exit code**: the exit code
+collapses 21 checks into one number.
+
+AICR selects which checks apply. In this sweep it dispatched 9 of 21: the performance phase selected
+0, and several conformance checks skipped because the recipe components they target were not
+deployed. A check that is never dispatched is recorded `not dispatched`, never as a pass.
+
+## How to read A/B/C/G, and K/U/X
+
+Two independent axes. Keeping them apart is what makes the result trustworthy.
+
+**Bucket** says what a check would prove. It is judged from AICR source before any run, and never
+edited to match a result.
+
+| | |
+|---|---|
+| **A** | Exercises real integration. Could plausibly fail for a real reason. This is the movable-left set. |
+| **B** | Green only because the mock answers the API. Would pass regardless of correctness. Not a win. |
+| **C** | Hardware-dependent. Cannot be judged pre-silicon. These are why the final gate stays on silicon. |
+| **G** | Would be meaningful pre-silicon, but Mokka lacks the capability. Closable, so it is roadmap. |
+
+**Cause** says what stopped a particular run.
+
+| | |
+|---|---|
+| **K** | kind or single-host artifact. Would not happen on a real cluster. **Not** a Mokka finding. |
+| **U** | An upstream dependency has not released what is needed. **Not** a Mokka gap. |
+| **X** | AICR has no recipe for the combination. **Not** a Mokka gap. |
+| **BUDGET** | The host ran out of memory; the cell was not attempted. |
+
+The rule for telling **G** from **K**, fixed before any cell ran so it cannot be bent to fit a number:
+
+> **Did Mokka promise to render this path or speak this protocol?**
+> If the failing read targets something Mokka stages (`/var/lib/nvml-mock/**`, `MOCK_IB_ROOT`, an
+> injected `/dev/nvidia*`, the topology ConfigMap) or a protocol Mokka speaks for real (IMEX gRPC, the
+> mock-ib TCP relay, an NVML or DCGM call), it is **G**.
+> If it targets real host kernel state Mokka never claimed (NUMA nodes, the real PCI tree, the NVLink
+> data plane, RDMA verbs), it is **K**.
+
+Worked examples from the sweep:
+
+- The DRA controller crashing on `/proc/devices` is **U**: Mokka renders the substitute, but the DRA
+  driver needs an `altProcDevices` flag that is on main and in no release.
+- `gb300` is **X**: AICR's catalog has no such accelerator, so there is nothing to run.
+- GFD crashing is **K**, provisionally: the repo's own CDI-path e2e asserts GFD labels and passes, so
+  the difference is this sweep's no-toolkit configuration. Marked "not distinguished" rather than
+  guessed, because the controlled cell did not fit the memory budget.
+- The PCI bus ID arriving without its domain prefix is **G**: Mokka renders the tree correctly, so the
+  malformed string is Mokka's to fix.

--- a/tests/aicr-sweep/CHECK-CATALOG.md
+++ b/tests/aicr-sweep/CHECK-CATALOG.md
@@ -1,0 +1,84 @@
+# Artifact 1: AICR check-coverage catalog under Mokka
+
+**Purpose:** the core deliverable. For every AICR validation and conformance check, classify what it
+actually proves when run on a Mokka-enabled cluster with no silicon. Mark's bar: separate checks that
+exercise **real integration** from checks that **pass trivially against mocked APIs**. A check in
+bucket B is not a win; recording it honestly as B is what makes the catalog credible.
+
+**Status:** filled from a real run on 2026-08-03. `Result` columns come only from that run; nothing is
+inferred. **Every row is `sim` provenance.** Source of the check list: `NVIDIA/aicr`
+`recipes/validators/catalog.yaml` at `upstream/main` `0752ea14` (21 checks: 4 deployment,
+4 performance, 13 conformance).
+
+The machine-readable form of the bucket column, with a file:line citation for every rationale, is
+[`catalog.yaml`](catalog.yaml). This page is the human view.
+
+## Buckets
+
+| Bucket | Meaning | Counts as POC value? |
+|---|---|---|
+| **A meaningful under Mokka** | Exercises real integration logic: GPU Operator or DRA install, NVML-facing components, resource advertisement, scheduling, control-plane behavior. Could plausibly fail for a real reason. | **Yes**, this is the movable-left set |
+| **B passes trivially against mock** | Green only because the mock answers the API; no real integration exercised. Would pass regardless of correctness. | **No**, record honestly, it bounds the claim |
+| **C hardware-dependent, N/A in sim** | Cannot be judged pre-silicon: CUDA execution, firmware and driver compat, NCCL / NVLink / NVLS, fabric data plane, TTFT / throughput. | **No**, these define why AICR-on-silicon stays the final gate |
+| **G gap: blocked by a missing Mokka capability** | Could be meaningful pre-silicon, but Mokka does not simulate the needed surface yet. **Not** hardware-dependent, so it is closable. | **Yes, as roadmap**: file an issue, size it |
+
+**Result vocabulary.** `pass` / `fail` mean the suite reached that verdict. `not dispatched` means
+AICR did not select the check for this recipe and cluster, so it never ran; it is never counted as a
+pass. `inconclusive` means the suite reached no verdict (CTRF `other`).
+
+## Catalog
+
+| # | AICR check | Area | Bucket | Result under Mokka | Evidence provenance | Why this bucket | Gap issue | Would it catch a real bring-up failure? |
+|---|---|---|---|---|---|---|---|---|
+| 1 | `operator-health` | operator-install | **A** | **pass** | sim | Reconciles the real GPU Operator against the mock driver surface and requires its pods healthy. This sweep saw it fail for a real reason first (operands demanded a runtime class the node lacked) and pass after the fix. | n/a | **Yes.** A broken operand or unschedulable DaemonSet fails it. |
+| 2 | `expected-resources` | control-plane | **A** | inconclusive | sim | Verifies every recipe componentRef and fans out to 37 in-process chainsaw health checks, one of which gates on `ClusterPolicy status.state == ready`. | n/a | **Yes.** Missing prerequisites and stuck operands fail it. |
+| 3 | `gpu-operator-version` | operator-install | **A** | **fail** | sim | Evaluates the deployed operator version against the recipe constraint. Failed correctly here: `v25.3.4 does not satisfy ">= v25.10.0"`. GPU-independent: it reads a Helm release, so any cluster runs it. | n/a | **Yes, and it did.** This is a version-skew catch, pre-silicon. |
+| 4 | `check-nvidia-smi` | nvml-surface | **A** | **pass** | sim | The strongest case in the suite. Schedules a CUDA base-image pod per GPU node and requires the NVIDIA-SMI banner, a driver version, a CUDA version and a success marker, exercising device-plugin allocation, device injection and `dlopen` of `libnvidia-ml.so.1`. | n/a | **Yes.** This is the classic "driver stack does not come up" failure. |
+| 5 | `nccl-all-reduce-bw` | nccl-nvlink-fabric | **C** | not dispatched | n/a | Measures collective bus bandwidth. Mokka simulates fabric management, not the data plane; NVLink counters accrue from a clock epoch, not traffic. | n/a | No. Needs silicon. |
+| 6 | `nccl-all-reduce-bw-net` | nccl-nvlink-fabric | **C** | not dispatched | n/a | As above, plus asserts the NET transport carried traffic. Needs EFA or RoCE. | n/a | No. Needs silicon. |
+| 7 | `nccl-all-reduce-bw-nvls` | nccl-nvlink-fabric | **C** | not dispatched | n/a | As above, plus asserts NVLS multicast availability across an NVL72 IMEX domain. Mokka renders IMEX channels but runs no collectives. | n/a | No. Needs silicon. |
+| 8 | `inference-perf` | ttft-throughput | **C** | not dispatched | n/a | Runs AIPerf and asserts throughput and p99 TTFT. The mock executes no CUDA kernel, so there is no inference to measure. This check is the literal definition of what simulation cannot prove. | n/a | No. Needs silicon. This is why the claim is "reduce" and never "hit first token on day one". |
+| 9 | `dra-support` | dra | **A** | **fail** | sim | Requires a served `resource.k8s.io`, an available DRA controller Deployment, a ready kubelet plugin, a validated `*.nvidia.com` ResourceSlice, and a behavioural ResourceClaim pod. Mokka drove the ResourceSlice half correctly (16 devices across 2 slices). Failed on the controller, which needs ComputeDomains, which needs an unreleased upstream flag: **cause U, not a Mokka gap**. | n/a (upstream) | **Yes.** A driver that cannot enumerate devices fails it. |
+| 10 | `gang-scheduling` | scheduling | **A** | not dispatched | n/a | Real KAI scheduling integration, but the validator uses CPU-only workers by design and asserts zero resourceClaims. Any cluster runs it, so Mokka is not what unlocks it. | n/a | Yes, but not a GPU-stack failure. |
+| 11 | `accelerator-metrics` | telemetry | **A** | **pass** | sim | Real dcgm-exporter scraped `DCGM_FI_DEV_GPU_UTIL`, `FB_USED`, `GPU_TEMP` and `POWER_USAGE` off the mock NVML. The whole exporter path is exercised. It asserts presence, not magnitude, which is why it is A and not B; the values themselves are clock-driven. | n/a | **Yes.** A telemetry path that does not come up fails it. |
+| 12 | `ai-service-metrics` | telemetry | **A** | **fail** | sim | Requires a DCGM series in Prometheus and a reachable custom-metrics API. Failed here because Prometheus is 1 of the 14 recipe components and this run deployed 2: **scope, not a Mokka gap**. | n/a | **Yes.** Broken scrape or adapter registration fails it. |
+| 13 | `inference-gateway` | control-plane | **A** | not dispatched | n/a | GatewayClass Accepted, Gateway Programmed, CRDs present, proxy endpoints Ready. Real reconciliation, no GPU-stack contact. | n/a | Yes, but not a GPU-stack failure. |
+| 14 | `pod-autoscaling` | telemetry | **B** | not dispatched | n/a | Gates on a `dcgm_gpu_power_usage` external metric, then drives an HPA against a 10 W target that an idle GPU already exceeds. Under Mokka the power number is clock-driven and never responds to load, so the HPA scales on a signal that cannot fall. The wiring is exercised; GPU-driven autoscaling is not. **Recorded B deliberately.** | n/a | No. It would pass whether or not autoscaling-on-GPU-load works. |
+| 15 | `cluster-autoscaling` | scheduling | **A** | not dispatched | n/a | Karpenter provisions nodes from pending pods. Real scheduling integration; AICR's own KWOK provider is the intended substrate, so it is not GPU-dependent. | n/a | Yes, but not a GPU-stack failure. |
+| 16 | `robust-controller` | control-plane | **A** | not dispatched | n/a | Requires the controller, a reachable ValidatingWebhook, and proof the webhook rejects an invalid CR. Real admission-path integration. | n/a | Yes, but not a GPU-stack failure. |
+| 17 | `secure-accelerator-access` | scheduling | **A** | not dispatched | n/a | The check that most directly exercises MEP-0002: a granted container must see exactly one GPU, an unauthorized sibling must see no `/dev/nvidia*`, and no hostPath may carry `/dev/nvidia`. **The highest-value check not yet run in this sweep.** | n/a | **Yes.** Wrong device-spec passing or NRI suppression fails it. |
+| 18 | `slinky-slurm-health` | control-plane | **A** | not dispatched | n/a | Slurm controller, scheduling, a GPU job and accounting. Notably the only validator in AICR that detects a simulated node and skips, and it detects KWOK, not Mokka. | n/a | Yes. |
+| 19 | `slinky-slurm-imex-channel` | dra | **A** | not dispatched | n/a | Concurrent Slurm jobs must receive distinct IMEX channels. v0.3.0 renders the channel surface, so this is fabric **management**, reachable in principle. Do not confuse with NVLS throughput, which is C. | n/a | Yes. |
+| 20 | `gpu-operator-health` | operator-install | **A** | **fail** | sim | Requires the operator Deployment, `ClusterPolicy status.state == ready`, and a ready dcgm-exporter DaemonSet. Failed because GFD crashed, keeping ClusterPolicy `notReady`. Classified **cause K** (this sweep's stock-kind, no-toolkit configuration) rather than G, because the repo's own CDI-path e2e asserts GFD labels and passes. **Not distinguished** by a controlled cell; see DECISIONS.md D-014. | n/a | **Yes.** This is the deepest single "did the GPU stack come up" assertion. |
+| 21 | `platform-health` | control-plane | **A** | **fail** | sim | Requires every enabled component namespace Active and every expected resource verified. Failed on 9 absent namespaces: **scope, not a Mokka gap**. | n/a | Yes, but not a GPU-stack failure. |
+
+## Roll-up
+
+- Checks total: **21** · **A: 16** · B: **1** · C: **4** · **G (closable gaps): 0**
+- **Analytical ceiling: 76%** (A / total). What carries real pre-silicon signal *if the full recipe
+  stack is deployed*. **This is not a measured result.**
+- **Reachable once tracked gaps close: 76%** ((A + G) / total). Identical, because no catalogued check
+  is blocked by a missing Mokka capability at v0.3.0. That is a genuine improvement over the
+  2026-07-25 POC, where `dra-support` and two others sat in G; v0.3.0 shipped them.
+- **Measured this run: 14%.** AICR dispatched 9 of 21 checks; 3 reached a meaningful pass. The gap
+  between 14% and 76% is almost entirely the 7.75 GiB host memory budget, not Mokka.
+- Of the 16 A-bucket checks, **10 are GPU-dependent**. The other 6 run on any cluster, so Mokka is
+  not what unlocks them, and they must not be counted as GPU coverage.
+- Gaps filed: **1** (PCI bus ID loses its domain prefix; see FINDINGS.md §3). Closed during this
+  sweep: **0**. Resulting bucket moves: **0**.
+- **Notable B-bucket surprise:** `pod-autoscaling`. It reads a GPU power metric that, under Mokka, is
+  clock-driven and cannot fall, so it would pass regardless of whether GPU-driven autoscaling works.
+- **Notable A-bucket win:** `gpu-operator-version` failed for a genuinely correct reason, catching a
+  GPU Operator version that violates the gb200 recipe's own `>= v25.10.0` floor. That is preflight
+  doing exactly its job, pre-silicon.
+
+## Rules used to fill this in
+
+1. **No result without a run.** Empty beats inferred. `not dispatched` is recorded as such and is
+   never a pass.
+2. **Bucket B is not failure, it is scope.** It tells a customer what preflight does not cover.
+3. **A check blocked by a missing Mokka capability is bucket G**, needs a tracked issue, and is
+   distinct from a check blocked by an upstream release (U), by the kind environment (K), or by the
+   AICR catalog (X). Conflating these is the easiest way to produce a misleading result.
+4. **Provenance stays attached.** Every row is `sim`. If any row is later confirmed on silicon, change
+   it to `silicon` and date it.

--- a/tests/aicr-sweep/CHECK-CATALOG.md
+++ b/tests/aicr-sweep/CHECK-CATALOG.md
@@ -1,5 +1,11 @@
 # Artifact 1: AICR check-coverage catalog under Mokka
 
+> **Result columns are the first run's (Mokka `v0.3.0`, 2026-08-03).** The bucket
+> classification (A/B/C/G) is a property of each check and did not change. The
+> **measured 14%** below is that run's. The 2026-08-26 re-run against
+> `57ef01659` reached a verdict on 53 of 210 check-results against 13, and is
+> written up in [FINDINGS-57ef016.md](FINDINGS-57ef016.md).
+
 **Purpose:** the core deliverable. For every AICR validation and conformance check, classify what it
 actually proves when run on a Mokka-enabled cluster with no silicon. Mark's bar: separate checks that
 exercise **real integration** from checks that **pass trivially against mocked APIs**. A check in

--- a/tests/aicr-sweep/DECISIONS.md
+++ b/tests/aicr-sweep/DECISIONS.md
@@ -1,5 +1,19 @@
 # Decisions log: Mokka + AICR compatibility sweep
 
+> **First run, 2026-08-03.** The 2026-08-26 re-run
+> ([FINDINGS-57ef016.md](FINDINGS-57ef016.md)) revisited two of these decisions
+> with fresh measurements:
+>
+> - **D-009** blocked the ComputeDomain cells as cause `U` because
+>   `altProcDevices` was in no DRA driver release. **v0.5.0 shipped it on
+>   2026-08-19**, and `dra-support` now passes. The cell itself is `X` for a
+>   different reason: it declares `intent=training`, which resolves no recipe on
+>   `kind`. See [results/dra-altprocdevices-evidence.log](results/dra-altprocdevices-evidence.log).
+> - **D-014** classified the GFD failure `K` and named the experiment that would
+>   settle it. That reasoning **survives** the re-run, and the experiment is still
+>   the one to run. What changed is the diagnosis, not the verdict. See
+>   [results/gfd-sysfs-evidence.log](results/gfd-sysfs-evidence.log).
+
 Every judgment call made while running this sweep, with its rationale. The mission brief told me to
 decide and keep going instead of asking, so this file is the audit trail for what I decided and why.
 

--- a/tests/aicr-sweep/DECISIONS.md
+++ b/tests/aicr-sweep/DECISIONS.md
@@ -1,0 +1,321 @@
+# Decisions log: Mokka + AICR compatibility sweep
+
+Every judgment call made while running this sweep, with its rationale. The mission brief told me to
+decide and keep going instead of asking, so this file is the audit trail for what I decided and why.
+
+Format: decision, the options considered, what I chose, why, and what it costs.
+
+---
+
+## D-001: Branch base is `upstream/main`, not the `v0.3.0` tag
+
+**Options**
+
+1. Branch from the `v0.3.0` tag (`e3546d09`), so the tree matches the pinned artifact exactly.
+2. Branch from `upstream/main` (`c8dc7077`).
+
+**Chosen:** option 2.
+
+**Why:** `v0.3.0` is an ancestor of `upstream/main`, and the only commit between them is
+`docs(e2e): correct the device plugin's CI status in VERSION-MATRIX (#579)`, which changes no code.
+A PR must merge cleanly into `main`, and branching from a tag that is one docs commit behind buys
+nothing. The pin that matters is the pin on the deployed artifacts (image `ghcr.io/nvidia/nvml-mock:0.3.0`
+and chart `--version 0.3.0`), not the pin on the branch base. The sweep never installs a
+locally built image unless a cell explicitly records that it did.
+
+**Cost:** the tree carries one docs commit that the `v0.3.0` artifact does not. No effect on results.
+
+---
+
+## D-002: This PR supersedes PR #503; I did not touch #503
+
+**Context:** PR [#503](https://github.com/NVIDIA/k8s-test-infra/pull/503), "poc: Mokka + AICR
+pre-silicon integration preflight", is open, draft, and conflicting. It is the 2026-07-25 attempt at
+the same POC, on branch `poc/mokka-aicr-presilicon-preflight`. It carries a working harness at
+`tests/aicr-preflight/`, a catalog of 21 AICR checks, a findings note, and diagrams. Two of its
+commits already merged to `main` separately: [#541](https://github.com/NVIDIA/k8s-test-infra/pull/541)
+(mock IMEX surface) and [#542](https://github.com/NVIDIA/k8s-test-infra/pull/542) (GFD label
+assertion). A third, [#512](https://github.com/NVIDIA/k8s-test-infra/pull/512), closed tier-1 gaps
+that POC found.
+
+**Options**
+
+1. Push new commits onto `poc/mokka-aicr-presilicon-preflight` and reuse PR #503.
+2. Branch from #503's head so the new PR contains its history.
+3. Branch from `upstream/main`, write the sweep fresh, and mark #503 superseded.
+
+**Chosen:** option 3.
+
+**Why:** the mission brief names the branch `poc/mokka-aicr-kind-sweep` explicitly, so option 1 is out.
+Option 2 drags stale pre-v0.3.0 results into the new PR, and #503 already conflicts with `main`, so it
+needs a rebase before it could be a base. The 2026-07-25 results predate v0.3.0 (cut 2026-08-01) and
+predate this sweep's scope, which is every recipe across a permutation matrix rather than one recipe.
+Reporting them next to fresh v0.3.0 numbers invites a reader to mix the two.
+
+**Cost:** `docs/aicr-preflight/` and the harness overlap between two open PRs. I state the supersede
+relationship in the PR body and recommend closing #503. I did not close it: closing a PR is an
+outward-facing action, and it needs Carlos's explicit approval.
+
+**Carried forward from #503 by design, not by copy:** the A/B/C/G bucket definitions, the
+"degrade to not-run, never to a pass" invariant set, the CTRF result parsing approach, and the
+GPU-dependent split inside bucket A. Those were sound and re-deriving them would waste effort.
+
+---
+
+## D-003: Harness lives at `tests/aicr-sweep/`
+
+**Options**
+
+1. `deployments/nvml-mock/examples/aicr-sweep/`, as the mission brief suggests.
+2. `tests/aicr-sweep/`.
+3. Extend `tests/e2e/go/` with sweep scenarios.
+
+**Chosen:** option 2.
+
+**Why:** the brief says "adjust to fit" the repo's conventions. `deployments/nvml-mock/examples/`
+does not exist in this repo, so option 1 invents a directory. Test harnesses in this repo live under
+`tests/`: `tests/e2e/`, `tests/mocknvml/`, `tests/poc-validation/`, and the superseded
+`tests/aicr-preflight/`. Option 3 is wrong because `tests/e2e/go` is a Ginkgo suite that gates CI,
+and a long sweep that deliberately records failures does not belong in a gating suite.
+
+**Cost:** none. `tests/aicr-sweep/` matches the neighbours.
+
+---
+
+## D-004: No brainstorming skill session; the brief is the plan input
+
+**Context:** the standing engineering rule starts every non-trivial task with an interactive
+brainstorming skill. The mission brief says "EXECUTE, DO NOT ASK" and "Do NOT come back to me with a
+menu of options", and the START-HERE file repeats it.
+
+**Chosen:** skip the interactive brainstorm. Write the plan and this decision log instead, which is
+what the brief's Phase 0 asks for.
+
+**Why:** the brainstorming skill works by asking the user questions. Running it would violate an
+explicit instruction from the same user who set the standing rule. The brief wins on precedence, and
+it asks for the same artifact a brainstorm would produce: a written plan plus recorded decisions.
+
+---
+
+## D-005: The v0.3.0 image must be pulled, not built, wherever a cell claims v0.3.0 provenance
+
+**Why:** the repo's e2e harness builds `nvml-mock:e2e` from the working tree by default. A sweep that
+builds from the tree and then labels the result "v0.3.0" is reporting a number that nobody can
+reproduce. Every cell records the image reference and its digest. Cells that must use a locally built
+image record that fact and are excluded from the v0.3.0 headline.
+
+---
+
+## D-006: Docker VM memory is the binding constraint, and the sweep degrades rather than fabricates
+
+**Context:** the host is arm64 macOS with 14 CPUs and 8.3 GB allocated to the Docker VM. A full
+factorial sweep of every AICR recipe across every axis does not fit.
+
+**Chosen:** run the base sweep first and completely, then axis cells in priority order until the
+budget runs out. Every cell that does not run is recorded `blocked` with the reason. `blocked` is
+never reported as `pass`, and the coverage denominator always includes blocked cells.
+
+**Why:** the brief is explicit that a missing input blocks one cell, not the run, and that "not run"
+is never "pass". Reporting a partial matrix honestly is the required behaviour.
+
+---
+
+## D-007: AICR is pinned to `upstream/main` at `0752ea14`, not to the local checkout
+
+**Context:** the local clone at `/Users/eduardoa/src/github/nvidia/aicr` sits on branch `agents-workbench`
+at `11f63576` (2026-07-26). Its `upstream/main` is `0752ea148aa1ae849cbef86ec59d0c970a582496`
+(2026-07-31). They differ by 88 files and 12172 insertions in exactly the paths this study reads:
+`validators/`, `recipes/`, `cmd/`, `tests/chainsaw/`. `validators/deployment/nvidia_smi.go` alone
+differs by 164 lines, and that file is the source of `check-nvidia-smi`.
+
+**Chosen:** pin to `upstream/main` at `0752ea14`. Extract that ref into scratch space with
+`git archive`, build the CLI there, never `git checkout` inside the AICR clone.
+
+**Why:** a coverage number measured against a stale local branch is not reproducible by anyone else.
+`git archive` into scratch makes no commit and writes nothing into the AICR repo, which keeps the
+sweep inside its "only write to k8s-test-infra" constraint.
+
+**Verified:** `CGO_ENABLED=0 go build -mod=vendor -o bin/aicr ./cmd/aicr` returns rc=0 from that tree.
+
+---
+
+## D-008: The `gb300` half of the base sweep is blocked by AICR, not by Mokka
+
+**Finding, verified by running the CLI rather than by reading it:**
+
+```
+$ aicr recipe --service kind --accelerator gb300 --intent inference
+[cli] command failed: error=[INVALID_REQUEST] no recipe provides accelerator 'gb300'
+      for criteria(service=kind, accelerator=gb300, intent=inference) exitCode=2
+```
+
+The same command succeeds for `gb200` (14 components, 5 overlays) and for `h100` (14 components,
+6 overlays). AICR's catalog at `0752ea14` knows seven accelerators: `a100`, `b200`, `gb200`, `h100`,
+`h200`, `l40s`, `rtx-pro-6000`. `grep -c gb300 recipes/registry.yaml` returns 0, and `gb300` appears
+nowhere under `recipes/`.
+
+**Consequence:** the brief's base sweep says "every AICR recipe x {gb200, gb300}". The `gb300` half
+cannot run, because AICR has no GB300 recipe. Mokka ships a `gb300` profile; AICR has no accelerator
+to match it to.
+
+**Chosen:** record every `gb300` cell as `blocked`, cause code **`X` (AICR catalog gap)**. It is
+deliberately not `G`, because Mokka lacks nothing here, and deliberately not `K`, because nothing about
+kind causes it. I added a distinct cause code rather than forcing it into an existing bucket: forcing
+it into `G` would put an issue on Mokka's backlog for work Mokka does not owe.
+
+**Not filed:** the brief forbids opening issues in NVIDIA/aicr without asking. This goes to Mark in the
+findings note, since the catalog is his side of the boundary.
+
+**Substitution, stated openly:** where the brief wants a second accelerator to contrast against gb200,
+the sweep uses `h100`, which AICR supports on `kind` and Mokka also ships. The findings label that a
+substitution. It is never presented as gb300 coverage.
+
+---
+
+## D-009: ComputeDomain cells are blocked by an unreleased upstream flag, not by a Mokka gap
+
+Mokka v0.3.0 renders the IMEX surface (`imex.mockChannels.enabled`, channel device nodes, and a
+substitute `/proc/devices`). The NVIDIA DRA driver reads the `nvidia-caps-imex-channels` major out of
+`/proc/devices` and needs `--set altProcDevices=...` to look elsewhere. That flag is on the DRA
+driver's main branch and is in no release, including v25.12.0. The chart's own `values.yaml` states
+this at lines 307 to 325.
+
+**Chosen:** cause code **`U` (upstream dependency)**, not `G`. Mokka already ships the capability.
+Filing a Mokka gap here would file against the wrong repo.
+
+---
+
+## D-010: Sequential clusters of two shapes, not one large cluster
+
+**Measured, not estimated:** the Docker VM has 7.75 GiB total and showed 4.08 GiB available with the
+host's unrelated containers running. An idle 5-node kind cluster costs 1152 MiB (control plane 682 MiB,
+each worker about 117 MiB). A fully loaded worker costs an estimated 550 to 700 MiB, of which
+dcgm-exporter with its embedded nv-hostengine is 250 to 400 MiB, over half.
+
+**Chosen:** two cluster shapes, created and destroyed in sequence, never coexisting.
+
+| Shape | Nodes | Carries | Rationale |
+|---|---|---|---|
+| `stack` | 1 control plane + 2 workers | GPU Operator, device plugin, GFD, dcgm-exporter, DRA driver | memory heavy, node light |
+| `fabric` | 1 control plane + 4 workers | NRI injection, IMEX channels, ComputeDomain topology, no operator, no dcgm | node heavy, memory light |
+
+**Why:** 4 loaded workers needs about 2.9 GiB and leaves roughly 1.2 GiB, which image pulls, Helm, and
+the validator Job all spike into at once. That is an OOM kill in the middle of a sweep, which produces
+a fake failure that looks like a Mokka finding. The two shapes never need to coexist: the two-clique
+ComputeDomain topology needs 4 workers but does not need the operator or dcgm.
+
+**Not chosen:** raising the Docker Desktop VM memory would remove this constraint entirely and is a
+settings change rather than an engineering one. I did not change it, because it mutates the user's
+machine configuration outside the throwaway kind cluster.
+
+---
+
+## D-011: Triage rule for separating `G` (Mokka gap) from `K` (kind artifact)
+
+The brief calls conflating these the easiest way to produce a misleading result. The rule the sweep
+applies, decided before any cell ran so it cannot be bent to fit a number:
+
+> **Did Mokka promise to render this path or speak this protocol?**
+>
+> If the failing read targets something Mokka stages (`/var/lib/nvml-mock/**`, `MOCK_IB_ROOT`, injected
+> `/dev/nvidia*`, the topology ConfigMap) or a protocol Mokka speaks for real (IMEX gRPC, the mock-ib
+> TCP relay, an NVML or DCGM call), the failure is **G**.
+>
+> If it targets real host kernel state that Mokka never claimed (NUMA nodes, real PCI tree, the NVLink
+> data plane, RDMA verbs, kernel modules), the failure is **K**.
+
+Verified inputs behind the rule, from a probe cluster on this host:
+
+- `/sys/devices/system/node/` does not exist in a kind node under the Docker Desktop VM at all, so every
+  NUMA affinity assertion is a guaranteed false negative. **K**.
+- `/sys/class/infiniband` does not exist, so RDMA verbs and real IB bandwidth are out of reach. **K**.
+- The ComputeDomain demo runs the real `nvidia-imex` daemon in `--nogpu` mode and forms domains over the
+  real gRPC peer protocol on the pod network. Failures there are real control-plane semantics. **G**.
+
+---
+
+## D-012: kind version skew against CI is recorded on every cell
+
+CI pins `KIND_VERSION: v0.31.0` (`.github/workflows/nvml-mock-e2e-go.yaml`). This host has kind 0.32.0,
+whose default node image is Kubernetes v1.36.1. The sweep therefore runs one minor version ahead of CI.
+
+**Chosen:** record the kind and Kubernetes versions in every result record, and re-test any DRA or GPU
+Operator failure that is unique to the sweep before classifying it `G`.
+
+**Why:** version skew is the most likely source of a spurious Mokka finding, and a spurious `G` costs a
+maintainer real time.
+
+---
+
+## D-013: `operator.runtimeClass=runc`, and why that is not cheating
+
+**Observed, on a real run:** every GPU Operator operand stayed in `Init:0/1` with
+
+```
+Failed to create pod sandbox: rpc error: code = Unknown desc = unable to get OCI runtime
+for sandbox "...": no runtime for "nvidia" is configured
+```
+
+**Diagnosis, verified rather than assumed:** the operator creates a RuntimeClass named `nvidia` with
+handler `nvidia` and sets `runtimeClassName: nvidia` on every operand. `docker exec <node> grep
+runtimes /etc/containerd/config.toml` shows a stock kind node has exactly two handlers, `runc` and
+`test-handler`. On a real cluster the NVIDIA container toolkit installs the `nvidia` handler. This
+sweep runs the NRI path on a stock `kindest/node`, where no toolkit exists.
+
+**Options**
+
+1. Install nvidia-container-toolkit into the kind nodes, as `tests/e2e/go` does for its GPU Operator
+   scenario, or use the repo's pre-baked node image.
+2. Point the operator at a handler that exists: `operator.runtimeClass=runc`.
+3. Hand-write an `nvidia` handler into containerd's config that aliases runc.
+
+**Chosen:** option 2.
+
+**Why:** under the NRI path no special runtime is needed. NRI hooks `CreateContainer` regardless of
+which OCI runtime handles the container, which is the whole point of node-wide injection, and the
+brief states the per-node CDI plus container-toolkit install is obsolete at v0.3.0. Option 1 would
+reintroduce the obsolete path just to satisfy a label. Option 3 produces the same effect as option 2
+with more moving parts and a containerd restart race.
+
+**Effect, measured after the patch:** the validator advanced from `Init:0/4` to `Init:3/4` to
+`Running`, both workers advertised `nvidia.com/gpu: 8`, and dcgm-exporter reached `Running`. So the
+operator's driver, toolkit and CUDA validation stages all pass against the mock.
+
+**Recorded as a finding, not hidden:** a first-time user following the GPU Operator path on stock
+kind hits this wall with a message that names neither Mokka nor the toolkit. That is worth a docs
+line in the chart README regardless of this sweep.
+
+---
+
+## D-014: The GFD failure is classified `K`, not `G`, and here is the reasoning I could have got wrong
+
+**Observed:** `gpu-feature-discovery` exits with
+
+```
+error creating labeler: error creating resource labeler: unable to read PCI device vendor id
+for :0a:00.0: open /sys/bus/pci/devices/:0a:00.0/vendor: no such file or directory
+```
+
+That kept `ClusterPolicy` at `notReady` for the whole run.
+
+**The tempting call:** file it as a Mokka gap. The BDF is malformed (`:0a:00.0` has no domain), the
+profile declares `0000:0A:00.0`, and Mokka renders `/var/lib/nvml-mock/sys/bus/pci/devices/0000:0a:00.0`
+correctly. It looks like Mokka handed GFD a bad bus ID.
+
+**Why I did not file it:** the repo's own `e2e-gpu-operator` scenario asserts GFD labels and passes,
+and [#542](https://github.com/NVIDIA/k8s-test-infra/pull/542) made that assertion strict. The
+difference between that scenario and this cell is mine, not Mokka's: the repo scenario installs the
+container toolkit and runs with `cdi.enabled=true`, and this sweep runs stock kind with
+`cdi.enabled=false` (see D-013). A green CI scenario on the CDI path is direct evidence that GFD
+works against this mock when the supported path is used.
+
+**Chosen:** cause **K**, an artifact of this sweep's stock-kind, no-toolkit configuration. Recorded
+with the exact error so a reader can re-open it, and queued as a targeted cell rather than an issue.
+
+**What would change the call:** running the same cell with `cdi.enabled=true` and the toolkit
+installed. If GFD still fails there, it becomes **G** and gets an issue. That cell did not fit in the
+memory budget, so the honest status is "not distinguished", and the findings note says so rather than
+claiming either answer.
+
+This is the exact failure mode the brief warned about, so I am writing down the reasoning rather than
+just the verdict.

--- a/tests/aicr-sweep/DECISIONS.md
+++ b/tests/aicr-sweep/DECISIONS.md
@@ -319,3 +319,54 @@ claiming either answer.
 
 This is the exact failure mode the brief warned about, so I am writing down the reasoning rather than
 just the verdict.
+
+---
+
+## D-015: Hybrid KWOK + Mokka cell runs, over a panel dissent that I agreed with
+
+**The question:** would combining KWOK (horizontal, node-count breadth) with Mokka (vertical, per-node
+GPU-stack depth) give this study a scale story?
+
+**The blocking fact, established before deciding:** `aicr validate` launches every one of the 21 checks
+as a containerized Kubernetes Job. A Job scheduled onto a KWOK node executes nothing, because a KWOK
+node has no kubelet; `stage-fast` walks the pod through phases without running a container. **Adding N
+KWOK nodes therefore adds exactly zero AICR check coverage**, and cannot move either the measured 14%
+or the 76% ceiling.
+
+**The recommendation panel overturned my proposal** to run a hybrid experiment. Its argument, which I
+agreed with on reading it: "KWOK nodes break `check-nvidia-smi`" is not a discovery, it is definitional,
+and spending an evening measuring it documents the obvious. Two further points I checked and conceded:
+
+- The DRA ResourceSlice-at-scale angle collapses for the same reason. The DRA kubelet plugin is a
+  DaemonSet and will not run on KWOK nodes either.
+- The one genuinely unknown question in the area (do the GPU Operator ClusterPolicy loop and NFD master
+  degrade as node count grows?) belongs to the Perf-and-Scale V-Team workstream. The POC SSOT says
+  explicitly not to conflate that 5K-node effort with this correctness-of-checks POC.
+
+**Chosen anyway: run it.** Carlos reaffirmed the hybrid experiment after reading the panel's dissent and
+my flip. That is his call to make, and it is recorded here rather than quietly followed.
+
+**What the cell is designed to measure**, given the above rules out a coverage number. The output is a
+*discipline*, not a percentage: what a fleet operator must do to combine the two without corrupting an
+AICR run.
+
+| Cell | KWOK nodes | Question |
+|---|---|---|
+| `hybrid-kwok-tainted` | present, `NoSchedule` | do Mokka and KWOK nodes coexist without changing any AICR verdict against the pure-Mokka baseline? |
+| `hybrid-kwok-schedulable` | present, schedulable, advertising `nvidia.com/gpu` | which checks change verdict, and by how much, when fleet-surveying checks can target hollow nodes? |
+
+The delta between those two cells and the `base-gb200-kind-inference-stack` baseline is the finding. If
+the delta is zero in the tainted case and non-zero in the schedulable case, the result is a concrete
+node-selector and taint requirement for anyone building a combined fleet, which is directly useful to
+Eliran's per-nodepool `backend` design.
+
+**What this cell will NOT be allowed to claim,** written down before it runs so the result cannot drift:
+it is not AICR coverage at scale, it is not a bring-up-time number, and it is not evidence of GPU-stack
+fidelity at KWOK node counts. The panel's dissent is reported alongside the result.
+
+**Outcome, recorded after the run:** the experiment did not document the obvious. It produced a
+**false pass**, not the predicted false fail: with 250 KWOK nodes present, all 9 AICR checks reported
+green in under 10 seconds with no container ever executing, and the documented `--node-selector`
+mitigation does not work because AICR never applies it to the validator Job pod spec. Both the panel
+and I were wrong about the direction of the result. Carlos's override was correct. Full writeup in
+`HYBRID-KWOK-FINDING.md`; the false passes are deliberately excluded from `cells.yaml` and the rollup.

--- a/tests/aicr-sweep/FINDINGS-57ef016.md
+++ b/tests/aicr-sweep/FINDINGS-57ef016.md
@@ -1,0 +1,232 @@
+# Re-run findings: the sweep against Mokka `upstream/main`, 2026-08-26
+
+The first run ([FINDINGS.md](FINDINGS.md)) measured Mokka `v0.3.0` on 2026-08-03. This is the same
+matrix re-measured against `57ef01659`, 60 commits later. AICR is held at the same pin, `0752ea14`,
+so Mokka is the only axis that moved. That is verified rather than assumed: the base cell's generated
+recipe is byte-identical to the one recorded on 2026-08-03.
+
+Both runs remain reproducible and neither overwrites the other:
+
+| Run | Cells file | Results | Mokka |
+|---|---|---|---|
+| First | [cells.yaml](cells.yaml) | [results/](results/) | `v0.3.0` |
+| This one | [cells-57ef016.yaml](cells-57ef016.yaml) | [results-57ef016/](results-57ef016/) | `57ef01659` |
+
+## 1. The headline, which is not the one that was expected
+
+The session handoff predicted that #672 would flip `gpu-operator-health` from fail to pass, and that
+"the honest verdict would improve on a re-run". **It did not.** The base cell's nine dispatched
+verdicts are byte-identical to the first run: 3 passed, 5 failed, 1 other.
+
+#672 is real and it landed. A differential probe of the two published images, same config file, same
+command, only the image differing:
+
+| Image | `nvmlPciInfo_t.busId` |
+|---|---|
+| `nvml-mock:0.3.0` | `0000:01:00.0` (4-digit domain, the bug) |
+| `nvml-mock:sha-57ef016` | `00000000:01:00.0` (8-digit domain, fixed) |
+
+And the consumer error changed accordingly:
+
+```
+v0.3.0       unable to read PCI device vendor id for :0a:00.0
+sha-57ef016  unable to read PCI device vendor id for 0000:0a:00.0
+```
+
+The BDF is now well formed. The path is simply not there. Mokka renders a correct tree at
+`/var/lib/nvml-mock/sys/bus/pci/devices/0000:0a:00.0/vendor` (`0x10de`), but its entries are
+*relative symlinks* into a sibling `devices/` subtree, and `gpu-feature-discovery` mounts the real
+host `/sys`. Two grafts were tried and both fail: replacing GFD's `/sys` breaks the container
+outright (it loses `/sys/class/dmi`), and mounting only `bus/pci/devices` leaves the symlinks
+resolving against the real `/sys/devices`. Evidence:
+[`results/gfd-sysfs-evidence.log`](results/gfd-sysfs-evidence.log).
+
+**This does not promote the GFD failure to a Mokka gap.** D-014 classified it `K` and named the
+distinguishing experiment: run the same cell with `cdi.enabled=true` and the toolkit installed. That
+reasoning survives. `tests/e2e/VERSION-MATRIX.md` confirms CI exercises the GPU Operator's own GFD
+operand, and `tests/e2e/kind-gpu-operator-config.yaml` differs from this sweep in exactly the way
+D-014 named (`enable_cdi = true`, an `nvidia` runtime handler, the toolkit installed). What #672
+changes is the diagnosis, not the classification: the "Mokka hands GFD a malformed bus ID" theory is
+dead by measurement, and what remains is a mount-visibility question. **The status is still
+"not distinguished", and that cell is now affordable.** It is the single most valuable cell not yet run.
+
+## 2. What did move: `dra-support`, for an upstream reason
+
+One verdict flipped in the entire re-run.
+
+| Check | First run | This run |
+|---|---|---|
+| `dra-support` | **failed** (DRA v25.12.0) | **passed** (DRA v0.5.0) |
+
+D-009 blocked the ComputeDomain work as cause `U` because `--set altProcDevices` was "on the DRA
+driver's main branch and in no release, including v25.12.0". That was correct when written and is no
+longer true: **k8s-dra-driver-gpu v0.5.0, released 2026-08-19, ships it**, and its own `values.yaml`
+documents the flag as being for mock NVML.
+
+Measured end to end: Mokka rendered `235 nvidia-caps-imex-channels` into its substitute
+`/proc/devices`, v0.5.0 consumed it, both kubelet-plugin containers (`compute-domains` and `gpus`)
+came up on both workers, 12 ResourceSlice devices were published, and the first run's abort
+(`error parsing '/proc/devices'`) appears **zero** times in 400 lines of driver logs.
+
+Mokka's IMEX rendering already worked at `v0.3.0`. What was missing was a released consumer.
+
+**Caveat that must travel with this result:** v0.5.0's chart was renamed
+(`nvidia-dra-driver-gpu` to `dra-driver-nvidia-gpu`), so its default resource names no longer match
+what AICR at `0752ea14` looks for. This cell passed `--set nameOverride=nvidia-dra-driver-gpu` to
+restore the expected name; AICR itself was not modified. Installed with chart defaults, `dra-support`
+fails `NOT_FOUND` on the name alone regardless of what the driver is doing. That rename is real drift
+and is worth raising on the AICR side. Evidence:
+[`results/dra-altprocdevices-evidence.log`](results/dra-altprocdevices-evidence.log).
+
+## 3. AICR's own snapshot agent cannot be reached by library interception
+
+Raised by Giulio Calzolari in review on 2026-08-27, and verified here independently against the
+published image before being written down.
+
+**This run recorded the symptom a day earlier without diagnosing it.** The base cell's validate log,
+line 12:
+
+```
+snapshot has no GPU data but cluster topology shows GPU-capable nodes
+  - agent likely ran on a non-GPU node
+  fix_1=--node-selector nvidia.com/gpu.present=true   fix_2=--node-selector kubernetes.io/hostname=<gpu-node>
+  fix_3=--require-gpu                                  fix_4=--runtime-class nvidia
+```
+
+All four fixes AICR suggests there are about node **placement**, and the agent had already been
+auto-targeted onto a GPU-labelled node (line 5 of the same log). So AICR's own diagnostic points away
+from the cause.
+
+**The cause.** `ghcr.io/nvidia/aicr:latest` is a distroless `ko` image with no shell, so the binary
+was extracted with `docker cp` and its ELF headers parsed directly:
+
+```
+/ko-app/aicr: ELF 64-bit LSB executable, ARM aarch64, statically linked, Go BuildID=..., stripped
+phdrs      : PT_PHDR, PT_NOTE, PT_LOAD, PT_LOAD, PT_LOAD, GNU_STACK
+PT_INTERP  : ABSENT      PT_DYNAMIC : ABSENT
+```
+
+With no `PT_INTERP` the kernel never invokes a dynamic loader, so `LD_PRELOAD` and `LD_LIBRARY_PATH`
+are inert **by construction, not by configuration**. With no `PT_DYNAMIC` there is no dynamic symbol
+resolution to hook at all. Mokka's NRI plugin injects an overlay mount and a library environment;
+against this binary the environment half has nothing to act on, so the agent reads the node's real
+sysfs and finds no NVIDIA devices.
+
+**What it does not affect.** `check-nvidia-smi` and `accelerator-metrics` run their own pods, which
+are ordinary dynamically linked consumers reachable through the NRI overlay. Those passes stand. What
+it affects is the cluster inventory AICR builds *before* dispatching checks.
+
+**It is a distinct cause class.** Not `K`, `U`, `X` or `BUDGET`. Not a Mokka defect: Mokka renders and
+injects correctly. Not an AICR defect: a static build is a deliberate, legitimate choice for a
+`ko`-built agent. It is an interception-model mismatch, and no configuration on either side closes it.
+Closing it needs the agent to read GPU state from the Kubernetes API rather than sysfs, or a
+filesystem-level graft of Mokka's rendered sysfs, or a dynamically linked agent build.
+
+**Note the convergence with section 1.** Two independent consumers, both defeated by reading the real
+`/sys` instead of Mokka's rendered tree: GFD is dynamically linked and fails on a sysfs *path*, the
+agent is static and fails on sysfs *content*. The common remedy is a filesystem graft, not library
+interception. That is a sharper conclusion than either finding alone.
+Evidence: [`results/aicr-agent-static-linkage-evidence.log`](results/aicr-agent-static-linkage-evidence.log).
+
+## 4. Coverage: the memory unlock was the real win
+
+| | First run | This run |
+|---|---|---|
+| Reached a verdict | 13 / 210 (**6%**) | 53 / 210 (**25%**) |
+| Passed | 4 | 20 |
+| Failed | 9 | 32 |
+| Blocked | 168 | 84 |
+| Blocked `BUDGET` | 105 | **0** |
+| Blocked `U` | 21 | **0** |
+| Blocked `X` | 42 | 84 |
+| Analytical ceiling | 76% | 76% |
+
+The ceiling is unchanged because the catalog is unchanged. What changed is how much of it was
+actually measured: four times as many check-results reached a real verdict, and the host memory
+budget no longer blocks anything.
+
+The largest single gain is the `h100` cell, which was `BUDGET`-blocked before. **AICR dispatches 14
+of 21 checks there against 9 for `gb200`, and 5 pass against 3.** `gpu-operator-version` passes on
+h100 and fails on gb200, and `gang-scheduling`, `inference-gateway`, `pod-autoscaling`,
+`cluster-autoscaling` and `secure-accelerator-access` are dispatched at all only there.
+
+## 5. Two cells were misattributed in the first run
+
+Both were recorded as blocked for reasons that were never tested, and both are actually `X`.
+
+`aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with
+`[INVALID_REQUEST] no recipe provides intent 'training'`. On the `kind` service, training resolves
+for **h100 and no other accelerator**. Full matrix:
+[`results/aicr-recipe-matrix-evidence.log`](results/aicr-recipe-matrix-evidence.log).
+
+| Cell | Was | Is | Why |
+|---|---|---|---|
+| `base-gb200-kind-training-stack` | `BUDGET` | `X` | The note predicted it would "differ from the inference cell only in component set". It does not resolve a recipe at all, so memory never mattered. |
+| `axis-compute-domain-fabric` | `U` | `X` | Declares `intent=training` on `kind`. Recipe resolution fails before the DRA driver can. The `altProcDevices` question it was meant to answer is now carried by `targeted-dra-installed`. |
+
+That is 42 check-results moving from `BUDGET`/`U` to `X`. This is the first run's own stated
+discipline applied to itself: the `gb300` block was verified by running the CLI, and these two were
+not.
+
+## 6. An injected ECC fault moves no verdict
+
+With `gpu.failureInjection` set to `enabled=true mode=ecc_uncorrectable probability=1`, the mock
+reports 6 and 9 volatile DRAM Uncorrectable errors on two GPUs while all four still enumerate.
+**Every one of the nine dispatched verdicts is identical to the base cell**, including
+`check-nvidia-smi` and `accelerator-metrics`, which both pass.
+
+That is a statement about the AICR check set, not about Mokka: the injection works end to end, and
+the checks this recipe dispatches do not read ECC state, so a degraded-but-enumerable GPU is
+indistinguishable from a healthy one. It says nothing about checks this recipe does not dispatch.
+
+Worth noting for the first run's record: the axis as declared in `cells.yaml`
+(`gpu.failureInjection.mode=ecc_uncorrectable` alone) is **inert**. The chart gates injection on
+`enabled` and never trips at the default probability of 0. Had that cell run as written it would have
+measured nothing and looked like a clean negative.
+
+## 7. Corrections to first-run figures
+
+The first run's numbers were correct when measured. #727 remodelled `gb200`/`gb300` as a 4-GPU NVL72
+compute tray, so these figures no longer describe current main:
+
+| [FINDINGS.md](FINDINGS.md) claim | Then | Now |
+|---|---|---|
+| device plugin advertised `nvidia.com/gpu: N` per worker | 8 | **4** (measured on both workers) |
+| node-wide injection pod listed N GB200s | 8 | 4 |
+| DRA driver published N devices across ResourceSlices | 16 | 12 |
+
+`h100` still stages 8 GPUs, which confirms #727 was correctly scoped to the Grace-Blackwell profiles.
+
+## 8. Traps hit while running this, recorded so they are not repeated
+
+**A failed install produced a plausible, flattering, wrong result.** The first attempt at the ECC cell
+returned 1 passed / 7 failed, with `check-nvidia-smi` and `accelerator-metrics` both flipping. That
+read as clean evidence that AICR detects the injected fault. It was not: `--set
+gpu.failureInjection.probability=1.0` types `1.0` as a **string**, `values.schema.json` wants a
+number, and the Mokka install failed. The cell ran against a cluster with no mock at all, and the two
+checks "flipped" only because there were no GPU nodes. Use `--set-json` for numeric values. The
+driver script now aborts a cell when the Mokka install fails rather than measuring an empty cluster,
+and every other cell in this run was audited for the same failure mode (all clean: `check-nvidia-smi`
+passed in each, which is impossible without GPU nodes).
+
+**The stale-citation pattern from the first run recurred.** D-009 cites the DRA chart's `values.yaml`
+"at lines 307 to 325". v25.12.0's `values.yaml` is 270 lines, so that range does not exist in the file
+a reader would open; the line numbers refer to the main-branch file. The substantive claim was right,
+the citation points somewhere else.
+
+## 9. What to do next, in order
+
+1. **Run D-014's distinguishing cell**: the base cell with `cdi.enabled=true` and the
+   nvidia-container-toolkit installed. It is the only thing standing between the GFD failure being
+   `K` and being `G`, it has been open since the first run, and the memory that blocked it is gone.
+2. **Raise the agent's static linkage with AICR.** Its snapshot reports no GPU data on a working mock
+   cluster, and its own remediation hints point at node placement, which cannot fix it. Reading GPU
+   state from the Kubernetes API rather than sysfs would close it for every mock backend, not just
+   this one.
+3. **Raise the DRA chart rename with AICR.** `dra-support` cannot pass against v0.5.0 with default
+   chart values, because AICR looks for `nvidia-dra-driver-gpu-controller` and the chart now produces
+   `dra-driver-nvidia-gpu-controller`.
+4. **Close #498 and fix the stale note** in `deployments/nvml-mock/helm/nvml-mock/values.yaml`, which
+   still says `altProcDevices` "is NOT in any release (absent at v25.12.0)".
+5. **Raise `gb300` with AICR again.** #699 made `gb300` the Mokka chart default while AICR still has
+   no such accelerator, so the two sides have drifted further apart, not closer.

--- a/tests/aicr-sweep/FINDINGS-57ef016.md
+++ b/tests/aicr-sweep/FINDINGS-57ef016.md
@@ -226,7 +226,8 @@ the citation points somewhere else.
 3. **Raise the DRA chart rename with AICR.** `dra-support` cannot pass against v0.5.0 with default
    chart values, because AICR looks for `nvidia-dra-driver-gpu-controller` and the chart now produces
    `dra-driver-nvidia-gpu-controller`.
-4. **Close #498 and fix the stale note** in `deployments/nvml-mock/helm/nvml-mock/values.yaml`, which
-   still says `altProcDevices` "is NOT in any release (absent at v25.12.0)".
+4. **Fix the stale note** in `deployments/nvml-mock/helm/nvml-mock/values.yaml`, which still says
+   `altProcDevices` "is NOT in any release (absent at v25.12.0)" and points readers at #498. #498 is
+   already closed; the note outlived it and is now wrong on the facts as well as the pointer.
 5. **Raise `gb300` with AICR again.** #699 made `gb300` the Mokka chart default while AICR still has
    no such accelerator, so the two sides have drifted further apart, not closer.

--- a/tests/aicr-sweep/FINDINGS.md
+++ b/tests/aicr-sweep/FINDINGS.md
@@ -1,5 +1,19 @@
 # Mokka + AICR pre-silicon preflight: sweep findings
 
+> **First run, 2026-08-03. Partly superseded by the 2026-08-26 re-run**
+> ([FINDINGS-57ef016.md](FINDINGS-57ef016.md)). Everything below was correct when
+> measured. Three things have changed since:
+>
+> - **Section 3, "the one real gap"** (the PCI bus ID without its domain) was
+>   **fixed upstream by #672** on 2026-08-19. Verified in the shipped image. But
+>   `gpu-operator-health` did **not** move: GFD now gets a well-formed BDF and
+>   still cannot read the vendor file, for a separate mount reason. See
+>   [results/gfd-sysfs-evidence.log](results/gfd-sysfs-evidence.log).
+> - **The 8-GPU figures in section 5** are now 4. #727 remodelled `gb200`/`gb300`
+>   as a 4-GPU NVL72 compute tray. The DRA device count went 16 to 12.
+> - **Two blocked cells were misattributed here** and are `X`, not `BUDGET`/`U`.
+>   See [results/aicr-recipe-matrix-evidence.log](results/aicr-recipe-matrix-evidence.log).
+
 **Date:** 2026-08-03 · **Ran by:** Carlos Eduardo Arango Gutierrez · **For review by:** Mark Chmarny
 **Cluster:** kind v0.32.0, Kubernetes v1.36.1, containerd 2.3.1, 1 control plane + 2 workers, arm64,
 one host, 7.75 GiB Docker VM

--- a/tests/aicr-sweep/FINDINGS.md
+++ b/tests/aicr-sweep/FINDINGS.md
@@ -166,6 +166,37 @@ quoting something I did not measure.
 
 **Scale is untested and this run cannot speak to it.** kind on one host. That is the whole caveat.
 
+## 6b. KWOK + Mokka: combining them makes the suite report green without running
+
+Run after the sections above, on Carlos's call and over a panel dissent I agreed with. Full writeup:
+[HYBRID-KWOK-FINDING.md](HYBRID-KWOK-FINDING.md). Evidence:
+[results/kwok-false-pass-evidence.log](results/kwok-false-pass-evidence.log).
+
+Added 250 hollow KWOK GPU nodes to the Mokka cluster, giving a 253-node fleet advertising 2016
+`nvidia.com/gpu`, and re-ran the identical recipe. **Every check passed, in 4.2s and 5.2s, against
+9m 0s on the pure-Mokka baseline. Nothing executed.**
+
+Four verified facts compose into it: AICR validator Jobs tolerate every taint (empty key,
+`operator: Exists`, asserted at `deployer_test.go:516`); KWOK nodes carry the full GPU label set and
+real `nvidia.com/gpu` capacity; so the scheduler places validators on them, 250 hollow against 2 real;
+and KWOK's `pod-complete` stage transitions any Job-owned pod to `Succeeded`. The container status
+shows an empty `imageID` and `started: false` with `startedAt == finishedAt`, so the image was never
+pulled, and `kubectl logs` returns `MethodNotAllowed` because there is no kubelet.
+
+**`--node-selector` does not mitigate it.** Measured: the flag reaches the snapshot agent's pod spec
+and stops. `deployer.go:66` states it is passed to inner workloads via `AICR_NODE_SELECTOR`, never
+applied to the validator Job's own pod spec. With the flag set as documented, all four deployment
+checks still passed in 4.2s on hollow nodes.
+
+Not a Mokka gap, and not a KWOK bug. It is a composition hazard whose actionable half is in AICR, and
+it is exactly the architecture Eliran's per-nodepool `backend` design produces.
+
+**Excluded from the coverage matrix on purpose.** These 9 passes are all false; feeding them into the
+denominator would raise the headline using fabricated results.
+
+Incidentally, the horizontal axis behaved: 250 hollow nodes cost about 1 GiB and took
+`kubectl get nodes` from 0.06s to 0.30s. No controller churn.
+
 ## 7. One structural finding worth your time, Mark
 
 AICR already ships a KWOK lane (`kwok/`, `.ctlptl-kwok.yaml`, `make kwok-test-all`) that covers 90

--- a/tests/aicr-sweep/FINDINGS.md
+++ b/tests/aicr-sweep/FINDINGS.md
@@ -1,0 +1,216 @@
+# Mokka + AICR pre-silicon preflight: sweep findings
+
+**Date:** 2026-08-03 · **Ran by:** Carlos Eduardo Arango Gutierrez · **For review by:** Mark Chmarny
+**Cluster:** kind v0.32.0, Kubernetes v1.36.1, containerd 2.3.1, 1 control plane + 2 workers, arm64,
+one host, 7.75 GiB Docker VM
+**Mokka:** nvml-mock v0.3.0, image `ghcr.io/nvidia/nvml-mock:0.3.0`
+(`sha256:3b9bcf33d8bf442fe203062b78abeef7633172b4e589b23192e27edb6e81d3cc`), chart 0.3.0
+(`sha256:99e0de7e7c3292e9f814e15841c6c7a5bec8f64ce07620dd9f5c05ccb68b516e`), profile `gb200`, NRI path
+**AICR:** `upstream/main` @ `0752ea148aa1ae849cbef86ec59d0c970a582496` (2026-07-31)
+**GPU Operator:** v25.3.4 · **DRA driver:** nvidia-dra-driver-gpu 25.12.0
+
+**All evidence below is simulation provenance (`sim`). None of it was run on silicon.**
+
+## The question
+
+Does Mokka + AICR materially reduce GB200 bring-up time, or does it merely prove the stack deploys
+against mocked APIs? (Mark Chmarny, 2026-07-24.)
+
+## Answer
+
+AICR ran unmodified against a Mokka cluster and dispatched 9 of its 21 checks; 3 passed for real
+integration reasons, including `check-nvidia-smi`, which exercises device-plugin allocation and the
+`dlopen` of `libnvidia-ml.so.1` end to end inside a CUDA base image. **None of the 5 failures was
+caused by a Mokka capability gap**: they were a GPU Operator version that violates the recipe's own
+constraint, an unreleased upstream DRA flag, and recipe components the host memory budget did not let
+me deploy. So this is more than "the stack deploys against mocked APIs", but the run is far too small
+to put a number on bring-up time saved, and it says nothing whatsoever about scale.
+
+## 1. What actually ran
+
+AICR resolved `--service kind --accelerator gb200 --intent inference` to a **14-component** recipe
+over 5 overlays, then **selected 9 of the 21 catalog checks** as applicable to this cluster. The other
+12 were never dispatched: the 4 performance checks selected 0 (no NCCL or inference workload
+declared for this criteria pair), and 8 conformance checks skipped at selection because the recipe
+components they target were not present.
+
+| Check | Phase | Bucket | Outcome | Why |
+|---|---|---|---|---|
+| `operator-health` | deployment | A | **pass** | GPU Operator pods reconciled and healthy against the mock driver surface |
+| `check-nvidia-smi` | deployment | A | **pass** | CUDA base-image pod ran `nvidia-smi` on every schedulable GPU node and produced the banner, driver version, CUDA version and success marker |
+| `accelerator-metrics` | conformance | A | **pass** | real dcgm-exporter served `DCGM_FI_DEV_GPU_UTIL`, `FB_USED`, `GPU_TEMP`, `POWER_USAGE` off the mock NVML |
+| `gpu-operator-version` | deployment | A | fail | `v25.3.4 does not satisfy constraint ">= v25.10.0"` |
+| `dra-support` | conformance | A | fail | `nvidia-dra-driver-gpu-controller` Deployment not found |
+| `ai-service-metrics` | conformance | A | fail | no Prometheus service on port 9090 in `monitoring` |
+| `gpu-operator-health` | conformance | A | fail | `ClusterPolicy state=notReady (want ready)` |
+| `platform-health` | conformance | A | fail | 9 recipe namespaces not found |
+| `expected-resources` | deployment | A | inconclusive | Job pod disappeared before the result could be read; recorded `not-run`, never a pass |
+
+Raw CTRF: [`results/base-gb200-kind-inference-stack/ctrf/validate.json`](results/base-gb200-kind-inference-stack/ctrf/validate.json).
+
+### Every failure, attributed
+
+This is the part worth checking hardest, because it is where a misleading result would come from.
+
+| Failure | Cause | Whose problem |
+|---|---|---|
+| `gpu-operator-version` | I installed v25.3.4; the gb200 recipe requires `>= v25.10.0` (the Blackwell floor) | **mine.** And the check did its job: this is precisely the kind of version violation preflight is meant to catch before silicon. |
+| `dra-support` | The controller Deployment only exists when `resources.computeDomains.enabled=true`. Enabling it makes the kubelet plugin CrashLoopBackOff with `error parsing '/proc/devices': unexpected regex match: []`. The DRA driver needs `--set altProcDevices` to read Mokka's substitute, and that flag is on the driver's main branch and in **no** release including v25.12.0. | **upstream (cause U).** Mokka already renders the IMEX surface. Verified by enabling it and reading the crash, not by citing the docs. |
+| `ai-service-metrics` | Prometheus is 1 of the 14 recipe components; I deployed 2 | **mine (scope).** 7.75 GiB does not hold the full stack. |
+| `platform-health` | 9 recipe namespaces absent, same reason | **mine (scope).** |
+| `gpu-operator-health` | `ClusterPolicy` stays `notReady` because `gpu-feature-discovery` crashes | **cause K, with a caveat.** See §3. |
+
+**Zero of the five failures is a Mokka capability gap.** I want that stated plainly because the
+opposite conclusion would have been the convenient one.
+
+## 2. Coverage, two numbers, both shown
+
+**Analytical** (what each check would prove under Mokka, judged from AICR source before any run,
+catalogued with a file:line citation each in [`catalog.yaml`](catalog.yaml)):
+
+| Bucket | Count | Share of 21 |
+|---|---|---|
+| **A meaningful** | 16 | 76% |
+| B trivial | 1 | 5% |
+| C hardware-dependent | 4 | 19% |
+| **G closable Mokka gap** | 0 | 0% |
+
+- **Analytical ceiling today: 76%** (A / total).
+- **Reachable once tracked gaps close: 76%** ((A + G) / total). No difference, because at v0.3.0 no
+  catalogued check is blocked by a missing Mokka capability. That is a real change from the
+  2026-07-25 POC, where `dra-support` and two others sat in G. v0.3.0 shipped those.
+
+**Observed** (what this run actually demonstrated):
+
+- AICR dispatched **9 of 21** checks (43%).
+- **3 checks (14% of the suite) reached a meaningful pass.**
+- 5 failed, none for a Mokka reason. 1 was inconclusive.
+
+**Do not read 76% as a measured result.** It is the ceiling if the whole recipe stack is deployed.
+The measured number from this run is 14%, and the gap between the two is almost entirely the host
+memory budget, not Mokka. Of the 16 A-bucket checks, **10 are GPU-dependent** and 6 run on any
+cluster at all, so Mokka is not what unlocks that 6.
+
+## 3. The one real gap this sweep found
+
+**The PCI bus ID reaches NVML consumers without its domain prefix.** Two independent consumers, one
+symptom:
+
+```
+DRA driver v25.12.0 (go-nvlib):
+  W nvlib.go:491] error getting PCIe root for device 0, continuing without attribute:
+                  invalid PCI Bus ID format: :0a:00.0      (all 8 devices)
+
+gpu-feature-discovery (GPU Operator v25.3.4):
+  E main.go:127] error creating labeler: error creating resource labeler:
+                 unable to read PCI device vendor id for :0a:00.0:
+                 open /sys/bus/pci/devices/:0a:00.0/vendor: no such file or directory
+```
+
+The `gb200` profile declares `bus_id: "0000:0A:00.0"`, and Mokka renders
+`/var/lib/nvml-mock/sys/bus/pci/devices/0000:0a:00.0` correctly. The domain is lost somewhere between
+the profile and what the consumer reads back over NVML. Evidence:
+[`results/pci-busid-evidence.log`](results/pci-busid-evidence.log).
+
+This matters beyond the two log lines. The repo currently documents `dra.k8s.io/pcieRoot` as
+unavailable (issue #265) and attributes it to Go's `os` package issuing raw syscalls that the
+`LD_PRELOAD` shim cannot intercept. **The DRA driver log shows the failure happening earlier than
+that, at bus-ID string parsing, before any sysfs read is attempted.** So #265's stated diagnosis is
+at least incomplete, and the fix may be much smaller than the docs imply. I did not isolate whether
+the defect is in the engine, the CGo bridge, or go-nvml marshalling, so I am not claiming which.
+
+It is bucket **G**: closable, not hardware-dependent. It is the only one.
+
+**Also worth noting, not a gap:** the GFD crash above is why `ClusterPolicy` never reached `ready`,
+which is why `gpu-operator-health` failed. I classified that **K** rather than **G** because the
+repo's own `e2e-gpu-operator` scenario asserts GFD labels and passes on the CDI path with the
+container toolkit installed, whereas this sweep runs stock kind with `cdi.enabled=false`. The
+distinguishing cell did not fit in the memory budget, so the honest status is **not distinguished**.
+Reasoning in [DECISIONS.md](DECISIONS.md) D-014.
+
+## 4. What the matrix did not cover, and why
+
+10 cells planned, 2 ran. Nothing is hidden: blocked cells stay in the denominator.
+
+| Cause | Cells | Meaning |
+|---|---|---|
+| **BUDGET** | 5 | Host memory. 7.75 GiB fits one cluster shape at a time; a loaded 4-worker cluster needs ~2.9 GiB and OOMs mid-run, which produces a fake failure that reads like a Mokka finding. |
+| **X** | 2 | **AICR has no `gb300` accelerator.** `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2: `no recipe provides accelerator 'gb300'`. The catalog knows a100, b200, gb200, h100, h200, l40s, rtx-pro-6000. Mokka ships a gb300 profile; AICR has nothing to match it to. **Not a Mokka gap.** This is yours to decide on, Mark, and I did not file an issue in NVIDIA/aicr. |
+| **U** | 1 | ComputeDomain, per §1. |
+
+The brief asked for every recipe across `{gb200, gb300}` and single/multi-node. The gb300 half is
+impossible on the AICR side. I substituted `h100` as the second accelerator, and that cell is
+recorded as a substitution, never as gb300 coverage. It did not run either, for budget.
+
+## 5. Claims this supports, and does not
+
+| Claim | Supported? | Basis |
+|---|---|---|
+| Pre-silicon **integration preflight** for the A-bucket checks | **Partly** | 3 checks passed for real integration reasons on a real run. 16 are analytically capable. But only 9 of 21 were dispatched, so the demonstration is narrow. |
+| AICR runs **unmodified** on a Mokka cluster | **Yes** | No AICR flag, recipe or check was modified. The only accommodations were cluster-side (`operator.runtimeClass=runc`). |
+| Node-wide injection needs no pod change | **Yes** | A plain `debian:bookworm-slim` pod with `resources: {}`, no hostPath and no runtimeClassName ran `nvidia-smi -L` and listed 8 GB200s. |
+| The GPU stack really installs against the mock | **Yes** | GPU Operator reconciled; device plugin advertised `nvidia.com/gpu: 8` per worker; dcgm-exporter served real DCGM fields; the DRA driver published 16 devices across 2 ResourceSlices. |
+| **Reduces** time to first token | **Not demonstrated here** | Plausible from the 3 real passes, but this run has no baseline to measure against and no bring-up failure history to back-test. See §6. |
+| **Hit** first token on day one | **No** | Simulation cannot prove it. The hardware-dependent path is untested by construction. |
+| AICR-on-silicon remains the final readiness gate | **Yes** | Bucket C is non-empty by construction: 4 checks (3 NCCL variants plus `inference-perf`) cannot be judged without hardware. |
+| Deep GPU-stack fidelity at KWOK scale | **No** | Not tested. This ran on 3 containers on one laptop. |
+
+## 6. What is missing, honestly
+
+**The back-test did not happen.** The POC design called for replaying a known GB200 NVL72 bring-up
+and checking which of its real failures a Mokka preflight would have caught. That was the money
+metric. It needs a real failure set from a real bring-up, and I do not have one: it was the top open
+blocker in the POC tracker on 2026-07-24 and it is still open. **Without it there is no defensible
+bring-up-time number, so this note does not give one.** Anyone quoting a time saving from this run is
+quoting something I did not measure.
+
+**Scale is untested and this run cannot speak to it.** kind on one host. That is the whole caveat.
+
+## 7. One structural finding worth your time, Mark
+
+AICR already ships a KWOK lane (`kwok/`, `.ctlptl-kwok.yaml`, `make kwok-test-all`) that covers 90
+non-OCP recipes end to end through resolve, bundle, deploy and schedule. Its own README states the
+boundary:
+
+> KWOK validates scheduling, not runtime: node selectors, tolerations, resource requests, scheduling
+> decisions, and Helm chart generation are checked. Container execution, GPU functionality, and
+> network connectivity are NOT.
+
+And its pass criterion is that no pod is left unscheduled. **`aicr validate` cannot run under KWOK at
+all**, because every validator is a containerized Job that needs a real pod on a real kubelet. Only
+one check in the whole validator tree even detects a KWOK node, and it skips
+(`slinky_slurm_health_check.go:346-353`).
+
+That is the vertical-versus-horizontal argument, stated in your own repo rather than by me: KWOK gives
+recipe and scheduling breadth cheaply; the 21 validator checks need a real kubelet with a real GPU
+stack under it. Mokka is what lets those 21 run before silicon. This sweep got 9 of them dispatched
+and 3 passing on a laptop.
+
+## 8. Recommendation
+
+**Go, with scope, and with the claim kept narrow.** Specifically:
+
+1. Re-run this sweep on a host with 32 GiB or more so the full 14-component recipe deploys. The gap
+   between the 14% observed and the 76% analytical is almost entirely memory, and closing it is the
+   single highest-value next step. Nothing about Mokka needs to change first.
+2. Install GPU Operator `>= v25.10.0` for gb200 so `gpu-operator-version` is testing the intended
+   thing.
+3. Get a real GB200 bring-up failure set, or drop the bring-up-time claim entirely until someone does.
+   Do not let it be quoted from this run.
+4. Fix the PCI bus-ID gap in §3. It is small, it unblocks `dra.k8s.io/pcieRoot`, and it may correct a
+   wrong diagnosis already written into issue #265.
+5. Decide, on your side, whether AICR should carry a `gb300` accelerator. Mokka has the profile.
+
+What I would **not** do yet: put a bring-up-time number in any leadership-facing artifact. The
+integration story is real and demonstrable; the time saving is not measured.
+
+## Appendix
+
+- Harness and how to re-run: [README.md](README.md)
+- Every judgment call, with rationale: [DECISIONS.md](DECISIONS.md)
+- Per-check analytical buckets with source citations: [catalog.yaml](catalog.yaml)
+- The permutation matrix, including cells that did not run: [cells.yaml](cells.yaml)
+- Machine-readable results: [results/report.json](results/report.json)
+- Rendered coverage read: [results/coverage.md](results/coverage.md)
+- Supersedes the 2026-07-25 POC in [PR #503](https://github.com/NVIDIA/k8s-test-infra/pull/503),
+  which predates v0.3.0.

--- a/tests/aicr-sweep/FINDINGS.md
+++ b/tests/aicr-sweep/FINDINGS.md
@@ -173,8 +173,9 @@ Run after the sections above, on Carlos's call and over a panel dissent I agreed
 [results/kwok-false-pass-evidence.log](results/kwok-false-pass-evidence.log).
 
 Added 250 hollow KWOK GPU nodes to the Mokka cluster, giving a 253-node fleet advertising 2016
-`nvidia.com/gpu`, and re-ran the identical recipe. **Every check passed, in 4.2s and 5.2s, against
-9m 0s on the pure-Mokka baseline. Nothing executed.**
+`nvidia.com/gpu`, and re-ran the identical recipe. AICR dispatched **the same 9 of 21 checks** as the
+baseline, so this is not a coverage increase. What changed is the verdicts: **3 pass / 5 fail /
+1 inconclusive became 9 pass / 0 fail, in 4.2s and 5.2s against 9m 0s. Nothing executed.**
 
 Four verified facts compose into it: AICR validator Jobs tolerate every taint (empty key,
 `operator: Exists`, asserted at `deployer_test.go:516`); KWOK nodes carry the full GPU label set and

--- a/tests/aicr-sweep/HYBRID-KWOK-FINDING.md
+++ b/tests/aicr-sweep/HYBRID-KWOK-FINDING.md
@@ -1,0 +1,167 @@
+# KWOK + Mokka: combining them silently turns the AICR suite into a rubber stamp
+
+**Run 2026-08-03, cluster `mokka-hybrid`.** Raw evidence:
+[`results/kwok-false-pass-evidence.log`](results/kwok-false-pass-evidence.log).
+
+## What we set out to test
+
+Whether combining KWOK (horizontal, node-count breadth) with Mokka (vertical, per-node GPU-stack
+depth) gives this study a scale story. That is the open question Mark named on 2026-07-24: the mock
+backend needs real nodes, KWOK nodes stay the fake backend, so fidelity at KWOK scale is a claim to
+prove rather than assert.
+
+**The prediction was wrong, and the recommendation panel's objection was wrong in the same direction.**
+Both expected the result to be a tautology: hollow nodes cannot run `nvidia-smi`, so fleet-surveying
+checks would obviously go red. The actual result is the opposite, and it is worse.
+
+## What happened
+
+| | pure Mokka (baseline) | + 250 KWOK nodes |
+|---|---|---|
+| deployment phase | 9m 0s, 2 pass / 1 fail / 1 inconclusive | **4.2s, 4 pass / 0 fail** |
+| conformance phase | 5 selected, 1 pass / 4 fail | **5.2s, 5 pass / 0 fail** |
+
+**Every check reported PASS. Nothing ran.**
+
+The fleet was 253 nodes: 1 control plane, 2 real Mokka workers, 250 hollow KWOK nodes, advertising
+2016 `nvidia.com/gpu` between them.
+
+## Why
+
+Four facts compose into a false pass. Each was verified on the live cluster, not inferred.
+
+1. **AICR validator Job pods tolerate every taint.** Observed on the live pod: a single toleration with
+   empty key and `operator: Exists`. Confirmed in source at
+   `pkg/validator/job/deployer_test.go:516`, which asserts exactly that default. This is correct
+   design on a real cluster: validators must be able to land on tainted GPU nodes.
+
+2. **KWOK nodes look like GPU nodes.** They carry `nvidia.com/gpu.present`, `gpu.product`, `gpu.count`,
+   the CUDA driver labels, and real `nvidia.com/gpu` capacity. Nothing above the API server can tell
+   them from a Mokka node by labels alone.
+
+3. **So the scheduler puts validators on them.** 250 hollow nodes against 2 real ones. The
+   `kwok.x-k8s.io/node=fake:NoSchedule` taint does not help, because of fact 1. Observed placement,
+   with the taint applied:
+
+   ```
+   aicr-check-nvidia-smi-...      kwok-gpu-0158   Succeeded
+   aicr-expected-resources-...    kwok-gpu-0169   Succeeded
+   aicr-gpu-operator-version-...  kwok-gpu-0037   Succeeded
+   aicr-operator-health-...       kwok-gpu-0048   Succeeded
+   ```
+
+4. **KWOK then manufactures the success.** Its `pod-complete` stage matches any pod whose
+   `ownerReferences[].kind` is `Job` and whose phase is `Running`, and transitions it to `Succeeded`.
+   Every AICR validator is a Job.
+
+The container status is the proof that nothing executed:
+
+```json
+{"image":"ghcr.io/nvidia/aicr-validators/deployment:latest","imageID":"","started":false,
+ "state":{"terminated":{"exitCode":0,"reason":"Completed",
+ "startedAt":"2026-08-03T19:11:33Z","finishedAt":"2026-08-03T19:11:33Z"}}}
+```
+
+`imageID` is empty, so the image was never pulled. `started` is false. `startedAt` equals `finishedAt`.
+And `kubectl logs` on that pod returns `MethodNotAllowed`, because there is no kubelet to serve logs.
+
+Control experiment, to rule out any other explanation: a pod running `sh -c 'exit 7'` reports
+`phase=Failed, exitCode=7` on a real node, and `Succeeded` on a KWOK node.
+
+## The obvious mitigation does not work
+
+`aicr validate --node-selector` reads as the fix. It is not. Measured:
+
+```
+aicr-validate-6qxk2 (snapshot agent)      nodeSelector={"aicr.run/real-node":"true"}
+aicr-check-nvidia-smi-2bb73994-d9hc4      nodeSelector=NONE   -> ran on kwok-gpu-0213
+aicr-expected-resources-345bc8fa-fqprd    nodeSelector=NONE   -> ran on kwok-gpu-0224
+aicr-gpu-operator-version-32a497d6-fh5j2  nodeSelector=NONE   -> ran on kwok-gpu-0092
+aicr-operator-health-72210902-5jxcg       nodeSelector=NONE   -> ran on kwok-gpu-0103
+```
+
+The flag reaches the snapshot agent's pod spec and stops there. `pkg/validator/job/deployer.go:66`
+states the intent plainly:
+
+> `// NodeSelector is passed through to inner workloads via AICR_NODE_SELECTOR.`
+
+It is delivered to the validator container as an environment variable, so a validator can apply it to
+workloads *it* creates (the NCCL benchmark pod, the `nvidia-smi` probe pod). It is never applied to
+the validator Job's own pod spec. With the flag set exactly as documented, the run still reported
+4 of 4 passes in 4.2 seconds, with every validator on a hollow node.
+
+## Whose problem this is
+
+**Not Mokka's.** Mokka's nodes behaved correctly throughout; the pure-Mokka baseline on the identical
+recipe produced honest, mixed results.
+
+**Not KWOK's.** `pod-complete` is doing exactly what it is documented to do, and AICR's own KWOK lane
+depends on that behaviour for its scheduling tests.
+
+**It is a composition hazard, and the actionable half sits in AICR.** The validator Job pod spec has a
+universal toleration and no node selector of its own, so it cannot be constrained by the operator
+running the suite. On any cluster containing hollow nodes that advertise GPUs, AICR reports green
+without executing.
+
+## Why this matters beyond a lab curiosity
+
+This is the exact architecture Eliran's `fake-gpu-operator` per-nodepool `backend` design produces:
+KWOK nodes on the `fake` backend for cheap breadth, real nodes on the `mock` backend for fidelity, in
+one cluster. Anyone who builds that fleet and then runs AICR against it gets a clean green
+conformance report that means nothing, with no warning and no error.
+
+The failure mode is silent, fast and flattering, which is the worst combination. A run that takes
+4 seconds instead of 9 minutes and passes everything looks like good news.
+
+## What would fix it
+
+In rough order of how much it helps:
+
+1. **AICR: apply `--node-selector` to the validator Job pod spec**, not only to inner workloads. That
+   makes the documented mitigation actually work and is the smallest change.
+2. **AICR: refuse to report a pass for a check whose pod never pulled its image.** An empty `imageID`
+   with `started: false` is a reliable signal that nothing executed, and it is available in the pod
+   status AICR already reads. This is a fail-closed guard that does not depend on the operator
+   configuring anything correctly.
+3. **AICR: detect the `kwok.x-k8s.io/node` annotation** and skip or fail, the way
+   `slinky_slurm_health_check.go:346-353` already does for its own NodeSets. That precedent exists in
+   the codebase; it is simply not applied to the Job deployer.
+4. **Fleet side:** keep hollow nodes out of any namespace or node pool AICR targets, and do not let
+   them advertise `nvidia.com/gpu` unless something can actually serve it.
+
+**None of these is a Mokka change.** We are not filing them in `NVIDIA/aicr` without Mark's sign-off.
+
+## What this does and does not add to the study
+
+**Does not:** it is not AICR coverage at scale, not a bring-up-time number, and not evidence of
+GPU-stack fidelity at KWOK node counts. Adding KWOK nodes cannot move the measured 14% or the 76%
+ceiling, because the checks structurally cannot execute on them.
+
+**Does:** it answers Mark's July open question with a measurement instead of an assertion. Fidelity
+and scale compose *across* a fleet, not *within* a node, and combining them naively does not merely
+fail to help, it actively destroys the trustworthiness of the result.
+
+**Recorded separately from the coverage matrix on purpose.** These runs produced 9 passes that are all
+false. They are deliberately excluded from `cells.yaml` and from the rollup, because feeding them into
+the denominator would raise the headline coverage number using results we know are fabricated. The
+raw CTRF is kept under `results/hybrid-kwok-*/` for audit.
+
+## Control-plane observations, incidentally
+
+Cheap to collect while the fleet was up, and unremarkable, which is itself worth knowing:
+
+| Measure | 3 nodes | 253 nodes |
+|---|---|---|
+| `kubectl get nodes` wall clock | 0.06s | 0.30s |
+| Docker VM memory used | 1961 MiB | 2983 MiB |
+
+250 hollow nodes cost about 1 GiB and a 5x increase on a trivially small API call. No controller
+churn, no OOM, nothing degraded. That is a genuine if narrow data point for the horizontal axis, and
+it says nothing about the vertical one.
+
+## Provenance note
+
+The recommendation panel dissented against running this experiment, arguing it would document the
+obvious, and I agreed with that dissent before Carlos overrode it. Both of us were wrong about what
+the experiment would show. The dissent is recorded in
+[`DECISIONS.md`](DECISIONS.md) D-015 rather than quietly dropped now that the result is interesting.

--- a/tests/aicr-sweep/HYBRID-KWOK-FINDING.md
+++ b/tests/aicr-sweep/HYBRID-KWOK-FINDING.md
@@ -16,12 +16,18 @@ checks would obviously go red. The actual result is the opposite, and it is wors
 
 ## What happened
 
+**AICR dispatched the same 9 checks in both runs.** Adding KWOK nodes did not change which checks were
+selected. It changed their verdicts.
+
 | | pure Mokka (baseline) | + 250 KWOK nodes |
 |---|---|---|
+| checks dispatched | 9 of 21 | 9 of 21 (identical set) |
 | deployment phase | 9m 0s, 2 pass / 1 fail / 1 inconclusive | **4.2s, 4 pass / 0 fail** |
 | conformance phase | 5 selected, 1 pass / 4 fail | **5.2s, 5 pass / 0 fail** |
+| overall | 3 pass / 5 fail / 1 inconclusive | **9 pass / 0 fail** |
 
-**Every check reported PASS. Nothing ran.**
+**Every one of the 9 dispatched checks reported PASS. Nothing ran.** The other 12 stayed undispatched
+in both runs, so this is not a coverage increase; it is the same 9 verdicts, fabricated.
 
 The fleet was 253 nodes: 1 control plane, 2 real Mokka workers, 250 hollow KWOK nodes, advertising
 2016 `nvidia.com/gpu` between them.

--- a/tests/aicr-sweep/HYBRID-KWOK-FINDING.md
+++ b/tests/aicr-sweep/HYBRID-KWOK-FINDING.md
@@ -1,5 +1,10 @@
 # KWOK + Mokka: combining them silently turns the AICR suite into a rubber stamp
 
+> **First run, 2026-08-03. This finding is unaffected by the 2026-08-26 re-run**,
+> which did not repeat the KWOK composition. The `14%` and `76%` figures quoted
+> below are the first run's; see [FINDINGS-57ef016.md](FINDINGS-57ef016.md) for
+> the current ones.
+
 **Run 2026-08-03, cluster `mokka-hybrid`.** Raw evidence:
 [`results/kwok-false-pass-evidence.log`](results/kwok-false-pass-evidence.log).
 

--- a/tests/aicr-sweep/README.md
+++ b/tests/aicr-sweep/README.md
@@ -1,5 +1,12 @@
 # Mokka + AICR compatibility sweep
 
+> **There are two runs.** This README describes the harness and the first run
+> (Mokka `v0.3.0`, 2026-08-03). A second run against `upstream/main` `57ef01659`
+> on 2026-08-26 is written up in [FINDINGS-57ef016.md](FINDINGS-57ef016.md), and
+> pairs with [cells-57ef016.yaml](cells-57ef016.yaml) and
+> [results-57ef016/](results-57ef016/). Both runs regenerate byte-identically and
+> neither overwrites the other. Any figure below is the first run's.
+
 Runs the [AICR](https://github.com/NVIDIA/aicr) recipe and validation suite against an
 `nvml-mock` (Mokka) cluster on kind, and classifies what each check actually proves when no GPU is
 present.

--- a/tests/aicr-sweep/README.md
+++ b/tests/aicr-sweep/README.md
@@ -1,0 +1,199 @@
+# Mokka + AICR compatibility sweep
+
+Runs the [AICR](https://github.com/NVIDIA/aicr) recipe and validation suite against an
+`nvml-mock` (Mokka) cluster on kind, and classifies what each check actually proves when no GPU is
+present.
+
+This exists to answer one question, put by the AICR maintainer on 2026-07-24:
+
+> Does Mokka + AICR materially reduce GB200 bring-up time, or does it merely prove the stack deploys
+> against mocked APIs?
+
+An honest negative answer is a successful run. Nothing here is tuned toward a favourable number.
+
+## What this is not
+
+This is a **pre-silicon integration preflight**, not a readiness gate. AICR validation on real silicon
+remains the final gate. Preflight cannot judge CUDA execution, firmware and driver compatibility,
+NCCL / NVLink / NVLS and the network fabric, or workload time-to-first-token. Those determine first
+token. Preflight reduces the integration failures you carry into silicon; it does not prove you will
+hit first token on day one.
+
+**This sweep runs on kind, so it proves nothing about scale.** Every number here comes from a
+handful of containers on one laptop. Fidelity at KWOK-scale node counts is unproven and is not
+claimed.
+
+## Buckets and causes
+
+Two independent axes. Keeping them separate is the whole point.
+
+**Bucket** says what a check would prove. It is an analytical judgment from AICR source, recorded in
+[`catalog.yaml`](catalog.yaml), and the harness never edits it to match a result.
+
+| Bucket | Meaning | Counts as coverage? |
+|---|---|---|
+| **A** | Exercises real integration. Could plausibly fail for a real reason. | Yes. This is the movable-left set. |
+| **B** | Green only because the mock answers the API. Would pass regardless of correctness. | No. Recorded honestly because it bounds the claim. |
+| **C** | Hardware-dependent. Cannot be judged pre-silicon. | No. These are why AICR-on-silicon stays the final gate. |
+| **G** | Would be meaningful pre-silicon, but Mokka lacks the capability. Closable. | As roadmap only. Requires a tracked issue. |
+
+**Cause** says what stopped a particular run.
+
+| Cause | Meaning | Whose problem |
+|---|---|---|
+| **K** | kind or single-host artifact | nobody's. Would not occur on a real cluster. |
+| **U** | upstream dependency has not released what is needed | the dependency's |
+| **X** | AICR catalog has no recipe for the combination | AICR's |
+| **BUDGET** | host memory exhausted, cell not attempted | this harness's |
+
+A failure is **G** only if Mokka promised to render the path or speak the protocol. If the failing
+read targets real host kernel state that Mokka never claimed (NUMA nodes, the real PCI tree, the
+NVLink data plane, RDMA verbs), it is **K**. That rule was fixed before any cell ran, so it cannot be
+bent to fit a number.
+
+## Two numbers, always together
+
+- **A / total**: the share carrying real pre-silicon signal **today**.
+- **(A + G) / total**: the share **reachable** once tracked gaps close. Roadmap, never a current claim.
+
+A third number keeps the first honest. Some bucket-A checks are GPU-independent: `gang-scheduling` is
+explicitly CPU-only upstream, `platform-health` is pure control plane. They move left, but any
+cluster runs them, so Mokka is not what unlocks them. The report splits bucket A into GPU-dependent
+and GPU-independent so the headline cannot be inflated by control-plane checks.
+
+## Design invariants
+
+The harness is built so an incomplete run degrades to "not run" rather than to a favourable number.
+Each invariant has a test that goes red if it regresses.
+
+1. A check the run never reported is `not-run`. It is never promoted to a pass.
+   (`TestCheckAbsentFromRunIsNotRunNeverPass`)
+2. CTRF `pending` and `other` mean the suite reached no verdict, and map to `not-run` rather than
+   being laundered into a pass or a fail. (`TestPendingAndOtherBecomeNotRun`)
+3. A bucket-C check reporting green under `sim` provenance is flagged `suspect`, because a
+   hardware-dependent check cannot legitimately pass without hardware.
+   (`TestBucketCPassUnderSimIsFlaggedSuspect`)
+4. Every emitted record carries `provenance`, `sim` or `silicon`. They are never conflated.
+5. A bucket-G row without a tracked gap issue fails catalog validation. An untracked gap is not a
+   roadmap. (`TestCatalogRejectsBucketGWithoutIssue`)
+6. A check present in the run but absent from the catalog is reported as catalog drift rather than
+   silently dropped. (`TestUnknownCheckInRunIsReportedAsDrift`)
+7. Blocked and not-run results stay in the rollup denominator.
+   (`TestRollupDenominatorIncludesBlockedAndNotRun`)
+
+Invariant 1 was mutation-checked: flipping `OutcomeNotRun` to `OutcomePass` in `Classify` turns two
+tests red.
+
+## Prerequisites
+
+- `docker`, `kind`, `kubectl`, `helm`, and a Go toolchain matching the project.
+- The `aicr` CLI, built from [NVIDIA/aicr](https://github.com/NVIDIA/aicr) at the pinned ref:
+  ```bash
+  git -C <aicr-checkout> archive upstream/main | tar -x -C /tmp/aicr-pinned
+  cd /tmp/aicr-pinned && CGO_ENABLED=0 go build -mod=vendor -o /tmp/bin/aicr ./cmd/aicr
+  ```
+- **Real nodes.** The mock replaces `libnvidia-ml.so.1` on the host and needs a real kubelet and
+  container runtime. KWOK nodes cannot host it. This harness therefore says nothing about GPU-stack
+  fidelity at KWOK-scale node counts.
+- **Memory.** The Docker VM used for this sweep held 7.75 GiB, which fits one cluster shape at a
+  time. A fully loaded worker costs 550 to 700 MiB, of which dcgm-exporter is over half. Budget
+  12 to 16 GiB to run the matrix without blocking cells.
+
+## Resource cost of a full sweep
+
+| Shape | Nodes | Carries | Idle | Loaded (est.) |
+|---|---|---|---|---|
+| `stack` | 1 control plane + 2 workers | GPU Operator, device plugin, GFD, dcgm-exporter, DRA | ~920 MiB | ~2.0 GiB |
+| `fabric` | 1 control plane + 4 workers | NRI injection, IMEX channels, ComputeDomain topology | ~1150 MiB | ~1.4 GiB |
+
+The two shapes are created and destroyed in sequence and never coexist. Merging them into one
+5-worker loaded cluster does not fit in 7.75 GiB and will OOM mid-sweep, which produces a fake
+failure that reads like a Mokka finding.
+
+## Running it
+
+### 1. Create the cluster and install Mokka v0.3.0
+
+```bash
+kind create cluster --name mokka-aicr-stack --config tests/aicr-sweep/assets/kind-stack.yaml --wait 300s
+```
+
+```bash
+docker save --platform linux/arm64 ghcr.io/nvidia/nvml-mock:0.3.0 -o /tmp/nvml-mock-030.tar && kind load image-archive /tmp/nvml-mock-030.tar --name mokka-aicr-stack
+```
+
+The two-step save-then-load matters: `kind load docker-image` cannot load a multi-arch image out of
+Docker Desktop's containerd store.
+
+```bash
+helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock --version 0.3.0 --kube-context kind-mokka-aicr-stack -n mokka --create-namespace --set image.repository=ghcr.io/nvidia/nvml-mock --set image.tag=0.3.0 --set gpu.profile=gb200 --set nri.enabled=true --set nri.deviceInjectionMode=raw --wait --timeout 6m
+```
+
+`-n mokka` is load-bearing. Install without it and the NRI plugin renders
+`--excluded-namespaces=default,kube-system`, so it silently skips every pod a first-time user runs,
+while the DaemonSet still reports Ready.
+
+`image.tag` defaults to `latest`, not to the chart version. Pin it or the run is not reproducible.
+
+### 2. Install the GPU Operator
+
+```bash
+helm install gpu-operator nvidia/gpu-operator --version v25.3.4 --kube-context kind-mokka-aicr-stack -n gpu-operator --create-namespace -f tests/aicr-sweep/assets/gpu-operator-values.yaml --set operator.runtimeClass=runc --timeout 12m
+```
+
+`operator.runtimeClass=runc` is required on a stock kind node. The operator otherwise creates a
+RuntimeClass named `nvidia` and sets `runtimeClassName: nvidia` on every operand, and stock kind
+containerd has only the `runc` and `test-handler` runtimes. Without this every operand fails sandbox
+creation with `no runtime for "nvidia" is configured`. See DECISIONS.md D-013.
+
+### 3. Generate the recipe and run AICR
+
+```bash
+aicr recipe --service kind --accelerator gb200 --intent inference -o recipe.yaml
+```
+
+```bash
+aicr validate --recipe recipe.yaml --phase deployment --phase conformance --phase performance --namespace aicr-validation --fail-on-error=false --timeout 12m --output ctrf/validate.json
+```
+
+`--fail-on-error=false` matters: the point is to record every outcome, not to stop at the first
+failure. The exit code collapses 21 checks into one number, so read the CTRF report, never the exit
+code.
+
+### 4. Classify
+
+```bash
+go run ./tests/aicr-sweep -catalog tests/aicr-sweep/catalog.yaml -cells tests/aicr-sweep/cells.yaml -results tests/aicr-sweep/results -json report.json -markdown coverage.md
+```
+
+Omitting `-results` is legal and prints the catalog with every outcome recorded `not-run`. That is
+the correct output when no run happened.
+
+## Reading the results
+
+A failing check is not automatically a Mokka gap. Separate the causes before filing anything:
+
+1. **Did Mokka promise this?** If the failing read targets `/var/lib/nvml-mock/**`, `MOCK_IB_ROOT`,
+   an injected `/dev/nvidia*`, the topology ConfigMap, or a protocol Mokka speaks for real, it is a
+   candidate **G**. Otherwise it is **K**.
+2. **Is the dependency released?** ComputeDomain needs a DRA driver flag that exists only on main.
+   That is **U**.
+3. **Does AICR have the recipe at all?** `gb300` does not exist in AICR's catalog. That is **X**.
+4. **Is it version skew?** CI pins kind v0.31.0; this sweep ran v0.32.0 with Kubernetes v1.36.1.
+   Re-test any DRA or operator failure unique to the sweep before calling it **G**.
+
+## Layout
+
+```text
+tests/aicr-sweep/
+  DECISIONS.md      every judgment call made instead of asking, with rationale
+  catalog.yaml      analytical A/B/C/G bucket per AICR check, with source evidence
+  cells.yaml        the permutation matrix, including cells that did not run
+  types.go          bucket, cause, outcome and record types
+  classify.go       the join, the invariants and the rollup
+  ctrf.go           CTRF report and catalog loading
+  report.go         JSON and markdown rendering
+  main.go           the CLI
+  assets/           pinned kind configs and the GPU Operator values overlay
+  results/          per-cell CTRF output and logs
+```

--- a/tests/aicr-sweep/assets/gpu-operator-values.yaml
+++ b/tests/aicr-sweep/assets/gpu-operator-values.yaml
@@ -1,0 +1,73 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# GPU Operator overlay for the AICR sweep. Derived from
+# tests/e2e/gpu-operator-values.yaml, with two deliberate differences:
+#
+#  1. cdi.enabled=false. The e2e overlay turns CDI on, which needs
+#     nvidia-container-toolkit configured in the Kind node. The sweep runs the
+#     NRI path on a stock kindest/node, where no toolkit is installed. MEP-0002
+#     covers this composition: the device plugin serves allocated containers via
+#     PASS_DEVICE_SPECS, and the NRI plugin suppresses its own device injection
+#     for any container that already carries /dev/nvidia* nodes.
+#
+#  2. PASS_DEVICE_SPECS=true on the device plugin. Without it the allocation is
+#     inert: MEP-0002's measured Case A shows a pod requesting 1 GPU seeing all
+#     of them, because nothing narrows the visible set.
+driver:
+  enabled: false
+toolkit:
+  enabled: false
+dcgm:
+  enabled: false
+dcgmExporter:
+  enabled: true
+  env:
+    - name: NVIDIA_DRIVER_ROOT
+      value: "/var/lib/nvml-mock/driver"
+    - name: DCGM_EXPORTER_COLLECT_INTERVAL
+      value: "5000"
+mig:
+  strategy: none
+migManager:
+  enabled: false
+nodeStatusExporter:
+  enabled: false
+cdi:
+  enabled: false
+  default: false
+devicePlugin:
+  enabled: true
+  config:
+    name: ""
+  env:
+    - name: NVIDIA_DRIVER_ROOT
+      value: "/var/lib/nvml-mock/driver"
+    - name: PASS_DEVICE_SPECS
+      value: "true"
+gfd:
+  enabled: true
+  env:
+    - name: NVIDIA_DRIVER_ROOT
+      value: "/var/lib/nvml-mock/driver"
+validator:
+  driver:
+    env:
+      - name: DRIVER_INSTALL_DIR
+        value: "/run/nvidia/driver"
+      - name: LD_LIBRARY_PATH
+        value: "/run/nvidia/driver/usr/lib64"
+      - name: DISABLE_DEV_CHAR_SYMLINK_CREATION
+        value: "true"
+  toolkit:
+    env:
+      - name: NVIDIA_VISIBLE_DEVICES
+        value: "all"
+  cuda:
+    env:
+      - name: WITH_WORKLOAD
+        value: "false"
+  plugin:
+    env:
+      - name: LD_LIBRARY_PATH
+        value: "/run/nvidia/driver/usr/lib64"

--- a/tests/aicr-sweep/assets/kind-fabric.yaml
+++ b/tests/aicr-sweep/assets/kind-fabric.yaml
@@ -1,0 +1,24 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# "fabric" cluster shape for the AICR sweep: node heavy, memory light.
+# Carries node-wide NRI injection, mock IMEX channels and the two-clique
+# ComputeDomain topology overlay. No GPU Operator, no dcgm-exporter, which is
+# what makes four workers fit. See tests/aicr-sweep/DECISIONS.md D-010.
+#
+# Four workers so the ComputeDomain overlay has two cliques to assign
+# (workers 1-2 -> clique 0, workers 3-4 -> clique 1), matching
+# tests/e2e/go/assets/kind-nri-config.yaml.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.nri.v1.nri"]
+      disable = false
+      socket_path = "/var/run/nri/nri.sock"
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker
+  - role: worker
+  - role: worker

--- a/tests/aicr-sweep/assets/kind-stack.yaml
+++ b/tests/aicr-sweep/assets/kind-stack.yaml
@@ -1,0 +1,22 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# "stack" cluster shape for the AICR sweep: memory heavy, node light.
+# Carries the GPU Operator, device plugin, GFD, dcgm-exporter and the DRA driver.
+# Two workers, because a fully loaded worker costs 550-700 MiB and the Docker VM
+# on the sweep host has 7.75 GiB total. See tests/aicr-sweep/DECISIONS.md D-010.
+#
+# The NRI patch restates the containerd 2.x default (verified: kind 0.32.0's
+# kindest/node v1.36.1 ships containerd 2.2.0 with NRI already enabled). It is
+# kept because it is the difference between working and not on containerd 1.7.x.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.nri.v1.nri"]
+      disable = false
+      socket_path = "/var/run/nri/nri.sock"
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker

--- a/tests/aicr-sweep/assets/kwok-gpu-nodes.sh
+++ b/tests/aicr-sweep/assets/kwok-gpu-nodes.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Emit N KWOK fake GPU nodes for the hybrid Mokka + KWOK cell.
+#
+# These nodes are hollow: no kubelet, no container runtime, no GPU. KWOK's
+# controller answers for them at the API level and `stage-fast` walks pods
+# through their phases without executing anything. That is the whole point of
+# the cell: a KWOK node advertises the same GPU labels and the same
+# nvidia.com/gpu capacity that a Mokka node does, and NOTHING above the API
+# server can tell them apart from labels alone.
+#
+# The label set mirrors what AICR's own kwok/scripts/apply-nodes.sh injects, so
+# the fleet looks to AICR exactly like its own KWOK lane's fleet does. Values
+# are taken from Mokka's gb200 profile so the fake nodes and the real Mokka
+# nodes claim the same hardware.
+#
+# Usage:
+#   kwok-gpu-nodes.sh <count> [taint]     taint: "true" (default) | "false"
+#
+#   kwok-gpu-nodes.sh 250          | kubectl apply -f -
+#   kwok-gpu-nodes.sh 250 false    | kubectl apply -f -
+#
+# With taint=true the nodes carry kwok.x-k8s.io/node=fake:NoSchedule, which is
+# how AICR's KWOK lane ships them: workloads must tolerate the taint explicitly.
+# With taint=false they are freely schedulable, which is the configuration that
+# lets a fleet-surveying AICR check target a hollow node.
+set -euo pipefail
+
+COUNT="${1:?usage: kwok-gpu-nodes.sh <count> [taint true|false]}"
+TAINT="${2:-true}"
+
+# gb200 profile shape, from deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
+GPU_PRODUCT="NVIDIA-GB200"
+GPU_COUNT="8"
+GPU_MEMORY="196608"        # MiB per GPU (192 GiB)
+DRIVER_MAJOR="580"
+DRIVER_MINOR="65"
+DRIVER_VERSION="580.65.06"
+
+for i in $(seq 1 "${COUNT}"); do
+  NAME=$(printf "kwok-gpu-%04d" "${i}")
+  cat <<YAML
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: ${NAME}
+  annotations:
+    kwok.x-k8s.io/node: "fake"
+    node.alpha.kubernetes.io/ttl: "0"
+    nvidia.com/gpu.driver.version: "${DRIVER_VERSION}"
+  labels:
+    beta.kubernetes.io/arch: arm64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: arm64
+    kubernetes.io/hostname: ${NAME}
+    kubernetes.io/os: linux
+    kubernetes.io/role: agent
+    node-role.kubernetes.io/agent: ""
+    type: kwok
+    aicr.run/node-type: accelerated
+    nvidia.com/gpu.present: "true"
+    nvidia.com/gpu.product: ${GPU_PRODUCT}
+    nvidia.com/gpu.count: "${GPU_COUNT}"
+    nvidia.com/gpu.memory: "${GPU_MEMORY}"
+    nvidia.com/cuda.driver.major: "${DRIVER_MAJOR}"
+    nvidia.com/cuda.driver.minor: "${DRIVER_MINOR}"
+spec:
+YAML
+  if [ "${TAINT}" = "true" ]; then
+    cat <<'YAML'
+  taints:
+    - key: kwok.x-k8s.io/node
+      value: fake
+      effect: NoSchedule
+YAML
+  fi
+  cat <<YAML
+status:
+  allocatable:
+    cpu: "192"
+    memory: 2048Gi
+    pods: "250"
+    nvidia.com/gpu: "${GPU_COUNT}"
+  capacity:
+    cpu: "192"
+    memory: 2048Gi
+    pods: "250"
+    nvidia.com/gpu: "${GPU_COUNT}"
+  nodeInfo:
+    architecture: arm64
+    containerRuntimeVersion: containerd://2.3.1
+    kernelVersion: 6.1.0-fake
+    kubeProxyVersion: fake
+    kubeletVersion: fake
+    operatingSystem: linux
+    osImage: fake
+  phase: Running
+YAML
+done

--- a/tests/aicr-sweep/catalog.yaml
+++ b/tests/aicr-sweep/catalog.yaml
@@ -1,0 +1,308 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# AICR check-coverage catalog under Mokka (nvml-mock).
+#
+# One row per check in the AICR validate catalog. The bucket is an ANALYTICAL
+# judgment about what the check proves when it runs against a simulated cluster.
+# It is made from source evidence and is reviewable independently of any run.
+# The harness supplies the observed outcome separately and never edits a bucket
+# to match a result.
+#
+# Buckets:
+#   A  exercises real integration; could plausibly fail for a real reason.
+#   B  green only because the mock answers the API; would pass regardless of
+#      correctness. Not a win. Recorded honestly because it bounds the claim.
+#   C  hardware-dependent; cannot be judged pre-silicon. These are why
+#      AICR-on-silicon remains the final readiness gate.
+#   G  would be meaningful pre-silicon, but Mokka lacks the capability. Not
+#      hardware-dependent, therefore closable, therefore roadmap. Needs an issue.
+#
+# gpuDependent records whether the check actually touches the GPU stack. A
+# bucket-A row with gpuDependent:false still moves left, but ANY cluster runs it,
+# so Mokka is not what unlocks it. Keeping that split visible is what stops the
+# headline A number from being inflated by pure control-plane checks.
+#
+# Check names and evidence lines are from NVIDIA/aicr at upstream/main
+# 0752ea148aa1ae849cbef86ec59d0c970a582496 (2026-07-31). The authoritative
+# source list is recipes/validators/catalog.yaml: 21 entries, 4 deployment,
+# 4 performance, 13 conformance.
+
+source: "NVIDIA/aicr recipes/validators/catalog.yaml @0752ea14 (21 checks)"
+
+checks:
+  # ---------------------------------------------------------------- deployment
+  - name: operator-health
+    area: operator-install
+    phase: deployment
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      Installs and reconciles the real NVIDIA GPU Operator against the mock
+      driver surface, then requires its pods to reach a healthy state. Fails for
+      real reasons: a broken operand, an unschedulable DaemonSet, a driver-root
+      misconfiguration. This sweep saw exactly that class of failure when the
+      operator demanded a runtime class the node did not have, which is
+      integration work that genuinely moves left.
+    evidence: "validators/deployment/operator_health.go:33,45"
+
+  - name: expected-resources
+    area: control-plane
+    phase: deployment
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      Verifies every resource declared in the recipe's componentRefs exists and
+      is healthy, then dispatches 37 nested chainsaw component health checks
+      in-process. One of those asserts ClusterPolicy status.state == ready, the
+      deepest driver-coupled signal in the suite. Real control-plane
+      reconciliation; a missing prerequisite or a stuck operand fails it.
+    evidence: "validators/deployment/expected_resources.go:196,240-257,299"
+
+  - name: gpu-operator-version
+    area: operator-install
+    phase: deployment
+    bucket: A
+    gpuDependent: false
+    rationale: >-
+      Reads the deployed operator version and evaluates it against the recipe
+      constraint, so a wrong or unpinned chart version fails it for a real
+      reason. Marked GPU-independent: it inspects a Helm release and would work
+      on any cluster with the operator installed, so Mokka is not what unlocks
+      it. Skips when the recipe declares no constraint.
+    evidence: "validators/deployment/gpu_operator_version.go:31,42"
+
+  - name: check-nvidia-smi
+    area: nvml-surface
+    phase: deployment
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      The strongest bucket-A case in the suite. Schedules a CUDA base-image pod
+      on every schedulable GPU node and requires the log to carry the NVIDIA-SMI
+      banner, a Driver or KMD version, a CUDA or CUDA-UMD version, and a success
+      marker. That exercises the whole chain: device-plugin allocation, device
+      injection, and dlopen resolution of libnvidia-ml.so.1. It is exactly the
+      class of breakage that otherwise waits for silicon.
+    evidence: "validators/deployment/nvidia_smi.go:126,328-333"
+
+  # --------------------------------------------------------------- performance
+  - name: nccl-all-reduce-bw
+    area: nccl-nvlink-fabric
+    phase: performance
+    bucket: C
+    gpuDependent: true
+    rationale: >-
+      Measures NCCL all-reduce bus bandwidth against a GB/s threshold. Mokka
+      simulates fabric MANAGEMENT (NVSwitch topology, fabricmanager, IB subnet
+      manager) but not the collective data plane. NVLink throughput counters in
+      the mock accrue from a clock epoch, not from traffic, so no bandwidth
+      number here can be meaningful. Hardware-dependent by construction.
+    evidence: "validators/performance/nccl_all_reduce_bw.go:30"
+
+  - name: nccl-all-reduce-bw-net
+    area: nccl-nvlink-fabric
+    phase: performance
+    bucket: C
+    gpuDependent: true
+    rationale: >-
+      As nccl-all-reduce-bw, and additionally asserts the NET transport actually
+      carried traffic by matching an NCCL log line naming the network. Requires
+      EFA or RoCE. Data-plane, therefore hardware-dependent.
+    evidence: "validators/performance/nccl_all_reduce_bw_constraint.go:198"
+
+  - name: nccl-all-reduce-bw-nvls
+    area: nccl-nvlink-fabric
+    phase: performance
+    bucket: C
+    gpuDependent: true
+    rationale: >-
+      As nccl-all-reduce-bw, and additionally asserts NVLS multicast was
+      available and an NVLS communicator was initialised, across an NVL72 IMEX
+      domain. Mokka renders IMEX channels but runs no collectives. Hardware.
+    evidence: "validators/performance/nccl_all_reduce_bw_constraint.go:199-200"
+
+  - name: inference-perf
+    area: ttft-throughput
+    phase: performance
+    bucket: C
+    gpuDependent: true
+    rationale: >-
+      Runs AIPerf against a live Dynamo endpoint and asserts throughput and p99
+      time-to-first-token against thresholds. The mock executes no CUDA kernel,
+      so there is no inference to measure. This check is the literal definition
+      of what simulation cannot prove, and it is why "reduce time to first
+      token" is the defensible claim rather than "hit first token on day one".
+    evidence: "validators/performance/inference_perf.go:29,93"
+
+  # --------------------------------------------------------------- conformance
+  - name: dra-support
+    area: dra
+    phase: conformance
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      Requires a served resource.k8s.io version, an available DRA driver
+      controller Deployment, a ready kubelet-plugin DaemonSet, at least one
+      validated *.nvidia.com ResourceSlice on a schedulable node, and a
+      behavioural ResourceClaim pod that reaches PodSucceeded. Every one of
+      those is real control-plane and allocation work that Mokka's NVML surface
+      drives. A driver that cannot enumerate devices fails it for a real reason.
+    evidence: "validators/conformance/dra_support_check.go:55,263-320,524"
+
+  - name: gang-scheduling
+    area: scheduling
+    phase: conformance
+    bucket: A
+    gpuDependent: false
+    rationale: >-
+      Verifies KAI scheduler Deployments, the queue and podgroup CRDs, and that
+      two pods co-schedule inside a window with the right scheduler name and
+      pod-group label. Real scheduling integration, but the validator uses
+      CPU-only workers by design and asserts zero resourceClaims, so any cluster
+      runs it. Mokka is not what unlocks this one, and counting it as GPU
+      coverage would inflate the headline.
+    evidence: "validators/conformance/gang_scheduling_check.go:96-99,352-420"
+
+  - name: accelerator-metrics
+    area: telemetry
+    phase: conformance
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      Scrapes dcgm-exporter and requires DCGM_FI_DEV_GPU_UTIL, FB_USED, GPU_TEMP
+      and POWER_USAGE to be present. v0.3.0 backs these through
+      nvmlDeviceGetFieldValues, so a real dcgm-exporter loads the mock NVML like
+      any other consumer and the whole exporter path is exercised. Note the
+      values themselves are clock-driven, not workload-driven; this check
+      asserts presence, not magnitude, which is why it is A and not B.
+    evidence: "validators/conformance/accelerator_metrics_check.go:27-32,39"
+
+  - name: ai-service-metrics
+    area: telemetry
+    phase: conformance
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      Queries Prometheus for a DCGM_FI_DEV_GPU_UTIL series and requires the
+      custom-metrics API to be reachable. Exercises the full scrape and
+      registration path from the mock NVML through dcgm-exporter into Prometheus
+      and prometheus-adapter. Plumbing failures here are real.
+    evidence: "validators/conformance/ai_service_metrics_check.go:41,105,143,164-176"
+
+  - name: inference-gateway
+    area: control-plane
+    phase: conformance
+    bucket: A
+    gpuDependent: false
+    rationale: >-
+      Requires the agentgateway GatewayClass Accepted, the Gateway Programmed,
+      the Gateway API and Inference Extension CRDs present, and proxy endpoints
+      Ready. Real reconciliation, but nothing in it touches the GPU stack, so it
+      runs on any cluster.
+    evidence: "validators/conformance/inference_gateway_check.go:54,68,91,121,385"
+
+  - name: pod-autoscaling
+    area: telemetry
+    phase: conformance
+    bucket: B
+    gpuDependent: true
+    rationale: >-
+      Gates on a non-empty dcgm_gpu_power_usage external metric and then drives
+      an HPA against a 10 W target. The validator's own comment says an idle
+      H100 draws about 46 W so the HPA always computes a scale-up. Under Mokka
+      the power number is clock-driven and never responds to load, so the HPA
+      scales on a signal that cannot fall. The wiring is exercised, but the
+      check passes regardless of whether GPU-driven autoscaling would work,
+      which is the definition of bucket B. Recorded as B deliberately.
+    evidence: "validators/conformance/pod_autoscaling_check.go:70,208,228,417-420"
+
+  - name: cluster-autoscaling
+    area: scheduling
+    phase: conformance
+    bucket: A
+    gpuDependent: false
+    rationale: >-
+      Requires a Karpenter controller, a GPU NodePool with nvidia.com/gpu
+      limits, and a behavioural scale-up in which pending pods drive node
+      provisioning above baseline. Real scheduling and provisioning integration.
+      AICR's own KWOK provider is the intended substrate for this check, so it
+      is not GPU-dependent, and it skips outside EKS or GKE when Karpenter is
+      absent.
+    evidence: "validators/conformance/cluster_autoscaling_check.go:68,112,276-289,494"
+
+  - name: robust-controller
+    area: control-plane
+    phase: conformance
+    bucket: A
+    gpuDependent: false
+    rationale: >-
+      Requires an AI operator controller Deployment, a ValidatingWebhook with a
+      reachable endpoint, the CRD, and proof that the webhook actively rejects an
+      invalid custom resource. Real admission-path integration. Skips when the
+      recipe carries neither dynamo-platform nor kubeflow-trainer.
+    evidence: "validators/conformance/robust_controller_check.go:78,93,193,425"
+
+  - name: secure-accelerator-access
+    area: scheduling
+    phase: conformance
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      The check that most directly exercises MEP-0002. A granted container must
+      see exactly one GPU, an unauthorized sibling and a standalone probe must
+      see no /dev/nvidia* at all, and no hostPath may carry /dev/nvidia. That is
+      precisely the "exactly one component serves a container" contract, and it
+      fails for a real reason if device-spec passing or NRI suppression is wrong.
+    evidence: "validators/conformance/secure_access_check.go:99,111-115,276,663"
+
+  - name: slinky-slurm-health
+    area: control-plane
+    phase: conformance
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      Requires a responsive Slurm controller, idle or mixed nodes, a successful
+      srun, and on GPU NodeSets a containerized GPU job. Controller, scheduling
+      and accounting are real integration. Note the validator explicitly skips
+      when every NodeSet pod sits on a KWOK node, which is the one place in the
+      whole AICR validator tree that detects a simulated node.
+    evidence: "validators/conformance/slinky_slurm_health_check.go:95,106,346-353"
+
+  - name: slinky-slurm-imex-channel
+    area: dra
+    phase: conformance
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      Requires concurrent Slurm jobs to receive fixed IMEX resources and
+      distinct channels through the ComputeDomain API. v0.3.0 renders the IMEX
+      channel surface, so the semantics are reachable in principle rather than
+      hardware-bound. Distinguish carefully from NVLS throughput, which is C:
+      channel assignment is fabric MANAGEMENT, not the data plane.
+    evidence: "validators/conformance/slinky_slurm_imex_channel_check.go:85,96"
+
+  - name: gpu-operator-health
+    area: operator-install
+    phase: conformance
+    bucket: A
+    gpuDependent: true
+    rationale: >-
+      Requires the gpu-operator Deployment, the singleton ClusterPolicy at
+      status.state == ready, and a ready nvidia-dcgm-exporter DaemonSet. The
+      ClusterPolicy gate only clears once the driver, toolkit, CUDA and plugin
+      validators have all passed, so this is the deepest single assertion about
+      whether the GPU stack actually came up.
+    evidence: "validators/conformance/gpu_operator_health_check.go:30,38,55-66,69"
+
+  - name: platform-health
+    area: control-plane
+    phase: conformance
+    bucket: A
+    gpuDependent: false
+    rationale: >-
+      Requires every enabled component namespace to be Active and every declared
+      expected resource to verify. Real control-plane reconciliation across the
+      whole recipe, but no part of it reads the GPU stack, so any cluster runs
+      it.
+    evidence: "validators/conformance/platform_health_check.go:31,47,58,72"

--- a/tests/aicr-sweep/cells-57ef016.yaml
+++ b/tests/aicr-sweep/cells-57ef016.yaml
@@ -1,0 +1,194 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Re-run of the sweep matrix against Mokka upstream/main, 2026-08-26.
+#
+# This file is the SECOND run. cells.yaml is the first one (Mokka v0.3.0,
+# 2026-08-03) and is left untouched so both remain reproducible: each pairs with
+# its own results directory.
+#
+#   cells.yaml          + results/            Mokka v0.3.0
+#   cells-57ef016.yaml  + results-57ef016/    Mokka 57ef01659
+#
+# AICR is pinned to the SAME ref as the first run, 0752ea14. That is deliberate:
+# with AICR held fixed, Mokka is the only axis that moved, so a flipped verdict
+# is attributable. Verified rather than assumed: the generated recipe for the
+# base cell is byte-identical to the one recorded on 2026-08-03.
+#
+# Cause codes are unchanged from cells.yaml:
+#   K       kind or single-host artifact. NOT a Mokka finding.
+#   U       upstream dependency has not released what is needed. NOT a Mokka gap.
+#   X       AICR catalog has no recipe for the combination. NOT a Mokka gap.
+#   BUDGET  host memory budget exhausted; cell not attempted.
+
+versions:
+  mokka: 57ef01659 (HEAD~1 of upstream/main on 2026-08-26; no tag yet)
+  mokkaImage: ghcr.io/nvidia/nvml-mock:sha-57ef016
+  mokkaDigest: sha256:115cb887ec53ffb7a17a913257b8f55594fda31ad2d1174745b5e20a1400db9e
+  chart: deployments/nvml-mock/helm/nvml-mock at 57ef01659 (chart version 0.3.0)
+  chartDigest: not published; Chart.yaml on main is still 0.3.0, so the released
+    OCI chart does NOT carry these 60 commits and the chart must come from the
+    checkout. This is the one provenance gap in this run and it is deliberate.
+  profile: gb200
+  kind: v0.32.0
+  nodeImage: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
+  kubernetes: v1.36.1 (containerd 2.3.1)
+  gpuOperator: v25.3.4
+  dcgmExporter: bundled with gpu-operator v25.3.4
+  aicr: 0752ea148aa1ae849cbef86ec59d0c970a582496
+  aicrImage: ghcr.io/nvidia/aicr:latest
+  hostArch: linux/arm64 (Docker Desktop VM on arm64 macOS)
+  hostContainerRuntime: Docker 29.6.2, 14 CPU, 15.84 GiB VM
+
+cells:
+  # ---------------------------------------------------------------- BASE sweep
+  - id: base-gb200-kind-inference-stack
+    recipe: {service: kind, accelerator: gb200, intent: inference}
+    shape: stack
+    workers: 2
+    notes: >-
+      The backbone cell, re-run against 57ef016. Its 9 dispatched verdicts are
+      byte-identical to the v0.3.0 run: 3 passed, 5 failed, 1 other. #672 landed
+      and is real (busId went from 0000:0a:00.0 to 00000000:0a:00.0, verified by
+      a differential probe of the two images and live in cluster), but it did NOT
+      move gpu-operator-health. GFD now receives a well-formed BDF and still
+      cannot read /sys/bus/pci/devices/<bdf>/vendor, because Mokka's rendered PCI
+      tree is not grafted onto GFD's /sys. Evidence: results/gfd-sysfs-evidence.log.
+
+  - id: base-gb200-kind-training-stack
+    recipe: {service: kind, accelerator: gb200, intent: training}
+    shape: stack
+    workers: 2
+    blockedCause: X
+    blockedWhy: >-
+      RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on
+      host memory and predicted it would "differ from the inference cell only in
+      component set". That prediction was never tested. It is wrong: AICR at
+      0752ea14 resolves no training recipe on the kind service for gb200.
+      `aicr recipe --service kind --accelerator gb200 --intent training` exits 2
+      with "[INVALID_REQUEST] no recipe provides intent 'training'". On kind,
+      training resolves for h100 and for no other accelerator. The cell fails at
+      recipe resolution, before memory could ever matter, so the cause is X.
+      Evidence: results/aicr-recipe-matrix-evidence.log.
+
+  - id: base-h100-kind-inference-stack
+    recipe: {service: kind, accelerator: h100, intent: inference}
+    shape: stack
+    workers: 2
+    axes: {accelerator: "h100 (substitute for gb300)"}
+    notes: >-
+      Was BUDGET in the first run; the host VM is now 15.84 GiB and it ran. This
+      is the largest single coverage gain in the re-run: AICR dispatched 14 of 21
+      checks here against 9 for gb200, and 5 passed against 3. gpu-operator-version
+      passes on h100 and fails on gb200, and gang-scheduling, inference-gateway,
+      pod-autoscaling, cluster-autoscaling and secure-accelerator-access are
+      dispatched at all only here. It remains a substitution and is never counted
+      as gb300 coverage.
+
+  - id: base-gb300-kind-inference-stack
+    recipe: {service: kind, accelerator: gb300, intent: inference}
+    shape: stack
+    workers: 2
+    blockedCause: X
+    blockedWhy: >-
+      Unchanged from the first run and re-verified by running the CLI at the same
+      pin: `aicr recipe --service kind --accelerator gb300 --intent inference`
+      exits 2 with "[INVALID_REQUEST] no recipe provides accelerator 'gb300'".
+      The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000.
+      Mokka ships a gb300 profile, and #699 made it the chart default, so the two
+      sides have drifted further apart rather than closer. Not a Mokka gap.
+
+  - id: base-gb300-kind-training-stack
+    recipe: {service: kind, accelerator: gb300, intent: training}
+    shape: stack
+    workers: 2
+    blockedCause: X
+    blockedWhy: >-
+      Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports
+      both "no recipe provides accelerator 'gb300'" and "no recipe provides
+      intent 'training'" for this combination.
+
+  - id: targeted-dra-installed
+    recipe: {service: kind, accelerator: gb200, intent: inference}
+    shape: stack
+    workers: 2
+    axes: {"nvidia-dra-driver-gpu": "v0.5.0 with altProcDevices (first run used v25.12.0, which lacked it)", "imex.mockChannels.enabled": "true"}
+    notes: >-
+      The one cell whose verdict moved. dra-support went FAILED to PASSED. Mokka
+      rendered the /proc/devices substitute (235 nvidia-caps-imex-channels), DRA
+      v0.5.0 consumed it via altProcDevices, both kubelet-plugin containers
+      (compute-domains and gpus) came up on both workers, and 12 ResourceSlice
+      devices were published. The first run's abort, "error parsing
+      '/proc/devices'", appears zero times in 400 lines of driver logs.
+      This closes the cause-U block D-009 recorded, for an UPSTREAM reason:
+      Mokka's IMEX rendering already worked at v0.3.0, and what was missing was a
+      released consumer. v0.5.0 shipped it on 2026-08-19.
+      CAVEAT: the v0.5.0 chart was renamed nvidia-dra-driver-gpu to
+      dra-driver-nvidia-gpu, so its default resource names no longer match what
+      AICR at 0752ea14 looks for. This cell passed
+      --set nameOverride=nvidia-dra-driver-gpu to restore the expected name. AICR
+      itself was not modified. Without that flag dra-support fails NOT_FOUND on
+      the name alone, whatever the driver does.
+      Evidence: results/dra-altprocdevices-evidence.log.
+
+  # ---------------------------------------------------------------- AXIS sweep
+  - id: axis-nri-cdi
+    recipe: {service: kind, accelerator: gb200, intent: inference}
+    shape: stack
+    workers: 2
+    axes: {"nri.deviceInjectionMode": "cdi (base is raw)"}
+    notes: >-
+      Was BUDGET; ran. Verdicts identical to the base cell (3 passed, 5 failed,
+      1 other). The CDI injection mode is a Mokka-side device-injection change
+      and does not touch the ClusterPolicy path that holds gpu-operator-health
+      down, so no movement is the expected and correct result.
+
+  - id: axis-allocation-watcher-on
+    recipe: {service: kind, accelerator: gb200, intent: inference}
+    shape: stack
+    workers: 2
+    axes: {"allocationWatcher.enabled": "true (base is false)"}
+    notes: >-
+      Was BUDGET; ran. The sidecar came up (3/3 containers in the nvml-mock
+      DaemonSet) and verdicts are identical to the base cell. As the first run
+      predicted in advance, any check reading GPU memory utilization as evidence
+      of real work stays bucket B whatever this cell shows, because the
+      allocation bytes are synthetic by construction.
+
+  - id: axis-failure-injection-ecc
+    recipe: {service: kind, accelerator: gb200, intent: inference}
+    shape: stack
+    workers: 2
+    axes: {"gpu.failureInjection": "enabled=true mode=ecc_uncorrectable probability=1 (base is off)"}
+    notes: >-
+      Was BUDGET; ran. Verdicts identical to the base cell. The fault is real and
+      was verified before the result was read: the mock reports 6 and 9 volatile
+      DRAM Uncorrectable errors on two GPUs while all 4 still enumerate, and
+      check-nvidia-smi and accelerator-metrics both still pass. So a degraded but
+      enumerable GPU is indistinguishable from a healthy one at this recipe. That
+      is a statement about which checks AICR dispatches for kind/gb200/inference,
+      not about Mokka: the injection works end to end.
+      NOTE the first run recorded in cells.yaml declared this axis as
+      `gpu.failureInjection.mode=ecc_uncorrectable` alone, which is inert, because
+      the chart gates injection on `enabled` and never trips at the default
+      probability of 0. Had that cell run as declared it would have measured
+      nothing and looked like a clean negative. Evidence, including a second trap
+      that produced a plausible but wrong result:
+      results/ecc-injection-evidence.log.
+
+  - id: axis-compute-domain-fabric
+    recipe: {service: kind, accelerator: gb200, intent: training}
+    shape: fabric
+    workers: 4
+    axes: {"imex.mockChannels.enabled": "true", "topology.domains": "two cliques"}
+    blockedCause: X
+    blockedWhy: >-
+      RECLASSIFIED from U. The first run blocked this on the DRA driver lacking
+      --set altProcDevices, which was true of v25.12.0 and is no longer true:
+      v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml
+      documents it as being for mock NVML. But the cell cannot run for a reason
+      that predates that: it declares intent=training on the kind service, and
+      AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution
+      failure comes first, so the cause is X, not U. The altProcDevices question
+      it was meant to answer is now carried by targeted-dra-installed instead.
+      Evidence: results/aicr-recipe-matrix-evidence.log.

--- a/tests/aicr-sweep/cells.yaml
+++ b/tests/aicr-sweep/cells.yaml
@@ -1,0 +1,147 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# The permutation matrix for the Mokka + AICR sweep.
+#
+# A full factorial explodes, so the matrix follows the brief's structure:
+#   BASE   every AICR recipe reachable on the `kind` service, across accelerators
+#          and cluster shapes. This is the backbone result.
+#   AXIS   one axis varied off the base.
+#
+# Cells carrying blockedCause never ran. They stay in the file, and in the
+# denominator, so the coverage percentage cannot be inflated by deleting the
+# work that did not happen.
+#
+# Cause codes:
+#   K       kind or single-host artifact. NOT a Mokka finding.
+#   U       upstream dependency has not released what is needed. NOT a Mokka gap.
+#   X       AICR catalog has no recipe for the combination. NOT a Mokka gap.
+#   BUDGET  host memory budget exhausted; cell not attempted.
+
+versions:
+  mokka: v0.3.0
+  mokkaImage: ghcr.io/nvidia/nvml-mock:0.3.0
+  mokkaDigest: sha256:3b9bcf33d8bf442fe203062b78abeef7633172b4e589b23192e27edb6e81d3cc
+  chart: oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock 0.3.0
+  chartDigest: sha256:99e0de7e7c3292e9f814e15841c6c7a5bec8f64ce07620dd9f5c05ccb68b516e
+  profile: gb200
+  kind: v0.32.0
+  nodeImage: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
+  kubernetes: v1.36.1 (containerd 2.3.1)
+  gpuOperator: v25.3.4
+  dcgmExporter: bundled with gpu-operator v25.3.4
+  aicr: 0752ea148aa1ae849cbef86ec59d0c970a582496
+  aicrImage: ghcr.io/nvidia/aicr:latest
+  hostArch: linux/arm64 (Docker Desktop VM on arm64 macOS)
+  hostContainerRuntime: Docker 29.6.1, 14 CPU, 7.75 GiB VM
+
+cells:
+  # ---------------------------------------------------------------- BASE sweep
+  - id: base-gb200-kind-inference-stack
+    recipe: {service: kind, accelerator: gb200, intent: inference}
+    shape: stack
+    workers: 2
+    notes: >-
+      The backbone cell. Mokka v0.3.0 gb200 profile over the NRI path, plus the
+      real GPU Operator, device plugin, GFD and dcgm-exporter. AICR resolves this
+      combination to a 14-component recipe over 5 overlays.
+
+  - id: base-gb200-kind-training-stack
+    recipe: {service: kind, accelerator: gb200, intent: training}
+    shape: stack
+    workers: 2
+    blockedCause: BUDGET
+    blockedWhy: >-
+      Not attempted. The host Docker VM holds 7.75 GiB and the inference cell
+      already consumed the window available for this sweep. The intent axis is a
+      recipe-resolution difference, so this cell is expected to differ from the
+      inference cell only in component set, not in Mokka behaviour. Re-run it
+      first when more memory is available.
+
+  - id: base-h100-kind-inference-stack
+    recipe: {service: kind, accelerator: h100, intent: inference}
+    shape: stack
+    workers: 2
+    axes: {accelerator: "h100 (substitute for gb300)"}
+    blockedCause: BUDGET
+    blockedWhy: >-
+      Not attempted, same memory window. This is the deliberate substitution for
+      the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so
+      h100 is the nearest second accelerator that both AICR and Mokka support on
+      the kind service. It is a substitution and is never counted as gb300 coverage.
+
+  - id: base-gb300-kind-inference-stack
+    recipe: {service: kind, accelerator: gb300, intent: inference}
+    shape: stack
+    workers: 2
+    blockedCause: X
+    blockedWhy: >-
+      AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by
+      running the CLI, not by reading it: `aicr recipe --service kind
+      --accelerator gb300 --intent inference` exits 2 with "[INVALID_REQUEST] no
+      recipe provides accelerator 'gb300'". The catalog knows a100, b200, gb200,
+      h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no
+      accelerator to match it to. This is an AICR catalog gap, not a Mokka gap.
+
+  - id: base-gb300-kind-training-stack
+    recipe: {service: kind, accelerator: gb300, intent: training}
+    shape: stack
+    workers: 2
+    blockedCause: X
+    blockedWhy: >-
+      Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator.
+
+  - id: targeted-dra-installed
+    recipe: {service: kind, accelerator: gb200, intent: inference}
+    shape: stack
+    workers: 2
+    axes: {"nvidia-dra-driver-gpu": "installed (base cell had none)"}
+    notes: >-
+      Targeted follow-up to the base cell, suggested by its dra-support failure.
+      Conformance phase only, re-run after installing nvidia-dra-driver-gpu
+      25.12.0 against the mock driver root. The DRA kubelet plugin published 16
+      devices across two ResourceSlices derived from the mock NVML, which is the
+      GPU half of dra-support working. The check still fails: see the findings
+      note for why that is cause U and not a Mokka gap.
+
+  # ---------------------------------------------------------------- AXIS sweep
+  - id: axis-nri-cdi
+    recipe: {service: kind, accelerator: gb200, intent: inference}
+    shape: stack
+    workers: 2
+    axes: {"nri.deviceInjectionMode": "cdi (base is raw)"}
+    blockedCause: BUDGET
+    blockedWhy: Not attempted; host memory window exhausted after the base cell.
+
+  - id: axis-allocation-watcher-on
+    recipe: {service: kind, accelerator: gb200, intent: inference}
+    shape: stack
+    workers: 2
+    axes: {"allocationWatcher.enabled": "true (base is false)"}
+    blockedCause: BUDGET
+    blockedWhy: >-
+      Not attempted. Note in advance that any check reading GPU memory
+      utilization as evidence of real work stays bucket B whatever this cell
+      shows, because the allocation bytes are synthetic by construction.
+
+  - id: axis-failure-injection-ecc
+    recipe: {service: kind, accelerator: gb200, intent: inference}
+    shape: stack
+    workers: 2
+    axes: {"gpu.failureInjection.mode": "ecc_uncorrectable (base is off)"}
+    blockedCause: BUDGET
+    blockedWhy: Not attempted; host memory window exhausted after the base cell.
+
+  - id: axis-compute-domain-fabric
+    recipe: {service: kind, accelerator: gb200, intent: training}
+    shape: fabric
+    workers: 4
+    axes: {"imex.mockChannels.enabled": "true", "topology.domains": "two cliques"}
+    blockedCause: U
+    blockedWhy: >-
+      The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major
+      out of /proc/devices and needs --set altProcDevices to read Mokka's
+      substitute. That flag is on the DRA driver's main branch and is in no
+      release, including v25.12.0, as the chart's own values.yaml records at
+      lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an
+      upstream release gap, not a Mokka gap.

--- a/tests/aicr-sweep/classify.go
+++ b/tests/aicr-sweep/classify.go
@@ -1,0 +1,204 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// statusToOutcome maps a CTRF status onto a sweep outcome.
+//
+// The mapping is deliberately conservative at both ends. CTRF "pending" and
+// "other" mean the suite reached no verdict: "other" is AICR's own code for a
+// crash, an OOM, a timeout, or a Job that failed with no inspectable pod. Those
+// become OutcomeNotRun rather than being laundered into either a pass or a
+// fail. A run that half-finished must look half-finished in the numbers.
+func statusToOutcome(status string) Outcome {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "passed":
+		return OutcomePass
+	case "failed":
+		return OutcomeFail
+	case "skipped":
+		return OutcomeSkip
+	case "pending", "other", "":
+		return OutcomeNotRun
+	default:
+		// An unrecognised status is not a pass. Fail closed.
+		return OutcomeNotRun
+	}
+}
+
+// Classify joins a catalog against one run's results for one cell.
+//
+// Invariants, each of which exists because breaking it produces a flattering
+// number instead of a true one:
+//
+//  1. A catalog check that the run never reported is OutcomeNotRun. It is never
+//     promoted to a pass.
+//  2. A check present in the run but absent from the catalog is reported as
+//     drift, not silently dropped.
+//  3. A bucket-C check reporting a pass under sim provenance is flagged
+//     Suspect. A hardware-dependent check cannot legitimately pass without
+//     hardware, so a green there means the check is weaker than its name.
+//  4. Every emitted record carries provenance.
+//
+// blockedCause, when not CauseNone, marks the whole cell blocked: every check
+// becomes OutcomeBlocked carrying that cause. This is how a cell that never ran
+// stays visibly distinct from a cell that ran and passed.
+func Classify(cat *Catalog, run *RunResults, cell Cell, versions Versions, prov Provenance, blockedCause Cause, blockedWhy string) CellResult {
+	result := CellResult{
+		Cell:       cell,
+		Versions:   versions,
+		Provenance: prov,
+		Checks:     make([]CheckResult, 0, len(cat.Checks)),
+	}
+
+	if blockedCause != CauseNone {
+		result.Status = "blocked"
+		result.Cause = blockedCause
+		result.BlockedWhy = blockedWhy
+		for _, c := range cat.Checks {
+			result.Checks = append(result.Checks, CheckResult{
+				Check: c.Name, Area: c.Area, Phase: c.Phase,
+				Bucket: c.Bucket, GPUDep: c.GPUDependent,
+				Outcome: OutcomeBlocked, Cause: blockedCause,
+				Provenance: prov, GapIssue: c.GapIssue,
+				Message: blockedWhy,
+			})
+		}
+		return result
+	}
+
+	byName := map[string]RunTest{}
+	if run != nil {
+		for _, t := range run.Tests {
+			byName[t.Name] = t
+		}
+	}
+
+	seen := map[string]bool{}
+	for _, c := range cat.Checks {
+		cr := CheckResult{
+			Check: c.Name, Area: c.Area, Phase: c.Phase,
+			Bucket: c.Bucket, GPUDep: c.GPUDependent,
+			Provenance: prov, GapIssue: c.GapIssue,
+		}
+
+		t, ok := byName[c.Name]
+		if !ok {
+			// Invariant 1: absent from the run means no verdict, not a pass.
+			cr.Outcome = OutcomeNotRun
+			cr.Note = "check absent from run output"
+			result.Checks = append(result.Checks, cr)
+			continue
+		}
+		seen[c.Name] = true
+
+		cr.Outcome = statusToOutcome(t.Status)
+		cr.Message = t.Message
+
+		// Invariant 3: a hardware-dependent check cannot honestly pass without
+		// hardware. Flag it rather than counting it.
+		if c.Bucket == BucketC && cr.Outcome == OutcomePass && prov == ProvenanceSim {
+			cr.Suspect = true
+			cr.Note = "bucket C passed under sim provenance: the check does not actually exercise the hardware path it names"
+		}
+
+		result.Checks = append(result.Checks, cr)
+	}
+
+	// Invariant 2: report drift instead of dropping it.
+	for name := range byName {
+		if !seen[name] {
+			result.Drift = append(result.Drift, name)
+		}
+	}
+	sort.Strings(result.Drift)
+
+	result.Status = "ran"
+	return result
+}
+
+// Roll aggregates check results across cells into the coverage read.
+//
+// The denominator is every catalog check in every cell, including blocked and
+// not-run ones. Dropping them would raise the percentage by hiding the work
+// that did not happen, which is the specific dishonesty this sweep exists to
+// avoid.
+func Roll(cells []CellResult) Rollup {
+	r := Rollup{ByCause: map[Cause]int{}, ByOutcome: map[Outcome]int{}}
+	for _, cell := range cells {
+		for _, c := range cell.Checks {
+			r.Total++
+			r.ByOutcome[c.Outcome]++
+			if c.Cause != CauseNone {
+				r.ByCause[c.Cause]++
+			}
+			if c.Suspect {
+				r.Suspect++
+			}
+			if c.Outcome == OutcomeBlocked || c.Outcome == OutcomeNotRun {
+				r.Blocked++
+			}
+			switch c.Bucket {
+			case BucketA:
+				r.A++
+				if c.GPUDep {
+					r.AGPUDependent++
+				}
+			case BucketB:
+				r.B++
+			case BucketC:
+				r.C++
+			case BucketG:
+				r.G++
+			}
+		}
+	}
+	return r
+}
+
+// Validate rejects a catalog that would produce a misleading number.
+func (c *Catalog) Validate() error {
+	if len(c.Checks) == 0 {
+		return fmt.Errorf("catalog has no checks")
+	}
+	if strings.TrimSpace(c.Source) == "" {
+		return fmt.Errorf("catalog has no source ref: a catalog whose provenance is unknown cannot be audited")
+	}
+
+	seen := map[string]bool{}
+	for i, ch := range c.Checks {
+		if strings.TrimSpace(ch.Name) == "" {
+			return fmt.Errorf("check %d has no name", i)
+		}
+		if seen[ch.Name] {
+			return fmt.Errorf("check %q appears twice: a duplicate double-counts in the rollup", ch.Name)
+		}
+		seen[ch.Name] = true
+
+		switch ch.Bucket {
+		case BucketA, BucketB, BucketC, BucketG:
+		default:
+			return fmt.Errorf("check %q has invalid bucket %q, want one of A B C G", ch.Name, ch.Bucket)
+		}
+
+		if strings.TrimSpace(ch.Rationale) == "" {
+			return fmt.Errorf("check %q has no rationale: an unexplained bucket cannot be reviewed", ch.Name)
+		}
+		if strings.TrimSpace(ch.Evidence) == "" {
+			return fmt.Errorf("check %q has no evidence ref: a bucket with no source citation is an assertion", ch.Name)
+		}
+
+		// A bucket-G check without a tracked issue is not a roadmap, it is a
+		// claim. Reject it.
+		if ch.Bucket == BucketG && strings.TrimSpace(ch.GapIssue) == "" {
+			return fmt.Errorf("check %q is bucket G but has no gapIssue: an untracked gap is not a roadmap", ch.Name)
+		}
+	}
+	return nil
+}

--- a/tests/aicr-sweep/classify.go
+++ b/tests/aicr-sweep/classify.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -49,6 +50,8 @@ func statusToOutcome(status string) Outcome {
 // blockedCause, when not CauseNone, marks the whole cell blocked: every check
 // becomes OutcomeBlocked carrying that cause. This is how a cell that never ran
 // stays visibly distinct from a cell that ran and passed.
+//
+//nolint:cyclop // existing complexity; refactor deferred
 func Classify(cat *Catalog, run *RunResults, cell Cell, versions Versions, prov Provenance, blockedCause Cause, blockedWhy string) CellResult {
 	result := CellResult{
 		Cell:       cell,
@@ -129,6 +132,8 @@ func Classify(cat *Catalog, run *RunResults, cell Cell, versions Versions, prov 
 // not-run ones. Dropping them would raise the percentage by hiding the work
 // that did not happen, which is the specific dishonesty this sweep exists to
 // avoid.
+//
+//nolint:cyclop // existing complexity; refactor deferred
 func Roll(cells []CellResult) Rollup {
 	r := Rollup{ByCause: map[Cause]int{}, ByOutcome: map[Outcome]int{}}
 	for _, cell := range cells {
@@ -163,12 +168,14 @@ func Roll(cells []CellResult) Rollup {
 }
 
 // Validate rejects a catalog that would produce a misleading number.
+//
+//nolint:cyclop // existing complexity; refactor deferred
 func (c *Catalog) Validate() error {
 	if len(c.Checks) == 0 {
-		return fmt.Errorf("catalog has no checks")
+		return errors.New("catalog has no checks")
 	}
 	if strings.TrimSpace(c.Source) == "" {
-		return fmt.Errorf("catalog has no source ref: a catalog whose provenance is unknown cannot be audited")
+		return errors.New("catalog has no source ref: a catalog whose provenance is unknown cannot be audited")
 	}
 
 	seen := map[string]bool{}

--- a/tests/aicr-sweep/classify_test.go
+++ b/tests/aicr-sweep/classify_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testCatalog() *Catalog {
+	return &Catalog{
+		Source: "test",
+		Checks: []Check{
+			{Name: "a-gpu", Area: "nvml", Phase: "deployment", Bucket: BucketA, GPUDependent: true, Rationale: "r", Evidence: "e"},
+			{Name: "a-cpu", Area: "cp", Phase: "conformance", Bucket: BucketA, GPUDependent: false, Rationale: "r", Evidence: "e"},
+			{Name: "b-one", Area: "tel", Phase: "conformance", Bucket: BucketB, GPUDependent: true, Rationale: "r", Evidence: "e"},
+			{Name: "c-one", Area: "nccl", Phase: "performance", Bucket: BucketC, GPUDependent: true, Rationale: "r", Evidence: "e"},
+		},
+	}
+}
+
+func find(t *testing.T, res CellResult, name string) CheckResult {
+	t.Helper()
+	for _, c := range res.Checks {
+		if c.Check == name {
+			return c
+		}
+	}
+	t.Fatalf("check %q not found in result", name)
+	return CheckResult{}
+}
+
+// The single most important invariant: a check the run never mentioned must not
+// become a pass. If this regresses, an incomplete run reports a good number.
+func TestCheckAbsentFromRunIsNotRunNeverPass(t *testing.T) {
+	t.Parallel()
+
+	run := &RunResults{Tests: []RunTest{{Name: "a-gpu", Status: "passed"}}}
+	res := Classify(testCatalog(), run, Cell{ID: "x"}, Versions{}, ProvenanceSim, CauseNone, "")
+
+	assert.Equal(t, OutcomePass, find(t, res, "a-gpu").Outcome, "a reported pass must stay a pass")
+
+	for _, absent := range []string{"a-cpu", "b-one", "c-one"} {
+		got := find(t, res, absent)
+		assert.Equal(t, OutcomeNotRun, got.Outcome, "check %q was absent from the run and must be not-run", absent)
+		assert.NotEqual(t, OutcomePass, got.Outcome, "check %q must never be promoted to a pass", absent)
+	}
+}
+
+// CTRF "pending" and "other" mean the suite reached no verdict. AICR uses
+// "other" for a crash, an OOM, or a timeout. Laundering either into a pass, or
+// into a fail, would misreport what happened.
+func TestPendingAndOtherBecomeNotRun(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]Outcome{
+		"passed":    OutcomePass,
+		"failed":    OutcomeFail,
+		"skipped":   OutcomeSkip,
+		"pending":   OutcomeNotRun,
+		"other":     OutcomeNotRun,
+		"":          OutcomeNotRun,
+		"nonsense":  OutcomeNotRun,
+		" PASSED  ": OutcomePass,
+	}
+	for status, want := range cases {
+		assert.Equal(t, want, statusToOutcome(status), "status %q", status)
+	}
+}
+
+// A hardware-dependent check cannot legitimately pass without hardware. When it
+// reports green under sim provenance, that means the check is weaker than its
+// name, and the report must say so rather than bank the pass.
+func TestBucketCPassUnderSimIsFlaggedSuspect(t *testing.T) {
+	t.Parallel()
+
+	run := &RunResults{Tests: []RunTest{{Name: "c-one", Status: "passed"}}}
+	res := Classify(testCatalog(), run, Cell{ID: "x"}, Versions{}, ProvenanceSim, CauseNone, "")
+	got := find(t, res, "c-one")
+
+	assert.True(t, got.Suspect, "bucket C passing under sim must be flagged suspect")
+	assert.Contains(t, got.Note, "bucket C")
+
+	// The same result on silicon is legitimate and must NOT be flagged.
+	resSilicon := Classify(testCatalog(), run, Cell{ID: "x"}, Versions{}, ProvenanceSilicon, CauseNone, "")
+	assert.False(t, find(t, resSilicon, "c-one").Suspect, "bucket C passing on silicon is legitimate")
+}
+
+// A blocked cell must not silently disappear from the denominator, and every
+// check in it must carry the cause so K never gets read as G.
+func TestBlockedCellMarksEveryCheckWithCause(t *testing.T) {
+	t.Parallel()
+
+	res := Classify(testCatalog(), nil, Cell{ID: "x"}, Versions{}, ProvenanceSim, CauseX, "AICR has no gb300 accelerator")
+
+	assert.Equal(t, "blocked", res.Status)
+	assert.Equal(t, CauseX, res.Cause)
+	require.Len(t, res.Checks, 4, "a blocked cell still enumerates every catalog check")
+	for _, c := range res.Checks {
+		assert.Equal(t, OutcomeBlocked, c.Outcome, "check %q", c.Check)
+		assert.Equal(t, CauseX, c.Cause, "check %q must carry the blocking cause", c.Check)
+		assert.NotEqual(t, CauseG(), c.Cause, "a blocked-by-AICR cell must never be attributed to a Mokka gap")
+	}
+}
+
+// CauseG does not exist as a Cause on purpose: G is a bucket, not a cause. This
+// helper exists so the assertion above reads clearly and fails to compile if
+// someone later adds a CauseG that would blur the two axes.
+func CauseG() Cause { return Cause("G") }
+
+// A check the run reported but the catalog does not know about must surface as
+// drift. Dropping it would hide a catalog that has fallen behind AICR.
+func TestUnknownCheckInRunIsReportedAsDrift(t *testing.T) {
+	t.Parallel()
+
+	run := &RunResults{Tests: []RunTest{
+		{Name: "a-gpu", Status: "passed"},
+		{Name: "brand-new-check", Status: "failed"},
+	}}
+	res := Classify(testCatalog(), run, Cell{ID: "x"}, Versions{}, ProvenanceSim, CauseNone, "")
+
+	assert.Equal(t, []string{"brand-new-check"}, res.Drift)
+}
+
+// The rollup denominator must include blocked and not-run results. Excluding
+// them would raise the coverage percentage by hiding the work that did not
+// happen.
+func TestRollupDenominatorIncludesBlockedAndNotRun(t *testing.T) {
+	t.Parallel()
+
+	ran := Classify(testCatalog(), &RunResults{Tests: []RunTest{{Name: "a-gpu", Status: "passed"}}},
+		Cell{ID: "ran"}, Versions{}, ProvenanceSim, CauseNone, "")
+	blocked := Classify(testCatalog(), nil, Cell{ID: "blocked"}, Versions{}, ProvenanceSim, CauseK, "kind artifact")
+
+	roll := Roll([]CellResult{ran, blocked})
+
+	assert.Equal(t, 8, roll.Total, "two cells of four checks each must give a denominator of 8")
+	assert.Equal(t, 4, roll.A, "two A checks per cell across two cells")
+	assert.Equal(t, 2, roll.AGPUDependent, "only one A check per cell is GPU-dependent")
+	assert.Equal(t, 7, roll.Blocked, "one pass; the other seven results reached no verdict")
+	assert.Equal(t, 4, roll.ByCause[CauseK])
+}
+
+func TestPctZeroDenominatorIsNotAPercentage(t *testing.T) {
+	t.Parallel()
+
+	// 0% reads as a measured result; n/a does not.
+	assert.Equal(t, "n/a", pct(0, 0))
+	assert.Equal(t, "50%", pct(1, 2))
+}
+
+// An untracked gap is a claim, not a roadmap. The catalog must refuse it.
+func TestCatalogRejectsBucketGWithoutIssue(t *testing.T) {
+	t.Parallel()
+
+	cat := &Catalog{Source: "s", Checks: []Check{
+		{Name: "g1", Bucket: BucketG, Rationale: "r", Evidence: "e"},
+	}}
+	err := cat.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gapIssue")
+
+	cat.Checks[0].GapIssue = "https://github.com/NVIDIA/k8s-test-infra/issues/1"
+	assert.NoError(t, cat.Validate())
+}
+
+func TestCatalogRejectsMalformedEntries(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		cat  Catalog
+		want string
+	}{
+		{"no source", Catalog{Checks: []Check{{Name: "a", Bucket: BucketA, Rationale: "r", Evidence: "e"}}}, "source"},
+		{"no checks", Catalog{Source: "s"}, "no checks"},
+		{"bad bucket", Catalog{Source: "s", Checks: []Check{{Name: "a", Bucket: "Z", Rationale: "r", Evidence: "e"}}}, "invalid bucket"},
+		{"no rationale", Catalog{Source: "s", Checks: []Check{{Name: "a", Bucket: BucketA, Evidence: "e"}}}, "rationale"},
+		{"no evidence", Catalog{Source: "s", Checks: []Check{{Name: "a", Bucket: BucketA, Rationale: "r"}}}, "evidence"},
+		{"duplicate", Catalog{Source: "s", Checks: []Check{
+			{Name: "a", Bucket: BucketA, Rationale: "r", Evidence: "e"},
+			{Name: "a", Bucket: BucketA, Rationale: "r", Evidence: "e"},
+		}}, "twice"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cat.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+// An empty CTRF report and a clean run must not look alike.
+func TestEmptyCTRFReportIsAnError(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseCTRF([]byte(`{"reportFormat":"CTRF","results":{"tests":[]}}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no tests")
+}
+
+func TestParseCTRFReadsPhaseFromSuite(t *testing.T) {
+	t.Parallel()
+
+	run, err := ParseCTRF([]byte(`{"reportFormat":"CTRF","results":{"tests":[
+	  {"name":"operator-health","status":"passed","suite":["deployment"],"message":"ok"}]}}`))
+	require.NoError(t, err)
+	require.Len(t, run.Tests, 1)
+	assert.Equal(t, "operator-health", run.Tests[0].Name)
+	assert.Equal(t, "deployment", run.Tests[0].Suite)
+	assert.Equal(t, "passed", run.Tests[0].Status)
+}
+
+// The real shipped catalog must satisfy its own validation rules.
+func TestShippedCatalogIsValid(t *testing.T) {
+	t.Parallel()
+
+	cat, err := LoadCatalog("catalog.yaml")
+	require.NoError(t, err)
+	assert.Len(t, cat.Checks, 21, "AICR @0752ea14 defines 21 validator checks")
+
+	byPhase := map[string]int{}
+	for _, c := range cat.Checks {
+		byPhase[c.Phase]++
+	}
+	assert.Equal(t, 4, byPhase["deployment"])
+	assert.Equal(t, 4, byPhase["performance"])
+	assert.Equal(t, 13, byPhase["conformance"])
+}

--- a/tests/aicr-sweep/ctrf.go
+++ b/tests/aicr-sweep/ctrf.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,7 +41,7 @@ func ParseCTRF(data []byte) (*RunResults, error) {
 	}
 
 	if len(report.Results.Tests) == 0 {
-		return nil, fmt.Errorf("CTRF report contains no tests, refusing to treat an empty report as a run")
+		return nil, errors.New("CTRF report contains no tests, refusing to treat an empty report as a run")
 	}
 
 	run := &RunResults{Tests: make([]RunTest, 0, len(report.Results.Tests))}

--- a/tests/aicr-sweep/ctrf.go
+++ b/tests/aicr-sweep/ctrf.go
@@ -1,0 +1,110 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"sigs.k8s.io/yaml"
+)
+
+// ctrfReport is the subset of the CTRF schema that AICR emits and this harness
+// consumes. AICR's own definition is pkg/validator/ctrf/types.go; the full
+// schema is at https://ctrf.io.
+type ctrfReport struct {
+	ReportFormat string `json:"reportFormat"`
+	Results      struct {
+		Tests []struct {
+			Name    string   `json:"name"`
+			Status  string   `json:"status"`
+			Suite   []string `json:"suite"`
+			Message string   `json:"message"`
+		} `json:"tests"`
+	} `json:"results"`
+}
+
+// ParseCTRF reads one CTRF report.
+//
+// A report with no tests is an error rather than an empty success. An empty
+// result set and a clean run are indistinguishable in the output otherwise, and
+// the first would silently become a 0-denominator pass.
+func ParseCTRF(data []byte) (*RunResults, error) {
+	var report ctrfReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		return nil, fmt.Errorf("parse CTRF report: %w", err)
+	}
+
+	if len(report.Results.Tests) == 0 {
+		return nil, fmt.Errorf("CTRF report contains no tests, refusing to treat an empty report as a run")
+	}
+
+	run := &RunResults{Tests: make([]RunTest, 0, len(report.Results.Tests))}
+	for _, test := range report.Results.Tests {
+		var suite string
+		if len(test.Suite) > 0 {
+			suite = test.Suite[0]
+		}
+		run.Tests = append(run.Tests, RunTest{
+			Name:    test.Name,
+			Status:  test.Status,
+			Suite:   suite,
+			Message: test.Message,
+		})
+	}
+
+	return run, nil
+}
+
+// LoadCTRFDir merges every *.json CTRF report in dir, so a run split across
+// deployment, performance and conformance phase reports lands as one result set.
+func LoadCTRFDir(dir string) (*RunResults, error) {
+	entries, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil {
+		return nil, fmt.Errorf("scan CTRF directory %s: %w", dir, err)
+	}
+	sort.Strings(entries)
+
+	merged := &RunResults{}
+	for _, path := range entries {
+		data, err := os.ReadFile(path) //nolint:gosec // operator-supplied results path
+		if err != nil {
+			return nil, fmt.Errorf("read CTRF report %s: %w", path, err)
+		}
+		run, err := ParseCTRF(data)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+		merged.Tests = append(merged.Tests, run.Tests...)
+	}
+
+	if len(merged.Tests) == 0 {
+		return nil, fmt.Errorf("no CTRF reports with results found in %s", dir)
+	}
+
+	return merged, nil
+}
+
+// LoadCatalog reads and validates the coverage catalog. An invalid catalog is an
+// error rather than a warning, because every downstream number depends on it.
+func LoadCatalog(path string) (*Catalog, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // operator-supplied catalog path
+	if err != nil {
+		return nil, fmt.Errorf("read catalog %s: %w", path, err)
+	}
+
+	var catalog Catalog
+	if err := yaml.Unmarshal(data, &catalog); err != nil {
+		return nil, fmt.Errorf("parse catalog %s: %w", path, err)
+	}
+
+	if err := catalog.Validate(); err != nil {
+		return nil, fmt.Errorf("catalog %s is invalid: %w", path, err)
+	}
+
+	return &catalog, nil
+}

--- a/tests/aicr-sweep/main.go
+++ b/tests/aicr-sweep/main.go
@@ -1,0 +1,132 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// Command aicr-sweep classifies AICR validate/conformance results collected on a
+// Mokka (nvml-mock) cluster into the A/B/C/G coverage buckets, and rolls them up
+// across the permutation matrix.
+//
+// It answers one question, posed by the AICR maintainer on 2026-07-24:
+//
+//	Does Mokka + AICR materially reduce GB200 bring-up time, or does it merely
+//	prove the stack deploys against mocked APIs?
+//
+// An honest negative answer is a successful run. Nothing here is tuned toward a
+// favourable number: see the invariants on Classify.
+//
+// Usage:
+//
+//	aicr-sweep -catalog catalog.yaml -cells cells.yaml \
+//	           -results results/<run-id> \
+//	           -json report.json -markdown coverage.md
+//
+// Running with no -results is legal and prints the catalog with every outcome
+// recorded not-run. That is the correct output when no run happened.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"sigs.k8s.io/yaml"
+)
+
+// cellSpec is one planned matrix cell as written in cells.yaml, together with
+// any pre-known blocking reason.
+type cellSpec struct {
+	Cell         `json:",inline" yaml:",inline"`
+	BlockedCause Cause  `json:"blockedCause,omitempty" yaml:"blockedCause,omitempty"`
+	BlockedWhy   string `json:"blockedWhy,omitempty" yaml:"blockedWhy,omitempty"`
+}
+
+type cellsDoc struct {
+	Versions Versions   `json:"versions" yaml:"versions"`
+	Cells    []cellSpec `json:"cells" yaml:"cells"`
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "aicr-sweep: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var (
+		catalogPath = flag.String("catalog", "catalog.yaml", "path to the coverage catalog")
+		cellsPath   = flag.String("cells", "cells.yaml", "path to the matrix cell definitions")
+		resultsDir  = flag.String("results", "", "directory holding per-cell CTRF output (results/<cell-id>/*.json); empty means no run happened")
+		jsonOut     = flag.String("json", "", "write the machine-readable report here")
+		markdownOut = flag.String("markdown", "", "write the human-readable coverage read here")
+	)
+	flag.Parse()
+
+	catalog, err := LoadCatalog(*catalogPath)
+	if err != nil {
+		return err
+	}
+
+	data, err := os.ReadFile(*cellsPath) //nolint:gosec // operator-supplied path
+	if err != nil {
+		return fmt.Errorf("read cells %s: %w", *cellsPath, err)
+	}
+	var doc cellsDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("parse cells %s: %w", *cellsPath, err)
+	}
+	if len(doc.Cells) == 0 {
+		return fmt.Errorf("cells file %s defines no cells", *cellsPath)
+	}
+
+	results := make([]CellResult, 0, len(doc.Cells))
+	for _, spec := range doc.Cells {
+		var run *RunResults
+		cause, why := spec.BlockedCause, spec.BlockedWhy
+
+		if cause == CauseNone && *resultsDir != "" {
+			// Per-cell CTRF lives at results/<cell-id>/ctrf/*.json. `aicr
+			// validate --output` writes one report per invocation, so a cell
+			// that ran several phases separately has several files here.
+			dir := filepath.Join(*resultsDir, spec.Cell.ID, "ctrf")
+			if _, statErr := os.Stat(dir); statErr == nil {
+				run, err = LoadCTRFDir(dir)
+				if err != nil {
+					// A results directory that exists but cannot be parsed is
+					// reported, not swallowed. Swallowing it would silently
+					// convert the whole cell to not-run and hide a harness bug.
+					return fmt.Errorf("cell %s: %w", spec.Cell.ID, err)
+				}
+			}
+		}
+
+		cr := Classify(catalog, run, spec.Cell, doc.Versions, ProvenanceSim, cause, why)
+		if run != nil {
+			cr.LogsPointer = filepath.Join(*resultsDir, spec.Cell.ID)
+		}
+		results = append(results, cr)
+	}
+
+	roll := Roll(results)
+
+	if *jsonOut != "" {
+		out, err := RenderJSON(results, roll)
+		if err != nil {
+			return fmt.Errorf("render JSON: %w", err)
+		}
+		if err := os.WriteFile(*jsonOut, out, 0o600); err != nil {
+			return fmt.Errorf("write %s: %w", *jsonOut, err)
+		}
+	}
+
+	md := RenderMarkdown(results, roll)
+	if *markdownOut != "" {
+		if err := os.WriteFile(*markdownOut, []byte(md), 0o600); err != nil {
+			return fmt.Errorf("write %s: %w", *markdownOut, err)
+		}
+	} else {
+		fmt.Print(md)
+	}
+
+	return nil
+}

--- a/tests/aicr-sweep/main.go
+++ b/tests/aicr-sweep/main.go
@@ -52,6 +52,7 @@ func main() {
 	}
 }
 
+//nolint:cyclop // existing complexity; refactor deferred
 func run() error {
 	var (
 		catalogPath = flag.String("catalog", "catalog.yaml", "path to the coverage catalog")

--- a/tests/aicr-sweep/report.go
+++ b/tests/aicr-sweep/report.go
@@ -1,0 +1,120 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// pct renders a share as a percentage string. A zero denominator renders "n/a"
+// rather than 0%, because 0% reads as a measured result and n/a does not.
+func pct(num, den int) string {
+	if den == 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.0f%%", 100*float64(num)/float64(den))
+}
+
+// RenderJSON emits the machine-readable sweep record.
+func RenderJSON(cells []CellResult, roll Rollup) ([]byte, error) {
+	doc := struct {
+		Rollup Rollup       `json:"rollup"`
+		Cells  []CellResult `json:"cells"`
+	}{Rollup: roll, Cells: cells}
+	return json.MarshalIndent(doc, "", "  ")
+}
+
+// RenderMarkdown emits the human-readable coverage read.
+//
+// Two numbers always appear together: A/total is what carries real pre-silicon
+// signal today, and (A+G)/total is what becomes reachable once tracked gaps
+// close. The second is never printed without the first, because presenting the
+// roadmap number alone is the specific overclaim this sweep exists to avoid.
+func RenderMarkdown(cells []CellResult, roll Rollup) string {
+	var b strings.Builder
+
+	b.WriteString("# AICR check coverage under Mokka\n\n")
+	b.WriteString("All evidence below is simulation provenance (`sim`). None of it was run on silicon.\n\n")
+
+	b.WriteString("## Roll-up\n\n")
+	fmt.Fprintf(&b, "- Check results total: %d (checks x cells)\n", roll.Total)
+	fmt.Fprintf(&b, "- A meaningful: %d  ·  B trivial: %d  ·  C hardware-dependent: %d  ·  G closable gap: %d\n",
+		roll.A, roll.B, roll.C, roll.G)
+	fmt.Fprintf(&b, "- **Meaningful pre-silicon today: %s** (A / total)\n", pct(roll.A, roll.Total))
+	fmt.Fprintf(&b, "- **Reachable once tracked gaps close: %s** ((A + G) / total). Roadmap, not a current claim.\n",
+		pct(roll.A+roll.G, roll.Total))
+	fmt.Fprintf(&b, "- Of the A set, %d are GPU-dependent (%s of A). The remainder run on any cluster, so Mokka is not what unlocks them.\n",
+		roll.AGPUDependent, pct(roll.AGPUDependent, roll.A))
+	fmt.Fprintf(&b, "- Never reached a verdict (blocked or not-run): %d (%s)\n", roll.Blocked, pct(roll.Blocked, roll.Total))
+	if roll.Suspect > 0 {
+		fmt.Fprintf(&b, "- **Suspect: %d** hardware-dependent checks reported a pass without hardware. See the cell tables.\n", roll.Suspect)
+	}
+
+	if len(roll.ByCause) > 0 {
+		b.WriteString("\n### Why cells did not reach a verdict\n\n")
+		b.WriteString("| Cause | Meaning | Count |\n|---|---|---|\n")
+		meanings := map[Cause]string{
+			CauseK:      "kind or single-host artifact. NOT a Mokka finding.",
+			CauseU:      "upstream dependency has not released what is needed. NOT a Mokka gap.",
+			CauseX:      "AICR catalog has no recipe for the combination. NOT a Mokka gap.",
+			CauseBudget: "host memory budget exhausted; cell not attempted.",
+		}
+		causes := make([]Cause, 0, len(roll.ByCause))
+		for c := range roll.ByCause {
+			causes = append(causes, c)
+		}
+		sort.Slice(causes, func(i, j int) bool { return causes[i] < causes[j] })
+		for _, c := range causes {
+			fmt.Fprintf(&b, "| %s | %s | %d |\n", c, meanings[c], roll.ByCause[c])
+		}
+	}
+
+	b.WriteString("\n## Cells\n\n")
+	for _, cell := range cells {
+		fmt.Fprintf(&b, "### `%s`\n\n", cell.Cell.ID)
+		fmt.Fprintf(&b, "Recipe: service=%s accelerator=%s intent=%s · shape=%s workers=%d · status=%s\n\n",
+			cell.Cell.Recipe.Service, cell.Cell.Recipe.Accelerator, cell.Cell.Recipe.Intent,
+			cell.Cell.Shape, cell.Cell.Workers, cell.Status)
+		if cell.BlockedWhy != "" {
+			fmt.Fprintf(&b, "**Blocked (%s):** %s\n\n", cell.Cause, cell.BlockedWhy)
+		}
+		if len(cell.Cell.Axes) > 0 {
+			keys := make([]string, 0, len(cell.Cell.Axes))
+			for k := range cell.Cell.Axes {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			parts := make([]string, 0, len(keys))
+			for _, k := range keys {
+				parts = append(parts, fmt.Sprintf("%s=%s", k, cell.Cell.Axes[k]))
+			}
+			fmt.Fprintf(&b, "Axes off base: %s\n\n", strings.Join(parts, ", "))
+		}
+
+		b.WriteString("| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |\n")
+		b.WriteString("|---|---|---|---|---|---|---|\n")
+		for _, c := range cell.Checks {
+			note := c.Note
+			if c.Suspect {
+				note = "SUSPECT: " + note
+			}
+			gpu := "no"
+			if c.GPUDep {
+				gpu = "yes"
+			}
+			fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s | %s |\n",
+				c.Check, c.Phase, c.Bucket, gpu, c.Outcome, c.Cause, note)
+		}
+		if len(cell.Drift) > 0 {
+			fmt.Fprintf(&b, "\n**Catalog drift:** the run reported checks absent from the catalog: %s\n",
+				strings.Join(cell.Drift, ", "))
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}

--- a/tests/aicr-sweep/report.go
+++ b/tests/aicr-sweep/report.go
@@ -34,6 +34,8 @@ func RenderJSON(cells []CellResult, roll Rollup) ([]byte, error) {
 // signal today, and (A+G)/total is what becomes reachable once tracked gaps
 // close. The second is never printed without the first, because presenting the
 // roadmap number alone is the specific overclaim this sweep exists to avoid.
+//
+//nolint:cyclop // existing complexity; refactor deferred
 func RenderMarkdown(cells []CellResult, roll Rollup) string {
 	var b strings.Builder
 

--- a/tests/aicr-sweep/results-57ef016/axis-allocation-watcher-on/ctrf/validate.json
+++ b/tests/aicr-sweep/results-57ef016/axis-allocation-watcher-on/ctrf/validate.json
@@ -1,0 +1,201 @@
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-08-26T16:35:09Z",
+  "generatedBy": "aicr",
+  "results": {
+    "tool": {
+      "name": "aicr",
+      "version": "dev"
+    },
+    "summary": {
+      "tests": 9,
+      "passed": 3,
+      "failed": 5,
+      "skipped": 0,
+      "pending": 0,
+      "other": 1,
+      "start": 1787761407411,
+      "stop": 1787762153760
+    },
+    "tests": [
+      {
+        "name": "operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "stdout": [
+          "time=2026-08-26T16:24:35.420Z level=INFO msg=\"starting check\" name=operator-health",
+          "time=2026-08-26T16:24:35.426Z level=INFO msg=\"listing pods\" namespace=gpu-operator label=\"app=gpu-operator\"",
+          "time=2026-08-26T16:24:35.430Z level=INFO msg=\"operator-health: passed\" running=1",
+          "Found 1 gpu-operator pod(s):",
+          "  gpu-operator-869cf5b4c-x9tq6: Running",
+          "Running: 1/1"
+        ]
+      },
+      {
+        "name": "expected-resources",
+        "status": "other",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "message": "pod not found for Job aicr-expected-resources-ba9ec431: [NOT_FOUND] pod for job not found"
+      },
+      {
+        "name": "gpu-operator-version",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "message": "[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \"\u003e= v25.10.0\"",
+        "stdout": [
+          "time=2026-08-26T16:32:40.162Z level=INFO msg=\"starting check\" name=gpu-operator-version",
+          "time=2026-08-26T16:32:40.173Z level=ERROR msg=FAIL message=\"[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \\\"\u003e= v25.10.0\\\"\"",
+          "Detected GPU Operator version: v25.3.4",
+          "Constraint: \u003e= v25.10.0 → false"
+        ]
+      },
+      {
+        "name": "check-nvidia-smi",
+        "status": "passed",
+        "duration": 52000,
+        "suite": [
+          "deployment"
+        ],
+        "stdout": [
+          "time=2026-08-26T16:34:15.624Z level=INFO msg=\"starting check\" name=check-nvidia-smi",
+          "Found 2 GPU node(s), 2 schedulable, 0 cordoned:",
+          "  mokka-aicr-stack-worker",
+          "  mokka-aicr-stack-worker2",
+          "All 2 GPU node(s) available. Verifying...",
+          "time=2026-08-26T16:34:15.637Z level=INFO msg=\"verifying node\" node=mokka-aicr-stack-worker",
+          "time=2026-08-26T16:34:15.637Z level=INFO msg=\"deploying nvidia-smi verify pod\" node=mokka-aicr-stack-worker podName=nvidia-smi-verify-mokka-aicr-stack-worker image=nvcr.io/nvidia/cuda:13.0.0-base-ubuntu22.04 namespace=aicr-validation",
+          "time=2026-08-26T16:34:15.642Z level=INFO msg=\"waiting for pod to reach Succeeded state\" name=nvidia-smi-verify-mokka-aicr-stack-worker",
+          "time=2026-08-26T16:34:15.656Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T16:34:16.056Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T16:34:39.633Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-26T16:34:40.739Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-26T16:34:41.837Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Succeeded",
+          "time=2026-08-26T16:34:41.837Z level=INFO msg=\"pod successfully completed\" name=nvidia-smi-verify-mokka-aicr-stack-worker",
+          "  mokka-aicr-stack-worker: OK",
+          "time=2026-08-26T16:34:41.848Z level=INFO msg=\"verifying node\" node=mokka-aicr-stack-worker2",
+          "time=2026-08-26T16:34:41.848Z level=INFO msg=\"deploying nvidia-smi verify pod\" node=mokka-aicr-stack-worker2 podName=nvidia-smi-verify-mokka-aicr-stack-worker2 image=nvcr.io/nvidia/cuda:13.0.0-base-ubuntu22.04 namespace=aicr-validation",
+          "time=2026-08-26T16:34:41.855Z level=INFO msg=\"waiting for pod to reach Succeeded state\" name=nvidia-smi-verify-mokka-aicr-stack-worker2",
+          "time=2026-08-26T16:34:41.869Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T16:34:42.254Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T16:35:05.959Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T16:35:06.581Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T16:35:07.585Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T16:35:07.658Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Succeeded",
+          "time=2026-08-26T16:35:07.659Z level=INFO msg=\"pod successfully completed\" name=nvidia-smi-verify-mokka-aicr-stack-worker2",
+          "  mokka-aicr-stack-worker2: OK",
+          "RESULT: nodesValidated: 2/2",
+          "Successfully verified GPU on all 2 schedulable node(s)"
+        ],
+        "extra": {
+          "nodesTotal": "2",
+          "nodesValidated": "2"
+        }
+      },
+      {
+        "name": "dra-support",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found",
+        "stdout": [
+          "time=2026-08-26T16:35:32.418Z level=INFO msg=\"starting check\" name=dra-support",
+          "--- DRA driver namespace ---",
+          "Namespace: nvidia-dra-driver",
+          "Source:    resolved recipe componentRef nvidia-dra-driver-gpu",
+          "--- DRA API resources ---",
+          "Equivalent: kubectl api-resources --api-group=resource.k8s.io",
+          "",
+          "Served version: resource.k8s.io/v1",
+          "deviceclasses              DeviceClass            namespaced=false",
+          "resourceclaims             ResourceClaim          namespaced=true",
+          "resourceclaims/status      ResourceClaim          namespaced=true",
+          "resourceclaimtemplates     ResourceClaimTemplate  namespaced=true",
+          "resourceslices             ResourceSlice          namespaced=false",
+          "",
+          "--- DRA driver pods ---",
+          "Equivalent: kubectl get pods -n nvidia-dra-driver -o wide",
+          "",
+          "",
+          "time=2026-08-26T16:35:32.431Z level=ERROR msg=FAIL message=\"[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \\\"nvidia-dra-driver-gpu-controller\\\" not found\""
+        ]
+      },
+      {
+        "name": "accelerator-metrics",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "stdout": [
+          "time=2026-08-26T16:35:36.651Z level=INFO msg=\"starting check\" name=accelerator-metrics",
+          "--- DCGM Exporter Metrics (sample) ---",
+          "# HELP DCGM_FI_DEV_SM_CLOCK SM clock frequency (in MHz).",
+          "# TYPE DCGM_FI_DEV_SM_CLOCK gauge",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"0\",UUID=\"GPU-b200b200-0000-0000-0000-000000000000\",pci_bus_id=\"00000000:0A:00.0\",device=\"nvidia0\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"1\",UUID=\"GPU-b200b200-0000-0000-0000-000000000001\",pci_bus_id=\"00000000:0B:00.0\",device=\"nvidia1\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"2\",UUID=\"GPU-b200b200-0000-0000-0000-000000000002\",pci_bus_id=\"00000000:4A:00.0\",device=\"nvidia2\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"3\",UUID=\"GPU-b200b200-0000-0000-0000-000000000003\",pci_bus_id=\"00000000:4B:00.0\",device=\"nvidia3\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "# HELP DCGM_FI_DEV_MEM_CLOCK Memory clock frequency (in MHz).",
+          "# TYPE DCGM_FI_DEV_MEM_CLOCK gauge",
+          "... [truncated]",
+          "--- Required DCGM Metrics ---",
+          "  DCGM_FI_DEV_GPU_UTIL           FOUND",
+          "  DCGM_FI_DEV_FB_USED            FOUND",
+          "  DCGM_FI_DEV_GPU_TEMP           FOUND",
+          "  DCGM_FI_DEV_POWER_USAGE        FOUND"
+        ]
+      },
+      {
+        "name": "ai-service-metrics",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\"",
+        "stdout": [
+          "time=2026-08-26T16:35:41.717Z level=INFO msg=\"starting check\" name=ai-service-metrics",
+          "time=2026-08-26T16:35:41.741Z level=ERROR msg=FAIL message=\"[NOT_FOUND] no Prometheus service with port 9090 found in namespace \\\"monitoring\\\"\""
+        ]
+      },
+      {
+        "name": "gpu-operator-health",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[INTERNAL] ClusterPolicy state=notReady (want ready)",
+        "stdout": [
+          "time=2026-08-26T16:35:46.742Z level=INFO msg=\"starting check\" name=gpu-operator-health",
+          "time=2026-08-26T16:35:46.759Z level=ERROR msg=FAIL message=\"[INTERNAL] ClusterPolicy state=notReady (want ready)\""
+        ]
+      },
+      {
+        "name": "platform-health",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] platform health check failed (9 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvidia-dra-driver: not found\n  namespace nvsentinel: not found",
+        "stdout": [
+          "time=2026-08-26T16:35:51.635Z level=INFO msg=\"starting check\" name=platform-health",
+          "time=2026-08-26T16:35:51.651Z level=ERROR msg=FAIL message=\"[NOT_FOUND] platform health check failed (9 issues):\\n  namespace agentgateway-system: not found\\n  namespace cert-manager: not found\\n  namespace monitoring: not found\\n  namespace kai-scheduler: not found\\n  namespace nvidia-network-operator: not found\\n  namespace node-feature-discovery: not found\\n  namespace skyhook: not found\\n  namespace nvidia-dra-driver: not found\\n  namespace nvsentinel: not found\""
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aicr-sweep/results-57ef016/axis-allocation-watcher-on/recipe.yaml
+++ b/tests/aicr-sweep/results-57ef016/axis-allocation-watcher-on/recipe.yaml
@@ -1,0 +1,2021 @@
+apiVersion: aicr.run/v1alpha2
+componentRefs:
+  - chart: agentgateway
+    dependencyRefs:
+      - agentgateway-crds
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Agentgateway Health Check
+      #
+      # Validates that agentgateway is running and healthy in the agentgateway-system
+      # namespace. Checks that the agentgateway deployment has at least one available
+      # replica and that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # agentgateway deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: agentgateway
+                      namespace: agentgateway-system
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    manifestFiles:
+      - components/agentgateway/manifests/inference-gateway.yaml
+    name: agentgateway
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway/values.yaml
+    version: v1.3.1
+  - chart: agentgateway-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # agentgateway-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this component installs
+      # has reached the `Established=True` condition (CRD storage is up and
+      # the apiserver will accept CRs of those kinds).
+      #
+      # Scope: this component bundles BOTH the chart's agentgateway.dev/v1alpha1
+      # CRDs and the vendored Gateway API + Inference Extension manifests under
+      # recipes/components/agentgateway-crds/manifests/.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-gateway-api-crds-established
+            # Standard Gateway API CRDs vendored under
+            # manifests/gateway-api-crds.yaml. Verified against the in-tree
+            # manifest content.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gatewayclasses.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gateways.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: grpcroutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: httproutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: referencegrants.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-agentgateway-crds-established
+            # agentgateway.dev/v1alpha1 CRDs installed by the agentgateway-crds
+            # Helm chart.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaybackends.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewayparameters.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaypolicies.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-inference-extension-crds-established
+            # Gateway API Inference Extension CRDs vendored under
+            # manifests/inference-extension-crds.yaml.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencemodelrewrites.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferenceobjectives.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepoolimports.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    manifestFiles:
+      - components/agentgateway-crds/manifests/gateway-api-crds.yaml
+      - components/agentgateway-crds/manifests/inference-extension-crds.yaml
+    name: agentgateway-crds
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway-crds/values.yaml
+    version: v1.3.1
+  - chart: cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Cert Manager Health Check
+      #
+      # Validates that cert-manager is running and healthy in the cert-manager
+      # namespace. The chart deploys three Deployments — the controller
+      # (cert-manager), the CA injector (cert-manager-cainjector), and the
+      # webhook (cert-manager-webhook) — all of which must be available for
+      # the operator to issue / inject / validate certificates. The previous
+      # check only asserted the controller; this check covers all three to
+      # avoid silently passing while the webhook is down (which would block
+      # every Certificate/Issuer CR admission).
+      #
+      # Also asserts the three core CRDs are Established=True so the
+      # apiserver will accept CRs of those kinds (per #1222 / #660).
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: cert-manager-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: certificates.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: issuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterissuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-controller-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cainjector-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-cainjector
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-webhook-deployment
+            try:
+              # The webhook must be ready before any Certificate / Issuer CR
+              # can be admitted. Without this assert, a healthy controller
+              # with a dead webhook would still pass the check while the
+              # cluster silently rejects every cert-manager CR.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-webhook
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: cert-manager
+    namespace: cert-manager
+    source: https://charts.jetstack.io
+    type: Helm
+    valuesFile: components/cert-manager/values.yaml
+    version: v1.20.2
+  - chart: gpu-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # GPU Operator Health Check
+      #
+      # Validates the GPU operator stack:
+      # 1. The gpu-operator Deployment has at least one available replica.
+      # 2. The clusterpolicies.nvidia.com CRD is Established (apiserver will
+      #    accept the singleton ClusterPolicy CR).
+      # 3. The ClusterPolicy singleton named "cluster-policy" has reconciled
+      #    to status.state == "ready" — this is the deepest signal that the
+      #    full GPU stack (driver, toolkit, cuda, plugin DaemonSets, validators)
+      #    is healthy. Migrates the verifyClusterPolicyReady Go check that
+      #    PR #1235 task 7 deferred for assertion-equivalence proof.
+      # 4. No pods in unhealthy phases or stuck container-waiting states.
+      #
+      # The nvidia-operator-validator DaemonSet runs 4 sequential init
+      # containers (driver, toolkit, cuda, plugin) before reaching Running;
+      # the ClusterPolicy state assertion is the canonical post-reconcile
+      # signal that all four passed.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: gpu-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-cluster-policy-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterpolicies.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # gpu-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: gpu-operator
+                      namespace: gpu-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cluster-policy-ready
+            try:
+              # Deepest GPU readiness signal: ClusterPolicy singleton has
+              # reconciled to state=ready. Replaces the deferred
+              # verifyClusterPolicyReady Go check from PR #1235 task 7.
+              - assert:
+                  resource:
+                    apiVersion: nvidia.com/v1
+                    kind: ClusterPolicy
+                    metadata:
+                      name: cluster-policy
+                    status:
+                      state: ready
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: gpu-operator
+    namespace: gpu-operator
+    overrides:
+      daemonsets:
+        tolerations: []
+      dcgm:
+        enabled: false
+      dcgmExporter:
+        config:
+          create: false
+          data: ""
+          name: ""
+      devicePlugin:
+        env: []
+      driver:
+        enabled: false
+        rdma:
+          enabled: false
+      gdrcopy:
+        enabled: false
+      migManager:
+        enabled: false
+      operator:
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+      toolkit:
+        enabled: false
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/gpu-operator/values.yaml
+    version: v26.3.3
+  - chart: k8s-ephemeral-storage-metrics
+    dependencyRefs:
+      - kube-prometheus-stack
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # K8s Ephemeral Storage Metrics Health Check
+      #
+      # Validates that the k8s-ephemeral-storage-metrics Deployment is running and
+      # healthy in the monitoring namespace. Checks that the Deployment has at least
+      # one available replica and that no ephemeral storage metrics pods (selected by label)
+      # are stuck in Pending, Failed, or Unknown phases. Label selectors are used
+      # because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: k8s-ephemeral-storage-metrics-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the k8s-ephemeral-storage-metrics
+              # DaemonSet exists and has at least one ready pod.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: k8s-ephemeral-storage-metrics
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no ephemeral storage metrics pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: k8s-ephemeral-storage-metrics
+    namespace: monitoring
+    source: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
+    type: Helm
+    valuesFile: components/k8s-ephemeral-storage-metrics/values.yaml
+    version: 1.19.2
+  - chart: kai-scheduler
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # KAI Scheduler Health Check
+      #
+      # Validates that the KAI Scheduler is running and healthy in the kai-scheduler
+      # namespace. Checks that the kai-operator deployment has at least one
+      # available replica and that no pods in the namespace are stuck in Pending,
+      # Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kai-scheduler-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # kai-scheduler deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kai-operator
+                      namespace: kai-scheduler
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kai-scheduler
+    namespace: kai-scheduler
+    source: oci://ghcr.io/kai-scheduler/kai-scheduler
+    type: Helm
+    valuesFile: components/kai-scheduler/values.yaml
+    version: v0.14.1
+  - chart: kube-prometheus-stack
+    dependencyRefs:
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Kube Prometheus Stack Health Check
+      #
+      # Validates that the kube-prometheus-stack operator, its managed CRs, and
+      # associated workloads are running and healthy in the monitoring namespace:
+      #
+      # 1. The kube-prometheus-operator Deployment has at least one available replica.
+      # 2. The Prometheus CR (kube-prometheus-prometheus) reports Available=True.
+      #    This explicitly catches operator-level reconcile stalls (e.g., webhook
+      #    rejections) where a target StatefulSet might never be created at all.
+      # 3. The Alertmanager CR (kube-prometheus-alertmanager) reports Available=True.
+      # 4. The Prometheus StatefulSet (prometheus-kube-prometheus-prometheus) has
+      #    reached full rollout: readyReplicas >= replicas, with a replicas > 0
+      #    vacuous-pass guard so a missing StatefulSet does not silently pass.
+      # 5. The Alertmanager StatefulSet (alertmanager-kube-prometheus-alertmanager)
+      #    reaches the same full-rollout threshold.
+      # 6. No stack operator pods (label-scoped to app.kubernetes.io/name:
+      #    kube-prometheus-stack) are stuck in Pending, Failed, Unknown, or a
+      #    known-bad container-waiting reason (CrashLoopBackOff, ImagePullBackOff,
+      #    ErrImagePull, CreateContainerConfigError).
+      #
+      # StatefulSet and CR names are derived from fullnameOverride=kube-prometheus
+      # in recipes/components/kube-prometheus-stack/values.yaml. The prometheus-
+      # operator creates StatefulSets named <workload>-<cr-name>, and the chart
+      # renders CR names as <fullname>-<workload>. Names verified against
+      # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml and
+      # tests/chainsaw/ai-conformance/kind-common/assert-monitoring.yaml
+      # (both live-cluster-validated). Label selectors are used in the pod-health
+      # step because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kube-prometheus-stack-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the kube-prometheus-stack-operator
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kube-prometheus-operator
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-prometheus-cr-available
+            try:
+              # Assert the Prometheus CR has been reconciled by the operator.
+              # The prometheus-operator sets an Available condition on the CR once
+              # it has successfully reconciled the CR into a running StatefulSet.
+              # CR name kube-prometheus-prometheus derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -prometheus suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Prometheus
+                    metadata:
+                      name: kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-alertmanager-cr-available
+            try:
+              # Assert the Alertmanager CR has been reconciled by the operator.
+              # CR name kube-prometheus-alertmanager derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -alertmanager suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Alertmanager
+                    metadata:
+                      name: kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-prometheus-statefulset-ready
+            try:
+              # Assert the Prometheus StatefulSet created by the operator has
+              # reached full rollout. readyReplicas >= replicas ensures all pods
+              # are ready, not just some. The replicas > 0 guard prevents a
+              # vacuous pass when the StatefulSet is missing or has 0 replicas.
+              # StatefulSet name prometheus-kube-prometheus-prometheus is
+              # <workload>-<cr-name> per prometheus-operator convention, verified
+              # from tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: prometheus-kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-alertmanager-statefulset-ready
+            try:
+              # Assert the Alertmanager StatefulSet has reached full rollout.
+              # Same pattern as Prometheus above. StatefulSet name
+              # alertmanager-kube-prometheus-alertmanager is <workload>-<cr-name>
+              # per prometheus-operator convention, verified from
+              # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: alertmanager-kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus stack pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kube-prometheus-stack
+    namespace: monitoring
+    overrides:
+      alertmanager:
+        alertmanagerSpec:
+          resources:
+            limits:
+              cpu: 250m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+      defaultRules:
+        create: false
+      grafana:
+        enabled: false
+      prometheus:
+        prometheusSpec:
+          resources:
+            limits:
+              cpu: 1
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          retention: 7d
+          storageSpec:
+            emptyDir:
+              medium: ""
+              sizeLimit: 5Gi
+      prometheusOperator:
+        alertmanagerConfigNamespaces:
+          - monitoring
+        alertmanagerInstanceNamespaces:
+          - monitoring
+        livenessProbe:
+          failureThreshold: 10
+          timeoutSeconds: 10
+        prometheusInstanceNamespaces:
+          - monitoring
+        readinessProbe:
+          failureThreshold: 6
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        thanosRulerInstanceNamespaces:
+          - monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/kube-prometheus-stack/values.yaml
+    version: 84.4.0
+  - chart: network-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Network Operator Health Check
+      #
+      # Validates that the NVIDIA Network Operator is running and healthy in
+      # the nvidia-network-operator namespace. Also asserts
+      # nicclusterpolicies.mellanox.com is Established=True (verified against
+      # chart 26.4.1; re-verify on defaultVersion bump). Chart 26.4.1 also
+      # ships nicnodepolicies.mellanox.com, deliberately NOT asserted here:
+      # no in-tree recipe instantiates a CR against it, so it fails the same
+      # load-bearing-only bar the rest of this PR's assertions are held to.
+      # Checks that the
+      # network-operator deployment has at least one available replica and
+      # that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: network-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: nicclusterpolicies.mellanox.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # network-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: network-operator
+                      namespace: nvidia-network-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: network-operator
+    namespace: nvidia-network-operator
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/network-operator/values.yaml
+    version: 26.4.1
+  - chart: node-feature-discovery
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Node Feature Discovery Health Check
+      #
+      # Validates the standalone NFD deployment by checking:
+      # 1. NFD Master Deployment has at least one ready replica
+      # 2. NFD Worker DaemonSet has fully rolled out (desiredNumberScheduled > 0
+      #    and numberReady == desiredNumberScheduled, so partial failures don't pass)
+      # 3. NFD GC Deployment has at least one ready replica (gc.enable: true)
+      #
+      # Resource names: AICR deploys the kubernetes-sigs/node-feature-discovery
+      # chart under release name "nfd" (matching the ComponentRef Name in
+      # recipes/registry.yaml). The chart's fullname template prefixes the
+      # release name to the chart name when they don't overlap, yielding
+      # "nfd-node-feature-discovery-*" for the master Deployment, worker
+      # DaemonSet, and gc Deployment. If a deployer ever switches the release
+      # name to "node-feature-discovery", these asserts need updating in
+      # lockstep.
+      # 4. No pods in unhealthy phases (Pending, Failed, Unknown) or stuck in
+      #    Running with a known-unhealthy container waiting reason
+      #    (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+      #    CreateContainerConfigError)
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nfd-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-master-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-master
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-worker-daemonset
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nfd-node-feature-discovery-worker
+                      namespace: node-feature-discovery
+                    status:
+                      # Guard against vacuous pass when 0 nodes match the
+                      # DaemonSet: require at least one scheduled pod.
+                      (desiredNumberScheduled > `0`): true
+                      # Full rollout: every scheduled pod is ready. Combined with
+                      # the guard above, this rejects partial failures. We assert on
+                      # numberReady (always present in DaemonSetStatus) rather than
+                      # numberUnavailable, which is `omitempty` and disappears from
+                      # the status when zero — making `numberUnavailable == 0`
+                      # evaluate `null == 0` (false) on a fully-healthy DaemonSet.
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-gc-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-gc
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nfd
+    namespace: node-feature-discovery
+    source: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+    type: Helm
+    valuesFile: components/nfd/values.yaml
+    version: 0.19.0
+  - chart: nodewright
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Nodewright Operator Health Check
+      #
+      # Validates that the Nodewright Operator is running and healthy in the
+      # skyhook namespace:
+      # 1. skyhooks.skyhook.nvidia.com CRD Established=True (the apiserver
+      #    will accept Skyhook CRs that nodewright-customizations declares).
+      # 2. skyhook-operator-controller-manager Deployment has at least one
+      #    available replica.
+      # 3. No pods stuck in Pending/Failed/Unknown phases or known-bad
+      #    container-waiting states.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nodewright-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-skyhook-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: skyhooks.skyhook.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: skyhook-operator-controller-manager
+                      namespace: skyhook
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nodewright-operator
+    namespace: skyhook
+    overrides:
+      controllerManager:
+        manager:
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+    source: oci://ghcr.io/nvidia/nodewright/charts
+    type: Helm
+    valuesFile: components/nodewright-operator/values.yaml
+    version: v0.17.1
+  - chart: dra-driver-nvidia-gpu
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVIDIA DRA Driver GPU Health Check
+      #
+      # Validates that the NVIDIA DRA (Dynamic Resource Allocation) GPU driver
+      # is running and healthy in the nvidia-dra-driver namespace. The
+      # kubelet-plugin DaemonSet must roll out fully — numberReady ==
+      # desiredNumberScheduled (with desiredNumberScheduled > 0 as a guard).
+      # Previous check gated only on numberReady > 0, passing on partial
+      # failures; see #1222 and recipes/checks/nfd/health-check.yaml for
+      # the same rationale.
+      #
+      # Resource names: the DaemonSet name is release-derived
+      # (<release>-kubelet-plugin). AICR's release name is
+      # `nvidia-dra-driver-gpu` (matches ComponentRef Name in registry.yaml).
+      # If a deployer renames the release, this assert needs updating in
+      # lockstep — see verifyDRAKubeletPluginReady commentary in
+      # validators/deployment/expected_resources.go for why a chart-shape
+      # label would be a more robust selector.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvidia-dra-driver-gpu-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-kubelet-plugin-daemonset-fully-rolled-out
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nvidia-dra-driver-gpu-kubelet-plugin
+                      namespace: nvidia-dra-driver
+                    status:
+                      (desiredNumberScheduled > `0`): true
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvidia-dra-driver-gpu
+    namespace: nvidia-dra-driver
+    overrides:
+      nvidiaDriverRoot: /
+    source: oci://registry.k8s.io/dra-driver-nvidia/charts
+    type: Helm
+    valuesFile: components/nvidia-dra-driver-gpu/values.yaml
+    version: 0.4.1
+  - chart: nvsentinel
+    dependencyRefs:
+      - cert-manager
+      - gpu-operator
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVSentinel Health Check
+      #
+      # Validates that the NVSentinel labeler is running and healthy in
+      # the nvsentinel namespace. Checks that the labeler deployment has at
+      # least one available replica and that no pods in the
+      # namespace are stuck in Pending, Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvsentinel-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # nvsentinel-controller-manager deployment exists and has at least
+              # one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: labeler
+                      namespace: nvsentinel
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvsentinel
+    namespace: nvsentinel
+    overrides:
+      platformConnector:
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+    source: oci://ghcr.io/nvidia
+    type: Helm
+    valuesFile: components/nvsentinel/values.yaml
+    version: v1.9.0
+  - chart: prometheus-adapter
+    dependencyRefs:
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Prometheus Adapter Health Check
+      #
+      # Validates that the Prometheus Adapter is running and healthy in the
+      # monitoring namespace. Checks that the prometheus-adapter deployment has
+      # at least one available replica and that no prometheus adapter pods
+      # (selected by label) are stuck in Pending, Failed, or Unknown phases.
+      # Label selectors are used because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-adapter-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the prometheus-adapter
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: prometheus-adapter
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus adapter pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: prometheus-adapter
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-adapter/values.yaml
+    version: 5.3.0
+  - chart: prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # prometheus-operator-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this chart installs has
+      # reached the `Established=True` condition (CRD storage is up and the
+      # apiserver will accept CRs of those kinds).
+      #
+      # CRDs come from the upstream prometheus-community/prometheus-operator-crds
+      # chart pinned to 28.0.1 in recipes/registry.yaml. The 8 kinds under
+      # monitoring.coreos.com/v1 are enumerated in
+      # recipes/components/prometheus-operator-crds/values.yaml header:
+      # Alertmanager, AlertmanagerConfig, PodMonitor, Probe, Prometheus,
+      # PrometheusRule, ServiceMonitor, ThanosRuler. Plural names match the
+      # long-standing upstream prometheus-operator chart shape.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-operator-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-prometheus-operator-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagerconfigs.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: podmonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: probes.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheuses.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheusrules.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: servicemonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: thanosrulers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    name: prometheus-operator-crds
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-operator-crds/values.yaml
+    version: 28.0.1
+constraints:
+  - name: K8s.server.version
+    value: '>= 1.30'
+criteria:
+  accelerator: gb200
+  intent: inference
+  os: any
+  platform: any
+  service: kind
+deploymentOrder:
+  - agentgateway-crds
+  - cert-manager
+  - agentgateway
+  - nfd
+  - network-operator
+  - nodewright-operator
+  - prometheus-operator-crds
+  - kube-prometheus-stack
+  - gpu-operator
+  - k8s-ephemeral-storage-metrics
+  - kai-scheduler
+  - nvidia-dra-driver-gpu
+  - nvsentinel
+  - prometheus-adapter
+kind: RecipeResult
+metadata:
+  appliedOverlays:
+    - base
+    - monitoring-hpa
+    - gb200-any
+    - kind
+    - kind-inference
+  version: dev
+validation:
+  conformance:
+    checks:
+      - platform-health
+      - gpu-operator-health
+      - dra-support
+      - accelerator-metrics
+      - ai-service-metrics
+  deployment:
+    checks:
+      - operator-health
+      - expected-resources
+      - gpu-operator-version
+      - check-nvidia-smi
+    constraints:
+      - name: Deployment.gpu-operator.version
+        value: '>= v25.10.0'

--- a/tests/aicr-sweep/results-57ef016/axis-failure-injection-ecc/ctrf/validate.json
+++ b/tests/aicr-sweep/results-57ef016/axis-failure-injection-ecc/ctrf/validate.json
@@ -1,0 +1,202 @@
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-08-26T17:20:14Z",
+  "generatedBy": "aicr",
+  "results": {
+    "tool": {
+      "name": "aicr",
+      "version": "dev"
+    },
+    "summary": {
+      "tests": 9,
+      "passed": 3,
+      "failed": 5,
+      "skipped": 0,
+      "pending": 0,
+      "other": 1,
+      "start": 1787764255143,
+      "stop": 1787764903260
+    },
+    "tests": [
+      {
+        "name": "operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "stdout": [
+          "time=2026-08-26T17:11:09.714Z level=INFO msg=\"starting check\" name=operator-health",
+          "time=2026-08-26T17:11:09.720Z level=INFO msg=\"listing pods\" namespace=gpu-operator label=\"app=gpu-operator\"",
+          "time=2026-08-26T17:11:09.724Z level=INFO msg=\"operator-health: passed\" running=1",
+          "Found 1 gpu-operator pod(s):",
+          "  gpu-operator-869cf5b4c-xh77q: Running",
+          "Running: 1/1"
+        ]
+      },
+      {
+        "name": "expected-resources",
+        "status": "other",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "message": "pod not found for Job aicr-expected-resources-cc04b61a: [NOT_FOUND] pod for job not found"
+      },
+      {
+        "name": "gpu-operator-version",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "message": "[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \"\u003e= v25.10.0\"",
+        "stdout": [
+          "time=2026-08-26T17:19:15.106Z level=INFO msg=\"starting check\" name=gpu-operator-version",
+          "time=2026-08-26T17:19:15.115Z level=ERROR msg=FAIL message=\"[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \\\"\u003e= v25.10.0\\\"\"",
+          "Detected GPU Operator version: v25.3.4",
+          "Constraint: \u003e= v25.10.0 → false"
+        ]
+      },
+      {
+        "name": "check-nvidia-smi",
+        "status": "passed",
+        "duration": 53000,
+        "suite": [
+          "deployment"
+        ],
+        "stdout": [
+          "time=2026-08-26T17:19:19.496Z level=INFO msg=\"starting check\" name=check-nvidia-smi",
+          "Found 2 GPU node(s), 2 schedulable, 0 cordoned:",
+          "  mokka-aicr-stack-worker",
+          "  mokka-aicr-stack-worker2",
+          "All 2 GPU node(s) available. Verifying...",
+          "time=2026-08-26T17:19:19.508Z level=INFO msg=\"verifying node\" node=mokka-aicr-stack-worker",
+          "time=2026-08-26T17:19:19.508Z level=INFO msg=\"deploying nvidia-smi verify pod\" node=mokka-aicr-stack-worker podName=nvidia-smi-verify-mokka-aicr-stack-worker image=nvcr.io/nvidia/cuda:13.0.0-base-ubuntu22.04 namespace=aicr-validation",
+          "time=2026-08-26T17:19:19.511Z level=INFO msg=\"waiting for pod to reach Succeeded state\" name=nvidia-smi-verify-mokka-aicr-stack-worker",
+          "time=2026-08-26T17:19:19.520Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T17:19:19.901Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T17:19:43.249Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-26T17:19:43.825Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-26T17:19:44.842Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-26T17:19:44.915Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Succeeded",
+          "time=2026-08-26T17:19:44.915Z level=INFO msg=\"pod successfully completed\" name=nvidia-smi-verify-mokka-aicr-stack-worker",
+          "time=2026-08-26T17:19:44.922Z level=INFO msg=\"verifying node\" node=mokka-aicr-stack-worker2",
+          "time=2026-08-26T17:19:44.922Z level=INFO msg=\"deploying nvidia-smi verify pod\" node=mokka-aicr-stack-worker2 podName=nvidia-smi-verify-mokka-aicr-stack-worker2 image=nvcr.io/nvidia/cuda:13.0.0-base-ubuntu22.04 namespace=aicr-validation",
+          "  mokka-aicr-stack-worker: OK",
+          "time=2026-08-26T17:19:44.925Z level=INFO msg=\"waiting for pod to reach Succeeded state\" name=nvidia-smi-verify-mokka-aicr-stack-worker2",
+          "time=2026-08-26T17:19:44.935Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T17:19:45.325Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T17:20:10.483Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T17:20:11.241Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T17:20:12.249Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T17:20:12.306Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Succeeded",
+          "time=2026-08-26T17:20:12.306Z level=INFO msg=\"pod successfully completed\" name=nvidia-smi-verify-mokka-aicr-stack-worker2",
+          "  mokka-aicr-stack-worker2: OK",
+          "RESULT: nodesValidated: 2/2",
+          "Successfully verified GPU on all 2 schedulable node(s)"
+        ],
+        "extra": {
+          "nodesTotal": "2",
+          "nodesValidated": "2"
+        }
+      },
+      {
+        "name": "dra-support",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found",
+        "stdout": [
+          "time=2026-08-26T17:21:23.970Z level=INFO msg=\"starting check\" name=dra-support",
+          "--- DRA driver namespace ---",
+          "Namespace: nvidia-dra-driver",
+          "Source:    resolved recipe componentRef nvidia-dra-driver-gpu",
+          "--- DRA API resources ---",
+          "Equivalent: kubectl api-resources --api-group=resource.k8s.io",
+          "",
+          "Served version: resource.k8s.io/v1",
+          "deviceclasses              DeviceClass            namespaced=false",
+          "resourceclaims             ResourceClaim          namespaced=true",
+          "resourceclaims/status      ResourceClaim          namespaced=true",
+          "resourceclaimtemplates     ResourceClaimTemplate  namespaced=true",
+          "resourceslices             ResourceSlice          namespaced=false",
+          "",
+          "--- DRA driver pods ---",
+          "Equivalent: kubectl get pods -n nvidia-dra-driver -o wide",
+          "",
+          "",
+          "time=2026-08-26T17:21:23.984Z level=ERROR msg=FAIL message=\"[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \\\"nvidia-dra-driver-gpu-controller\\\" not found\""
+        ]
+      },
+      {
+        "name": "accelerator-metrics",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "stdout": [
+          "time=2026-08-26T17:21:28.234Z level=INFO msg=\"starting check\" name=accelerator-metrics",
+          "--- DCGM Exporter Metrics (sample) ---",
+          "# HELP DCGM_FI_DEV_SM_CLOCK SM clock frequency (in MHz).",
+          "# TYPE DCGM_FI_DEV_SM_CLOCK gauge",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"0\",UUID=\"GPU-b200b200-0000-0000-0000-000000000000\",pci_bus_id=\"00000000:0A:00.0\",device=\"nvidia0\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"1\",UUID=\"GPU-b200b200-0000-0000-0000-000000000001\",pci_bus_id=\"00000000:0B:00.0\",device=\"nvidia1\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"2\",UUID=\"GPU-b200b200-0000-0000-0000-000000000002\",pci_bus_id=\"00000000:4A:00.0\",device=\"nvidia2\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"3\",UUID=\"GPU-b200b200-0000-0000-0000-000000000003\",pci_bus_id=\"00000000:4B:00.0\",device=\"nvidia3\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "# HELP DCGM_FI_DEV_MEM_CLOCK Memory clock frequency (in MHz).",
+          "# TYPE DCGM_FI_DEV_MEM_CLOCK gauge",
+          "... [truncated]",
+          "--- Required DCGM Metrics ---",
+          "  DCGM_FI_DEV_GPU_UTIL           FOUND",
+          "  DCGM_FI_DEV_FB_USED            FOUND",
+          "  DCGM_FI_DEV_GPU_TEMP           FOUND",
+          "  DCGM_FI_DEV_POWER_USAGE        FOUND"
+        ]
+      },
+      {
+        "name": "ai-service-metrics",
+        "status": "failed",
+        "duration": 1000,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\"",
+        "stdout": [
+          "time=2026-08-26T17:21:32.998Z level=INFO msg=\"starting check\" name=ai-service-metrics",
+          "time=2026-08-26T17:21:33.007Z level=ERROR msg=FAIL message=\"[NOT_FOUND] no Prometheus service with port 9090 found in namespace \\\"monitoring\\\"\""
+        ]
+      },
+      {
+        "name": "gpu-operator-health",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[INTERNAL] ClusterPolicy state=notReady (want ready)",
+        "stdout": [
+          "time=2026-08-26T17:21:37.026Z level=INFO msg=\"starting check\" name=gpu-operator-health",
+          "time=2026-08-26T17:21:37.038Z level=ERROR msg=FAIL message=\"[INTERNAL] ClusterPolicy state=notReady (want ready)\""
+        ]
+      },
+      {
+        "name": "platform-health",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] platform health check failed (9 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvidia-dra-driver: not found\n  namespace nvsentinel: not found",
+        "stdout": [
+          "time=2026-08-26T17:21:41.146Z level=INFO msg=\"starting check\" name=platform-health",
+          "time=2026-08-26T17:21:41.161Z level=ERROR msg=FAIL message=\"[NOT_FOUND] platform health check failed (9 issues):\\n  namespace agentgateway-system: not found\\n  namespace cert-manager: not found\\n  namespace monitoring: not found\\n  namespace kai-scheduler: not found\\n  namespace nvidia-network-operator: not found\\n  namespace node-feature-discovery: not found\\n  namespace skyhook: not found\\n  namespace nvidia-dra-driver: not found\\n  namespace nvsentinel: not found\""
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aicr-sweep/results-57ef016/axis-failure-injection-ecc/recipe.yaml
+++ b/tests/aicr-sweep/results-57ef016/axis-failure-injection-ecc/recipe.yaml
@@ -1,0 +1,2021 @@
+apiVersion: aicr.run/v1alpha2
+componentRefs:
+  - chart: agentgateway
+    dependencyRefs:
+      - agentgateway-crds
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Agentgateway Health Check
+      #
+      # Validates that agentgateway is running and healthy in the agentgateway-system
+      # namespace. Checks that the agentgateway deployment has at least one available
+      # replica and that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # agentgateway deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: agentgateway
+                      namespace: agentgateway-system
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    manifestFiles:
+      - components/agentgateway/manifests/inference-gateway.yaml
+    name: agentgateway
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway/values.yaml
+    version: v1.3.1
+  - chart: agentgateway-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # agentgateway-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this component installs
+      # has reached the `Established=True` condition (CRD storage is up and
+      # the apiserver will accept CRs of those kinds).
+      #
+      # Scope: this component bundles BOTH the chart's agentgateway.dev/v1alpha1
+      # CRDs and the vendored Gateway API + Inference Extension manifests under
+      # recipes/components/agentgateway-crds/manifests/.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-gateway-api-crds-established
+            # Standard Gateway API CRDs vendored under
+            # manifests/gateway-api-crds.yaml. Verified against the in-tree
+            # manifest content.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gatewayclasses.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gateways.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: grpcroutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: httproutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: referencegrants.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-agentgateway-crds-established
+            # agentgateway.dev/v1alpha1 CRDs installed by the agentgateway-crds
+            # Helm chart.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaybackends.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewayparameters.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaypolicies.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-inference-extension-crds-established
+            # Gateway API Inference Extension CRDs vendored under
+            # manifests/inference-extension-crds.yaml.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencemodelrewrites.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferenceobjectives.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepoolimports.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    manifestFiles:
+      - components/agentgateway-crds/manifests/gateway-api-crds.yaml
+      - components/agentgateway-crds/manifests/inference-extension-crds.yaml
+    name: agentgateway-crds
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway-crds/values.yaml
+    version: v1.3.1
+  - chart: cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Cert Manager Health Check
+      #
+      # Validates that cert-manager is running and healthy in the cert-manager
+      # namespace. The chart deploys three Deployments — the controller
+      # (cert-manager), the CA injector (cert-manager-cainjector), and the
+      # webhook (cert-manager-webhook) — all of which must be available for
+      # the operator to issue / inject / validate certificates. The previous
+      # check only asserted the controller; this check covers all three to
+      # avoid silently passing while the webhook is down (which would block
+      # every Certificate/Issuer CR admission).
+      #
+      # Also asserts the three core CRDs are Established=True so the
+      # apiserver will accept CRs of those kinds (per #1222 / #660).
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: cert-manager-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: certificates.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: issuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterissuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-controller-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cainjector-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-cainjector
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-webhook-deployment
+            try:
+              # The webhook must be ready before any Certificate / Issuer CR
+              # can be admitted. Without this assert, a healthy controller
+              # with a dead webhook would still pass the check while the
+              # cluster silently rejects every cert-manager CR.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-webhook
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: cert-manager
+    namespace: cert-manager
+    source: https://charts.jetstack.io
+    type: Helm
+    valuesFile: components/cert-manager/values.yaml
+    version: v1.20.2
+  - chart: gpu-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # GPU Operator Health Check
+      #
+      # Validates the GPU operator stack:
+      # 1. The gpu-operator Deployment has at least one available replica.
+      # 2. The clusterpolicies.nvidia.com CRD is Established (apiserver will
+      #    accept the singleton ClusterPolicy CR).
+      # 3. The ClusterPolicy singleton named "cluster-policy" has reconciled
+      #    to status.state == "ready" — this is the deepest signal that the
+      #    full GPU stack (driver, toolkit, cuda, plugin DaemonSets, validators)
+      #    is healthy. Migrates the verifyClusterPolicyReady Go check that
+      #    PR #1235 task 7 deferred for assertion-equivalence proof.
+      # 4. No pods in unhealthy phases or stuck container-waiting states.
+      #
+      # The nvidia-operator-validator DaemonSet runs 4 sequential init
+      # containers (driver, toolkit, cuda, plugin) before reaching Running;
+      # the ClusterPolicy state assertion is the canonical post-reconcile
+      # signal that all four passed.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: gpu-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-cluster-policy-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterpolicies.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # gpu-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: gpu-operator
+                      namespace: gpu-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cluster-policy-ready
+            try:
+              # Deepest GPU readiness signal: ClusterPolicy singleton has
+              # reconciled to state=ready. Replaces the deferred
+              # verifyClusterPolicyReady Go check from PR #1235 task 7.
+              - assert:
+                  resource:
+                    apiVersion: nvidia.com/v1
+                    kind: ClusterPolicy
+                    metadata:
+                      name: cluster-policy
+                    status:
+                      state: ready
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: gpu-operator
+    namespace: gpu-operator
+    overrides:
+      daemonsets:
+        tolerations: []
+      dcgm:
+        enabled: false
+      dcgmExporter:
+        config:
+          create: false
+          data: ""
+          name: ""
+      devicePlugin:
+        env: []
+      driver:
+        enabled: false
+        rdma:
+          enabled: false
+      gdrcopy:
+        enabled: false
+      migManager:
+        enabled: false
+      operator:
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+      toolkit:
+        enabled: false
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/gpu-operator/values.yaml
+    version: v26.3.3
+  - chart: k8s-ephemeral-storage-metrics
+    dependencyRefs:
+      - kube-prometheus-stack
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # K8s Ephemeral Storage Metrics Health Check
+      #
+      # Validates that the k8s-ephemeral-storage-metrics Deployment is running and
+      # healthy in the monitoring namespace. Checks that the Deployment has at least
+      # one available replica and that no ephemeral storage metrics pods (selected by label)
+      # are stuck in Pending, Failed, or Unknown phases. Label selectors are used
+      # because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: k8s-ephemeral-storage-metrics-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the k8s-ephemeral-storage-metrics
+              # DaemonSet exists and has at least one ready pod.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: k8s-ephemeral-storage-metrics
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no ephemeral storage metrics pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: k8s-ephemeral-storage-metrics
+    namespace: monitoring
+    source: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
+    type: Helm
+    valuesFile: components/k8s-ephemeral-storage-metrics/values.yaml
+    version: 1.19.2
+  - chart: kai-scheduler
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # KAI Scheduler Health Check
+      #
+      # Validates that the KAI Scheduler is running and healthy in the kai-scheduler
+      # namespace. Checks that the kai-operator deployment has at least one
+      # available replica and that no pods in the namespace are stuck in Pending,
+      # Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kai-scheduler-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # kai-scheduler deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kai-operator
+                      namespace: kai-scheduler
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kai-scheduler
+    namespace: kai-scheduler
+    source: oci://ghcr.io/kai-scheduler/kai-scheduler
+    type: Helm
+    valuesFile: components/kai-scheduler/values.yaml
+    version: v0.14.1
+  - chart: kube-prometheus-stack
+    dependencyRefs:
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Kube Prometheus Stack Health Check
+      #
+      # Validates that the kube-prometheus-stack operator, its managed CRs, and
+      # associated workloads are running and healthy in the monitoring namespace:
+      #
+      # 1. The kube-prometheus-operator Deployment has at least one available replica.
+      # 2. The Prometheus CR (kube-prometheus-prometheus) reports Available=True.
+      #    This explicitly catches operator-level reconcile stalls (e.g., webhook
+      #    rejections) where a target StatefulSet might never be created at all.
+      # 3. The Alertmanager CR (kube-prometheus-alertmanager) reports Available=True.
+      # 4. The Prometheus StatefulSet (prometheus-kube-prometheus-prometheus) has
+      #    reached full rollout: readyReplicas >= replicas, with a replicas > 0
+      #    vacuous-pass guard so a missing StatefulSet does not silently pass.
+      # 5. The Alertmanager StatefulSet (alertmanager-kube-prometheus-alertmanager)
+      #    reaches the same full-rollout threshold.
+      # 6. No stack operator pods (label-scoped to app.kubernetes.io/name:
+      #    kube-prometheus-stack) are stuck in Pending, Failed, Unknown, or a
+      #    known-bad container-waiting reason (CrashLoopBackOff, ImagePullBackOff,
+      #    ErrImagePull, CreateContainerConfigError).
+      #
+      # StatefulSet and CR names are derived from fullnameOverride=kube-prometheus
+      # in recipes/components/kube-prometheus-stack/values.yaml. The prometheus-
+      # operator creates StatefulSets named <workload>-<cr-name>, and the chart
+      # renders CR names as <fullname>-<workload>. Names verified against
+      # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml and
+      # tests/chainsaw/ai-conformance/kind-common/assert-monitoring.yaml
+      # (both live-cluster-validated). Label selectors are used in the pod-health
+      # step because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kube-prometheus-stack-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the kube-prometheus-stack-operator
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kube-prometheus-operator
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-prometheus-cr-available
+            try:
+              # Assert the Prometheus CR has been reconciled by the operator.
+              # The prometheus-operator sets an Available condition on the CR once
+              # it has successfully reconciled the CR into a running StatefulSet.
+              # CR name kube-prometheus-prometheus derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -prometheus suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Prometheus
+                    metadata:
+                      name: kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-alertmanager-cr-available
+            try:
+              # Assert the Alertmanager CR has been reconciled by the operator.
+              # CR name kube-prometheus-alertmanager derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -alertmanager suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Alertmanager
+                    metadata:
+                      name: kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-prometheus-statefulset-ready
+            try:
+              # Assert the Prometheus StatefulSet created by the operator has
+              # reached full rollout. readyReplicas >= replicas ensures all pods
+              # are ready, not just some. The replicas > 0 guard prevents a
+              # vacuous pass when the StatefulSet is missing or has 0 replicas.
+              # StatefulSet name prometheus-kube-prometheus-prometheus is
+              # <workload>-<cr-name> per prometheus-operator convention, verified
+              # from tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: prometheus-kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-alertmanager-statefulset-ready
+            try:
+              # Assert the Alertmanager StatefulSet has reached full rollout.
+              # Same pattern as Prometheus above. StatefulSet name
+              # alertmanager-kube-prometheus-alertmanager is <workload>-<cr-name>
+              # per prometheus-operator convention, verified from
+              # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: alertmanager-kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus stack pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kube-prometheus-stack
+    namespace: monitoring
+    overrides:
+      alertmanager:
+        alertmanagerSpec:
+          resources:
+            limits:
+              cpu: 250m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+      defaultRules:
+        create: false
+      grafana:
+        enabled: false
+      prometheus:
+        prometheusSpec:
+          resources:
+            limits:
+              cpu: 1
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          retention: 7d
+          storageSpec:
+            emptyDir:
+              medium: ""
+              sizeLimit: 5Gi
+      prometheusOperator:
+        alertmanagerConfigNamespaces:
+          - monitoring
+        alertmanagerInstanceNamespaces:
+          - monitoring
+        livenessProbe:
+          failureThreshold: 10
+          timeoutSeconds: 10
+        prometheusInstanceNamespaces:
+          - monitoring
+        readinessProbe:
+          failureThreshold: 6
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        thanosRulerInstanceNamespaces:
+          - monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/kube-prometheus-stack/values.yaml
+    version: 84.4.0
+  - chart: network-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Network Operator Health Check
+      #
+      # Validates that the NVIDIA Network Operator is running and healthy in
+      # the nvidia-network-operator namespace. Also asserts
+      # nicclusterpolicies.mellanox.com is Established=True (verified against
+      # chart 26.4.1; re-verify on defaultVersion bump). Chart 26.4.1 also
+      # ships nicnodepolicies.mellanox.com, deliberately NOT asserted here:
+      # no in-tree recipe instantiates a CR against it, so it fails the same
+      # load-bearing-only bar the rest of this PR's assertions are held to.
+      # Checks that the
+      # network-operator deployment has at least one available replica and
+      # that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: network-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: nicclusterpolicies.mellanox.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # network-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: network-operator
+                      namespace: nvidia-network-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: network-operator
+    namespace: nvidia-network-operator
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/network-operator/values.yaml
+    version: 26.4.1
+  - chart: node-feature-discovery
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Node Feature Discovery Health Check
+      #
+      # Validates the standalone NFD deployment by checking:
+      # 1. NFD Master Deployment has at least one ready replica
+      # 2. NFD Worker DaemonSet has fully rolled out (desiredNumberScheduled > 0
+      #    and numberReady == desiredNumberScheduled, so partial failures don't pass)
+      # 3. NFD GC Deployment has at least one ready replica (gc.enable: true)
+      #
+      # Resource names: AICR deploys the kubernetes-sigs/node-feature-discovery
+      # chart under release name "nfd" (matching the ComponentRef Name in
+      # recipes/registry.yaml). The chart's fullname template prefixes the
+      # release name to the chart name when they don't overlap, yielding
+      # "nfd-node-feature-discovery-*" for the master Deployment, worker
+      # DaemonSet, and gc Deployment. If a deployer ever switches the release
+      # name to "node-feature-discovery", these asserts need updating in
+      # lockstep.
+      # 4. No pods in unhealthy phases (Pending, Failed, Unknown) or stuck in
+      #    Running with a known-unhealthy container waiting reason
+      #    (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+      #    CreateContainerConfigError)
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nfd-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-master-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-master
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-worker-daemonset
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nfd-node-feature-discovery-worker
+                      namespace: node-feature-discovery
+                    status:
+                      # Guard against vacuous pass when 0 nodes match the
+                      # DaemonSet: require at least one scheduled pod.
+                      (desiredNumberScheduled > `0`): true
+                      # Full rollout: every scheduled pod is ready. Combined with
+                      # the guard above, this rejects partial failures. We assert on
+                      # numberReady (always present in DaemonSetStatus) rather than
+                      # numberUnavailable, which is `omitempty` and disappears from
+                      # the status when zero — making `numberUnavailable == 0`
+                      # evaluate `null == 0` (false) on a fully-healthy DaemonSet.
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-gc-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-gc
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nfd
+    namespace: node-feature-discovery
+    source: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+    type: Helm
+    valuesFile: components/nfd/values.yaml
+    version: 0.19.0
+  - chart: nodewright
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Nodewright Operator Health Check
+      #
+      # Validates that the Nodewright Operator is running and healthy in the
+      # skyhook namespace:
+      # 1. skyhooks.skyhook.nvidia.com CRD Established=True (the apiserver
+      #    will accept Skyhook CRs that nodewright-customizations declares).
+      # 2. skyhook-operator-controller-manager Deployment has at least one
+      #    available replica.
+      # 3. No pods stuck in Pending/Failed/Unknown phases or known-bad
+      #    container-waiting states.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nodewright-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-skyhook-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: skyhooks.skyhook.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: skyhook-operator-controller-manager
+                      namespace: skyhook
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nodewright-operator
+    namespace: skyhook
+    overrides:
+      controllerManager:
+        manager:
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+    source: oci://ghcr.io/nvidia/nodewright/charts
+    type: Helm
+    valuesFile: components/nodewright-operator/values.yaml
+    version: v0.17.1
+  - chart: dra-driver-nvidia-gpu
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVIDIA DRA Driver GPU Health Check
+      #
+      # Validates that the NVIDIA DRA (Dynamic Resource Allocation) GPU driver
+      # is running and healthy in the nvidia-dra-driver namespace. The
+      # kubelet-plugin DaemonSet must roll out fully — numberReady ==
+      # desiredNumberScheduled (with desiredNumberScheduled > 0 as a guard).
+      # Previous check gated only on numberReady > 0, passing on partial
+      # failures; see #1222 and recipes/checks/nfd/health-check.yaml for
+      # the same rationale.
+      #
+      # Resource names: the DaemonSet name is release-derived
+      # (<release>-kubelet-plugin). AICR's release name is
+      # `nvidia-dra-driver-gpu` (matches ComponentRef Name in registry.yaml).
+      # If a deployer renames the release, this assert needs updating in
+      # lockstep — see verifyDRAKubeletPluginReady commentary in
+      # validators/deployment/expected_resources.go for why a chart-shape
+      # label would be a more robust selector.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvidia-dra-driver-gpu-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-kubelet-plugin-daemonset-fully-rolled-out
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nvidia-dra-driver-gpu-kubelet-plugin
+                      namespace: nvidia-dra-driver
+                    status:
+                      (desiredNumberScheduled > `0`): true
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvidia-dra-driver-gpu
+    namespace: nvidia-dra-driver
+    overrides:
+      nvidiaDriverRoot: /
+    source: oci://registry.k8s.io/dra-driver-nvidia/charts
+    type: Helm
+    valuesFile: components/nvidia-dra-driver-gpu/values.yaml
+    version: 0.4.1
+  - chart: nvsentinel
+    dependencyRefs:
+      - cert-manager
+      - gpu-operator
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVSentinel Health Check
+      #
+      # Validates that the NVSentinel labeler is running and healthy in
+      # the nvsentinel namespace. Checks that the labeler deployment has at
+      # least one available replica and that no pods in the
+      # namespace are stuck in Pending, Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvsentinel-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # nvsentinel-controller-manager deployment exists and has at least
+              # one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: labeler
+                      namespace: nvsentinel
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvsentinel
+    namespace: nvsentinel
+    overrides:
+      platformConnector:
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+    source: oci://ghcr.io/nvidia
+    type: Helm
+    valuesFile: components/nvsentinel/values.yaml
+    version: v1.9.0
+  - chart: prometheus-adapter
+    dependencyRefs:
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Prometheus Adapter Health Check
+      #
+      # Validates that the Prometheus Adapter is running and healthy in the
+      # monitoring namespace. Checks that the prometheus-adapter deployment has
+      # at least one available replica and that no prometheus adapter pods
+      # (selected by label) are stuck in Pending, Failed, or Unknown phases.
+      # Label selectors are used because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-adapter-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the prometheus-adapter
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: prometheus-adapter
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus adapter pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: prometheus-adapter
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-adapter/values.yaml
+    version: 5.3.0
+  - chart: prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # prometheus-operator-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this chart installs has
+      # reached the `Established=True` condition (CRD storage is up and the
+      # apiserver will accept CRs of those kinds).
+      #
+      # CRDs come from the upstream prometheus-community/prometheus-operator-crds
+      # chart pinned to 28.0.1 in recipes/registry.yaml. The 8 kinds under
+      # monitoring.coreos.com/v1 are enumerated in
+      # recipes/components/prometheus-operator-crds/values.yaml header:
+      # Alertmanager, AlertmanagerConfig, PodMonitor, Probe, Prometheus,
+      # PrometheusRule, ServiceMonitor, ThanosRuler. Plural names match the
+      # long-standing upstream prometheus-operator chart shape.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-operator-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-prometheus-operator-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagerconfigs.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: podmonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: probes.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheuses.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheusrules.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: servicemonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: thanosrulers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    name: prometheus-operator-crds
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-operator-crds/values.yaml
+    version: 28.0.1
+constraints:
+  - name: K8s.server.version
+    value: '>= 1.30'
+criteria:
+  accelerator: gb200
+  intent: inference
+  os: any
+  platform: any
+  service: kind
+deploymentOrder:
+  - agentgateway-crds
+  - cert-manager
+  - agentgateway
+  - nfd
+  - network-operator
+  - nodewright-operator
+  - prometheus-operator-crds
+  - kube-prometheus-stack
+  - gpu-operator
+  - k8s-ephemeral-storage-metrics
+  - kai-scheduler
+  - nvidia-dra-driver-gpu
+  - nvsentinel
+  - prometheus-adapter
+kind: RecipeResult
+metadata:
+  appliedOverlays:
+    - base
+    - monitoring-hpa
+    - gb200-any
+    - kind
+    - kind-inference
+  version: dev
+validation:
+  conformance:
+    checks:
+      - platform-health
+      - gpu-operator-health
+      - dra-support
+      - accelerator-metrics
+      - ai-service-metrics
+  deployment:
+    checks:
+      - operator-health
+      - expected-resources
+      - gpu-operator-version
+      - check-nvidia-smi
+    constraints:
+      - name: Deployment.gpu-operator.version
+        value: '>= v25.10.0'

--- a/tests/aicr-sweep/results-57ef016/axis-nri-cdi/ctrf/validate.json
+++ b/tests/aicr-sweep/results-57ef016/axis-nri-cdi/ctrf/validate.json
@@ -1,0 +1,202 @@
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-08-26T16:10:17Z",
+  "generatedBy": "aicr",
+  "results": {
+    "tool": {
+      "name": "aicr",
+      "version": "dev"
+    },
+    "summary": {
+      "tests": 9,
+      "passed": 3,
+      "failed": 5,
+      "skipped": 0,
+      "pending": 0,
+      "other": 1,
+      "start": 1787759953754,
+      "stop": 1787760675843
+    },
+    "tests": [
+      {
+        "name": "operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "stdout": [
+          "time=2026-08-26T16:00:55.473Z level=INFO msg=\"starting check\" name=operator-health",
+          "time=2026-08-26T16:00:55.481Z level=INFO msg=\"listing pods\" namespace=gpu-operator label=\"app=gpu-operator\"",
+          "Found 1 gpu-operator pod(s):",
+          "  gpu-operator-869cf5b4c-gl2ph: Running",
+          "Running: 1/1",
+          "time=2026-08-26T16:00:55.486Z level=INFO msg=\"operator-health: passed\" running=1"
+        ]
+      },
+      {
+        "name": "expected-resources",
+        "status": "other",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "message": "pod not found for Job aicr-expected-resources-6c6c4efc: [NOT_FOUND] pod for job not found"
+      },
+      {
+        "name": "gpu-operator-version",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "message": "[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \"\u003e= v25.10.0\"",
+        "stdout": [
+          "time=2026-08-26T16:09:01.289Z level=INFO msg=\"starting check\" name=gpu-operator-version",
+          "time=2026-08-26T16:09:01.300Z level=ERROR msg=FAIL message=\"[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \\\"\u003e= v25.10.0\\\"\"",
+          "Detected GPU Operator version: v25.3.4",
+          "Constraint: \u003e= v25.10.0 → false"
+        ]
+      },
+      {
+        "name": "check-nvidia-smi",
+        "status": "passed",
+        "duration": 69000,
+        "suite": [
+          "deployment"
+        ],
+        "stdout": [
+          "time=2026-08-26T16:09:05.355Z level=INFO msg=\"starting check\" name=check-nvidia-smi",
+          "Found 2 GPU node(s), 2 schedulable, 0 cordoned:",
+          "  mokka-aicr-stack-worker",
+          "  mokka-aicr-stack-worker2",
+          "time=2026-08-26T16:09:05.369Z level=INFO msg=\"verifying node\" node=mokka-aicr-stack-worker",
+          "All 2 GPU node(s) available. Verifying...",
+          "time=2026-08-26T16:09:05.369Z level=INFO msg=\"deploying nvidia-smi verify pod\" node=mokka-aicr-stack-worker podName=nvidia-smi-verify-mokka-aicr-stack-worker image=nvcr.io/nvidia/cuda:13.0.0-base-ubuntu22.04 namespace=aicr-validation",
+          "time=2026-08-26T16:09:05.372Z level=INFO msg=\"waiting for pod to reach Succeeded state\" name=nvidia-smi-verify-mokka-aicr-stack-worker",
+          "time=2026-08-26T16:09:05.393Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T16:09:05.774Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T16:09:34.695Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-26T16:09:35.548Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-26T16:09:36.550Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-26T16:09:36.616Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Succeeded",
+          "time=2026-08-26T16:09:36.616Z level=INFO msg=\"pod successfully completed\" name=nvidia-smi-verify-mokka-aicr-stack-worker",
+          "  mokka-aicr-stack-worker: OK",
+          "time=2026-08-26T16:09:36.629Z level=INFO msg=\"verifying node\" node=mokka-aicr-stack-worker2",
+          "time=2026-08-26T16:09:36.629Z level=INFO msg=\"deploying nvidia-smi verify pod\" node=mokka-aicr-stack-worker2 podName=nvidia-smi-verify-mokka-aicr-stack-worker2 image=nvcr.io/nvidia/cuda:13.0.0-base-ubuntu22.04 namespace=aicr-validation",
+          "time=2026-08-26T16:09:36.632Z level=INFO msg=\"waiting for pod to reach Succeeded state\" name=nvidia-smi-verify-mokka-aicr-stack-worker2",
+          "time=2026-08-26T16:09:36.641Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T16:09:37.018Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T16:10:13.339Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T16:10:13.674Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T16:10:14.678Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T16:10:14.755Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Succeeded",
+          "time=2026-08-26T16:10:14.755Z level=INFO msg=\"pod successfully completed\" name=nvidia-smi-verify-mokka-aicr-stack-worker2",
+          "  mokka-aicr-stack-worker2: OK",
+          "RESULT: nodesValidated: 2/2",
+          "Successfully verified GPU on all 2 schedulable node(s)"
+        ],
+        "extra": {
+          "nodesTotal": "2",
+          "nodesValidated": "2"
+        }
+      },
+      {
+        "name": "dra-support",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found",
+        "stdout": [
+          "time=2026-08-26T16:10:57.099Z level=INFO msg=\"starting check\" name=dra-support",
+          "--- DRA driver namespace ---",
+          "Namespace: nvidia-dra-driver",
+          "Source:    resolved recipe componentRef nvidia-dra-driver-gpu",
+          "--- DRA API resources ---",
+          "Equivalent: kubectl api-resources --api-group=resource.k8s.io",
+          "",
+          "Served version: resource.k8s.io/v1",
+          "deviceclasses              DeviceClass            namespaced=false",
+          "resourceclaims             ResourceClaim          namespaced=true",
+          "resourceclaims/status      ResourceClaim          namespaced=true",
+          "resourceclaimtemplates     ResourceClaimTemplate  namespaced=true",
+          "resourceslices             ResourceSlice          namespaced=false",
+          "",
+          "--- DRA driver pods ---",
+          "Equivalent: kubectl get pods -n nvidia-dra-driver -o wide",
+          "",
+          "",
+          "time=2026-08-26T16:10:57.112Z level=ERROR msg=FAIL message=\"[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \\\"nvidia-dra-driver-gpu-controller\\\" not found\""
+        ]
+      },
+      {
+        "name": "accelerator-metrics",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "stdout": [
+          "time=2026-08-26T16:11:01.607Z level=INFO msg=\"starting check\" name=accelerator-metrics",
+          "--- DCGM Exporter Metrics (sample) ---",
+          "# HELP DCGM_FI_DEV_SM_CLOCK SM clock frequency (in MHz).",
+          "# TYPE DCGM_FI_DEV_SM_CLOCK gauge",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"0\",UUID=\"GPU-b200b200-0000-0000-0000-000000000000\",pci_bus_id=\"00000000:0A:00.0\",device=\"nvidia0\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"1\",UUID=\"GPU-b200b200-0000-0000-0000-000000000001\",pci_bus_id=\"00000000:0B:00.0\",device=\"nvidia1\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"2\",UUID=\"GPU-b200b200-0000-0000-0000-000000000002\",pci_bus_id=\"00000000:4A:00.0\",device=\"nvidia2\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"3\",UUID=\"GPU-b200b200-0000-0000-0000-000000000003\",pci_bus_id=\"00000000:4B:00.0\",device=\"nvidia3\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "# HELP DCGM_FI_DEV_MEM_CLOCK Memory clock frequency (in MHz).",
+          "# TYPE DCGM_FI_DEV_MEM_CLOCK gauge",
+          "... [truncated]",
+          "--- Required DCGM Metrics ---",
+          "  DCGM_FI_DEV_GPU_UTIL           FOUND",
+          "  DCGM_FI_DEV_FB_USED            FOUND",
+          "  DCGM_FI_DEV_GPU_TEMP           FOUND",
+          "  DCGM_FI_DEV_POWER_USAGE        FOUND"
+        ]
+      },
+      {
+        "name": "ai-service-metrics",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\"",
+        "stdout": [
+          "time=2026-08-26T16:11:05.492Z level=INFO msg=\"starting check\" name=ai-service-metrics",
+          "time=2026-08-26T16:11:05.502Z level=ERROR msg=FAIL message=\"[NOT_FOUND] no Prometheus service with port 9090 found in namespace \\\"monitoring\\\"\""
+        ]
+      },
+      {
+        "name": "gpu-operator-health",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[INTERNAL] ClusterPolicy state=notReady (want ready)",
+        "stdout": [
+          "time=2026-08-26T16:11:09.630Z level=INFO msg=\"starting check\" name=gpu-operator-health",
+          "time=2026-08-26T16:11:09.643Z level=ERROR msg=FAIL message=\"[INTERNAL] ClusterPolicy state=notReady (want ready)\""
+        ]
+      },
+      {
+        "name": "platform-health",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] platform health check failed (9 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvidia-dra-driver: not found\n  namespace nvsentinel: not found",
+        "stdout": [
+          "time=2026-08-26T16:11:13.527Z level=INFO msg=\"starting check\" name=platform-health",
+          "time=2026-08-26T16:11:13.541Z level=ERROR msg=FAIL message=\"[NOT_FOUND] platform health check failed (9 issues):\\n  namespace agentgateway-system: not found\\n  namespace cert-manager: not found\\n  namespace monitoring: not found\\n  namespace kai-scheduler: not found\\n  namespace nvidia-network-operator: not found\\n  namespace node-feature-discovery: not found\\n  namespace skyhook: not found\\n  namespace nvidia-dra-driver: not found\\n  namespace nvsentinel: not found\""
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aicr-sweep/results-57ef016/axis-nri-cdi/recipe.yaml
+++ b/tests/aicr-sweep/results-57ef016/axis-nri-cdi/recipe.yaml
@@ -1,0 +1,2021 @@
+apiVersion: aicr.run/v1alpha2
+componentRefs:
+  - chart: agentgateway
+    dependencyRefs:
+      - agentgateway-crds
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Agentgateway Health Check
+      #
+      # Validates that agentgateway is running and healthy in the agentgateway-system
+      # namespace. Checks that the agentgateway deployment has at least one available
+      # replica and that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # agentgateway deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: agentgateway
+                      namespace: agentgateway-system
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    manifestFiles:
+      - components/agentgateway/manifests/inference-gateway.yaml
+    name: agentgateway
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway/values.yaml
+    version: v1.3.1
+  - chart: agentgateway-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # agentgateway-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this component installs
+      # has reached the `Established=True` condition (CRD storage is up and
+      # the apiserver will accept CRs of those kinds).
+      #
+      # Scope: this component bundles BOTH the chart's agentgateway.dev/v1alpha1
+      # CRDs and the vendored Gateway API + Inference Extension manifests under
+      # recipes/components/agentgateway-crds/manifests/.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-gateway-api-crds-established
+            # Standard Gateway API CRDs vendored under
+            # manifests/gateway-api-crds.yaml. Verified against the in-tree
+            # manifest content.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gatewayclasses.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gateways.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: grpcroutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: httproutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: referencegrants.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-agentgateway-crds-established
+            # agentgateway.dev/v1alpha1 CRDs installed by the agentgateway-crds
+            # Helm chart.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaybackends.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewayparameters.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaypolicies.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-inference-extension-crds-established
+            # Gateway API Inference Extension CRDs vendored under
+            # manifests/inference-extension-crds.yaml.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencemodelrewrites.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferenceobjectives.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepoolimports.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    manifestFiles:
+      - components/agentgateway-crds/manifests/gateway-api-crds.yaml
+      - components/agentgateway-crds/manifests/inference-extension-crds.yaml
+    name: agentgateway-crds
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway-crds/values.yaml
+    version: v1.3.1
+  - chart: cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Cert Manager Health Check
+      #
+      # Validates that cert-manager is running and healthy in the cert-manager
+      # namespace. The chart deploys three Deployments — the controller
+      # (cert-manager), the CA injector (cert-manager-cainjector), and the
+      # webhook (cert-manager-webhook) — all of which must be available for
+      # the operator to issue / inject / validate certificates. The previous
+      # check only asserted the controller; this check covers all three to
+      # avoid silently passing while the webhook is down (which would block
+      # every Certificate/Issuer CR admission).
+      #
+      # Also asserts the three core CRDs are Established=True so the
+      # apiserver will accept CRs of those kinds (per #1222 / #660).
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: cert-manager-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: certificates.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: issuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterissuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-controller-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cainjector-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-cainjector
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-webhook-deployment
+            try:
+              # The webhook must be ready before any Certificate / Issuer CR
+              # can be admitted. Without this assert, a healthy controller
+              # with a dead webhook would still pass the check while the
+              # cluster silently rejects every cert-manager CR.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-webhook
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: cert-manager
+    namespace: cert-manager
+    source: https://charts.jetstack.io
+    type: Helm
+    valuesFile: components/cert-manager/values.yaml
+    version: v1.20.2
+  - chart: gpu-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # GPU Operator Health Check
+      #
+      # Validates the GPU operator stack:
+      # 1. The gpu-operator Deployment has at least one available replica.
+      # 2. The clusterpolicies.nvidia.com CRD is Established (apiserver will
+      #    accept the singleton ClusterPolicy CR).
+      # 3. The ClusterPolicy singleton named "cluster-policy" has reconciled
+      #    to status.state == "ready" — this is the deepest signal that the
+      #    full GPU stack (driver, toolkit, cuda, plugin DaemonSets, validators)
+      #    is healthy. Migrates the verifyClusterPolicyReady Go check that
+      #    PR #1235 task 7 deferred for assertion-equivalence proof.
+      # 4. No pods in unhealthy phases or stuck container-waiting states.
+      #
+      # The nvidia-operator-validator DaemonSet runs 4 sequential init
+      # containers (driver, toolkit, cuda, plugin) before reaching Running;
+      # the ClusterPolicy state assertion is the canonical post-reconcile
+      # signal that all four passed.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: gpu-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-cluster-policy-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterpolicies.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # gpu-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: gpu-operator
+                      namespace: gpu-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cluster-policy-ready
+            try:
+              # Deepest GPU readiness signal: ClusterPolicy singleton has
+              # reconciled to state=ready. Replaces the deferred
+              # verifyClusterPolicyReady Go check from PR #1235 task 7.
+              - assert:
+                  resource:
+                    apiVersion: nvidia.com/v1
+                    kind: ClusterPolicy
+                    metadata:
+                      name: cluster-policy
+                    status:
+                      state: ready
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: gpu-operator
+    namespace: gpu-operator
+    overrides:
+      daemonsets:
+        tolerations: []
+      dcgm:
+        enabled: false
+      dcgmExporter:
+        config:
+          create: false
+          data: ""
+          name: ""
+      devicePlugin:
+        env: []
+      driver:
+        enabled: false
+        rdma:
+          enabled: false
+      gdrcopy:
+        enabled: false
+      migManager:
+        enabled: false
+      operator:
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+      toolkit:
+        enabled: false
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/gpu-operator/values.yaml
+    version: v26.3.3
+  - chart: k8s-ephemeral-storage-metrics
+    dependencyRefs:
+      - kube-prometheus-stack
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # K8s Ephemeral Storage Metrics Health Check
+      #
+      # Validates that the k8s-ephemeral-storage-metrics Deployment is running and
+      # healthy in the monitoring namespace. Checks that the Deployment has at least
+      # one available replica and that no ephemeral storage metrics pods (selected by label)
+      # are stuck in Pending, Failed, or Unknown phases. Label selectors are used
+      # because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: k8s-ephemeral-storage-metrics-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the k8s-ephemeral-storage-metrics
+              # DaemonSet exists and has at least one ready pod.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: k8s-ephemeral-storage-metrics
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no ephemeral storage metrics pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: k8s-ephemeral-storage-metrics
+    namespace: monitoring
+    source: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
+    type: Helm
+    valuesFile: components/k8s-ephemeral-storage-metrics/values.yaml
+    version: 1.19.2
+  - chart: kai-scheduler
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # KAI Scheduler Health Check
+      #
+      # Validates that the KAI Scheduler is running and healthy in the kai-scheduler
+      # namespace. Checks that the kai-operator deployment has at least one
+      # available replica and that no pods in the namespace are stuck in Pending,
+      # Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kai-scheduler-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # kai-scheduler deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kai-operator
+                      namespace: kai-scheduler
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kai-scheduler
+    namespace: kai-scheduler
+    source: oci://ghcr.io/kai-scheduler/kai-scheduler
+    type: Helm
+    valuesFile: components/kai-scheduler/values.yaml
+    version: v0.14.1
+  - chart: kube-prometheus-stack
+    dependencyRefs:
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Kube Prometheus Stack Health Check
+      #
+      # Validates that the kube-prometheus-stack operator, its managed CRs, and
+      # associated workloads are running and healthy in the monitoring namespace:
+      #
+      # 1. The kube-prometheus-operator Deployment has at least one available replica.
+      # 2. The Prometheus CR (kube-prometheus-prometheus) reports Available=True.
+      #    This explicitly catches operator-level reconcile stalls (e.g., webhook
+      #    rejections) where a target StatefulSet might never be created at all.
+      # 3. The Alertmanager CR (kube-prometheus-alertmanager) reports Available=True.
+      # 4. The Prometheus StatefulSet (prometheus-kube-prometheus-prometheus) has
+      #    reached full rollout: readyReplicas >= replicas, with a replicas > 0
+      #    vacuous-pass guard so a missing StatefulSet does not silently pass.
+      # 5. The Alertmanager StatefulSet (alertmanager-kube-prometheus-alertmanager)
+      #    reaches the same full-rollout threshold.
+      # 6. No stack operator pods (label-scoped to app.kubernetes.io/name:
+      #    kube-prometheus-stack) are stuck in Pending, Failed, Unknown, or a
+      #    known-bad container-waiting reason (CrashLoopBackOff, ImagePullBackOff,
+      #    ErrImagePull, CreateContainerConfigError).
+      #
+      # StatefulSet and CR names are derived from fullnameOverride=kube-prometheus
+      # in recipes/components/kube-prometheus-stack/values.yaml. The prometheus-
+      # operator creates StatefulSets named <workload>-<cr-name>, and the chart
+      # renders CR names as <fullname>-<workload>. Names verified against
+      # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml and
+      # tests/chainsaw/ai-conformance/kind-common/assert-monitoring.yaml
+      # (both live-cluster-validated). Label selectors are used in the pod-health
+      # step because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kube-prometheus-stack-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the kube-prometheus-stack-operator
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kube-prometheus-operator
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-prometheus-cr-available
+            try:
+              # Assert the Prometheus CR has been reconciled by the operator.
+              # The prometheus-operator sets an Available condition on the CR once
+              # it has successfully reconciled the CR into a running StatefulSet.
+              # CR name kube-prometheus-prometheus derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -prometheus suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Prometheus
+                    metadata:
+                      name: kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-alertmanager-cr-available
+            try:
+              # Assert the Alertmanager CR has been reconciled by the operator.
+              # CR name kube-prometheus-alertmanager derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -alertmanager suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Alertmanager
+                    metadata:
+                      name: kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-prometheus-statefulset-ready
+            try:
+              # Assert the Prometheus StatefulSet created by the operator has
+              # reached full rollout. readyReplicas >= replicas ensures all pods
+              # are ready, not just some. The replicas > 0 guard prevents a
+              # vacuous pass when the StatefulSet is missing or has 0 replicas.
+              # StatefulSet name prometheus-kube-prometheus-prometheus is
+              # <workload>-<cr-name> per prometheus-operator convention, verified
+              # from tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: prometheus-kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-alertmanager-statefulset-ready
+            try:
+              # Assert the Alertmanager StatefulSet has reached full rollout.
+              # Same pattern as Prometheus above. StatefulSet name
+              # alertmanager-kube-prometheus-alertmanager is <workload>-<cr-name>
+              # per prometheus-operator convention, verified from
+              # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: alertmanager-kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus stack pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kube-prometheus-stack
+    namespace: monitoring
+    overrides:
+      alertmanager:
+        alertmanagerSpec:
+          resources:
+            limits:
+              cpu: 250m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+      defaultRules:
+        create: false
+      grafana:
+        enabled: false
+      prometheus:
+        prometheusSpec:
+          resources:
+            limits:
+              cpu: 1
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          retention: 7d
+          storageSpec:
+            emptyDir:
+              medium: ""
+              sizeLimit: 5Gi
+      prometheusOperator:
+        alertmanagerConfigNamespaces:
+          - monitoring
+        alertmanagerInstanceNamespaces:
+          - monitoring
+        livenessProbe:
+          failureThreshold: 10
+          timeoutSeconds: 10
+        prometheusInstanceNamespaces:
+          - monitoring
+        readinessProbe:
+          failureThreshold: 6
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        thanosRulerInstanceNamespaces:
+          - monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/kube-prometheus-stack/values.yaml
+    version: 84.4.0
+  - chart: network-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Network Operator Health Check
+      #
+      # Validates that the NVIDIA Network Operator is running and healthy in
+      # the nvidia-network-operator namespace. Also asserts
+      # nicclusterpolicies.mellanox.com is Established=True (verified against
+      # chart 26.4.1; re-verify on defaultVersion bump). Chart 26.4.1 also
+      # ships nicnodepolicies.mellanox.com, deliberately NOT asserted here:
+      # no in-tree recipe instantiates a CR against it, so it fails the same
+      # load-bearing-only bar the rest of this PR's assertions are held to.
+      # Checks that the
+      # network-operator deployment has at least one available replica and
+      # that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: network-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: nicclusterpolicies.mellanox.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # network-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: network-operator
+                      namespace: nvidia-network-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: network-operator
+    namespace: nvidia-network-operator
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/network-operator/values.yaml
+    version: 26.4.1
+  - chart: node-feature-discovery
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Node Feature Discovery Health Check
+      #
+      # Validates the standalone NFD deployment by checking:
+      # 1. NFD Master Deployment has at least one ready replica
+      # 2. NFD Worker DaemonSet has fully rolled out (desiredNumberScheduled > 0
+      #    and numberReady == desiredNumberScheduled, so partial failures don't pass)
+      # 3. NFD GC Deployment has at least one ready replica (gc.enable: true)
+      #
+      # Resource names: AICR deploys the kubernetes-sigs/node-feature-discovery
+      # chart under release name "nfd" (matching the ComponentRef Name in
+      # recipes/registry.yaml). The chart's fullname template prefixes the
+      # release name to the chart name when they don't overlap, yielding
+      # "nfd-node-feature-discovery-*" for the master Deployment, worker
+      # DaemonSet, and gc Deployment. If a deployer ever switches the release
+      # name to "node-feature-discovery", these asserts need updating in
+      # lockstep.
+      # 4. No pods in unhealthy phases (Pending, Failed, Unknown) or stuck in
+      #    Running with a known-unhealthy container waiting reason
+      #    (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+      #    CreateContainerConfigError)
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nfd-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-master-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-master
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-worker-daemonset
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nfd-node-feature-discovery-worker
+                      namespace: node-feature-discovery
+                    status:
+                      # Guard against vacuous pass when 0 nodes match the
+                      # DaemonSet: require at least one scheduled pod.
+                      (desiredNumberScheduled > `0`): true
+                      # Full rollout: every scheduled pod is ready. Combined with
+                      # the guard above, this rejects partial failures. We assert on
+                      # numberReady (always present in DaemonSetStatus) rather than
+                      # numberUnavailable, which is `omitempty` and disappears from
+                      # the status when zero — making `numberUnavailable == 0`
+                      # evaluate `null == 0` (false) on a fully-healthy DaemonSet.
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-gc-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-gc
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nfd
+    namespace: node-feature-discovery
+    source: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+    type: Helm
+    valuesFile: components/nfd/values.yaml
+    version: 0.19.0
+  - chart: nodewright
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Nodewright Operator Health Check
+      #
+      # Validates that the Nodewright Operator is running and healthy in the
+      # skyhook namespace:
+      # 1. skyhooks.skyhook.nvidia.com CRD Established=True (the apiserver
+      #    will accept Skyhook CRs that nodewright-customizations declares).
+      # 2. skyhook-operator-controller-manager Deployment has at least one
+      #    available replica.
+      # 3. No pods stuck in Pending/Failed/Unknown phases or known-bad
+      #    container-waiting states.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nodewright-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-skyhook-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: skyhooks.skyhook.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: skyhook-operator-controller-manager
+                      namespace: skyhook
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nodewright-operator
+    namespace: skyhook
+    overrides:
+      controllerManager:
+        manager:
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+    source: oci://ghcr.io/nvidia/nodewright/charts
+    type: Helm
+    valuesFile: components/nodewright-operator/values.yaml
+    version: v0.17.1
+  - chart: dra-driver-nvidia-gpu
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVIDIA DRA Driver GPU Health Check
+      #
+      # Validates that the NVIDIA DRA (Dynamic Resource Allocation) GPU driver
+      # is running and healthy in the nvidia-dra-driver namespace. The
+      # kubelet-plugin DaemonSet must roll out fully — numberReady ==
+      # desiredNumberScheduled (with desiredNumberScheduled > 0 as a guard).
+      # Previous check gated only on numberReady > 0, passing on partial
+      # failures; see #1222 and recipes/checks/nfd/health-check.yaml for
+      # the same rationale.
+      #
+      # Resource names: the DaemonSet name is release-derived
+      # (<release>-kubelet-plugin). AICR's release name is
+      # `nvidia-dra-driver-gpu` (matches ComponentRef Name in registry.yaml).
+      # If a deployer renames the release, this assert needs updating in
+      # lockstep — see verifyDRAKubeletPluginReady commentary in
+      # validators/deployment/expected_resources.go for why a chart-shape
+      # label would be a more robust selector.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvidia-dra-driver-gpu-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-kubelet-plugin-daemonset-fully-rolled-out
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nvidia-dra-driver-gpu-kubelet-plugin
+                      namespace: nvidia-dra-driver
+                    status:
+                      (desiredNumberScheduled > `0`): true
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvidia-dra-driver-gpu
+    namespace: nvidia-dra-driver
+    overrides:
+      nvidiaDriverRoot: /
+    source: oci://registry.k8s.io/dra-driver-nvidia/charts
+    type: Helm
+    valuesFile: components/nvidia-dra-driver-gpu/values.yaml
+    version: 0.4.1
+  - chart: nvsentinel
+    dependencyRefs:
+      - cert-manager
+      - gpu-operator
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVSentinel Health Check
+      #
+      # Validates that the NVSentinel labeler is running and healthy in
+      # the nvsentinel namespace. Checks that the labeler deployment has at
+      # least one available replica and that no pods in the
+      # namespace are stuck in Pending, Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvsentinel-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # nvsentinel-controller-manager deployment exists and has at least
+              # one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: labeler
+                      namespace: nvsentinel
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvsentinel
+    namespace: nvsentinel
+    overrides:
+      platformConnector:
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+    source: oci://ghcr.io/nvidia
+    type: Helm
+    valuesFile: components/nvsentinel/values.yaml
+    version: v1.9.0
+  - chart: prometheus-adapter
+    dependencyRefs:
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Prometheus Adapter Health Check
+      #
+      # Validates that the Prometheus Adapter is running and healthy in the
+      # monitoring namespace. Checks that the prometheus-adapter deployment has
+      # at least one available replica and that no prometheus adapter pods
+      # (selected by label) are stuck in Pending, Failed, or Unknown phases.
+      # Label selectors are used because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-adapter-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the prometheus-adapter
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: prometheus-adapter
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus adapter pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: prometheus-adapter
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-adapter/values.yaml
+    version: 5.3.0
+  - chart: prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # prometheus-operator-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this chart installs has
+      # reached the `Established=True` condition (CRD storage is up and the
+      # apiserver will accept CRs of those kinds).
+      #
+      # CRDs come from the upstream prometheus-community/prometheus-operator-crds
+      # chart pinned to 28.0.1 in recipes/registry.yaml. The 8 kinds under
+      # monitoring.coreos.com/v1 are enumerated in
+      # recipes/components/prometheus-operator-crds/values.yaml header:
+      # Alertmanager, AlertmanagerConfig, PodMonitor, Probe, Prometheus,
+      # PrometheusRule, ServiceMonitor, ThanosRuler. Plural names match the
+      # long-standing upstream prometheus-operator chart shape.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-operator-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-prometheus-operator-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagerconfigs.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: podmonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: probes.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheuses.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheusrules.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: servicemonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: thanosrulers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    name: prometheus-operator-crds
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-operator-crds/values.yaml
+    version: 28.0.1
+constraints:
+  - name: K8s.server.version
+    value: '>= 1.30'
+criteria:
+  accelerator: gb200
+  intent: inference
+  os: any
+  platform: any
+  service: kind
+deploymentOrder:
+  - agentgateway-crds
+  - cert-manager
+  - agentgateway
+  - nfd
+  - network-operator
+  - nodewright-operator
+  - prometheus-operator-crds
+  - kube-prometheus-stack
+  - gpu-operator
+  - k8s-ephemeral-storage-metrics
+  - kai-scheduler
+  - nvidia-dra-driver-gpu
+  - nvsentinel
+  - prometheus-adapter
+kind: RecipeResult
+metadata:
+  appliedOverlays:
+    - base
+    - monitoring-hpa
+    - gb200-any
+    - kind
+    - kind-inference
+  version: dev
+validation:
+  conformance:
+    checks:
+      - platform-health
+      - gpu-operator-health
+      - dra-support
+      - accelerator-metrics
+      - ai-service-metrics
+  deployment:
+    checks:
+      - operator-health
+      - expected-resources
+      - gpu-operator-version
+      - check-nvidia-smi
+    constraints:
+      - name: Deployment.gpu-operator.version
+        value: '>= v25.10.0'

--- a/tests/aicr-sweep/results-57ef016/base-gb200-kind-inference-stack/ctrf/validate.json
+++ b/tests/aicr-sweep/results-57ef016/base-gb200-kind-inference-stack/ctrf/validate.json
@@ -1,0 +1,201 @@
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-08-26T14:59:54Z",
+  "generatedBy": "aicr",
+  "results": {
+    "tool": {
+      "name": "aicr",
+      "version": "dev"
+    },
+    "summary": {
+      "tests": 9,
+      "passed": 3,
+      "failed": 5,
+      "skipped": 0,
+      "pending": 0,
+      "other": 1,
+      "start": 1787755831687,
+      "stop": 1787756600563
+    },
+    "tests": [
+      {
+        "name": "operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "stdout": [
+          "time=2026-08-26T14:50:33.140Z level=INFO msg=\"starting check\" name=operator-health",
+          "time=2026-08-26T14:50:33.150Z level=INFO msg=\"listing pods\" namespace=gpu-operator label=\"app=gpu-operator\"",
+          "time=2026-08-26T14:50:33.157Z level=INFO msg=\"operator-health: passed\" running=1",
+          "Found 1 gpu-operator pod(s):",
+          "  gpu-operator-869cf5b4c-pg57n: Running",
+          "Running: 1/1"
+        ]
+      },
+      {
+        "name": "expected-resources",
+        "status": "other",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "message": "pod not found for Job aicr-expected-resources-ce03baa3: [NOT_FOUND] pod for job not found"
+      },
+      {
+        "name": "gpu-operator-version",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "message": "[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \"\u003e= v25.10.0\"",
+        "stdout": [
+          "time=2026-08-26T14:58:37.809Z level=INFO msg=\"starting check\" name=gpu-operator-version",
+          "time=2026-08-26T14:58:37.837Z level=ERROR msg=FAIL message=\"[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \\\"\u003e= v25.10.0\\\"\"",
+          "Detected GPU Operator version: v25.3.4",
+          "Constraint: \u003e= v25.10.0 → false"
+        ]
+      },
+      {
+        "name": "check-nvidia-smi",
+        "status": "passed",
+        "duration": 70000,
+        "suite": [
+          "deployment"
+        ],
+        "stdout": [
+          "time=2026-08-26T14:58:42.145Z level=INFO msg=\"starting check\" name=check-nvidia-smi",
+          "Found 2 GPU node(s), 2 schedulable, 0 cordoned:",
+          "  mokka-aicr-stack-worker",
+          "  mokka-aicr-stack-worker2",
+          "time=2026-08-26T14:58:42.216Z level=INFO msg=\"verifying node\" node=mokka-aicr-stack-worker",
+          "time=2026-08-26T14:58:42.216Z level=INFO msg=\"deploying nvidia-smi verify pod\" node=mokka-aicr-stack-worker podName=nvidia-smi-verify-mokka-aicr-stack-worker image=nvcr.io/nvidia/cuda:13.0.0-base-ubuntu22.04 namespace=aicr-validation",
+          "All 2 GPU node(s) available. Verifying...",
+          "time=2026-08-26T14:58:42.226Z level=INFO msg=\"waiting for pod to reach Succeeded state\" name=nvidia-smi-verify-mokka-aicr-stack-worker",
+          "time=2026-08-26T14:58:42.262Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T14:58:42.719Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T14:59:13.290Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-26T14:59:14.543Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-26T14:59:15.633Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Succeeded",
+          "time=2026-08-26T14:59:15.633Z level=INFO msg=\"pod successfully completed\" name=nvidia-smi-verify-mokka-aicr-stack-worker",
+          "time=2026-08-26T14:59:15.664Z level=INFO msg=\"verifying node\" node=mokka-aicr-stack-worker2",
+          "time=2026-08-26T14:59:15.664Z level=INFO msg=\"deploying nvidia-smi verify pod\" node=mokka-aicr-stack-worker2 podName=nvidia-smi-verify-mokka-aicr-stack-worker2 image=nvcr.io/nvidia/cuda:13.0.0-base-ubuntu22.04 namespace=aicr-validation",
+          "  mokka-aicr-stack-worker: OK",
+          "time=2026-08-26T14:59:15.676Z level=INFO msg=\"waiting for pod to reach Succeeded state\" name=nvidia-smi-verify-mokka-aicr-stack-worker2",
+          "time=2026-08-26T14:59:15.709Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T14:59:16.136Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T14:59:50.650Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T14:59:51.236Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T14:59:52.238Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T14:59:52.319Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Succeeded",
+          "time=2026-08-26T14:59:52.319Z level=INFO msg=\"pod successfully completed\" name=nvidia-smi-verify-mokka-aicr-stack-worker2",
+          "  mokka-aicr-stack-worker2: OK",
+          "RESULT: nodesValidated: 2/2",
+          "Successfully verified GPU on all 2 schedulable node(s)"
+        ],
+        "extra": {
+          "nodesTotal": "2",
+          "nodesValidated": "2"
+        }
+      },
+      {
+        "name": "dra-support",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found",
+        "stdout": [
+          "time=2026-08-26T15:02:59.208Z level=INFO msg=\"starting check\" name=dra-support",
+          "--- DRA driver namespace ---",
+          "Namespace: nvidia-dra-driver",
+          "Source:    resolved recipe componentRef nvidia-dra-driver-gpu",
+          "--- DRA API resources ---",
+          "Equivalent: kubectl api-resources --api-group=resource.k8s.io",
+          "",
+          "Served version: resource.k8s.io/v1",
+          "deviceclasses              DeviceClass            namespaced=false",
+          "resourceclaims             ResourceClaim          namespaced=true",
+          "resourceclaims/status      ResourceClaim          namespaced=true",
+          "resourceclaimtemplates     ResourceClaimTemplate  namespaced=true",
+          "resourceslices             ResourceSlice          namespaced=false",
+          "",
+          "--- DRA driver pods ---",
+          "Equivalent: kubectl get pods -n nvidia-dra-driver -o wide",
+          "",
+          "",
+          "time=2026-08-26T15:02:59.223Z level=ERROR msg=FAIL message=\"[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \\\"nvidia-dra-driver-gpu-controller\\\" not found\""
+        ]
+      },
+      {
+        "name": "accelerator-metrics",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "stdout": [
+          "time=2026-08-26T15:03:03.629Z level=INFO msg=\"starting check\" name=accelerator-metrics",
+          "--- DCGM Exporter Metrics (sample) ---",
+          "# HELP DCGM_FI_DEV_SM_CLOCK SM clock frequency (in MHz).",
+          "# TYPE DCGM_FI_DEV_SM_CLOCK gauge",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"0\",UUID=\"GPU-b200b200-0000-0000-0000-000000000000\",pci_bus_id=\"00000000:0A:00.0\",device=\"nvidia0\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"1\",UUID=\"GPU-b200b200-0000-0000-0000-000000000001\",pci_bus_id=\"00000000:0B:00.0\",device=\"nvidia1\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"2\",UUID=\"GPU-b200b200-0000-0000-0000-000000000002\",pci_bus_id=\"00000000:4A:00.0\",device=\"nvidia2\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"3\",UUID=\"GPU-b200b200-0000-0000-0000-000000000003\",pci_bus_id=\"00000000:4B:00.0\",device=\"nvidia3\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "# HELP DCGM_FI_DEV_MEM_CLOCK Memory clock frequency (in MHz).",
+          "# TYPE DCGM_FI_DEV_MEM_CLOCK gauge",
+          "... [truncated]",
+          "--- Required DCGM Metrics ---",
+          "  DCGM_FI_DEV_GPU_UTIL           FOUND",
+          "  DCGM_FI_DEV_FB_USED            FOUND",
+          "  DCGM_FI_DEV_GPU_TEMP           FOUND",
+          "  DCGM_FI_DEV_POWER_USAGE        FOUND"
+        ]
+      },
+      {
+        "name": "ai-service-metrics",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\"",
+        "stdout": [
+          "time=2026-08-26T15:03:08.525Z level=INFO msg=\"starting check\" name=ai-service-metrics",
+          "time=2026-08-26T15:03:08.542Z level=ERROR msg=FAIL message=\"[NOT_FOUND] no Prometheus service with port 9090 found in namespace \\\"monitoring\\\"\""
+        ]
+      },
+      {
+        "name": "gpu-operator-health",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[INTERNAL] ClusterPolicy state=notReady (want ready)",
+        "stdout": [
+          "time=2026-08-26T15:03:13.705Z level=INFO msg=\"starting check\" name=gpu-operator-health",
+          "time=2026-08-26T15:03:13.723Z level=ERROR msg=FAIL message=\"[INTERNAL] ClusterPolicy state=notReady (want ready)\""
+        ]
+      },
+      {
+        "name": "platform-health",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] platform health check failed (9 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvidia-dra-driver: not found\n  namespace nvsentinel: not found",
+        "stdout": [
+          "time=2026-08-26T15:03:18.425Z level=INFO msg=\"starting check\" name=platform-health",
+          "time=2026-08-26T15:03:18.447Z level=ERROR msg=FAIL message=\"[NOT_FOUND] platform health check failed (9 issues):\\n  namespace agentgateway-system: not found\\n  namespace cert-manager: not found\\n  namespace monitoring: not found\\n  namespace kai-scheduler: not found\\n  namespace nvidia-network-operator: not found\\n  namespace node-feature-discovery: not found\\n  namespace skyhook: not found\\n  namespace nvidia-dra-driver: not found\\n  namespace nvsentinel: not found\""
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aicr-sweep/results-57ef016/base-gb200-kind-inference-stack/recipe.yaml
+++ b/tests/aicr-sweep/results-57ef016/base-gb200-kind-inference-stack/recipe.yaml
@@ -1,0 +1,2021 @@
+apiVersion: aicr.run/v1alpha2
+componentRefs:
+  - chart: agentgateway
+    dependencyRefs:
+      - agentgateway-crds
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Agentgateway Health Check
+      #
+      # Validates that agentgateway is running and healthy in the agentgateway-system
+      # namespace. Checks that the agentgateway deployment has at least one available
+      # replica and that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # agentgateway deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: agentgateway
+                      namespace: agentgateway-system
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    manifestFiles:
+      - components/agentgateway/manifests/inference-gateway.yaml
+    name: agentgateway
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway/values.yaml
+    version: v1.3.1
+  - chart: agentgateway-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # agentgateway-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this component installs
+      # has reached the `Established=True` condition (CRD storage is up and
+      # the apiserver will accept CRs of those kinds).
+      #
+      # Scope: this component bundles BOTH the chart's agentgateway.dev/v1alpha1
+      # CRDs and the vendored Gateway API + Inference Extension manifests under
+      # recipes/components/agentgateway-crds/manifests/.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-gateway-api-crds-established
+            # Standard Gateway API CRDs vendored under
+            # manifests/gateway-api-crds.yaml. Verified against the in-tree
+            # manifest content.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gatewayclasses.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gateways.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: grpcroutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: httproutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: referencegrants.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-agentgateway-crds-established
+            # agentgateway.dev/v1alpha1 CRDs installed by the agentgateway-crds
+            # Helm chart.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaybackends.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewayparameters.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaypolicies.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-inference-extension-crds-established
+            # Gateway API Inference Extension CRDs vendored under
+            # manifests/inference-extension-crds.yaml.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencemodelrewrites.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferenceobjectives.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepoolimports.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    manifestFiles:
+      - components/agentgateway-crds/manifests/gateway-api-crds.yaml
+      - components/agentgateway-crds/manifests/inference-extension-crds.yaml
+    name: agentgateway-crds
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway-crds/values.yaml
+    version: v1.3.1
+  - chart: cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Cert Manager Health Check
+      #
+      # Validates that cert-manager is running and healthy in the cert-manager
+      # namespace. The chart deploys three Deployments — the controller
+      # (cert-manager), the CA injector (cert-manager-cainjector), and the
+      # webhook (cert-manager-webhook) — all of which must be available for
+      # the operator to issue / inject / validate certificates. The previous
+      # check only asserted the controller; this check covers all three to
+      # avoid silently passing while the webhook is down (which would block
+      # every Certificate/Issuer CR admission).
+      #
+      # Also asserts the three core CRDs are Established=True so the
+      # apiserver will accept CRs of those kinds (per #1222 / #660).
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: cert-manager-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: certificates.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: issuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterissuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-controller-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cainjector-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-cainjector
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-webhook-deployment
+            try:
+              # The webhook must be ready before any Certificate / Issuer CR
+              # can be admitted. Without this assert, a healthy controller
+              # with a dead webhook would still pass the check while the
+              # cluster silently rejects every cert-manager CR.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-webhook
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: cert-manager
+    namespace: cert-manager
+    source: https://charts.jetstack.io
+    type: Helm
+    valuesFile: components/cert-manager/values.yaml
+    version: v1.20.2
+  - chart: gpu-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # GPU Operator Health Check
+      #
+      # Validates the GPU operator stack:
+      # 1. The gpu-operator Deployment has at least one available replica.
+      # 2. The clusterpolicies.nvidia.com CRD is Established (apiserver will
+      #    accept the singleton ClusterPolicy CR).
+      # 3. The ClusterPolicy singleton named "cluster-policy" has reconciled
+      #    to status.state == "ready" — this is the deepest signal that the
+      #    full GPU stack (driver, toolkit, cuda, plugin DaemonSets, validators)
+      #    is healthy. Migrates the verifyClusterPolicyReady Go check that
+      #    PR #1235 task 7 deferred for assertion-equivalence proof.
+      # 4. No pods in unhealthy phases or stuck container-waiting states.
+      #
+      # The nvidia-operator-validator DaemonSet runs 4 sequential init
+      # containers (driver, toolkit, cuda, plugin) before reaching Running;
+      # the ClusterPolicy state assertion is the canonical post-reconcile
+      # signal that all four passed.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: gpu-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-cluster-policy-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterpolicies.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # gpu-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: gpu-operator
+                      namespace: gpu-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cluster-policy-ready
+            try:
+              # Deepest GPU readiness signal: ClusterPolicy singleton has
+              # reconciled to state=ready. Replaces the deferred
+              # verifyClusterPolicyReady Go check from PR #1235 task 7.
+              - assert:
+                  resource:
+                    apiVersion: nvidia.com/v1
+                    kind: ClusterPolicy
+                    metadata:
+                      name: cluster-policy
+                    status:
+                      state: ready
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: gpu-operator
+    namespace: gpu-operator
+    overrides:
+      daemonsets:
+        tolerations: []
+      dcgm:
+        enabled: false
+      dcgmExporter:
+        config:
+          create: false
+          data: ""
+          name: ""
+      devicePlugin:
+        env: []
+      driver:
+        enabled: false
+        rdma:
+          enabled: false
+      gdrcopy:
+        enabled: false
+      migManager:
+        enabled: false
+      operator:
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+      toolkit:
+        enabled: false
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/gpu-operator/values.yaml
+    version: v26.3.3
+  - chart: k8s-ephemeral-storage-metrics
+    dependencyRefs:
+      - kube-prometheus-stack
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # K8s Ephemeral Storage Metrics Health Check
+      #
+      # Validates that the k8s-ephemeral-storage-metrics Deployment is running and
+      # healthy in the monitoring namespace. Checks that the Deployment has at least
+      # one available replica and that no ephemeral storage metrics pods (selected by label)
+      # are stuck in Pending, Failed, or Unknown phases. Label selectors are used
+      # because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: k8s-ephemeral-storage-metrics-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the k8s-ephemeral-storage-metrics
+              # DaemonSet exists and has at least one ready pod.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: k8s-ephemeral-storage-metrics
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no ephemeral storage metrics pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: k8s-ephemeral-storage-metrics
+    namespace: monitoring
+    source: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
+    type: Helm
+    valuesFile: components/k8s-ephemeral-storage-metrics/values.yaml
+    version: 1.19.2
+  - chart: kai-scheduler
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # KAI Scheduler Health Check
+      #
+      # Validates that the KAI Scheduler is running and healthy in the kai-scheduler
+      # namespace. Checks that the kai-operator deployment has at least one
+      # available replica and that no pods in the namespace are stuck in Pending,
+      # Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kai-scheduler-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # kai-scheduler deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kai-operator
+                      namespace: kai-scheduler
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kai-scheduler
+    namespace: kai-scheduler
+    source: oci://ghcr.io/kai-scheduler/kai-scheduler
+    type: Helm
+    valuesFile: components/kai-scheduler/values.yaml
+    version: v0.14.1
+  - chart: kube-prometheus-stack
+    dependencyRefs:
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Kube Prometheus Stack Health Check
+      #
+      # Validates that the kube-prometheus-stack operator, its managed CRs, and
+      # associated workloads are running and healthy in the monitoring namespace:
+      #
+      # 1. The kube-prometheus-operator Deployment has at least one available replica.
+      # 2. The Prometheus CR (kube-prometheus-prometheus) reports Available=True.
+      #    This explicitly catches operator-level reconcile stalls (e.g., webhook
+      #    rejections) where a target StatefulSet might never be created at all.
+      # 3. The Alertmanager CR (kube-prometheus-alertmanager) reports Available=True.
+      # 4. The Prometheus StatefulSet (prometheus-kube-prometheus-prometheus) has
+      #    reached full rollout: readyReplicas >= replicas, with a replicas > 0
+      #    vacuous-pass guard so a missing StatefulSet does not silently pass.
+      # 5. The Alertmanager StatefulSet (alertmanager-kube-prometheus-alertmanager)
+      #    reaches the same full-rollout threshold.
+      # 6. No stack operator pods (label-scoped to app.kubernetes.io/name:
+      #    kube-prometheus-stack) are stuck in Pending, Failed, Unknown, or a
+      #    known-bad container-waiting reason (CrashLoopBackOff, ImagePullBackOff,
+      #    ErrImagePull, CreateContainerConfigError).
+      #
+      # StatefulSet and CR names are derived from fullnameOverride=kube-prometheus
+      # in recipes/components/kube-prometheus-stack/values.yaml. The prometheus-
+      # operator creates StatefulSets named <workload>-<cr-name>, and the chart
+      # renders CR names as <fullname>-<workload>. Names verified against
+      # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml and
+      # tests/chainsaw/ai-conformance/kind-common/assert-monitoring.yaml
+      # (both live-cluster-validated). Label selectors are used in the pod-health
+      # step because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kube-prometheus-stack-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the kube-prometheus-stack-operator
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kube-prometheus-operator
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-prometheus-cr-available
+            try:
+              # Assert the Prometheus CR has been reconciled by the operator.
+              # The prometheus-operator sets an Available condition on the CR once
+              # it has successfully reconciled the CR into a running StatefulSet.
+              # CR name kube-prometheus-prometheus derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -prometheus suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Prometheus
+                    metadata:
+                      name: kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-alertmanager-cr-available
+            try:
+              # Assert the Alertmanager CR has been reconciled by the operator.
+              # CR name kube-prometheus-alertmanager derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -alertmanager suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Alertmanager
+                    metadata:
+                      name: kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-prometheus-statefulset-ready
+            try:
+              # Assert the Prometheus StatefulSet created by the operator has
+              # reached full rollout. readyReplicas >= replicas ensures all pods
+              # are ready, not just some. The replicas > 0 guard prevents a
+              # vacuous pass when the StatefulSet is missing or has 0 replicas.
+              # StatefulSet name prometheus-kube-prometheus-prometheus is
+              # <workload>-<cr-name> per prometheus-operator convention, verified
+              # from tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: prometheus-kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-alertmanager-statefulset-ready
+            try:
+              # Assert the Alertmanager StatefulSet has reached full rollout.
+              # Same pattern as Prometheus above. StatefulSet name
+              # alertmanager-kube-prometheus-alertmanager is <workload>-<cr-name>
+              # per prometheus-operator convention, verified from
+              # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: alertmanager-kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus stack pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kube-prometheus-stack
+    namespace: monitoring
+    overrides:
+      alertmanager:
+        alertmanagerSpec:
+          resources:
+            limits:
+              cpu: 250m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+      defaultRules:
+        create: false
+      grafana:
+        enabled: false
+      prometheus:
+        prometheusSpec:
+          resources:
+            limits:
+              cpu: 1
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          retention: 7d
+          storageSpec:
+            emptyDir:
+              medium: ""
+              sizeLimit: 5Gi
+      prometheusOperator:
+        alertmanagerConfigNamespaces:
+          - monitoring
+        alertmanagerInstanceNamespaces:
+          - monitoring
+        livenessProbe:
+          failureThreshold: 10
+          timeoutSeconds: 10
+        prometheusInstanceNamespaces:
+          - monitoring
+        readinessProbe:
+          failureThreshold: 6
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        thanosRulerInstanceNamespaces:
+          - monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/kube-prometheus-stack/values.yaml
+    version: 84.4.0
+  - chart: network-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Network Operator Health Check
+      #
+      # Validates that the NVIDIA Network Operator is running and healthy in
+      # the nvidia-network-operator namespace. Also asserts
+      # nicclusterpolicies.mellanox.com is Established=True (verified against
+      # chart 26.4.1; re-verify on defaultVersion bump). Chart 26.4.1 also
+      # ships nicnodepolicies.mellanox.com, deliberately NOT asserted here:
+      # no in-tree recipe instantiates a CR against it, so it fails the same
+      # load-bearing-only bar the rest of this PR's assertions are held to.
+      # Checks that the
+      # network-operator deployment has at least one available replica and
+      # that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: network-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: nicclusterpolicies.mellanox.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # network-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: network-operator
+                      namespace: nvidia-network-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: network-operator
+    namespace: nvidia-network-operator
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/network-operator/values.yaml
+    version: 26.4.1
+  - chart: node-feature-discovery
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Node Feature Discovery Health Check
+      #
+      # Validates the standalone NFD deployment by checking:
+      # 1. NFD Master Deployment has at least one ready replica
+      # 2. NFD Worker DaemonSet has fully rolled out (desiredNumberScheduled > 0
+      #    and numberReady == desiredNumberScheduled, so partial failures don't pass)
+      # 3. NFD GC Deployment has at least one ready replica (gc.enable: true)
+      #
+      # Resource names: AICR deploys the kubernetes-sigs/node-feature-discovery
+      # chart under release name "nfd" (matching the ComponentRef Name in
+      # recipes/registry.yaml). The chart's fullname template prefixes the
+      # release name to the chart name when they don't overlap, yielding
+      # "nfd-node-feature-discovery-*" for the master Deployment, worker
+      # DaemonSet, and gc Deployment. If a deployer ever switches the release
+      # name to "node-feature-discovery", these asserts need updating in
+      # lockstep.
+      # 4. No pods in unhealthy phases (Pending, Failed, Unknown) or stuck in
+      #    Running with a known-unhealthy container waiting reason
+      #    (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+      #    CreateContainerConfigError)
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nfd-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-master-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-master
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-worker-daemonset
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nfd-node-feature-discovery-worker
+                      namespace: node-feature-discovery
+                    status:
+                      # Guard against vacuous pass when 0 nodes match the
+                      # DaemonSet: require at least one scheduled pod.
+                      (desiredNumberScheduled > `0`): true
+                      # Full rollout: every scheduled pod is ready. Combined with
+                      # the guard above, this rejects partial failures. We assert on
+                      # numberReady (always present in DaemonSetStatus) rather than
+                      # numberUnavailable, which is `omitempty` and disappears from
+                      # the status when zero — making `numberUnavailable == 0`
+                      # evaluate `null == 0` (false) on a fully-healthy DaemonSet.
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-gc-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-gc
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nfd
+    namespace: node-feature-discovery
+    source: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+    type: Helm
+    valuesFile: components/nfd/values.yaml
+    version: 0.19.0
+  - chart: nodewright
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Nodewright Operator Health Check
+      #
+      # Validates that the Nodewright Operator is running and healthy in the
+      # skyhook namespace:
+      # 1. skyhooks.skyhook.nvidia.com CRD Established=True (the apiserver
+      #    will accept Skyhook CRs that nodewright-customizations declares).
+      # 2. skyhook-operator-controller-manager Deployment has at least one
+      #    available replica.
+      # 3. No pods stuck in Pending/Failed/Unknown phases or known-bad
+      #    container-waiting states.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nodewright-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-skyhook-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: skyhooks.skyhook.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: skyhook-operator-controller-manager
+                      namespace: skyhook
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nodewright-operator
+    namespace: skyhook
+    overrides:
+      controllerManager:
+        manager:
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+    source: oci://ghcr.io/nvidia/nodewright/charts
+    type: Helm
+    valuesFile: components/nodewright-operator/values.yaml
+    version: v0.17.1
+  - chart: dra-driver-nvidia-gpu
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVIDIA DRA Driver GPU Health Check
+      #
+      # Validates that the NVIDIA DRA (Dynamic Resource Allocation) GPU driver
+      # is running and healthy in the nvidia-dra-driver namespace. The
+      # kubelet-plugin DaemonSet must roll out fully — numberReady ==
+      # desiredNumberScheduled (with desiredNumberScheduled > 0 as a guard).
+      # Previous check gated only on numberReady > 0, passing on partial
+      # failures; see #1222 and recipes/checks/nfd/health-check.yaml for
+      # the same rationale.
+      #
+      # Resource names: the DaemonSet name is release-derived
+      # (<release>-kubelet-plugin). AICR's release name is
+      # `nvidia-dra-driver-gpu` (matches ComponentRef Name in registry.yaml).
+      # If a deployer renames the release, this assert needs updating in
+      # lockstep — see verifyDRAKubeletPluginReady commentary in
+      # validators/deployment/expected_resources.go for why a chart-shape
+      # label would be a more robust selector.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvidia-dra-driver-gpu-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-kubelet-plugin-daemonset-fully-rolled-out
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nvidia-dra-driver-gpu-kubelet-plugin
+                      namespace: nvidia-dra-driver
+                    status:
+                      (desiredNumberScheduled > `0`): true
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvidia-dra-driver-gpu
+    namespace: nvidia-dra-driver
+    overrides:
+      nvidiaDriverRoot: /
+    source: oci://registry.k8s.io/dra-driver-nvidia/charts
+    type: Helm
+    valuesFile: components/nvidia-dra-driver-gpu/values.yaml
+    version: 0.4.1
+  - chart: nvsentinel
+    dependencyRefs:
+      - cert-manager
+      - gpu-operator
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVSentinel Health Check
+      #
+      # Validates that the NVSentinel labeler is running and healthy in
+      # the nvsentinel namespace. Checks that the labeler deployment has at
+      # least one available replica and that no pods in the
+      # namespace are stuck in Pending, Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvsentinel-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # nvsentinel-controller-manager deployment exists and has at least
+              # one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: labeler
+                      namespace: nvsentinel
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvsentinel
+    namespace: nvsentinel
+    overrides:
+      platformConnector:
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+    source: oci://ghcr.io/nvidia
+    type: Helm
+    valuesFile: components/nvsentinel/values.yaml
+    version: v1.9.0
+  - chart: prometheus-adapter
+    dependencyRefs:
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Prometheus Adapter Health Check
+      #
+      # Validates that the Prometheus Adapter is running and healthy in the
+      # monitoring namespace. Checks that the prometheus-adapter deployment has
+      # at least one available replica and that no prometheus adapter pods
+      # (selected by label) are stuck in Pending, Failed, or Unknown phases.
+      # Label selectors are used because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-adapter-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the prometheus-adapter
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: prometheus-adapter
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus adapter pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: prometheus-adapter
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-adapter/values.yaml
+    version: 5.3.0
+  - chart: prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # prometheus-operator-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this chart installs has
+      # reached the `Established=True` condition (CRD storage is up and the
+      # apiserver will accept CRs of those kinds).
+      #
+      # CRDs come from the upstream prometheus-community/prometheus-operator-crds
+      # chart pinned to 28.0.1 in recipes/registry.yaml. The 8 kinds under
+      # monitoring.coreos.com/v1 are enumerated in
+      # recipes/components/prometheus-operator-crds/values.yaml header:
+      # Alertmanager, AlertmanagerConfig, PodMonitor, Probe, Prometheus,
+      # PrometheusRule, ServiceMonitor, ThanosRuler. Plural names match the
+      # long-standing upstream prometheus-operator chart shape.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-operator-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-prometheus-operator-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagerconfigs.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: podmonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: probes.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheuses.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheusrules.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: servicemonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: thanosrulers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    name: prometheus-operator-crds
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-operator-crds/values.yaml
+    version: 28.0.1
+constraints:
+  - name: K8s.server.version
+    value: '>= 1.30'
+criteria:
+  accelerator: gb200
+  intent: inference
+  os: any
+  platform: any
+  service: kind
+deploymentOrder:
+  - agentgateway-crds
+  - cert-manager
+  - agentgateway
+  - nfd
+  - network-operator
+  - nodewright-operator
+  - prometheus-operator-crds
+  - kube-prometheus-stack
+  - gpu-operator
+  - k8s-ephemeral-storage-metrics
+  - kai-scheduler
+  - nvidia-dra-driver-gpu
+  - nvsentinel
+  - prometheus-adapter
+kind: RecipeResult
+metadata:
+  appliedOverlays:
+    - base
+    - monitoring-hpa
+    - gb200-any
+    - kind
+    - kind-inference
+  version: dev
+validation:
+  conformance:
+    checks:
+      - platform-health
+      - gpu-operator-health
+      - dra-support
+      - accelerator-metrics
+      - ai-service-metrics
+  deployment:
+    checks:
+      - operator-health
+      - expected-resources
+      - gpu-operator-version
+      - check-nvidia-smi
+    constraints:
+      - name: Deployment.gpu-operator.version
+        value: '>= v25.10.0'

--- a/tests/aicr-sweep/results-57ef016/base-h100-kind-inference-stack/ctrf/validate.json
+++ b/tests/aicr-sweep/results-57ef016/base-h100-kind-inference-stack/ctrf/validate.json
@@ -1,0 +1,381 @@
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-08-26T15:35:29Z",
+  "generatedBy": "aicr",
+  "results": {
+    "tool": {
+      "name": "aicr",
+      "version": "dev"
+    },
+    "summary": {
+      "tests": 14,
+      "passed": 5,
+      "failed": 7,
+      "skipped": 1,
+      "pending": 0,
+      "other": 1,
+      "start": 1787757894028,
+      "stop": 1787758768971
+    },
+    "tests": [
+      {
+        "name": "operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "stdout": [
+          "time=2026-08-26T15:25:49.947Z level=INFO msg=\"starting check\" name=operator-health",
+          "time=2026-08-26T15:25:49.961Z level=INFO msg=\"listing pods\" namespace=gpu-operator label=\"app=gpu-operator\"",
+          "Found 1 gpu-operator pod(s):",
+          "  gpu-operator-869cf5b4c-cmxdp: Running",
+          "Running: 1/1",
+          "time=2026-08-26T15:25:49.970Z level=INFO msg=\"operator-health: passed\" running=1"
+        ]
+      },
+      {
+        "name": "expected-resources",
+        "status": "other",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "message": "pod not found for Job aicr-expected-resources-5ef990d4: [NOT_FOUND] pod for job not found"
+      },
+      {
+        "name": "gpu-operator-version",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "stdout": [
+          "time=2026-08-26T15:33:56.251Z level=INFO msg=\"starting check\" name=gpu-operator-version",
+          "Detected GPU Operator version: v25.3.4",
+          "Constraint: \u003e= v24.6.0 → true"
+        ]
+      },
+      {
+        "name": "check-nvidia-smi",
+        "status": "passed",
+        "duration": 86000,
+        "suite": [
+          "deployment"
+        ],
+        "stdout": [
+          "time=2026-08-26T15:34:01.084Z level=INFO msg=\"starting check\" name=check-nvidia-smi",
+          "Found 2 GPU node(s), 2 schedulable, 0 cordoned:",
+          "  mokka-aicr-stack-worker",
+          "  mokka-aicr-stack-worker2",
+          "time=2026-08-26T15:34:01.101Z level=INFO msg=\"verifying node\" node=mokka-aicr-stack-worker",
+          "time=2026-08-26T15:34:01.101Z level=INFO msg=\"deploying nvidia-smi verify pod\" node=mokka-aicr-stack-worker podName=nvidia-smi-verify-mokka-aicr-stack-worker image=nvcr.io/nvidia/cuda:13.0.0-base-ubuntu22.04 namespace=aicr-validation",
+          "All 2 GPU node(s) available. Verifying...",
+          "time=2026-08-26T15:34:01.104Z level=INFO msg=\"waiting for pod to reach Succeeded state\" name=nvidia-smi-verify-mokka-aicr-stack-worker",
+          "time=2026-08-26T15:34:01.118Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T15:34:01.508Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T15:34:40.441Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-26T15:34:41.294Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-26T15:34:42.285Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-26T15:34:42.358Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Succeeded",
+          "time=2026-08-26T15:34:42.358Z level=INFO msg=\"pod successfully completed\" name=nvidia-smi-verify-mokka-aicr-stack-worker",
+          "time=2026-08-26T15:34:42.370Z level=INFO msg=\"verifying node\" node=mokka-aicr-stack-worker2",
+          "time=2026-08-26T15:34:42.370Z level=INFO msg=\"deploying nvidia-smi verify pod\" node=mokka-aicr-stack-worker2 podName=nvidia-smi-verify-mokka-aicr-stack-worker2 image=nvcr.io/nvidia/cuda:13.0.0-base-ubuntu22.04 namespace=aicr-validation",
+          "  mokka-aicr-stack-worker: OK",
+          "time=2026-08-26T15:34:42.376Z level=INFO msg=\"waiting for pod to reach Succeeded state\" name=nvidia-smi-verify-mokka-aicr-stack-worker2",
+          "time=2026-08-26T15:34:42.394Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T15:34:42.808Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T15:35:25.503Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T15:35:26.190Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T15:35:27.194Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T15:35:27.261Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Succeeded",
+          "time=2026-08-26T15:35:27.261Z level=INFO msg=\"pod successfully completed\" name=nvidia-smi-verify-mokka-aicr-stack-worker2",
+          "  mokka-aicr-stack-worker2: OK",
+          "RESULT: nodesValidated: 2/2",
+          "Successfully verified GPU on all 2 schedulable node(s)"
+        ],
+        "extra": {
+          "nodesTotal": "2",
+          "nodesValidated": "2"
+        }
+      },
+      {
+        "name": "dra-support",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found",
+        "stdout": [
+          "time=2026-08-26T15:36:24.776Z level=INFO msg=\"starting check\" name=dra-support",
+          "--- DRA driver namespace ---",
+          "Namespace: nvidia-dra-driver",
+          "Source:    resolved recipe componentRef nvidia-dra-driver-gpu",
+          "--- DRA API resources ---",
+          "Equivalent: kubectl api-resources --api-group=resource.k8s.io",
+          "",
+          "Served version: resource.k8s.io/v1",
+          "deviceclasses              DeviceClass            namespaced=false",
+          "resourceclaims             ResourceClaim          namespaced=true",
+          "resourceclaims/status      ResourceClaim          namespaced=true",
+          "resourceclaimtemplates     ResourceClaimTemplate  namespaced=true",
+          "resourceslices             ResourceSlice          namespaced=false",
+          "",
+          "--- DRA driver pods ---",
+          "Equivalent: kubectl get pods -n nvidia-dra-driver -o wide",
+          "",
+          "",
+          "time=2026-08-26T15:36:24.800Z level=ERROR msg=FAIL message=\"[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \\\"nvidia-dra-driver-gpu-controller\\\" not found\""
+        ]
+      },
+      {
+        "name": "gang-scheduling",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] recipe declares kai-scheduler but its Deployment kai-scheduler/kai-scheduler-default is absent — apply the bundle or check RBAC: deployments.apps \"kai-scheduler-default\" not found",
+        "stdout": [
+          "time=2026-08-26T15:36:30.132Z level=INFO msg=\"starting check\" name=gang-scheduling",
+          "time=2026-08-26T15:36:30.146Z level=ERROR msg=FAIL message=\"[NOT_FOUND] recipe declares kai-scheduler but its Deployment kai-scheduler/kai-scheduler-default is absent — apply the bundle or check RBAC: deployments.apps \\\"kai-scheduler-default\\\" not found\""
+        ]
+      },
+      {
+        "name": "accelerator-metrics",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "stdout": [
+          "time=2026-08-26T15:36:34.779Z level=INFO msg=\"starting check\" name=accelerator-metrics",
+          "--- DCGM Exporter Metrics (sample) ---",
+          "# HELP DCGM_FI_DEV_SM_CLOCK SM clock frequency (in MHz).",
+          "# TYPE DCGM_FI_DEV_SM_CLOCK gauge",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"0\",UUID=\"GPU-01000100-0000-0000-0000-000000000000\",pci_bus_id=\"00000000:1A:00.0\",device=\"nvidia0\",modelName=\"NVIDIA H100 80GB HBM3\",Hostname=\"mokka-aicr-stack-worker\",DCGM_FI_DRIVER_VERSION=\"550.163.01\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"1\",UUID=\"GPU-01000100-0000-0000-0000-000000000001\",pci_bus_id=\"00000000:1B:00.0\",device=\"nvidia1\",modelName=\"NVIDIA H100 80GB HBM3\",Hostname=\"mokka-aicr-stack-worker\",DCGM_FI_DRIVER_VERSION=\"550.163.01\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"2\",UUID=\"GPU-01000100-0000-0000-0000-000000000002\",pci_bus_id=\"00000000:4A:00.0\",device=\"nvidia2\",modelName=\"NVIDIA H100 80GB HBM3\",Hostname=\"mokka-aicr-stack-worker\",DCGM_FI_DRIVER_VERSION=\"550.163.01\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"3\",UUID=\"GPU-01000100-0000-0000-0000-000000000003\",pci_bus_id=\"00000000:4B:00.0\",device=\"nvidia3\",modelName=\"NVIDIA H100 80GB HBM3\",Hostname=\"mokka-aicr-stack-worker\",DCGM_FI_DRIVER_VERSION=\"550.163.01\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"4\",UUID=\"GPU-01000100-0000-0000-0000-000000000004\",pci_bus_id=\"00000000:8A:00.0\",device=\"nvidia4\",modelName=\"NVIDIA H100 80GB HBM3\",Hostname=\"mokka-aicr-stack-worker\",DCGM_FI_DRIVER_VERSION=\"550.163.01\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"5\",UUID=\"GPU-01000100-0000-0000-0000-000000000005\",pci_bus_id=\"00000000:8B:00.0\",device=\"nvidia5\",modelName=\"NVIDIA H100 80GB HBM3\",Hostname=\"mokka-aicr-stack-worker\",DCGM_FI_DRIVER_VERSION=\"550.163.01\"} 345",
+          "... [truncated]",
+          "--- Required DCGM Metrics ---",
+          "  DCGM_FI_DEV_GPU_UTIL           FOUND",
+          "  DCGM_FI_DEV_FB_USED            FOUND",
+          "  DCGM_FI_DEV_GPU_TEMP           FOUND",
+          "  DCGM_FI_DEV_POWER_USAGE        FOUND"
+        ]
+      },
+      {
+        "name": "ai-service-metrics",
+        "status": "failed",
+        "duration": 1000,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\"",
+        "stdout": [
+          "time=2026-08-26T15:36:39.994Z level=INFO msg=\"starting check\" name=ai-service-metrics",
+          "time=2026-08-26T15:36:40.019Z level=ERROR msg=FAIL message=\"[NOT_FOUND] no Prometheus service with port 9090 found in namespace \\\"monitoring\\\"\""
+        ]
+      },
+      {
+        "name": "inference-gateway",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] GatewayClass 'agentgateway' not found: the server could not find the requested resource",
+        "stdout": [
+          "time=2026-08-26T15:36:44.943Z level=INFO msg=\"starting check\" name=inference-gateway",
+          "--- agentgateway deployments ---",
+          "Equivalent: kubectl get deploy -n agentgateway-system",
+          "",
+          "",
+          "--- agentgateway pods ---",
+          "Equivalent: kubectl get pods -n agentgateway-system",
+          "",
+          "",
+          "time=2026-08-26T15:36:44.966Z level=ERROR msg=FAIL message=\"[NOT_FOUND] GatewayClass 'agentgateway' not found: the server could not find the requested resource\""
+        ]
+      },
+      {
+        "name": "pod-autoscaling",
+        "status": "failed",
+        "duration": 61000,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] custom metrics API not available (prometheus-adapter not ready): client rate limiter Wait returned an error: context deadline exceeded",
+        "stdout": [
+          "time=2026-08-26T15:36:50.010Z level=INFO msg=\"starting check\" name=pod-autoscaling",
+          "time=2026-08-26T15:37:50.063Z level=ERROR msg=FAIL message=\"[NOT_FOUND] custom metrics API not available (prometheus-adapter not ready): client rate limiter Wait returned an error: context deadline exceeded\""
+        ]
+      },
+      {
+        "name": "cluster-autoscaling",
+        "status": "skipped",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[INTERNAL] Karpenter not found and cluster platform not recognized (not EKS or GKE): skip",
+        "stdout": [
+          "time=2026-08-26T15:37:55.576Z level=INFO msg=\"starting check\" name=cluster-autoscaling",
+          "time=2026-08-26T15:37:55.597Z level=INFO msg=\"Karpenter not found, falling back to platform autoscaling\" platform=\"\"",
+          "time=2026-08-26T15:37:55.597Z level=INFO msg=SKIP reason=\"[INTERNAL] Karpenter not found and cluster platform not recognized (not EKS or GKE): skip\""
+        ]
+      },
+      {
+        "name": "secure-accelerator-access",
+        "status": "passed",
+        "duration": 74000,
+        "suite": [
+          "conformance"
+        ],
+        "stdout": [
+          "time=2026-08-26T15:38:02.052Z level=INFO msg=\"starting check\" name=secure-accelerator-access",
+          "--- ClusterPolicy status ---",
+          "Equivalent: kubectl get clusterpolicy -o wide",
+          "",
+          "Name:   cluster-policy",
+          "State:  notReady",
+          "--- GPU operator pods ---",
+          "Equivalent: kubectl get pods -n gpu-operator -o wide",
+          "",
+          "gpu-feature-discovery-9rz6j                    ready=0/1 phase=Running node=mokka-aicr-stack-worker2",
+          "gpu-feature-discovery-vgktj                    ready=0/1 phase=Running node=mokka-aicr-stack-worker",
+          "gpu-operator-869cf5b4c-cmxdp                   ready=1/1 phase=Running node=mokka-aicr-stack-control-plane",
+          "gpu-operator-node-feature-discovery-gc-66bb9d6947-fbdk8 ready=1/1 phase=Running node=mokka-aicr-stack-worker2",
+          "gpu-operator-node-feature-discovery-master-fcb8f67db-469mj ready=1/1 phase=Running node=mokka-aicr-stack-control-plane",
+          "gpu-operator-node-feature-discovery-worker-2sxxh ready=1/1 phase=Running node=mokka-aicr-stack-worker",
+          "gpu-operator-node-feature-discovery-worker-67ndb ready=1/1 phase=Running node=mokka-aicr-stack-worker2",
+          "gpu-operator-node-feature-discovery-worker-cbk7c ready=1/1 phase=Running node=mokka-aicr-stack-control-plane",
+          "nvidia-dcgm-exporter-szfwx                     ready=1/1 phase=Running node=mokka-aicr-stack-worker",
+          "nvidia-dcgm-exporter-w2zhs                     ready=1/1 phase=Running node=mokka-aicr-stack-worker2",
+          "nvidia-device-plugin-daemonset-9hpkv           ready=1/1 phase=Running node=mokka-aicr-stack-worker2",
+          "nvidia-device-plugin-daemonset-xxrzq           ready=1/1 phase=Running node=mokka-aicr-stack-worker",
+          "nvidia-operator-validator-dsgg8                ready=1/1 phase=Running node=mokka-aicr-stack-worker",
+          "nvidia-operator-validator-t7cvt                ready=1/1 phase=Running node=mokka-aicr-stack-worker2",
+          "",
+          "--- GPU operator DaemonSets ---",
+          "Equivalent: kubectl get ds -n gpu-operator",
+          "",
+          "gpu-feature-discovery                  ready=0/2",
+          "gpu-operator-node-feature-discovery-worker ready=3/3",
+          "nvidia-dcgm-exporter                   ready=2/2",
+          "nvidia-device-plugin-daemonset         ready=2/2",
+          "nvidia-device-plugin-mps-control-daemon ready=0/0",
+          "nvidia-operator-validator              ready=2/2",
+          "",
+          "--- ResourceSlices ---",
+          "Equivalent: kubectl get resourceslices -o wide",
+          "",
+          "",
+          "--- GPU devices in ResourceSlice ---",
+          "Equivalent: kubectl get resourceslices -o yaml",
+          "",
+          "apiVersion: resource.k8s.io/v1",
+          "items: []",
+          "kind: ResourceSliceList",
+          "metadata:",
+          "  resourceVersion: \"5628\"",
+          "",
+          "--- GPU allocation mode ---",
+          "Equivalent: kubectl get deviceclass gpu.nvidia.com; kubectl get resourceslices; kubectl get nodes -o wide",
+          "",
+          "DRA (gpu.nvidia.com):              usable=false nodes=[]",
+          "Device plugin (nvidia.com/gpu):  usable=true nodes=[mokka-aicr-stack-worker,mokka-aicr-stack-worker2]",
+          "full-GPU DRA not usable: DeviceClass gpu.nvidia.com not found",
+          "device plugin usable: 2 Ready, schedulable node(s) with allocatable nvidia.com/gpu",
+          "extended-resource attribution: no DeviceClass maps nvidia.com/gpu to DRA",
+          "note: node eligibility is Ready+uncordoned only — node taints are not evaluated; workloads must tolerate any node taints",
+          "--- GPU allocation policy ---",
+          "configured policy: device-plugin-extended-resource",
+          "--- Secure access mode ---",
+          "mode exercised: device plugin (nvidia.com/gpu limits)",
+          "--- Pod status ---",
+          "Equivalent: kubectl get pod gpu-alloc-test-8ac85fdfa9af04947cca0addab26285f -n aicr-gpu-test-8ac85fdfa9af04947cca0addab26285f -o wide",
+          "",
+          "Name:      aicr-gpu-test-8ac85fdfa9af04947cca0addab26285f/gpu-alloc-test-8ac85fdfa9af04947cca0addab26285f",
+          "Phase:     Succeeded",
+          "Node:      mokka-aicr-stack-worker2",
+          "GPULimits: nvidia.com/gpu: 1",
+          "--- GPU test pod logs (gpu-test) ---",
+          "Equivalent: kubectl logs gpu-alloc-test-8ac85fdfa9af04947cca0addab26285f -n aicr-gpu-test-8ac85fdfa9af04947cca0addab26285f -c gpu-test",
+          "",
+          "granted GPU count: 1",
+          "granted GPU UUIDs: GPU-01000100-0000-0000-0000-000000000001",
+          "PASS: exactly one usable GPU visible",
+          "",
+          "--- GPU test pod logs (unauthorized) ---",
+          "Equivalent: kubectl logs gpu-alloc-test-8ac85fdfa9af04947cca0addab26285f -n aicr-gpu-test-8ac85fdfa9af04947cca0addab26285f -c unauthorized",
+          "",
+          "PASS: GPU isolated",
+          "",
+          "--- Pod GPU limits (device plugin) ---",
+          "Equivalent: kubectl get pod gpu-alloc-test-8ac85fdfa9af04947cca0addab26285f -n aicr-gpu-test-8ac85fdfa9af04947cca0addab26285f -o jsonpath='{.spec.containers[*].resources.limits}'",
+          "",
+          "Pod:             aicr-gpu-test-8ac85fdfa9af04947cca0addab26285f/gpu-alloc-test-8ac85fdfa9af04947cca0addab26285f",
+          "GPULimits:       1",
+          "ResourceClaims:  0",
+          "--- Pod volumes (no hostPath) ---",
+          "Equivalent: kubectl get pod gpu-alloc-test-8ac85fdfa9af04947cca0addab26285f -n aicr-gpu-test-8ac85fdfa9af04947cca0addab26285f -o jsonpath='{.spec.volumes}'",
+          "",
+          "Pod:               aicr-gpu-test-8ac85fdfa9af04947cca0addab26285f/gpu-alloc-test-8ac85fdfa9af04947cca0addab26285f",
+          "HostPathGPUMounts: 0",
+          "--- Container-level isolation ---",
+          "granted container:      gpu-test (nvidia.com/gpu limits, exactly one GPU visible via nvidia-smi, exit 0)",
+          "unauthorized container: unauthorized (no allocation, no GPU visible, exit 0)",
+          "--- No-allocation probe pod logs ---",
+          "Equivalent: kubectl logs no-alloc-probe-8ac85fdfa9af04947cca0addab26285f -n aicr-gpu-test-8ac85fdfa9af04947cca0addab26285f",
+          "",
+          "PASS: GPU isolated",
+          "",
+          "--- Device Plugin Isolation Test ---",
+          "Equivalent: kubectl logs no-alloc-probe-8ac85fdfa9af04947cca0addab26285f -n aicr-gpu-test-8ac85fdfa9af04947cca0addab26285f",
+          "",
+          "Pod:               aicr-gpu-test-8ac85fdfa9af04947cca0addab26285f/no-alloc-probe-8ac85fdfa9af04947cca0addab26285f",
+          "Phase:             Succeeded",
+          "ExitCode:          0",
+          "ResourceClaims:    0",
+          "HostPathGPUMounts: 0",
+          "--- Cleanup test namespace ---",
+          "Equivalent: kubectl get namespace aicr-gpu-test-8ac85fdfa9af04947cca0addab26285f --ignore-not-found -o jsonpath='{.metadata.uid} {.status.phase}'  # read-only inspection of the current state; see the artifact body for what cleanup actually did",
+          "",
+          "namespace aicr-gpu-test-8ac85fdfa9af04947cca0addab26285f deleted — confirmed absent (all test resources removed with it)"
+        ]
+      },
+      {
+        "name": "gpu-operator-health",
+        "status": "failed",
+        "duration": 1000,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[INTERNAL] ClusterPolicy state=notReady (want ready)",
+        "stdout": [
+          "time=2026-08-26T15:39:20.981Z level=INFO msg=\"starting check\" name=gpu-operator-health",
+          "time=2026-08-26T15:39:21.017Z level=ERROR msg=FAIL message=\"[INTERNAL] ClusterPolicy state=notReady (want ready)\""
+        ]
+      },
+      {
+        "name": "platform-health",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] platform health check failed (9 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvidia-dra-driver: not found\n  namespace nvsentinel: not found",
+        "stdout": [
+          "time=2026-08-26T15:39:26.248Z level=INFO msg=\"starting check\" name=platform-health",
+          "time=2026-08-26T15:39:26.313Z level=ERROR msg=FAIL message=\"[NOT_FOUND] platform health check failed (9 issues):\\n  namespace agentgateway-system: not found\\n  namespace cert-manager: not found\\n  namespace monitoring: not found\\n  namespace kai-scheduler: not found\\n  namespace nvidia-network-operator: not found\\n  namespace node-feature-discovery: not found\\n  namespace skyhook: not found\\n  namespace nvidia-dra-driver: not found\\n  namespace nvsentinel: not found\""
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aicr-sweep/results-57ef016/base-h100-kind-inference-stack/recipe.yaml
+++ b/tests/aicr-sweep/results-57ef016/base-h100-kind-inference-stack/recipe.yaml
@@ -1,0 +1,2027 @@
+apiVersion: aicr.run/v1alpha2
+componentRefs:
+  - chart: agentgateway
+    dependencyRefs:
+      - agentgateway-crds
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Agentgateway Health Check
+      #
+      # Validates that agentgateway is running and healthy in the agentgateway-system
+      # namespace. Checks that the agentgateway deployment has at least one available
+      # replica and that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # agentgateway deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: agentgateway
+                      namespace: agentgateway-system
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    manifestFiles:
+      - components/agentgateway/manifests/inference-gateway.yaml
+    name: agentgateway
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway/values.yaml
+    version: v1.3.1
+  - chart: agentgateway-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # agentgateway-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this component installs
+      # has reached the `Established=True` condition (CRD storage is up and
+      # the apiserver will accept CRs of those kinds).
+      #
+      # Scope: this component bundles BOTH the chart's agentgateway.dev/v1alpha1
+      # CRDs and the vendored Gateway API + Inference Extension manifests under
+      # recipes/components/agentgateway-crds/manifests/.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-gateway-api-crds-established
+            # Standard Gateway API CRDs vendored under
+            # manifests/gateway-api-crds.yaml. Verified against the in-tree
+            # manifest content.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gatewayclasses.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gateways.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: grpcroutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: httproutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: referencegrants.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-agentgateway-crds-established
+            # agentgateway.dev/v1alpha1 CRDs installed by the agentgateway-crds
+            # Helm chart.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaybackends.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewayparameters.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaypolicies.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-inference-extension-crds-established
+            # Gateway API Inference Extension CRDs vendored under
+            # manifests/inference-extension-crds.yaml.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencemodelrewrites.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferenceobjectives.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepoolimports.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    manifestFiles:
+      - components/agentgateway-crds/manifests/gateway-api-crds.yaml
+      - components/agentgateway-crds/manifests/inference-extension-crds.yaml
+    name: agentgateway-crds
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway-crds/values.yaml
+    version: v1.3.1
+  - chart: cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Cert Manager Health Check
+      #
+      # Validates that cert-manager is running and healthy in the cert-manager
+      # namespace. The chart deploys three Deployments — the controller
+      # (cert-manager), the CA injector (cert-manager-cainjector), and the
+      # webhook (cert-manager-webhook) — all of which must be available for
+      # the operator to issue / inject / validate certificates. The previous
+      # check only asserted the controller; this check covers all three to
+      # avoid silently passing while the webhook is down (which would block
+      # every Certificate/Issuer CR admission).
+      #
+      # Also asserts the three core CRDs are Established=True so the
+      # apiserver will accept CRs of those kinds (per #1222 / #660).
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: cert-manager-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: certificates.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: issuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterissuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-controller-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cainjector-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-cainjector
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-webhook-deployment
+            try:
+              # The webhook must be ready before any Certificate / Issuer CR
+              # can be admitted. Without this assert, a healthy controller
+              # with a dead webhook would still pass the check while the
+              # cluster silently rejects every cert-manager CR.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-webhook
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: cert-manager
+    namespace: cert-manager
+    source: https://charts.jetstack.io
+    type: Helm
+    valuesFile: components/cert-manager/values.yaml
+    version: v1.20.2
+  - chart: gpu-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # GPU Operator Health Check
+      #
+      # Validates the GPU operator stack:
+      # 1. The gpu-operator Deployment has at least one available replica.
+      # 2. The clusterpolicies.nvidia.com CRD is Established (apiserver will
+      #    accept the singleton ClusterPolicy CR).
+      # 3. The ClusterPolicy singleton named "cluster-policy" has reconciled
+      #    to status.state == "ready" — this is the deepest signal that the
+      #    full GPU stack (driver, toolkit, cuda, plugin DaemonSets, validators)
+      #    is healthy. Migrates the verifyClusterPolicyReady Go check that
+      #    PR #1235 task 7 deferred for assertion-equivalence proof.
+      # 4. No pods in unhealthy phases or stuck container-waiting states.
+      #
+      # The nvidia-operator-validator DaemonSet runs 4 sequential init
+      # containers (driver, toolkit, cuda, plugin) before reaching Running;
+      # the ClusterPolicy state assertion is the canonical post-reconcile
+      # signal that all four passed.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: gpu-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-cluster-policy-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterpolicies.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # gpu-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: gpu-operator
+                      namespace: gpu-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cluster-policy-ready
+            try:
+              # Deepest GPU readiness signal: ClusterPolicy singleton has
+              # reconciled to state=ready. Replaces the deferred
+              # verifyClusterPolicyReady Go check from PR #1235 task 7.
+              - assert:
+                  resource:
+                    apiVersion: nvidia.com/v1
+                    kind: ClusterPolicy
+                    metadata:
+                      name: cluster-policy
+                    status:
+                      state: ready
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: gpu-operator
+    namespace: gpu-operator
+    overrides:
+      daemonsets:
+        tolerations: []
+      dcgm:
+        enabled: false
+      dcgmExporter:
+        config:
+          create: false
+          data: ""
+          name: ""
+      devicePlugin:
+        env: []
+      driver:
+        enabled: false
+        rdma:
+          enabled: false
+      gdrcopy:
+        enabled: false
+      migManager:
+        enabled: false
+      operator:
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+      toolkit:
+        enabled: false
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/gpu-operator/values.yaml
+    version: v26.3.3
+  - chart: k8s-ephemeral-storage-metrics
+    dependencyRefs:
+      - kube-prometheus-stack
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # K8s Ephemeral Storage Metrics Health Check
+      #
+      # Validates that the k8s-ephemeral-storage-metrics Deployment is running and
+      # healthy in the monitoring namespace. Checks that the Deployment has at least
+      # one available replica and that no ephemeral storage metrics pods (selected by label)
+      # are stuck in Pending, Failed, or Unknown phases. Label selectors are used
+      # because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: k8s-ephemeral-storage-metrics-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the k8s-ephemeral-storage-metrics
+              # DaemonSet exists and has at least one ready pod.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: k8s-ephemeral-storage-metrics
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no ephemeral storage metrics pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: k8s-ephemeral-storage-metrics
+    namespace: monitoring
+    source: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
+    type: Helm
+    valuesFile: components/k8s-ephemeral-storage-metrics/values.yaml
+    version: 1.19.2
+  - chart: kai-scheduler
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # KAI Scheduler Health Check
+      #
+      # Validates that the KAI Scheduler is running and healthy in the kai-scheduler
+      # namespace. Checks that the kai-operator deployment has at least one
+      # available replica and that no pods in the namespace are stuck in Pending,
+      # Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kai-scheduler-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # kai-scheduler deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kai-operator
+                      namespace: kai-scheduler
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kai-scheduler
+    namespace: kai-scheduler
+    source: oci://ghcr.io/kai-scheduler/kai-scheduler
+    type: Helm
+    valuesFile: components/kai-scheduler/values.yaml
+    version: v0.14.1
+  - chart: kube-prometheus-stack
+    dependencyRefs:
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Kube Prometheus Stack Health Check
+      #
+      # Validates that the kube-prometheus-stack operator, its managed CRs, and
+      # associated workloads are running and healthy in the monitoring namespace:
+      #
+      # 1. The kube-prometheus-operator Deployment has at least one available replica.
+      # 2. The Prometheus CR (kube-prometheus-prometheus) reports Available=True.
+      #    This explicitly catches operator-level reconcile stalls (e.g., webhook
+      #    rejections) where a target StatefulSet might never be created at all.
+      # 3. The Alertmanager CR (kube-prometheus-alertmanager) reports Available=True.
+      # 4. The Prometheus StatefulSet (prometheus-kube-prometheus-prometheus) has
+      #    reached full rollout: readyReplicas >= replicas, with a replicas > 0
+      #    vacuous-pass guard so a missing StatefulSet does not silently pass.
+      # 5. The Alertmanager StatefulSet (alertmanager-kube-prometheus-alertmanager)
+      #    reaches the same full-rollout threshold.
+      # 6. No stack operator pods (label-scoped to app.kubernetes.io/name:
+      #    kube-prometheus-stack) are stuck in Pending, Failed, Unknown, or a
+      #    known-bad container-waiting reason (CrashLoopBackOff, ImagePullBackOff,
+      #    ErrImagePull, CreateContainerConfigError).
+      #
+      # StatefulSet and CR names are derived from fullnameOverride=kube-prometheus
+      # in recipes/components/kube-prometheus-stack/values.yaml. The prometheus-
+      # operator creates StatefulSets named <workload>-<cr-name>, and the chart
+      # renders CR names as <fullname>-<workload>. Names verified against
+      # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml and
+      # tests/chainsaw/ai-conformance/kind-common/assert-monitoring.yaml
+      # (both live-cluster-validated). Label selectors are used in the pod-health
+      # step because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kube-prometheus-stack-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the kube-prometheus-stack-operator
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kube-prometheus-operator
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-prometheus-cr-available
+            try:
+              # Assert the Prometheus CR has been reconciled by the operator.
+              # The prometheus-operator sets an Available condition on the CR once
+              # it has successfully reconciled the CR into a running StatefulSet.
+              # CR name kube-prometheus-prometheus derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -prometheus suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Prometheus
+                    metadata:
+                      name: kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-alertmanager-cr-available
+            try:
+              # Assert the Alertmanager CR has been reconciled by the operator.
+              # CR name kube-prometheus-alertmanager derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -alertmanager suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Alertmanager
+                    metadata:
+                      name: kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-prometheus-statefulset-ready
+            try:
+              # Assert the Prometheus StatefulSet created by the operator has
+              # reached full rollout. readyReplicas >= replicas ensures all pods
+              # are ready, not just some. The replicas > 0 guard prevents a
+              # vacuous pass when the StatefulSet is missing or has 0 replicas.
+              # StatefulSet name prometheus-kube-prometheus-prometheus is
+              # <workload>-<cr-name> per prometheus-operator convention, verified
+              # from tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: prometheus-kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-alertmanager-statefulset-ready
+            try:
+              # Assert the Alertmanager StatefulSet has reached full rollout.
+              # Same pattern as Prometheus above. StatefulSet name
+              # alertmanager-kube-prometheus-alertmanager is <workload>-<cr-name>
+              # per prometheus-operator convention, verified from
+              # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: alertmanager-kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus stack pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kube-prometheus-stack
+    namespace: monitoring
+    overrides:
+      alertmanager:
+        alertmanagerSpec:
+          resources:
+            limits:
+              cpu: 250m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+      defaultRules:
+        create: false
+      grafana:
+        enabled: false
+      prometheus:
+        prometheusSpec:
+          resources:
+            limits:
+              cpu: 1
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          retention: 7d
+          storageSpec:
+            emptyDir:
+              medium: ""
+              sizeLimit: 5Gi
+      prometheusOperator:
+        alertmanagerConfigNamespaces:
+          - monitoring
+        alertmanagerInstanceNamespaces:
+          - monitoring
+        livenessProbe:
+          failureThreshold: 10
+          timeoutSeconds: 10
+        prometheusInstanceNamespaces:
+          - monitoring
+        readinessProbe:
+          failureThreshold: 6
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        thanosRulerInstanceNamespaces:
+          - monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/kube-prometheus-stack/values.yaml
+    version: 84.4.0
+  - chart: network-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Network Operator Health Check
+      #
+      # Validates that the NVIDIA Network Operator is running and healthy in
+      # the nvidia-network-operator namespace. Also asserts
+      # nicclusterpolicies.mellanox.com is Established=True (verified against
+      # chart 26.4.1; re-verify on defaultVersion bump). Chart 26.4.1 also
+      # ships nicnodepolicies.mellanox.com, deliberately NOT asserted here:
+      # no in-tree recipe instantiates a CR against it, so it fails the same
+      # load-bearing-only bar the rest of this PR's assertions are held to.
+      # Checks that the
+      # network-operator deployment has at least one available replica and
+      # that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: network-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: nicclusterpolicies.mellanox.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # network-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: network-operator
+                      namespace: nvidia-network-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: network-operator
+    namespace: nvidia-network-operator
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/network-operator/values.yaml
+    version: 26.4.1
+  - chart: node-feature-discovery
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Node Feature Discovery Health Check
+      #
+      # Validates the standalone NFD deployment by checking:
+      # 1. NFD Master Deployment has at least one ready replica
+      # 2. NFD Worker DaemonSet has fully rolled out (desiredNumberScheduled > 0
+      #    and numberReady == desiredNumberScheduled, so partial failures don't pass)
+      # 3. NFD GC Deployment has at least one ready replica (gc.enable: true)
+      #
+      # Resource names: AICR deploys the kubernetes-sigs/node-feature-discovery
+      # chart under release name "nfd" (matching the ComponentRef Name in
+      # recipes/registry.yaml). The chart's fullname template prefixes the
+      # release name to the chart name when they don't overlap, yielding
+      # "nfd-node-feature-discovery-*" for the master Deployment, worker
+      # DaemonSet, and gc Deployment. If a deployer ever switches the release
+      # name to "node-feature-discovery", these asserts need updating in
+      # lockstep.
+      # 4. No pods in unhealthy phases (Pending, Failed, Unknown) or stuck in
+      #    Running with a known-unhealthy container waiting reason
+      #    (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+      #    CreateContainerConfigError)
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nfd-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-master-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-master
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-worker-daemonset
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nfd-node-feature-discovery-worker
+                      namespace: node-feature-discovery
+                    status:
+                      # Guard against vacuous pass when 0 nodes match the
+                      # DaemonSet: require at least one scheduled pod.
+                      (desiredNumberScheduled > `0`): true
+                      # Full rollout: every scheduled pod is ready. Combined with
+                      # the guard above, this rejects partial failures. We assert on
+                      # numberReady (always present in DaemonSetStatus) rather than
+                      # numberUnavailable, which is `omitempty` and disappears from
+                      # the status when zero — making `numberUnavailable == 0`
+                      # evaluate `null == 0` (false) on a fully-healthy DaemonSet.
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-gc-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-gc
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nfd
+    namespace: node-feature-discovery
+    source: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+    type: Helm
+    valuesFile: components/nfd/values.yaml
+    version: 0.19.0
+  - chart: nodewright
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Nodewright Operator Health Check
+      #
+      # Validates that the Nodewright Operator is running and healthy in the
+      # skyhook namespace:
+      # 1. skyhooks.skyhook.nvidia.com CRD Established=True (the apiserver
+      #    will accept Skyhook CRs that nodewright-customizations declares).
+      # 2. skyhook-operator-controller-manager Deployment has at least one
+      #    available replica.
+      # 3. No pods stuck in Pending/Failed/Unknown phases or known-bad
+      #    container-waiting states.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nodewright-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-skyhook-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: skyhooks.skyhook.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: skyhook-operator-controller-manager
+                      namespace: skyhook
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nodewright-operator
+    namespace: skyhook
+    overrides:
+      controllerManager:
+        manager:
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+    source: oci://ghcr.io/nvidia/nodewright/charts
+    type: Helm
+    valuesFile: components/nodewright-operator/values.yaml
+    version: v0.17.1
+  - chart: dra-driver-nvidia-gpu
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVIDIA DRA Driver GPU Health Check
+      #
+      # Validates that the NVIDIA DRA (Dynamic Resource Allocation) GPU driver
+      # is running and healthy in the nvidia-dra-driver namespace. The
+      # kubelet-plugin DaemonSet must roll out fully — numberReady ==
+      # desiredNumberScheduled (with desiredNumberScheduled > 0 as a guard).
+      # Previous check gated only on numberReady > 0, passing on partial
+      # failures; see #1222 and recipes/checks/nfd/health-check.yaml for
+      # the same rationale.
+      #
+      # Resource names: the DaemonSet name is release-derived
+      # (<release>-kubelet-plugin). AICR's release name is
+      # `nvidia-dra-driver-gpu` (matches ComponentRef Name in registry.yaml).
+      # If a deployer renames the release, this assert needs updating in
+      # lockstep — see verifyDRAKubeletPluginReady commentary in
+      # validators/deployment/expected_resources.go for why a chart-shape
+      # label would be a more robust selector.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvidia-dra-driver-gpu-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-kubelet-plugin-daemonset-fully-rolled-out
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nvidia-dra-driver-gpu-kubelet-plugin
+                      namespace: nvidia-dra-driver
+                    status:
+                      (desiredNumberScheduled > `0`): true
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvidia-dra-driver-gpu
+    namespace: nvidia-dra-driver
+    overrides:
+      nvidiaDriverRoot: /
+    source: oci://registry.k8s.io/dra-driver-nvidia/charts
+    type: Helm
+    valuesFile: components/nvidia-dra-driver-gpu/values.yaml
+    version: 0.4.1
+  - chart: nvsentinel
+    dependencyRefs:
+      - cert-manager
+      - gpu-operator
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVSentinel Health Check
+      #
+      # Validates that the NVSentinel labeler is running and healthy in
+      # the nvsentinel namespace. Checks that the labeler deployment has at
+      # least one available replica and that no pods in the
+      # namespace are stuck in Pending, Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvsentinel-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # nvsentinel-controller-manager deployment exists and has at least
+              # one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: labeler
+                      namespace: nvsentinel
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvsentinel
+    namespace: nvsentinel
+    overrides:
+      platformConnector:
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+    source: oci://ghcr.io/nvidia
+    type: Helm
+    valuesFile: components/nvsentinel/values.yaml
+    version: v1.9.0
+  - chart: prometheus-adapter
+    dependencyRefs:
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Prometheus Adapter Health Check
+      #
+      # Validates that the Prometheus Adapter is running and healthy in the
+      # monitoring namespace. Checks that the prometheus-adapter deployment has
+      # at least one available replica and that no prometheus adapter pods
+      # (selected by label) are stuck in Pending, Failed, or Unknown phases.
+      # Label selectors are used because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-adapter-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the prometheus-adapter
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: prometheus-adapter
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus adapter pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: prometheus-adapter
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-adapter/values.yaml
+    version: 5.3.0
+  - chart: prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # prometheus-operator-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this chart installs has
+      # reached the `Established=True` condition (CRD storage is up and the
+      # apiserver will accept CRs of those kinds).
+      #
+      # CRDs come from the upstream prometheus-community/prometheus-operator-crds
+      # chart pinned to 28.0.1 in recipes/registry.yaml. The 8 kinds under
+      # monitoring.coreos.com/v1 are enumerated in
+      # recipes/components/prometheus-operator-crds/values.yaml header:
+      # Alertmanager, AlertmanagerConfig, PodMonitor, Probe, Prometheus,
+      # PrometheusRule, ServiceMonitor, ThanosRuler. Plural names match the
+      # long-standing upstream prometheus-operator chart shape.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-operator-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-prometheus-operator-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagerconfigs.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: podmonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: probes.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheuses.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheusrules.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: servicemonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: thanosrulers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    name: prometheus-operator-crds
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-operator-crds/values.yaml
+    version: 28.0.1
+constraints:
+  - name: K8s.server.version
+    value: '>= 1.30'
+criteria:
+  accelerator: h100
+  intent: inference
+  os: any
+  platform: any
+  service: kind
+deploymentOrder:
+  - agentgateway-crds
+  - cert-manager
+  - agentgateway
+  - nfd
+  - network-operator
+  - nodewright-operator
+  - prometheus-operator-crds
+  - kube-prometheus-stack
+  - gpu-operator
+  - k8s-ephemeral-storage-metrics
+  - kai-scheduler
+  - nvidia-dra-driver-gpu
+  - nvsentinel
+  - prometheus-adapter
+kind: RecipeResult
+metadata:
+  appliedOverlays:
+    - base
+    - monitoring-hpa
+    - h100-any
+    - kind
+    - kind-inference
+    - h100-kind-inference
+  version: dev
+validation:
+  conformance:
+    checks:
+      - platform-health
+      - gpu-operator-health
+      - dra-support
+      - accelerator-metrics
+      - ai-service-metrics
+      - secure-accelerator-access
+      - gang-scheduling
+      - inference-gateway
+      - pod-autoscaling
+      - cluster-autoscaling
+  deployment:
+    checks:
+      - operator-health
+      - expected-resources
+      - gpu-operator-version
+      - check-nvidia-smi
+    constraints:
+      - name: Deployment.gpu-operator.version
+        value: '>= v24.6.0'

--- a/tests/aicr-sweep/results-57ef016/coverage.md
+++ b/tests/aicr-sweep/results-57ef016/coverage.md
@@ -1,0 +1,321 @@
+# AICR check coverage under Mokka
+
+All evidence below is simulation provenance (`sim`). None of it was run on silicon.
+
+## Roll-up
+
+- Check results total: 210 (checks x cells)
+- A meaningful: 160  ·  B trivial: 10  ·  C hardware-dependent: 40  ·  G closable gap: 0
+- **Meaningful pre-silicon today: 76%** (A / total)
+- **Reachable once tracked gaps close: 76%** ((A + G) / total). Roadmap, not a current claim.
+- Of the A set, 100 are GPU-dependent (62% of A). The remainder run on any cluster, so Mokka is not what unlocks them.
+- Never reached a verdict (blocked or not-run): 157 (75%)
+
+### Why cells did not reach a verdict
+
+| Cause | Meaning | Count |
+|---|---|---|
+| X | AICR catalog has no recipe for the combination. NOT a Mokka gap. | 84 |
+
+## Cells
+
+### `base-gb200-kind-inference-stack`
+
+Recipe: service=kind accelerator=gb200 intent=inference · shape=stack workers=2 · status=ran
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | pass |  |  |
+| expected-resources | deployment | A | yes | not-run |  |  |
+| gpu-operator-version | deployment | A | no | fail |  |  |
+| check-nvidia-smi | deployment | A | yes | pass |  |  |
+| nccl-all-reduce-bw | performance | C | yes | not-run |  | check absent from run output |
+| nccl-all-reduce-bw-net | performance | C | yes | not-run |  | check absent from run output |
+| nccl-all-reduce-bw-nvls | performance | C | yes | not-run |  | check absent from run output |
+| inference-perf | performance | C | yes | not-run |  | check absent from run output |
+| dra-support | conformance | A | yes | fail |  |  |
+| gang-scheduling | conformance | A | no | not-run |  | check absent from run output |
+| accelerator-metrics | conformance | A | yes | pass |  |  |
+| ai-service-metrics | conformance | A | yes | fail |  |  |
+| inference-gateway | conformance | A | no | not-run |  | check absent from run output |
+| pod-autoscaling | conformance | B | yes | not-run |  | check absent from run output |
+| cluster-autoscaling | conformance | A | no | not-run |  | check absent from run output |
+| robust-controller | conformance | A | no | not-run |  | check absent from run output |
+| secure-accelerator-access | conformance | A | yes | not-run |  | check absent from run output |
+| slinky-slurm-health | conformance | A | yes | not-run |  | check absent from run output |
+| slinky-slurm-imex-channel | conformance | A | yes | not-run |  | check absent from run output |
+| gpu-operator-health | conformance | A | yes | fail |  |  |
+| platform-health | conformance | A | no | fail |  |  |
+
+### `base-gb200-kind-training-stack`
+
+Recipe: service=kind accelerator=gb200 intent=training · shape=stack workers=2 · status=blocked
+
+**Blocked (X):** RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would "differ from the inference cell only in component set". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with "[INVALID_REQUEST] no recipe provides intent 'training'". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log.
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | blocked | X |  |
+| expected-resources | deployment | A | yes | blocked | X |  |
+| gpu-operator-version | deployment | A | no | blocked | X |  |
+| check-nvidia-smi | deployment | A | yes | blocked | X |  |
+| nccl-all-reduce-bw | performance | C | yes | blocked | X |  |
+| nccl-all-reduce-bw-net | performance | C | yes | blocked | X |  |
+| nccl-all-reduce-bw-nvls | performance | C | yes | blocked | X |  |
+| inference-perf | performance | C | yes | blocked | X |  |
+| dra-support | conformance | A | yes | blocked | X |  |
+| gang-scheduling | conformance | A | no | blocked | X |  |
+| accelerator-metrics | conformance | A | yes | blocked | X |  |
+| ai-service-metrics | conformance | A | yes | blocked | X |  |
+| inference-gateway | conformance | A | no | blocked | X |  |
+| pod-autoscaling | conformance | B | yes | blocked | X |  |
+| cluster-autoscaling | conformance | A | no | blocked | X |  |
+| robust-controller | conformance | A | no | blocked | X |  |
+| secure-accelerator-access | conformance | A | yes | blocked | X |  |
+| slinky-slurm-health | conformance | A | yes | blocked | X |  |
+| slinky-slurm-imex-channel | conformance | A | yes | blocked | X |  |
+| gpu-operator-health | conformance | A | yes | blocked | X |  |
+| platform-health | conformance | A | no | blocked | X |  |
+
+### `base-h100-kind-inference-stack`
+
+Recipe: service=kind accelerator=h100 intent=inference · shape=stack workers=2 · status=ran
+
+Axes off base: accelerator=h100 (substitute for gb300)
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | pass |  |  |
+| expected-resources | deployment | A | yes | not-run |  |  |
+| gpu-operator-version | deployment | A | no | pass |  |  |
+| check-nvidia-smi | deployment | A | yes | pass |  |  |
+| nccl-all-reduce-bw | performance | C | yes | not-run |  | check absent from run output |
+| nccl-all-reduce-bw-net | performance | C | yes | not-run |  | check absent from run output |
+| nccl-all-reduce-bw-nvls | performance | C | yes | not-run |  | check absent from run output |
+| inference-perf | performance | C | yes | not-run |  | check absent from run output |
+| dra-support | conformance | A | yes | fail |  |  |
+| gang-scheduling | conformance | A | no | fail |  |  |
+| accelerator-metrics | conformance | A | yes | pass |  |  |
+| ai-service-metrics | conformance | A | yes | fail |  |  |
+| inference-gateway | conformance | A | no | fail |  |  |
+| pod-autoscaling | conformance | B | yes | fail |  |  |
+| cluster-autoscaling | conformance | A | no | skip |  |  |
+| robust-controller | conformance | A | no | not-run |  | check absent from run output |
+| secure-accelerator-access | conformance | A | yes | pass |  |  |
+| slinky-slurm-health | conformance | A | yes | not-run |  | check absent from run output |
+| slinky-slurm-imex-channel | conformance | A | yes | not-run |  | check absent from run output |
+| gpu-operator-health | conformance | A | yes | fail |  |  |
+| platform-health | conformance | A | no | fail |  |  |
+
+### `base-gb300-kind-inference-stack`
+
+Recipe: service=kind accelerator=gb300 intent=inference · shape=stack workers=2 · status=blocked
+
+**Blocked (X):** Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with "[INVALID_REQUEST] no recipe provides accelerator 'gb300'". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap.
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | blocked | X |  |
+| expected-resources | deployment | A | yes | blocked | X |  |
+| gpu-operator-version | deployment | A | no | blocked | X |  |
+| check-nvidia-smi | deployment | A | yes | blocked | X |  |
+| nccl-all-reduce-bw | performance | C | yes | blocked | X |  |
+| nccl-all-reduce-bw-net | performance | C | yes | blocked | X |  |
+| nccl-all-reduce-bw-nvls | performance | C | yes | blocked | X |  |
+| inference-perf | performance | C | yes | blocked | X |  |
+| dra-support | conformance | A | yes | blocked | X |  |
+| gang-scheduling | conformance | A | no | blocked | X |  |
+| accelerator-metrics | conformance | A | yes | blocked | X |  |
+| ai-service-metrics | conformance | A | yes | blocked | X |  |
+| inference-gateway | conformance | A | no | blocked | X |  |
+| pod-autoscaling | conformance | B | yes | blocked | X |  |
+| cluster-autoscaling | conformance | A | no | blocked | X |  |
+| robust-controller | conformance | A | no | blocked | X |  |
+| secure-accelerator-access | conformance | A | yes | blocked | X |  |
+| slinky-slurm-health | conformance | A | yes | blocked | X |  |
+| slinky-slurm-imex-channel | conformance | A | yes | blocked | X |  |
+| gpu-operator-health | conformance | A | yes | blocked | X |  |
+| platform-health | conformance | A | no | blocked | X |  |
+
+### `base-gb300-kind-training-stack`
+
+Recipe: service=kind accelerator=gb300 intent=training · shape=stack workers=2 · status=blocked
+
+**Blocked (X):** Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both "no recipe provides accelerator 'gb300'" and "no recipe provides intent 'training'" for this combination.
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | blocked | X |  |
+| expected-resources | deployment | A | yes | blocked | X |  |
+| gpu-operator-version | deployment | A | no | blocked | X |  |
+| check-nvidia-smi | deployment | A | yes | blocked | X |  |
+| nccl-all-reduce-bw | performance | C | yes | blocked | X |  |
+| nccl-all-reduce-bw-net | performance | C | yes | blocked | X |  |
+| nccl-all-reduce-bw-nvls | performance | C | yes | blocked | X |  |
+| inference-perf | performance | C | yes | blocked | X |  |
+| dra-support | conformance | A | yes | blocked | X |  |
+| gang-scheduling | conformance | A | no | blocked | X |  |
+| accelerator-metrics | conformance | A | yes | blocked | X |  |
+| ai-service-metrics | conformance | A | yes | blocked | X |  |
+| inference-gateway | conformance | A | no | blocked | X |  |
+| pod-autoscaling | conformance | B | yes | blocked | X |  |
+| cluster-autoscaling | conformance | A | no | blocked | X |  |
+| robust-controller | conformance | A | no | blocked | X |  |
+| secure-accelerator-access | conformance | A | yes | blocked | X |  |
+| slinky-slurm-health | conformance | A | yes | blocked | X |  |
+| slinky-slurm-imex-channel | conformance | A | yes | blocked | X |  |
+| gpu-operator-health | conformance | A | yes | blocked | X |  |
+| platform-health | conformance | A | no | blocked | X |  |
+
+### `targeted-dra-installed`
+
+Recipe: service=kind accelerator=gb200 intent=inference · shape=stack workers=2 · status=ran
+
+Axes off base: imex.mockChannels.enabled=true, nvidia-dra-driver-gpu=v0.5.0 with altProcDevices (first run used v25.12.0, which lacked it)
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | not-run |  |  |
+| expected-resources | deployment | A | yes | fail |  |  |
+| gpu-operator-version | deployment | A | no | fail |  |  |
+| check-nvidia-smi | deployment | A | yes | pass |  |  |
+| nccl-all-reduce-bw | performance | C | yes | not-run |  | check absent from run output |
+| nccl-all-reduce-bw-net | performance | C | yes | not-run |  | check absent from run output |
+| nccl-all-reduce-bw-nvls | performance | C | yes | not-run |  | check absent from run output |
+| inference-perf | performance | C | yes | not-run |  | check absent from run output |
+| dra-support | conformance | A | yes | pass |  |  |
+| gang-scheduling | conformance | A | no | not-run |  | check absent from run output |
+| accelerator-metrics | conformance | A | yes | pass |  |  |
+| ai-service-metrics | conformance | A | yes | fail |  |  |
+| inference-gateway | conformance | A | no | not-run |  | check absent from run output |
+| pod-autoscaling | conformance | B | yes | not-run |  | check absent from run output |
+| cluster-autoscaling | conformance | A | no | not-run |  | check absent from run output |
+| robust-controller | conformance | A | no | not-run |  | check absent from run output |
+| secure-accelerator-access | conformance | A | yes | not-run |  | check absent from run output |
+| slinky-slurm-health | conformance | A | yes | not-run |  | check absent from run output |
+| slinky-slurm-imex-channel | conformance | A | yes | not-run |  | check absent from run output |
+| gpu-operator-health | conformance | A | yes | fail |  |  |
+| platform-health | conformance | A | no | fail |  |  |
+
+### `axis-nri-cdi`
+
+Recipe: service=kind accelerator=gb200 intent=inference · shape=stack workers=2 · status=ran
+
+Axes off base: nri.deviceInjectionMode=cdi (base is raw)
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | pass |  |  |
+| expected-resources | deployment | A | yes | not-run |  |  |
+| gpu-operator-version | deployment | A | no | fail |  |  |
+| check-nvidia-smi | deployment | A | yes | pass |  |  |
+| nccl-all-reduce-bw | performance | C | yes | not-run |  | check absent from run output |
+| nccl-all-reduce-bw-net | performance | C | yes | not-run |  | check absent from run output |
+| nccl-all-reduce-bw-nvls | performance | C | yes | not-run |  | check absent from run output |
+| inference-perf | performance | C | yes | not-run |  | check absent from run output |
+| dra-support | conformance | A | yes | fail |  |  |
+| gang-scheduling | conformance | A | no | not-run |  | check absent from run output |
+| accelerator-metrics | conformance | A | yes | pass |  |  |
+| ai-service-metrics | conformance | A | yes | fail |  |  |
+| inference-gateway | conformance | A | no | not-run |  | check absent from run output |
+| pod-autoscaling | conformance | B | yes | not-run |  | check absent from run output |
+| cluster-autoscaling | conformance | A | no | not-run |  | check absent from run output |
+| robust-controller | conformance | A | no | not-run |  | check absent from run output |
+| secure-accelerator-access | conformance | A | yes | not-run |  | check absent from run output |
+| slinky-slurm-health | conformance | A | yes | not-run |  | check absent from run output |
+| slinky-slurm-imex-channel | conformance | A | yes | not-run |  | check absent from run output |
+| gpu-operator-health | conformance | A | yes | fail |  |  |
+| platform-health | conformance | A | no | fail |  |  |
+
+### `axis-allocation-watcher-on`
+
+Recipe: service=kind accelerator=gb200 intent=inference · shape=stack workers=2 · status=ran
+
+Axes off base: allocationWatcher.enabled=true (base is false)
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | pass |  |  |
+| expected-resources | deployment | A | yes | not-run |  |  |
+| gpu-operator-version | deployment | A | no | fail |  |  |
+| check-nvidia-smi | deployment | A | yes | pass |  |  |
+| nccl-all-reduce-bw | performance | C | yes | not-run |  | check absent from run output |
+| nccl-all-reduce-bw-net | performance | C | yes | not-run |  | check absent from run output |
+| nccl-all-reduce-bw-nvls | performance | C | yes | not-run |  | check absent from run output |
+| inference-perf | performance | C | yes | not-run |  | check absent from run output |
+| dra-support | conformance | A | yes | fail |  |  |
+| gang-scheduling | conformance | A | no | not-run |  | check absent from run output |
+| accelerator-metrics | conformance | A | yes | pass |  |  |
+| ai-service-metrics | conformance | A | yes | fail |  |  |
+| inference-gateway | conformance | A | no | not-run |  | check absent from run output |
+| pod-autoscaling | conformance | B | yes | not-run |  | check absent from run output |
+| cluster-autoscaling | conformance | A | no | not-run |  | check absent from run output |
+| robust-controller | conformance | A | no | not-run |  | check absent from run output |
+| secure-accelerator-access | conformance | A | yes | not-run |  | check absent from run output |
+| slinky-slurm-health | conformance | A | yes | not-run |  | check absent from run output |
+| slinky-slurm-imex-channel | conformance | A | yes | not-run |  | check absent from run output |
+| gpu-operator-health | conformance | A | yes | fail |  |  |
+| platform-health | conformance | A | no | fail |  |  |
+
+### `axis-failure-injection-ecc`
+
+Recipe: service=kind accelerator=gb200 intent=inference · shape=stack workers=2 · status=ran
+
+Axes off base: gpu.failureInjection=enabled=true mode=ecc_uncorrectable probability=1 (base is off)
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | pass |  |  |
+| expected-resources | deployment | A | yes | not-run |  |  |
+| gpu-operator-version | deployment | A | no | fail |  |  |
+| check-nvidia-smi | deployment | A | yes | pass |  |  |
+| nccl-all-reduce-bw | performance | C | yes | not-run |  | check absent from run output |
+| nccl-all-reduce-bw-net | performance | C | yes | not-run |  | check absent from run output |
+| nccl-all-reduce-bw-nvls | performance | C | yes | not-run |  | check absent from run output |
+| inference-perf | performance | C | yes | not-run |  | check absent from run output |
+| dra-support | conformance | A | yes | fail |  |  |
+| gang-scheduling | conformance | A | no | not-run |  | check absent from run output |
+| accelerator-metrics | conformance | A | yes | pass |  |  |
+| ai-service-metrics | conformance | A | yes | fail |  |  |
+| inference-gateway | conformance | A | no | not-run |  | check absent from run output |
+| pod-autoscaling | conformance | B | yes | not-run |  | check absent from run output |
+| cluster-autoscaling | conformance | A | no | not-run |  | check absent from run output |
+| robust-controller | conformance | A | no | not-run |  | check absent from run output |
+| secure-accelerator-access | conformance | A | yes | not-run |  | check absent from run output |
+| slinky-slurm-health | conformance | A | yes | not-run |  | check absent from run output |
+| slinky-slurm-imex-channel | conformance | A | yes | not-run |  | check absent from run output |
+| gpu-operator-health | conformance | A | yes | fail |  |  |
+| platform-health | conformance | A | no | fail |  |  |
+
+### `axis-compute-domain-fabric`
+
+Recipe: service=kind accelerator=gb200 intent=training · shape=fabric workers=4 · status=blocked
+
+**Blocked (X):** RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log.
+
+Axes off base: imex.mockChannels.enabled=true, topology.domains=two cliques
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | blocked | X |  |
+| expected-resources | deployment | A | yes | blocked | X |  |
+| gpu-operator-version | deployment | A | no | blocked | X |  |
+| check-nvidia-smi | deployment | A | yes | blocked | X |  |
+| nccl-all-reduce-bw | performance | C | yes | blocked | X |  |
+| nccl-all-reduce-bw-net | performance | C | yes | blocked | X |  |
+| nccl-all-reduce-bw-nvls | performance | C | yes | blocked | X |  |
+| inference-perf | performance | C | yes | blocked | X |  |
+| dra-support | conformance | A | yes | blocked | X |  |
+| gang-scheduling | conformance | A | no | blocked | X |  |
+| accelerator-metrics | conformance | A | yes | blocked | X |  |
+| ai-service-metrics | conformance | A | yes | blocked | X |  |
+| inference-gateway | conformance | A | no | blocked | X |  |
+| pod-autoscaling | conformance | B | yes | blocked | X |  |
+| cluster-autoscaling | conformance | A | no | blocked | X |  |
+| robust-controller | conformance | A | no | blocked | X |  |
+| secure-accelerator-access | conformance | A | yes | blocked | X |  |
+| slinky-slurm-health | conformance | A | yes | blocked | X |  |
+| slinky-slurm-imex-channel | conformance | A | yes | blocked | X |  |
+| gpu-operator-health | conformance | A | yes | blocked | X |  |
+| platform-health | conformance | A | no | blocked | X |  |
+

--- a/tests/aicr-sweep/results-57ef016/report.json
+++ b/tests/aicr-sweep/results-57ef016/report.json
@@ -1,0 +1,2558 @@
+{
+  "rollup": {
+    "total": 210,
+    "a": 160,
+    "b": 10,
+    "c": 40,
+    "g": 0,
+    "aGpuDependent": 100,
+    "blocked": 157,
+    "byCause": {
+      "X": 84
+    },
+    "byOutcome": {
+      "blocked": 84,
+      "fail": 32,
+      "not-run": 73,
+      "pass": 20,
+      "skip": 1
+    },
+    "suspect": 0
+  },
+  "cells": [
+    {
+      "cell": {
+        "id": "base-gb200-kind-inference-stack",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb200",
+          "intent": "inference"
+        },
+        "shape": "stack",
+        "workers": 2,
+        "notes": "The backbone cell, re-run against 57ef016. Its 9 dispatched verdicts are byte-identical to the v0.3.0 run: 3 passed, 5 failed, 1 other. #672 landed and is real (busId went from 0000:0a:00.0 to 00000000:0a:00.0, verified by a differential probe of the two images and live in cluster), but it did NOT move gpu-operator-health. GFD now receives a well-formed BDF and still cannot read /sys/bus/pci/devices/\u003cbdf\u003e/vendor, because Mokka's rendered PCI tree is not grafted onto GFD's /sys. Evidence: results/gfd-sysfs-evidence.log."
+      },
+      "versions": {
+        "mokka": "57ef01659 (HEAD~1 of upstream/main on 2026-08-26; no tag yet)",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:sha-57ef016",
+        "mokkaDigest": "sha256:115cb887ec53ffb7a17a913257b8f55594fda31ad2d1174745b5e20a1400db9e",
+        "chart": "deployments/nvml-mock/helm/nvml-mock at 57ef01659 (chart version 0.3.0)",
+        "chartDigest": "not published; Chart.yaml on main is still 0.3.0, so the released OCI chart does NOT carry these 60 commits and the chart must come from the checkout. This is the one provenance gap in this run and it is deliberate.",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.2, 14 CPU, 15.84 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "ran",
+      "logsPointer": "tests/aicr-sweep/results-57ef016/base-gb200-kind-inference-stack",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "message": "pod not found for Job aicr-expected-resources-ce03baa3: [NOT_FOUND] pod for job not found"
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \"\u003e= v25.10.0\""
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found"
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\""
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[INTERNAL] ClusterPolicy state=notReady (want ready)"
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] platform health check failed (9 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvidia-dra-driver: not found\n  namespace nvsentinel: not found"
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "base-gb200-kind-training-stack",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb200",
+          "intent": "training"
+        },
+        "shape": "stack",
+        "workers": 2
+      },
+      "versions": {
+        "mokka": "57ef01659 (HEAD~1 of upstream/main on 2026-08-26; no tag yet)",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:sha-57ef016",
+        "mokkaDigest": "sha256:115cb887ec53ffb7a17a913257b8f55594fda31ad2d1174745b5e20a1400db9e",
+        "chart": "deployments/nvml-mock/helm/nvml-mock at 57ef01659 (chart version 0.3.0)",
+        "chartDigest": "not published; Chart.yaml on main is still 0.3.0, so the released OCI chart does NOT carry these 60 commits and the chart must come from the checkout. This is the one provenance gap in this run and it is deliberate.",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.2, 14 CPU, 15.84 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "blocked",
+      "cause": "X",
+      "blockedWhy": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log.",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from BUDGET. The first run recorded this cell as blocked on host memory and predicted it would \"differ from the inference cell only in component set\". That prediction was never tested. It is wrong: AICR at 0752ea14 resolves no training recipe on the kind service for gb200. `aicr recipe --service kind --accelerator gb200 --intent training` exits 2 with \"[INVALID_REQUEST] no recipe provides intent 'training'\". On kind, training resolves for h100 and for no other accelerator. The cell fails at recipe resolution, before memory could ever matter, so the cause is X. Evidence: results/aicr-recipe-matrix-evidence.log."
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "base-h100-kind-inference-stack",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "h100",
+          "intent": "inference"
+        },
+        "shape": "stack",
+        "workers": 2,
+        "axes": {
+          "accelerator": "h100 (substitute for gb300)"
+        },
+        "notes": "Was BUDGET in the first run; the host VM is now 15.84 GiB and it ran. This is the largest single coverage gain in the re-run: AICR dispatched 14 of 21 checks here against 9 for gb200, and 5 passed against 3. gpu-operator-version passes on h100 and fails on gb200, and gang-scheduling, inference-gateway, pod-autoscaling, cluster-autoscaling and secure-accelerator-access are dispatched at all only here. It remains a substitution and is never counted as gb300 coverage."
+      },
+      "versions": {
+        "mokka": "57ef01659 (HEAD~1 of upstream/main on 2026-08-26; no tag yet)",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:sha-57ef016",
+        "mokkaDigest": "sha256:115cb887ec53ffb7a17a913257b8f55594fda31ad2d1174745b5e20a1400db9e",
+        "chart": "deployments/nvml-mock/helm/nvml-mock at 57ef01659 (chart version 0.3.0)",
+        "chartDigest": "not published; Chart.yaml on main is still 0.3.0, so the released OCI chart does NOT carry these 60 commits and the chart must come from the checkout. This is the one provenance gap in this run and it is deliberate.",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.2, 14 CPU, 15.84 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "ran",
+      "logsPointer": "tests/aicr-sweep/results-57ef016/base-h100-kind-inference-stack",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "message": "pod not found for Job aicr-expected-resources-5ef990d4: [NOT_FOUND] pod for job not found"
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found"
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] recipe declares kai-scheduler but its Deployment kai-scheduler/kai-scheduler-default is absent — apply the bundle or check RBAC: deployments.apps \"kai-scheduler-default\" not found"
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\""
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] GatewayClass 'agentgateway' not found: the server could not find the requested resource"
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] custom metrics API not available (prometheus-adapter not ready): client rate limiter Wait returned an error: context deadline exceeded"
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "skip",
+          "provenance": "sim",
+          "message": "[INTERNAL] Karpenter not found and cluster platform not recognized (not EKS or GKE): skip"
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[INTERNAL] ClusterPolicy state=notReady (want ready)"
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] platform health check failed (9 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvidia-dra-driver: not found\n  namespace nvsentinel: not found"
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "base-gb300-kind-inference-stack",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb300",
+          "intent": "inference"
+        },
+        "shape": "stack",
+        "workers": 2
+      },
+      "versions": {
+        "mokka": "57ef01659 (HEAD~1 of upstream/main on 2026-08-26; no tag yet)",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:sha-57ef016",
+        "mokkaDigest": "sha256:115cb887ec53ffb7a17a913257b8f55594fda31ad2d1174745b5e20a1400db9e",
+        "chart": "deployments/nvml-mock/helm/nvml-mock at 57ef01659 (chart version 0.3.0)",
+        "chartDigest": "not published; Chart.yaml on main is still 0.3.0, so the released OCI chart does NOT carry these 60 commits and the chart must come from the checkout. This is the one provenance gap in this run and it is deliberate.",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.2, 14 CPU, 15.84 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "blocked",
+      "cause": "X",
+      "blockedWhy": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap.",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Unchanged from the first run and re-verified by running the CLI at the same pin: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile, and #699 made it the chart default, so the two sides have drifted further apart rather than closer. Not a Mokka gap."
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "base-gb300-kind-training-stack",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb300",
+          "intent": "training"
+        },
+        "shape": "stack",
+        "workers": 2
+      },
+      "versions": {
+        "mokka": "57ef01659 (HEAD~1 of upstream/main on 2026-08-26; no tag yet)",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:sha-57ef016",
+        "mokkaDigest": "sha256:115cb887ec53ffb7a17a913257b8f55594fda31ad2d1174745b5e20a1400db9e",
+        "chart": "deployments/nvml-mock/helm/nvml-mock at 57ef01659 (chart version 0.3.0)",
+        "chartDigest": "not published; Chart.yaml on main is still 0.3.0, so the released OCI chart does NOT carry these 60 commits and the chart must come from the checkout. This is the one provenance gap in this run and it is deliberate.",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.2, 14 CPU, 15.84 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "blocked",
+      "cause": "X",
+      "blockedWhy": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination.",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack, and now doubly so: AICR reports both \"no recipe provides accelerator 'gb300'\" and \"no recipe provides intent 'training'\" for this combination."
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "targeted-dra-installed",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb200",
+          "intent": "inference"
+        },
+        "shape": "stack",
+        "workers": 2,
+        "axes": {
+          "imex.mockChannels.enabled": "true",
+          "nvidia-dra-driver-gpu": "v0.5.0 with altProcDevices (first run used v25.12.0, which lacked it)"
+        },
+        "notes": "The one cell whose verdict moved. dra-support went FAILED to PASSED. Mokka rendered the /proc/devices substitute (235 nvidia-caps-imex-channels), DRA v0.5.0 consumed it via altProcDevices, both kubelet-plugin containers (compute-domains and gpus) came up on both workers, and 12 ResourceSlice devices were published. The first run's abort, \"error parsing '/proc/devices'\", appears zero times in 400 lines of driver logs. This closes the cause-U block D-009 recorded, for an UPSTREAM reason: Mokka's IMEX rendering already worked at v0.3.0, and what was missing was a released consumer. v0.5.0 shipped it on 2026-08-19. CAVEAT: the v0.5.0 chart was renamed nvidia-dra-driver-gpu to dra-driver-nvidia-gpu, so its default resource names no longer match what AICR at 0752ea14 looks for. This cell passed --set nameOverride=nvidia-dra-driver-gpu to restore the expected name. AICR itself was not modified. Without that flag dra-support fails NOT_FOUND on the name alone, whatever the driver does. Evidence: results/dra-altprocdevices-evidence.log."
+      },
+      "versions": {
+        "mokka": "57ef01659 (HEAD~1 of upstream/main on 2026-08-26; no tag yet)",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:sha-57ef016",
+        "mokkaDigest": "sha256:115cb887ec53ffb7a17a913257b8f55594fda31ad2d1174745b5e20a1400db9e",
+        "chart": "deployments/nvml-mock/helm/nvml-mock at 57ef01659 (chart version 0.3.0)",
+        "chartDigest": "not published; Chart.yaml on main is still 0.3.0, so the released OCI chart does NOT carry these 60 commits and the chart must come from the checkout. This is the one provenance gap in this run and it is deliberate.",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.2, 14 CPU, 15.84 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "ran",
+      "logsPointer": "tests/aicr-sweep/results-57ef016/targeted-dra-installed",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "message": "pod never reached running state"
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] Deployment agentgateway-system/agentgateway not found: deployments.apps \"agentgateway\" not found"
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \"\u003e= v25.10.0\""
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\""
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[INTERNAL] ClusterPolicy state=notReady (want ready)"
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] platform health check failed (8 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvsentinel: not found"
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "axis-nri-cdi",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb200",
+          "intent": "inference"
+        },
+        "shape": "stack",
+        "workers": 2,
+        "axes": {
+          "nri.deviceInjectionMode": "cdi (base is raw)"
+        },
+        "notes": "Was BUDGET; ran. Verdicts identical to the base cell (3 passed, 5 failed, 1 other). The CDI injection mode is a Mokka-side device-injection change and does not touch the ClusterPolicy path that holds gpu-operator-health down, so no movement is the expected and correct result."
+      },
+      "versions": {
+        "mokka": "57ef01659 (HEAD~1 of upstream/main on 2026-08-26; no tag yet)",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:sha-57ef016",
+        "mokkaDigest": "sha256:115cb887ec53ffb7a17a913257b8f55594fda31ad2d1174745b5e20a1400db9e",
+        "chart": "deployments/nvml-mock/helm/nvml-mock at 57ef01659 (chart version 0.3.0)",
+        "chartDigest": "not published; Chart.yaml on main is still 0.3.0, so the released OCI chart does NOT carry these 60 commits and the chart must come from the checkout. This is the one provenance gap in this run and it is deliberate.",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.2, 14 CPU, 15.84 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "ran",
+      "logsPointer": "tests/aicr-sweep/results-57ef016/axis-nri-cdi",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "message": "pod not found for Job aicr-expected-resources-6c6c4efc: [NOT_FOUND] pod for job not found"
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \"\u003e= v25.10.0\""
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found"
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\""
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[INTERNAL] ClusterPolicy state=notReady (want ready)"
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] platform health check failed (9 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvidia-dra-driver: not found\n  namespace nvsentinel: not found"
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "axis-allocation-watcher-on",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb200",
+          "intent": "inference"
+        },
+        "shape": "stack",
+        "workers": 2,
+        "axes": {
+          "allocationWatcher.enabled": "true (base is false)"
+        },
+        "notes": "Was BUDGET; ran. The sidecar came up (3/3 containers in the nvml-mock DaemonSet) and verdicts are identical to the base cell. As the first run predicted in advance, any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+      },
+      "versions": {
+        "mokka": "57ef01659 (HEAD~1 of upstream/main on 2026-08-26; no tag yet)",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:sha-57ef016",
+        "mokkaDigest": "sha256:115cb887ec53ffb7a17a913257b8f55594fda31ad2d1174745b5e20a1400db9e",
+        "chart": "deployments/nvml-mock/helm/nvml-mock at 57ef01659 (chart version 0.3.0)",
+        "chartDigest": "not published; Chart.yaml on main is still 0.3.0, so the released OCI chart does NOT carry these 60 commits and the chart must come from the checkout. This is the one provenance gap in this run and it is deliberate.",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.2, 14 CPU, 15.84 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "ran",
+      "logsPointer": "tests/aicr-sweep/results-57ef016/axis-allocation-watcher-on",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "message": "pod not found for Job aicr-expected-resources-ba9ec431: [NOT_FOUND] pod for job not found"
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \"\u003e= v25.10.0\""
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found"
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\""
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[INTERNAL] ClusterPolicy state=notReady (want ready)"
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] platform health check failed (9 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvidia-dra-driver: not found\n  namespace nvsentinel: not found"
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "axis-failure-injection-ecc",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb200",
+          "intent": "inference"
+        },
+        "shape": "stack",
+        "workers": 2,
+        "axes": {
+          "gpu.failureInjection": "enabled=true mode=ecc_uncorrectable probability=1 (base is off)"
+        },
+        "notes": "Was BUDGET; ran. Verdicts identical to the base cell. The fault is real and was verified before the result was read: the mock reports 6 and 9 volatile DRAM Uncorrectable errors on two GPUs while all 4 still enumerate, and check-nvidia-smi and accelerator-metrics both still pass. So a degraded but enumerable GPU is indistinguishable from a healthy one at this recipe. That is a statement about which checks AICR dispatches for kind/gb200/inference, not about Mokka: the injection works end to end. NOTE the first run recorded in cells.yaml declared this axis as `gpu.failureInjection.mode=ecc_uncorrectable` alone, which is inert, because the chart gates injection on `enabled` and never trips at the default probability of 0. Had that cell run as declared it would have measured nothing and looked like a clean negative. Evidence, including a second trap that produced a plausible but wrong result: results/ecc-injection-evidence.log."
+      },
+      "versions": {
+        "mokka": "57ef01659 (HEAD~1 of upstream/main on 2026-08-26; no tag yet)",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:sha-57ef016",
+        "mokkaDigest": "sha256:115cb887ec53ffb7a17a913257b8f55594fda31ad2d1174745b5e20a1400db9e",
+        "chart": "deployments/nvml-mock/helm/nvml-mock at 57ef01659 (chart version 0.3.0)",
+        "chartDigest": "not published; Chart.yaml on main is still 0.3.0, so the released OCI chart does NOT carry these 60 commits and the chart must come from the checkout. This is the one provenance gap in this run and it is deliberate.",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.2, 14 CPU, 15.84 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "ran",
+      "logsPointer": "tests/aicr-sweep/results-57ef016/axis-failure-injection-ecc",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "message": "pod not found for Job aicr-expected-resources-cc04b61a: [NOT_FOUND] pod for job not found"
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \"\u003e= v25.10.0\""
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found"
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\""
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[INTERNAL] ClusterPolicy state=notReady (want ready)"
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] platform health check failed (9 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvidia-dra-driver: not found\n  namespace nvsentinel: not found"
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "axis-compute-domain-fabric",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb200",
+          "intent": "training"
+        },
+        "shape": "fabric",
+        "workers": 4,
+        "axes": {
+          "imex.mockChannels.enabled": "true",
+          "topology.domains": "two cliques"
+        }
+      },
+      "versions": {
+        "mokka": "57ef01659 (HEAD~1 of upstream/main on 2026-08-26; no tag yet)",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:sha-57ef016",
+        "mokkaDigest": "sha256:115cb887ec53ffb7a17a913257b8f55594fda31ad2d1174745b5e20a1400db9e",
+        "chart": "deployments/nvml-mock/helm/nvml-mock at 57ef01659 (chart version 0.3.0)",
+        "chartDigest": "not published; Chart.yaml on main is still 0.3.0, so the released OCI chart does NOT carry these 60 commits and the chart must come from the checkout. This is the one provenance gap in this run and it is deliberate.",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.2, 14 CPU, 15.84 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "blocked",
+      "cause": "X",
+      "blockedWhy": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log.",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "RECLASSIFIED from U. The first run blocked this on the DRA driver lacking --set altProcDevices, which was true of v25.12.0 and is no longer true: v0.5.0, released 2026-08-19, ships altProcDevices, and its own values.yaml documents it as being for mock NVML. But the cell cannot run for a reason that predates that: it declares intent=training on the kind service, and AICR at 0752ea14 resolves no such recipe for gb200. The recipe-resolution failure comes first, so the cause is X, not U. The altProcDevices question it was meant to answer is now carried by targeted-dra-installed instead. Evidence: results/aicr-recipe-matrix-evidence.log."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aicr-sweep/results-57ef016/targeted-dra-installed/ctrf/validate.json
+++ b/tests/aicr-sweep/results-57ef016/targeted-dra-installed/ctrf/validate.json
@@ -1,0 +1,300 @@
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-08-26T17:47:00Z",
+  "generatedBy": "aicr",
+  "results": {
+    "tool": {
+      "name": "aicr",
+      "version": "dev"
+    },
+    "summary": {
+      "tests": 9,
+      "passed": 3,
+      "failed": 5,
+      "skipped": 0,
+      "pending": 0,
+      "other": 1,
+      "start": 1787765775169,
+      "stop": 1787766553999
+    },
+    "tests": [
+      {
+        "name": "operator-health",
+        "status": "other",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "message": "pod never reached running state"
+      },
+      {
+        "name": "expected-resources",
+        "status": "failed",
+        "duration": 360000,
+        "suite": [
+          "deployment"
+        ],
+        "message": "[NOT_FOUND] Deployment agentgateway-system/agentgateway not found: deployments.apps \"agentgateway\" not found",
+        "stdout": [
+          "time=2026-08-26T17:39:50.033Z level=INFO msg=\"starting check\" name=expected-resources",
+          "  Namespace gpu-operator: Active",
+          "  Namespace nvidia-dra-driver: Active",
+          "  DaemonSet nvidia-dra-driver/nvidia-dra-driver-gpu-kubelet-plugin: healthy (stable ≥1m0s)",
+          "time=2026-08-26T17:40:50.176Z level=INFO msg=\"running health check assertions\" components=14",
+          "time=2026-08-26T17:41:20.194Z level=WARN msg=\"health check failed\" component=cert-manager step=validate-crds-established error=\"[NOT_FOUND] CustomResourceDefinition /certificates.cert-manager.io not found: customresourcedefinitions.apiextensions.k8s.io \\\"certificates.cert-manager.io\\\" not found\"",
+          "time=2026-08-26T17:41:20.194Z level=WARN msg=\"health check failed\" component=agentgateway step=validate-deployment-exists error=\"[NOT_FOUND] Deployment agentgateway-system/agentgateway not found: deployments.apps \\\"agentgateway\\\" not found\"",
+          "time=2026-08-26T17:41:20.194Z level=WARN msg=\"health check failed\" component=agentgateway-crds step=validate-gateway-api-crds-established error=\"[NOT_FOUND] CustomResourceDefinition /gatewayclasses.gateway.networking.k8s.io not found: customresourcedefinitions.apiextensions.k8s.io \\\"gatewayclasses.gateway.networking.k8s.io\\\" not found\"",
+          "time=2026-08-26T17:41:50.208Z level=WARN msg=\"health check failed\" component=kube-prometheus-stack step=validate-deployment-exists error=\"[NOT_FOUND] Deployment monitoring/kube-prometheus-operator not found: deployments.apps \\\"kube-prometheus-operator\\\" not found\"",
+          "time=2026-08-26T17:41:50.208Z level=WARN msg=\"health check failed\" component=kai-scheduler step=validate-deployment-exists error=\"[NOT_FOUND] Deployment kai-scheduler/kai-operator not found: deployments.apps \\\"kai-operator\\\" not found\"",
+          "time=2026-08-26T17:41:50.208Z level=WARN msg=\"health check failed\" component=k8s-ephemeral-storage-metrics step=validate-deployment-exists error=\"[NOT_FOUND] Deployment monitoring/k8s-ephemeral-storage-metrics not found: deployments.apps \\\"k8s-ephemeral-storage-metrics\\\" not found\"",
+          "time=2026-08-26T17:42:20.221Z level=WARN msg=\"health check failed\" component=nfd step=validate-master-deployment error=\"[NOT_FOUND] Deployment node-feature-discovery/nfd-node-feature-discovery-master not found: deployments.apps \\\"nfd-node-feature-discovery-master\\\" not found\"",
+          "time=2026-08-26T17:42:20.221Z level=WARN msg=\"health check failed\" component=nodewright-operator step=validate-skyhook-crd-established error=\"[NOT_FOUND] CustomResourceDefinition /skyhooks.skyhook.nvidia.com not found: customresourcedefinitions.apiextensions.k8s.io \\\"skyhooks.skyhook.nvidia.com\\\" not found\"",
+          "time=2026-08-26T17:42:20.221Z level=WARN msg=\"health check failed\" component=network-operator step=validate-crds-established error=\"[NOT_FOUND] CustomResourceDefinition /nicclusterpolicies.mellanox.com not found: customresourcedefinitions.apiextensions.k8s.io \\\"nicclusterpolicies.mellanox.com\\\" not found\"",
+          "time=2026-08-26T17:42:20.246Z level=INFO msg=\"health check passed\" component=nvidia-dra-driver-gpu",
+          "time=2026-08-26T17:42:50.233Z level=WARN msg=\"health check failed\" component=nvsentinel step=validate-deployment-exists error=\"[NOT_FOUND] Deployment nvsentinel/labeler not found: deployments.apps \\\"labeler\\\" not found\"",
+          "time=2026-08-26T17:42:50.233Z level=WARN msg=\"health check failed\" component=prometheus-adapter step=validate-deployment-exists error=\"[NOT_FOUND] Deployment monitoring/prometheus-adapter not found: deployments.apps \\\"prometheus-adapter\\\" not found\"",
+          "time=2026-08-26T17:42:50.249Z level=WARN msg=\"health check failed\" component=prometheus-operator-crds step=validate-prometheus-operator-crds-established error=\"[NOT_FOUND] CustomResourceDefinition /alertmanagers.monitoring.coreos.com not found: customresourcedefinitions.apiextensions.k8s.io \\\"alertmanagers.monitoring.coreos.com\\\" not found\"",
+          "time=2026-08-26T17:45:50.188Z level=WARN msg=\"health check failed\" component=gpu-operator step=validate-cluster-policy-ready error=\"[INTERNAL] ClusterPolicy /cluster-policy: status.state: Invalid value: \\\"notReady\\\": Expected value: \\\"ready\\\"\"",
+          "  [chainsaw] nvidia-dra-driver-gpu: health check passed",
+          "Failed resources:",
+          "  namespace agentgateway-system: namespaces \"agentgateway-system\" not found",
+          "  namespace cert-manager: namespaces \"cert-manager\" not found",
+          "  namespace monitoring: namespaces \"monitoring\" not found",
+          "  namespace kai-scheduler: namespaces \"kai-scheduler\" not found",
+          "  namespace nvidia-network-operator: namespaces \"nvidia-network-operator\" not found",
+          "  namespace node-feature-discovery: namespaces \"node-feature-discovery\" not found",
+          "  namespace skyhook: namespaces \"skyhook\" not found",
+          "  namespace nvsentinel: namespaces \"nvsentinel\" not found",
+          "  [chainsaw] agentgateway: health check failed:",
+          "[NOT_FOUND] Deployment agentgateway-system/agentgateway not found: deployments.apps \"agentgateway\" not found",
+          "error: [NOT_FOUND] Deployment agentgateway-system/agentgateway not found: deployments.apps \"agentgateway\" not found",
+          "  [chainsaw] agentgateway-crds: health check failed:",
+          "[NOT_FOUND] CustomResourceDefinition /gatewayclasses.gateway.networking.k8s.io not found: customresourcedefinitions.apiextensions.k8s.io \"gatewayclasses.gateway.networking.k8s.io\" not found",
+          "error: [NOT_FOUND] CustomResourceDefinition /gatewayclasses.gateway.networking.k8s.io not found: customresourcedefinitions.apiextensions.k8s.io \"gatewayclasses.gateway.networking.k8s.io\" not found",
+          "  [chainsaw] cert-manager: health check failed:",
+          "[NOT_FOUND] CustomResourceDefinition /certificates.cert-manager.io not found: customresourcedefinitions.apiextensions.k8s.io \"certificates.cert-manager.io\" not found",
+          "error: [NOT_FOUND] CustomResourceDefinition /certificates.cert-manager.io not found: customresourcedefinitions.apiextensions.k8s.io \"certificates.cert-manager.io\" not found",
+          "  [chainsaw] gpu-operator: health check failed:",
+          "[INTERNAL] ClusterPolicy /cluster-policy: status.state: Invalid value: \"notReady\": Expected value: \"ready\"",
+          "error: [INTERNAL] ClusterPolicy /cluster-policy: status.state: Invalid value: \"notReady\": Expected value: \"ready\"",
+          "  [chainsaw] k8s-ephemeral-storage-metrics: health check failed:",
+          "[NOT_FOUND] Deployment monitoring/k8s-ephemeral-storage-metrics not found: deployments.apps \"k8s-ephemeral-storage-metrics\" not found",
+          "error: [NOT_FOUND] Deployment monitoring/k8s-ephemeral-storage-metrics not found: deployments.apps \"k8s-ephemeral-storage-metrics\" not found",
+          "  [chainsaw] kai-scheduler: health check failed:",
+          "[NOT_FOUND] Deployment kai-scheduler/kai-operator not found: deployments.apps \"kai-operator\" not found",
+          "error: [NOT_FOUND] Deployment kai-scheduler/kai-operator not found: deployments.apps \"kai-operator\" not found",
+          "  [chainsaw] kube-prometheus-stack: health check failed:",
+          "[NOT_FOUND] Deployment monitoring/kube-prometheus-operator not found: deployments.apps \"kube-prometheus-operator\" not found",
+          "error: [NOT_FOUND] Deployment monitoring/kube-prometheus-operator not found: deployments.apps \"kube-prometheus-operator\" not found",
+          "  [chainsaw] network-operator: health check failed:",
+          "[NOT_FOUND] CustomResourceDefinition /nicclusterpolicies.mellanox.com not found: customresourcedefinitions.apiextensions.k8s.io \"nicclusterpolicies.mellanox.com\" not found",
+          "error: [NOT_FOUND] CustomResourceDefinition /nicclusterpolicies.mellanox.com not found: customresourcedefinitions.apiextensions.k8s.io \"nicclusterpolicies.mellanox.com\" not found",
+          "  [chainsaw] nfd: health check failed:",
+          "[NOT_FOUND] Deployment node-feature-discovery/nfd-node-feature-discovery-master not found: deployments.apps \"nfd-node-feature-discovery-master\" not found",
+          "error: [NOT_FOUND] Deployment node-feature-discovery/nfd-node-feature-discovery-master not found: deployments.apps \"nfd-node-feature-discovery-master\" not found",
+          "  [chainsaw] nodewright-operator: health check failed:",
+          "[NOT_FOUND] CustomResourceDefinition /skyhooks.skyhook.nvidia.com not found: customresourcedefinitions.apiextensions.k8s.io \"skyhooks.skyhook.nvidia.com\" not found",
+          "error: [NOT_FOUND] CustomResourceDefinition /skyhooks.skyhook.nvidia.com not found: customresourcedefinitions.apiextensions.k8s.io \"skyhooks.skyhook.nvidia.com\" not found",
+          "  [chainsaw] nvsentinel: health check failed:",
+          "[NOT_FOUND] Deployment nvsentinel/labeler not found: deployments.apps \"labeler\" not found",
+          "error: [NOT_FOUND] Deployment nvsentinel/labeler not found: deployments.apps \"labeler\" not found",
+          "  [chainsaw] prometheus-adapter: health check failed:",
+          "[NOT_FOUND] Deployment monitoring/prometheus-adapter not found: deployments.apps \"prometheus-adapter\" not found",
+          "error: [NOT_FOUND] Deployment monitoring/prometheus-adapter not found: deployments.apps \"prometheus-adapter\" not found",
+          "  [chainsaw] prometheus-operator-crds: health check failed:",
+          "[NOT_FOUND] CustomResourceDefinition /alertmanagers.monitoring.coreos.com not found: customresourcedefinitions.apiextensions.k8s.io \"alertmanagers.monitoring.coreos.com\" not found",
+          "error: [NOT_FOUND] CustomResourceDefinition /alertmanagers.monitoring.coreos.com not found: customresourcedefinitions.apiextensions.k8s.io \"alertmanagers.monitoring.coreos.com\" not found",
+          "time=2026-08-26T17:45:50.189Z level=ERROR msg=FAIL message=\"[NOT_FOUND] Deployment agentgateway-system/agentgateway not found: deployments.apps \\\"agentgateway\\\" not found\""
+        ]
+      },
+      {
+        "name": "gpu-operator-version",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "message": "[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \"\u003e= v25.10.0\"",
+        "stdout": [
+          "time=2026-08-26T17:45:55.172Z level=INFO msg=\"starting check\" name=gpu-operator-version",
+          "Detected GPU Operator version: v25.3.4",
+          "Constraint: \u003e= v25.10.0 → false",
+          "time=2026-08-26T17:45:55.186Z level=ERROR msg=FAIL message=\"[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \\\"\u003e= v25.10.0\\\"\""
+        ]
+      },
+      {
+        "name": "check-nvidia-smi",
+        "status": "passed",
+        "duration": 58000,
+        "suite": [
+          "deployment"
+        ],
+        "stdout": [
+          "time=2026-08-26T17:45:59.242Z level=INFO msg=\"starting check\" name=check-nvidia-smi",
+          "Found 2 GPU node(s), 2 schedulable, 0 cordoned:",
+          "  mokka-aicr-stack-worker",
+          "  mokka-aicr-stack-worker2",
+          "All 2 GPU node(s) available. Verifying...",
+          "time=2026-08-26T17:45:59.258Z level=INFO msg=\"verifying node\" node=mokka-aicr-stack-worker",
+          "time=2026-08-26T17:45:59.258Z level=INFO msg=\"deploying nvidia-smi verify pod\" node=mokka-aicr-stack-worker podName=nvidia-smi-verify-mokka-aicr-stack-worker image=nvcr.io/nvidia/cuda:13.0.0-base-ubuntu22.04 namespace=aicr-validation",
+          "time=2026-08-26T17:45:59.262Z level=INFO msg=\"waiting for pod to reach Succeeded state\" name=nvidia-smi-verify-mokka-aicr-stack-worker",
+          "time=2026-08-26T17:45:59.284Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T17:45:59.669Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T17:46:27.407Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-26T17:46:27.807Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-26T17:46:28.813Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-26T17:46:28.885Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Succeeded",
+          "time=2026-08-26T17:46:28.885Z level=INFO msg=\"pod successfully completed\" name=nvidia-smi-verify-mokka-aicr-stack-worker",
+          "  mokka-aicr-stack-worker: OK",
+          "time=2026-08-26T17:46:28.892Z level=INFO msg=\"verifying node\" node=mokka-aicr-stack-worker2",
+          "time=2026-08-26T17:46:28.892Z level=INFO msg=\"deploying nvidia-smi verify pod\" node=mokka-aicr-stack-worker2 podName=nvidia-smi-verify-mokka-aicr-stack-worker2 image=nvcr.io/nvidia/cuda:13.0.0-base-ubuntu22.04 namespace=aicr-validation",
+          "time=2026-08-26T17:46:28.896Z level=INFO msg=\"waiting for pod to reach Succeeded state\" name=nvidia-smi-verify-mokka-aicr-stack-worker2",
+          "time=2026-08-26T17:46:28.905Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T17:46:29.286Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-26T17:46:55.834Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T17:46:56.524Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T17:46:57.525Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-26T17:46:57.604Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Succeeded",
+          "time=2026-08-26T17:46:57.604Z level=INFO msg=\"pod successfully completed\" name=nvidia-smi-verify-mokka-aicr-stack-worker2",
+          "  mokka-aicr-stack-worker2: OK",
+          "RESULT: nodesValidated: 2/2",
+          "Successfully verified GPU on all 2 schedulable node(s)"
+        ],
+        "extra": {
+          "nodesTotal": "2",
+          "nodesValidated": "2"
+        }
+      },
+      {
+        "name": "dra-support",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "stdout": [
+          "time=2026-08-26T17:48:52.785Z level=INFO msg=\"starting check\" name=dra-support",
+          "--- DRA driver namespace ---",
+          "Namespace: nvidia-dra-driver",
+          "Source:    resolved recipe componentRef nvidia-dra-driver-gpu",
+          "--- DRA API resources ---",
+          "Equivalent: kubectl api-resources --api-group=resource.k8s.io",
+          "",
+          "Served version: resource.k8s.io/v1",
+          "deviceclasses              DeviceClass            namespaced=false",
+          "resourceclaims             ResourceClaim          namespaced=true",
+          "resourceclaims/status      ResourceClaim          namespaced=true",
+          "resourceclaimtemplates     ResourceClaimTemplate  namespaced=true",
+          "resourceslices             ResourceSlice          namespaced=false",
+          "",
+          "--- DRA driver pods ---",
+          "Equivalent: kubectl get pods -n nvidia-dra-driver -o wide",
+          "",
+          "nvidia-dra-driver-gpu-controller-76c895d7c9-mnx7k ready=1/1 phase=Running node=mokka-aicr-stack-control-plane",
+          "nvidia-dra-driver-gpu-kubelet-plugin-77dsw       ready=2/2 phase=Running node=mokka-aicr-stack-worker2",
+          "nvidia-dra-driver-gpu-kubelet-plugin-f8j7h       ready=2/2 phase=Running node=mokka-aicr-stack-worker",
+          "",
+          "--- DRA Controller Deployment ---",
+          "Name:      nvidia-dra-driver/nvidia-dra-driver-gpu-controller",
+          "Replicas:  1/1 available",
+          "Image:     nvcr.io/nvidia/dra-driver-nvidia-gpu:v0.5.0",
+          "--- DRA Kubelet Plugin DaemonSet ---",
+          "Name:      nvidia-dra-driver/nvidia-dra-driver-gpu-kubelet-plugin",
+          "Ready:     2/2 pods",
+          "Image:     nvcr.io/nvidia/dra-driver-nvidia-gpu:v0.5.0",
+          "--- ResourceSlices ---",
+          "Equivalent: kubectl get resourceslices",
+          "",
+          "Total ResourceSlices: 4",
+          "00000-compute-domain.nvidia.com-mokka-aicr-stack-worker-nfxlp node=mokka-aicr-stack-worker driver=compute-domain.nvidia.com pool=mokka-aicr-stack-worker",
+          "00000-compute-domain.nvidia.com-mokka-aicr-stack-worker2-f4x2r node=mokka-aicr-stack-worker2 driver=compute-domain.nvidia.com pool=mokka-aicr-stack-worker2",
+          "00000-gpu.nvidia.com-mokka-aicr-stack-worker-hzxcs node=mokka-aicr-stack-worker driver=gpu.nvidia.com pool=mokka-aicr-stack-worker",
+          "00000-gpu.nvidia.com-mokka-aicr-stack-worker2-v58mw node=mokka-aicr-stack-worker2 driver=gpu.nvidia.com pool=mokka-aicr-stack-worker2",
+          "NVIDIA driver compute-domain.nvidia.com: 2 slice(s), usable device(s) on 2 Ready, schedulable node(s) [mokka-aicr-stack-worker,mokka-aicr-stack-worker2]",
+          "NVIDIA driver gpu.nvidia.com: 2 slice(s), usable device(s) on 2 Ready, schedulable node(s) [mokka-aicr-stack-worker,mokka-aicr-stack-worker2]",
+          "",
+          "--- GPU allocation policy ---",
+          "configured policy: device-plugin-extended-resource",
+          "--- GPU allocation mode ---",
+          "DRA (gpu.nvidia.com):              usable=true nodes=[mokka-aicr-stack-worker,mokka-aicr-stack-worker2]",
+          "Device plugin (nvidia.com/gpu):  usable=true nodes=[mokka-aicr-stack-worker,mokka-aicr-stack-worker2]",
+          "full-GPU DRA usable: DeviceClass gpu.nvidia.com exists (resource.k8s.io/v1) and 2 Ready, schedulable node(s) have advertised devices; note: DeviceClass carries 1 CEL selector(s), which this probe does not evaluate",
+          "device plugin usable: 2 Ready, schedulable node(s) with allocatable nvidia.com/gpu",
+          "time=2026-08-26T17:48:52.912Z level=WARN msg=\"both full-GPU DRA (gpu.nvidia.com) and the device plugin (nvidia.com/gpu) advertise GPUs on the same node(s) — GPU over-admission risk: the same physical GPU can be admitted through both mechanisms\" nodes=mokka-aicr-stack-worker,mokka-aicr-stack-worker2",
+          "extended-resource attribution: DeviceClass gpu.nvidia.com maps nvidia.com/gpu to DRA (spec.extendedResourceName) — allocatable nvidia.com/gpu may be served by DRA, not the device plugin",
+          "note: node eligibility is Ready+uncordoned only — node taints are not evaluated; workloads must tolerate any node taints",
+          "WARNING: both mechanisms advertise GPUs on node(s) [mokka-aicr-stack-worker,mokka-aicr-stack-worker2] — GPU over-admission risk",
+          "node-local raw gpu.nvidia.com ResourceSlice devices (unvalidated, kai-attributable): [mokka-aicr-stack-worker=4,mokka-aicr-stack-worker2=4] — kai-scheduler rejects scalar device-plugin GPU pods on these nodes",
+          "--- Behavioral GPU allocation ---",
+          "skipped (not applicable): configured GPU allocation policy is device-plugin-extended-resource — whole GPUs are device-plugin-allocated, so the full-GPU DRA behavioral subtest does not apply; DRA validated via driver health and validated ResourceSlices. full-GPU DRA usable: DeviceClass gpu.nvidia.com exists (resource.k8s.io/v1) and 2 Ready, schedulable node(s) have advertised devices; note: DeviceClass carries 1 CEL selector(s), which this probe does not evaluate"
+        ]
+      },
+      {
+        "name": "accelerator-metrics",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "stdout": [
+          "time=2026-08-26T17:48:57.919Z level=INFO msg=\"starting check\" name=accelerator-metrics",
+          "--- DCGM Exporter Metrics (sample) ---",
+          "# HELP DCGM_FI_DEV_SM_CLOCK SM clock frequency (in MHz).",
+          "# TYPE DCGM_FI_DEV_SM_CLOCK gauge",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"0\",UUID=\"GPU-b200b200-0000-0000-0000-000000000000\",pci_bus_id=\"00000000:0A:00.0\",device=\"nvidia0\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"1\",UUID=\"GPU-b200b200-0000-0000-0000-000000000001\",pci_bus_id=\"00000000:0B:00.0\",device=\"nvidia1\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"2\",UUID=\"GPU-b200b200-0000-0000-0000-000000000002\",pci_bus_id=\"00000000:4A:00.0\",device=\"nvidia2\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"3\",UUID=\"GPU-b200b200-0000-0000-0000-000000000003\",pci_bus_id=\"00000000:4B:00.0\",device=\"nvidia3\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "# HELP DCGM_FI_DEV_MEM_CLOCK Memory clock frequency (in MHz).",
+          "# TYPE DCGM_FI_DEV_MEM_CLOCK gauge",
+          "... [truncated]",
+          "--- Required DCGM Metrics ---",
+          "  DCGM_FI_DEV_GPU_UTIL           FOUND",
+          "  DCGM_FI_DEV_FB_USED            FOUND",
+          "  DCGM_FI_DEV_GPU_TEMP           FOUND",
+          "  DCGM_FI_DEV_POWER_USAGE        FOUND"
+        ]
+      },
+      {
+        "name": "ai-service-metrics",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\"",
+        "stdout": [
+          "time=2026-08-26T17:49:02.871Z level=INFO msg=\"starting check\" name=ai-service-metrics",
+          "time=2026-08-26T17:49:02.883Z level=ERROR msg=FAIL message=\"[NOT_FOUND] no Prometheus service with port 9090 found in namespace \\\"monitoring\\\"\""
+        ]
+      },
+      {
+        "name": "gpu-operator-health",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[INTERNAL] ClusterPolicy state=notReady (want ready)",
+        "stdout": [
+          "time=2026-08-26T17:49:06.810Z level=INFO msg=\"starting check\" name=gpu-operator-health",
+          "time=2026-08-26T17:49:06.827Z level=ERROR msg=FAIL message=\"[INTERNAL] ClusterPolicy state=notReady (want ready)\""
+        ]
+      },
+      {
+        "name": "platform-health",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] platform health check failed (8 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvsentinel: not found",
+        "stdout": [
+          "time=2026-08-26T17:49:11.186Z level=INFO msg=\"starting check\" name=platform-health",
+          "time=2026-08-26T17:49:11.205Z level=ERROR msg=FAIL message=\"[NOT_FOUND] platform health check failed (8 issues):\\n  namespace agentgateway-system: not found\\n  namespace cert-manager: not found\\n  namespace monitoring: not found\\n  namespace kai-scheduler: not found\\n  namespace nvidia-network-operator: not found\\n  namespace node-feature-discovery: not found\\n  namespace skyhook: not found\\n  namespace nvsentinel: not found\""
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aicr-sweep/results-57ef016/targeted-dra-installed/recipe.yaml
+++ b/tests/aicr-sweep/results-57ef016/targeted-dra-installed/recipe.yaml
@@ -1,0 +1,2021 @@
+apiVersion: aicr.run/v1alpha2
+componentRefs:
+  - chart: agentgateway
+    dependencyRefs:
+      - agentgateway-crds
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Agentgateway Health Check
+      #
+      # Validates that agentgateway is running and healthy in the agentgateway-system
+      # namespace. Checks that the agentgateway deployment has at least one available
+      # replica and that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # agentgateway deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: agentgateway
+                      namespace: agentgateway-system
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    manifestFiles:
+      - components/agentgateway/manifests/inference-gateway.yaml
+    name: agentgateway
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway/values.yaml
+    version: v1.3.1
+  - chart: agentgateway-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # agentgateway-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this component installs
+      # has reached the `Established=True` condition (CRD storage is up and
+      # the apiserver will accept CRs of those kinds).
+      #
+      # Scope: this component bundles BOTH the chart's agentgateway.dev/v1alpha1
+      # CRDs and the vendored Gateway API + Inference Extension manifests under
+      # recipes/components/agentgateway-crds/manifests/.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-gateway-api-crds-established
+            # Standard Gateway API CRDs vendored under
+            # manifests/gateway-api-crds.yaml. Verified against the in-tree
+            # manifest content.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gatewayclasses.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gateways.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: grpcroutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: httproutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: referencegrants.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-agentgateway-crds-established
+            # agentgateway.dev/v1alpha1 CRDs installed by the agentgateway-crds
+            # Helm chart.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaybackends.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewayparameters.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaypolicies.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-inference-extension-crds-established
+            # Gateway API Inference Extension CRDs vendored under
+            # manifests/inference-extension-crds.yaml.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencemodelrewrites.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferenceobjectives.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepoolimports.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    manifestFiles:
+      - components/agentgateway-crds/manifests/gateway-api-crds.yaml
+      - components/agentgateway-crds/manifests/inference-extension-crds.yaml
+    name: agentgateway-crds
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway-crds/values.yaml
+    version: v1.3.1
+  - chart: cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Cert Manager Health Check
+      #
+      # Validates that cert-manager is running and healthy in the cert-manager
+      # namespace. The chart deploys three Deployments — the controller
+      # (cert-manager), the CA injector (cert-manager-cainjector), and the
+      # webhook (cert-manager-webhook) — all of which must be available for
+      # the operator to issue / inject / validate certificates. The previous
+      # check only asserted the controller; this check covers all three to
+      # avoid silently passing while the webhook is down (which would block
+      # every Certificate/Issuer CR admission).
+      #
+      # Also asserts the three core CRDs are Established=True so the
+      # apiserver will accept CRs of those kinds (per #1222 / #660).
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: cert-manager-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: certificates.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: issuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterissuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-controller-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cainjector-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-cainjector
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-webhook-deployment
+            try:
+              # The webhook must be ready before any Certificate / Issuer CR
+              # can be admitted. Without this assert, a healthy controller
+              # with a dead webhook would still pass the check while the
+              # cluster silently rejects every cert-manager CR.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-webhook
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: cert-manager
+    namespace: cert-manager
+    source: https://charts.jetstack.io
+    type: Helm
+    valuesFile: components/cert-manager/values.yaml
+    version: v1.20.2
+  - chart: gpu-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # GPU Operator Health Check
+      #
+      # Validates the GPU operator stack:
+      # 1. The gpu-operator Deployment has at least one available replica.
+      # 2. The clusterpolicies.nvidia.com CRD is Established (apiserver will
+      #    accept the singleton ClusterPolicy CR).
+      # 3. The ClusterPolicy singleton named "cluster-policy" has reconciled
+      #    to status.state == "ready" — this is the deepest signal that the
+      #    full GPU stack (driver, toolkit, cuda, plugin DaemonSets, validators)
+      #    is healthy. Migrates the verifyClusterPolicyReady Go check that
+      #    PR #1235 task 7 deferred for assertion-equivalence proof.
+      # 4. No pods in unhealthy phases or stuck container-waiting states.
+      #
+      # The nvidia-operator-validator DaemonSet runs 4 sequential init
+      # containers (driver, toolkit, cuda, plugin) before reaching Running;
+      # the ClusterPolicy state assertion is the canonical post-reconcile
+      # signal that all four passed.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: gpu-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-cluster-policy-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterpolicies.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # gpu-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: gpu-operator
+                      namespace: gpu-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cluster-policy-ready
+            try:
+              # Deepest GPU readiness signal: ClusterPolicy singleton has
+              # reconciled to state=ready. Replaces the deferred
+              # verifyClusterPolicyReady Go check from PR #1235 task 7.
+              - assert:
+                  resource:
+                    apiVersion: nvidia.com/v1
+                    kind: ClusterPolicy
+                    metadata:
+                      name: cluster-policy
+                    status:
+                      state: ready
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: gpu-operator
+    namespace: gpu-operator
+    overrides:
+      daemonsets:
+        tolerations: []
+      dcgm:
+        enabled: false
+      dcgmExporter:
+        config:
+          create: false
+          data: ""
+          name: ""
+      devicePlugin:
+        env: []
+      driver:
+        enabled: false
+        rdma:
+          enabled: false
+      gdrcopy:
+        enabled: false
+      migManager:
+        enabled: false
+      operator:
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+      toolkit:
+        enabled: false
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/gpu-operator/values.yaml
+    version: v26.3.3
+  - chart: k8s-ephemeral-storage-metrics
+    dependencyRefs:
+      - kube-prometheus-stack
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # K8s Ephemeral Storage Metrics Health Check
+      #
+      # Validates that the k8s-ephemeral-storage-metrics Deployment is running and
+      # healthy in the monitoring namespace. Checks that the Deployment has at least
+      # one available replica and that no ephemeral storage metrics pods (selected by label)
+      # are stuck in Pending, Failed, or Unknown phases. Label selectors are used
+      # because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: k8s-ephemeral-storage-metrics-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the k8s-ephemeral-storage-metrics
+              # DaemonSet exists and has at least one ready pod.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: k8s-ephemeral-storage-metrics
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no ephemeral storage metrics pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: k8s-ephemeral-storage-metrics
+    namespace: monitoring
+    source: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
+    type: Helm
+    valuesFile: components/k8s-ephemeral-storage-metrics/values.yaml
+    version: 1.19.2
+  - chart: kai-scheduler
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # KAI Scheduler Health Check
+      #
+      # Validates that the KAI Scheduler is running and healthy in the kai-scheduler
+      # namespace. Checks that the kai-operator deployment has at least one
+      # available replica and that no pods in the namespace are stuck in Pending,
+      # Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kai-scheduler-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # kai-scheduler deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kai-operator
+                      namespace: kai-scheduler
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kai-scheduler
+    namespace: kai-scheduler
+    source: oci://ghcr.io/kai-scheduler/kai-scheduler
+    type: Helm
+    valuesFile: components/kai-scheduler/values.yaml
+    version: v0.14.1
+  - chart: kube-prometheus-stack
+    dependencyRefs:
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Kube Prometheus Stack Health Check
+      #
+      # Validates that the kube-prometheus-stack operator, its managed CRs, and
+      # associated workloads are running and healthy in the monitoring namespace:
+      #
+      # 1. The kube-prometheus-operator Deployment has at least one available replica.
+      # 2. The Prometheus CR (kube-prometheus-prometheus) reports Available=True.
+      #    This explicitly catches operator-level reconcile stalls (e.g., webhook
+      #    rejections) where a target StatefulSet might never be created at all.
+      # 3. The Alertmanager CR (kube-prometheus-alertmanager) reports Available=True.
+      # 4. The Prometheus StatefulSet (prometheus-kube-prometheus-prometheus) has
+      #    reached full rollout: readyReplicas >= replicas, with a replicas > 0
+      #    vacuous-pass guard so a missing StatefulSet does not silently pass.
+      # 5. The Alertmanager StatefulSet (alertmanager-kube-prometheus-alertmanager)
+      #    reaches the same full-rollout threshold.
+      # 6. No stack operator pods (label-scoped to app.kubernetes.io/name:
+      #    kube-prometheus-stack) are stuck in Pending, Failed, Unknown, or a
+      #    known-bad container-waiting reason (CrashLoopBackOff, ImagePullBackOff,
+      #    ErrImagePull, CreateContainerConfigError).
+      #
+      # StatefulSet and CR names are derived from fullnameOverride=kube-prometheus
+      # in recipes/components/kube-prometheus-stack/values.yaml. The prometheus-
+      # operator creates StatefulSets named <workload>-<cr-name>, and the chart
+      # renders CR names as <fullname>-<workload>. Names verified against
+      # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml and
+      # tests/chainsaw/ai-conformance/kind-common/assert-monitoring.yaml
+      # (both live-cluster-validated). Label selectors are used in the pod-health
+      # step because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kube-prometheus-stack-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the kube-prometheus-stack-operator
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kube-prometheus-operator
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-prometheus-cr-available
+            try:
+              # Assert the Prometheus CR has been reconciled by the operator.
+              # The prometheus-operator sets an Available condition on the CR once
+              # it has successfully reconciled the CR into a running StatefulSet.
+              # CR name kube-prometheus-prometheus derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -prometheus suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Prometheus
+                    metadata:
+                      name: kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-alertmanager-cr-available
+            try:
+              # Assert the Alertmanager CR has been reconciled by the operator.
+              # CR name kube-prometheus-alertmanager derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -alertmanager suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Alertmanager
+                    metadata:
+                      name: kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-prometheus-statefulset-ready
+            try:
+              # Assert the Prometheus StatefulSet created by the operator has
+              # reached full rollout. readyReplicas >= replicas ensures all pods
+              # are ready, not just some. The replicas > 0 guard prevents a
+              # vacuous pass when the StatefulSet is missing or has 0 replicas.
+              # StatefulSet name prometheus-kube-prometheus-prometheus is
+              # <workload>-<cr-name> per prometheus-operator convention, verified
+              # from tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: prometheus-kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-alertmanager-statefulset-ready
+            try:
+              # Assert the Alertmanager StatefulSet has reached full rollout.
+              # Same pattern as Prometheus above. StatefulSet name
+              # alertmanager-kube-prometheus-alertmanager is <workload>-<cr-name>
+              # per prometheus-operator convention, verified from
+              # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: alertmanager-kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus stack pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kube-prometheus-stack
+    namespace: monitoring
+    overrides:
+      alertmanager:
+        alertmanagerSpec:
+          resources:
+            limits:
+              cpu: 250m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+      defaultRules:
+        create: false
+      grafana:
+        enabled: false
+      prometheus:
+        prometheusSpec:
+          resources:
+            limits:
+              cpu: 1
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          retention: 7d
+          storageSpec:
+            emptyDir:
+              medium: ""
+              sizeLimit: 5Gi
+      prometheusOperator:
+        alertmanagerConfigNamespaces:
+          - monitoring
+        alertmanagerInstanceNamespaces:
+          - monitoring
+        livenessProbe:
+          failureThreshold: 10
+          timeoutSeconds: 10
+        prometheusInstanceNamespaces:
+          - monitoring
+        readinessProbe:
+          failureThreshold: 6
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        thanosRulerInstanceNamespaces:
+          - monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/kube-prometheus-stack/values.yaml
+    version: 84.4.0
+  - chart: network-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Network Operator Health Check
+      #
+      # Validates that the NVIDIA Network Operator is running and healthy in
+      # the nvidia-network-operator namespace. Also asserts
+      # nicclusterpolicies.mellanox.com is Established=True (verified against
+      # chart 26.4.1; re-verify on defaultVersion bump). Chart 26.4.1 also
+      # ships nicnodepolicies.mellanox.com, deliberately NOT asserted here:
+      # no in-tree recipe instantiates a CR against it, so it fails the same
+      # load-bearing-only bar the rest of this PR's assertions are held to.
+      # Checks that the
+      # network-operator deployment has at least one available replica and
+      # that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: network-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: nicclusterpolicies.mellanox.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # network-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: network-operator
+                      namespace: nvidia-network-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: network-operator
+    namespace: nvidia-network-operator
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/network-operator/values.yaml
+    version: 26.4.1
+  - chart: node-feature-discovery
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Node Feature Discovery Health Check
+      #
+      # Validates the standalone NFD deployment by checking:
+      # 1. NFD Master Deployment has at least one ready replica
+      # 2. NFD Worker DaemonSet has fully rolled out (desiredNumberScheduled > 0
+      #    and numberReady == desiredNumberScheduled, so partial failures don't pass)
+      # 3. NFD GC Deployment has at least one ready replica (gc.enable: true)
+      #
+      # Resource names: AICR deploys the kubernetes-sigs/node-feature-discovery
+      # chart under release name "nfd" (matching the ComponentRef Name in
+      # recipes/registry.yaml). The chart's fullname template prefixes the
+      # release name to the chart name when they don't overlap, yielding
+      # "nfd-node-feature-discovery-*" for the master Deployment, worker
+      # DaemonSet, and gc Deployment. If a deployer ever switches the release
+      # name to "node-feature-discovery", these asserts need updating in
+      # lockstep.
+      # 4. No pods in unhealthy phases (Pending, Failed, Unknown) or stuck in
+      #    Running with a known-unhealthy container waiting reason
+      #    (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+      #    CreateContainerConfigError)
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nfd-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-master-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-master
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-worker-daemonset
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nfd-node-feature-discovery-worker
+                      namespace: node-feature-discovery
+                    status:
+                      # Guard against vacuous pass when 0 nodes match the
+                      # DaemonSet: require at least one scheduled pod.
+                      (desiredNumberScheduled > `0`): true
+                      # Full rollout: every scheduled pod is ready. Combined with
+                      # the guard above, this rejects partial failures. We assert on
+                      # numberReady (always present in DaemonSetStatus) rather than
+                      # numberUnavailable, which is `omitempty` and disappears from
+                      # the status when zero — making `numberUnavailable == 0`
+                      # evaluate `null == 0` (false) on a fully-healthy DaemonSet.
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-gc-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-gc
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nfd
+    namespace: node-feature-discovery
+    source: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+    type: Helm
+    valuesFile: components/nfd/values.yaml
+    version: 0.19.0
+  - chart: nodewright
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Nodewright Operator Health Check
+      #
+      # Validates that the Nodewright Operator is running and healthy in the
+      # skyhook namespace:
+      # 1. skyhooks.skyhook.nvidia.com CRD Established=True (the apiserver
+      #    will accept Skyhook CRs that nodewright-customizations declares).
+      # 2. skyhook-operator-controller-manager Deployment has at least one
+      #    available replica.
+      # 3. No pods stuck in Pending/Failed/Unknown phases or known-bad
+      #    container-waiting states.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nodewright-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-skyhook-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: skyhooks.skyhook.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: skyhook-operator-controller-manager
+                      namespace: skyhook
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nodewright-operator
+    namespace: skyhook
+    overrides:
+      controllerManager:
+        manager:
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+    source: oci://ghcr.io/nvidia/nodewright/charts
+    type: Helm
+    valuesFile: components/nodewright-operator/values.yaml
+    version: v0.17.1
+  - chart: dra-driver-nvidia-gpu
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVIDIA DRA Driver GPU Health Check
+      #
+      # Validates that the NVIDIA DRA (Dynamic Resource Allocation) GPU driver
+      # is running and healthy in the nvidia-dra-driver namespace. The
+      # kubelet-plugin DaemonSet must roll out fully — numberReady ==
+      # desiredNumberScheduled (with desiredNumberScheduled > 0 as a guard).
+      # Previous check gated only on numberReady > 0, passing on partial
+      # failures; see #1222 and recipes/checks/nfd/health-check.yaml for
+      # the same rationale.
+      #
+      # Resource names: the DaemonSet name is release-derived
+      # (<release>-kubelet-plugin). AICR's release name is
+      # `nvidia-dra-driver-gpu` (matches ComponentRef Name in registry.yaml).
+      # If a deployer renames the release, this assert needs updating in
+      # lockstep — see verifyDRAKubeletPluginReady commentary in
+      # validators/deployment/expected_resources.go for why a chart-shape
+      # label would be a more robust selector.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvidia-dra-driver-gpu-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-kubelet-plugin-daemonset-fully-rolled-out
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nvidia-dra-driver-gpu-kubelet-plugin
+                      namespace: nvidia-dra-driver
+                    status:
+                      (desiredNumberScheduled > `0`): true
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvidia-dra-driver-gpu
+    namespace: nvidia-dra-driver
+    overrides:
+      nvidiaDriverRoot: /
+    source: oci://registry.k8s.io/dra-driver-nvidia/charts
+    type: Helm
+    valuesFile: components/nvidia-dra-driver-gpu/values.yaml
+    version: 0.4.1
+  - chart: nvsentinel
+    dependencyRefs:
+      - cert-manager
+      - gpu-operator
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVSentinel Health Check
+      #
+      # Validates that the NVSentinel labeler is running and healthy in
+      # the nvsentinel namespace. Checks that the labeler deployment has at
+      # least one available replica and that no pods in the
+      # namespace are stuck in Pending, Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvsentinel-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # nvsentinel-controller-manager deployment exists and has at least
+              # one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: labeler
+                      namespace: nvsentinel
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvsentinel
+    namespace: nvsentinel
+    overrides:
+      platformConnector:
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+    source: oci://ghcr.io/nvidia
+    type: Helm
+    valuesFile: components/nvsentinel/values.yaml
+    version: v1.9.0
+  - chart: prometheus-adapter
+    dependencyRefs:
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Prometheus Adapter Health Check
+      #
+      # Validates that the Prometheus Adapter is running and healthy in the
+      # monitoring namespace. Checks that the prometheus-adapter deployment has
+      # at least one available replica and that no prometheus adapter pods
+      # (selected by label) are stuck in Pending, Failed, or Unknown phases.
+      # Label selectors are used because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-adapter-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the prometheus-adapter
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: prometheus-adapter
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus adapter pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: prometheus-adapter
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-adapter/values.yaml
+    version: 5.3.0
+  - chart: prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # prometheus-operator-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this chart installs has
+      # reached the `Established=True` condition (CRD storage is up and the
+      # apiserver will accept CRs of those kinds).
+      #
+      # CRDs come from the upstream prometheus-community/prometheus-operator-crds
+      # chart pinned to 28.0.1 in recipes/registry.yaml. The 8 kinds under
+      # monitoring.coreos.com/v1 are enumerated in
+      # recipes/components/prometheus-operator-crds/values.yaml header:
+      # Alertmanager, AlertmanagerConfig, PodMonitor, Probe, Prometheus,
+      # PrometheusRule, ServiceMonitor, ThanosRuler. Plural names match the
+      # long-standing upstream prometheus-operator chart shape.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-operator-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-prometheus-operator-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagerconfigs.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: podmonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: probes.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheuses.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheusrules.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: servicemonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: thanosrulers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    name: prometheus-operator-crds
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-operator-crds/values.yaml
+    version: 28.0.1
+constraints:
+  - name: K8s.server.version
+    value: '>= 1.30'
+criteria:
+  accelerator: gb200
+  intent: inference
+  os: any
+  platform: any
+  service: kind
+deploymentOrder:
+  - agentgateway-crds
+  - cert-manager
+  - agentgateway
+  - nfd
+  - network-operator
+  - nodewright-operator
+  - prometheus-operator-crds
+  - kube-prometheus-stack
+  - gpu-operator
+  - k8s-ephemeral-storage-metrics
+  - kai-scheduler
+  - nvidia-dra-driver-gpu
+  - nvsentinel
+  - prometheus-adapter
+kind: RecipeResult
+metadata:
+  appliedOverlays:
+    - base
+    - monitoring-hpa
+    - gb200-any
+    - kind
+    - kind-inference
+  version: dev
+validation:
+  conformance:
+    checks:
+      - platform-health
+      - gpu-operator-health
+      - dra-support
+      - accelerator-metrics
+      - ai-service-metrics
+  deployment:
+    checks:
+      - operator-health
+      - expected-resources
+      - gpu-operator-version
+      - check-nvidia-smi
+    constraints:
+      - name: Deployment.gpu-operator.version
+        value: '>= v25.10.0'

--- a/tests/aicr-sweep/results/aicr-agent-static-linkage-evidence.log
+++ b/tests/aicr-sweep/results/aicr-agent-static-linkage-evidence.log
@@ -1,0 +1,74 @@
+# Evidence: AICR's snapshot agent cannot be reached by library interception
+# Captured 2026-08-27. Raised by Giulio Calzolari in Slack; verified here
+# independently against the published image before being written down.
+
+## The symptom, recorded in this sweep before the cause was known
+
+The base cell's validate log, line 12:
+
+  [cli] snapshot has no GPU data but cluster topology shows GPU-capable nodes
+        - agent likely ran on a non-GPU node
+        fix_1=--node-selector nvidia.com/gpu.present=true
+        fix_2=--node-selector kubernetes.io/hostname=<gpu-node>
+        fix_3=--require-gpu
+        fix_4=--runtime-class nvidia
+
+All four of AICR's own suggested fixes are about node PLACEMENT. None of them
+addresses the actual cause, and the agent had in fact been auto-targeted onto a
+GPU-labelled node already (line 5: selector=nvidia.com/gpu.present=true).
+
+## The cause, verified
+
+ghcr.io/nvidia/aicr:latest is a distroless ko image: it has no shell, so the
+binary was extracted with docker cp and inspected on the host.
+
+  file:
+    /ko-app/aicr: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV),
+    statically linked, Go BuildID=..., stripped
+
+  program headers (parsed from the ELF directly):
+    PT_PHDR, PT_NOTE, PT_LOAD, PT_LOAD, PT_LOAD, GNU_STACK
+
+    PT_INTERP   : ABSENT
+    PT_DYNAMIC  : ABSENT
+
+With no PT_INTERP the kernel never invokes a dynamic loader, so LD_PRELOAD and
+LD_LIBRARY_PATH are inert by construction, not by configuration. With no
+PT_DYNAMIC there is no dynamic symbol resolution to hook at all. Mokka's NRI
+plugin injects an overlay mount and library environment; against this binary the
+environment half has nothing to act on.
+
+The agent therefore reads the node's REAL sysfs, which on a stock kind node has
+no NVIDIA devices, and reports no GPU data.
+
+## What this does and does not affect
+
+DOES NOT affect the checks that passed in this sweep. check-nvidia-smi and
+accelerator-metrics run their own pods, which are ordinary dynamically linked
+consumers and are reachable through the NRI overlay. Those passes stand.
+
+DOES affect anything downstream of the agent's SNAPSHOT: the cluster inventory
+AICR builds before dispatching checks. That inventory reports no GPUs on a
+cluster where the GPU Operator, device plugin and dcgm-exporter are all working
+off the mock.
+
+## Why this is a distinct cause class
+
+The sweep's cause codes are K (kind artifact), U (upstream unreleased), X (AICR
+catalog gap) and BUDGET. This is none of them. It is not a Mokka defect: Mokka
+renders everything correctly and injects it correctly. It is not an AICR defect:
+a static build is a legitimate, deliberate choice for a ko-built agent. It is an
+INTERCEPTION-MODEL MISMATCH, and no amount of configuration on either side closes
+it. Closing it needs one of:
+
+  - the agent reading GPU state from the Kubernetes API (labels, capacity,
+    ResourceSlices) rather than from sysfs, or
+  - a filesystem-level graft of Mokka's rendered sysfs over the agent's /sys,
+    which is the same mechanism gpu-feature-discovery needs
+    (see results/gfd-sysfs-evidence.log), or
+  - a dynamically linked agent build.
+
+Note the convergence with the GFD finding: two independent consumers, both
+defeated by reading the real /sys rather than Mokka's rendered tree. GFD is
+dynamically linked and fails on a sysfs PATH; the agent is static and fails on
+sysfs CONTENT. The common fix is a filesystem graft, not library interception.

--- a/tests/aicr-sweep/results/aicr-recipe-matrix-evidence.log
+++ b/tests/aicr-sweep/results/aicr-recipe-matrix-evidence.log
@@ -1,0 +1,31 @@
+# Evidence: AICR recipe resolution on the kind service, pinned 0752ea14
+# Captured 2026-08-26T14:18:00Z by running the CLI, not by reading the catalog.
+#
+# Reason: two cells (base-gb200-kind-training-stack, axis-compute-domain-fabric)
+# declare intent=training and were recorded as BUDGET and U respectively. Neither
+# cell ever ran, so neither attribution was tested. Both are X: AICR resolves no
+# training recipe for gb200 on kind, so the cell fails before memory or the DRA
+# driver release can matter.
+
+ACCEL          INTENT     RC   MESSAGE
+gb200          inference  0    
+gb200          training   2    [INVALID_REQUEST] no recipe provides intent 'training' for criteria(service=kind, accelerator=gb200, intent=training)
+gb300          inference  2    [INVALID_REQUEST] no recipe provides accelerator 'gb300' for criteria(service=kind, accelerator=gb300, intent=inference)
+gb300          training   2    [INVALID_REQUEST] no recipe provides accelerator 'gb300' for criteria(service=kind, accelerator=gb300, intent=training); no recipe provides intent 'training' for criteria(service=kind, accelerator=gb300, intent=training)
+h100           inference  0    
+h100           training   0    
+h200           inference  0    
+h200           training   2    [INVALID_REQUEST] no recipe provides intent 'training' for criteria(service=kind, accelerator=h200, intent=training)
+b200           inference  0    
+b200           training   2    [INVALID_REQUEST] no recipe provides intent 'training' for criteria(service=kind, accelerator=b200, intent=training)
+a100           inference  0    
+a100           training   2    [INVALID_REQUEST] no recipe provides intent 'training' for criteria(service=kind, accelerator=a100, intent=training)
+l40s           inference  0    
+l40s           training   2    [INVALID_REQUEST] no recipe provides intent 'training' for criteria(service=kind, accelerator=l40s, intent=training)
+rtx-pro-6000   inference  0    
+rtx-pro-6000   training   2    [INVALID_REQUEST] no recipe provides intent 'training' for criteria(service=kind, accelerator=rtx-pro-6000, intent=training)
+
+## Summary
+- inference resolves for 7 accelerators: gb200 h100 h200 b200 a100 l40s rtx-pro-6000
+- training resolves for exactly one: h100
+- gb300 resolves for neither (no such accelerator in the catalog)

--- a/tests/aicr-sweep/results/base-gb200-kind-inference-stack/ctrf/validate.json
+++ b/tests/aicr-sweep/results/base-gb200-kind-inference-stack/ctrf/validate.json
@@ -1,0 +1,196 @@
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-08-03T06:39:26Z",
+  "generatedBy": "aicr",
+  "results": {
+    "tool": {
+      "name": "aicr",
+      "version": "dev"
+    },
+    "summary": {
+      "tests": 9,
+      "passed": 3,
+      "failed": 5,
+      "skipped": 0,
+      "pending": 0,
+      "other": 1,
+      "start": 1785738625802,
+      "stop": 1785739202219
+    },
+    "tests": [
+      {
+        "name": "operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "stdout": [
+          "time=2026-08-03T06:30:33.229Z level=INFO msg=\"starting check\" name=operator-health",
+          "time=2026-08-03T06:30:33.238Z level=INFO msg=\"listing pods\" namespace=gpu-operator label=\"app=gpu-operator\"",
+          "Found 1 gpu-operator pod(s):",
+          "time=2026-08-03T06:30:33.244Z level=INFO msg=\"operator-health: passed\" running=1",
+          "  gpu-operator-869cf5b4c-2vwvk: Running",
+          "Running: 1/1"
+        ]
+      },
+      {
+        "name": "expected-resources",
+        "status": "other",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "message": "pod not found for Job aicr-expected-resources-906acd01: [NOT_FOUND] pod for job not found"
+      },
+      {
+        "name": "gpu-operator-version",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ],
+        "message": "[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \"\u003e= v25.10.0\"",
+        "stdout": [
+          "time=2026-08-03T06:38:37.496Z level=INFO msg=\"starting check\" name=gpu-operator-version",
+          "Detected GPU Operator version: v25.3.4",
+          "Constraint: \u003e= v25.10.0 → false",
+          "time=2026-08-03T06:38:37.515Z level=ERROR msg=FAIL message=\"[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \\\"\u003e= v25.10.0\\\"\""
+        ]
+      },
+      {
+        "name": "check-nvidia-smi",
+        "status": "passed",
+        "duration": 42000,
+        "suite": [
+          "deployment"
+        ],
+        "stdout": [
+          "time=2026-08-03T06:38:41.167Z level=INFO msg=\"starting check\" name=check-nvidia-smi",
+          "Found 2 GPU node(s):",
+          "  mokka-aicr-stack-worker",
+          "  mokka-aicr-stack-worker2",
+          "All 2 GPU node(s) available. Verifying...",
+          "time=2026-08-03T06:38:41.187Z level=INFO msg=\"verifying node\" node=mokka-aicr-stack-worker",
+          "time=2026-08-03T06:38:41.187Z level=INFO msg=\"deploying nvidia-smi verify pod\" node=mokka-aicr-stack-worker podName=nvidia-smi-verify-mokka-aicr-stack-worker image=nvcr.io/nvidia/cuda:13.0.0-base-ubuntu22.04 namespace=aicr-validation",
+          "time=2026-08-03T06:38:41.193Z level=INFO msg=\"waiting for pod to reach Succeeded state\" name=nvidia-smi-verify-mokka-aicr-stack-worker",
+          "time=2026-08-03T06:38:41.537Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-03T06:38:41.942Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-03T06:39:00.025Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-03T06:39:01.023Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-03T06:39:02.027Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Running",
+          "time=2026-08-03T06:39:02.094Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker status=Succeeded",
+          "time=2026-08-03T06:39:02.094Z level=INFO msg=\"pod successfully completed\" name=nvidia-smi-verify-mokka-aicr-stack-worker",
+          "  mokka-aicr-stack-worker: OK",
+          "time=2026-08-03T06:39:02.105Z level=INFO msg=\"verifying node\" node=mokka-aicr-stack-worker2",
+          "time=2026-08-03T06:39:02.105Z level=INFO msg=\"deploying nvidia-smi verify pod\" node=mokka-aicr-stack-worker2 podName=nvidia-smi-verify-mokka-aicr-stack-worker2 image=nvcr.io/nvidia/cuda:13.0.0-base-ubuntu22.04 namespace=aicr-validation",
+          "time=2026-08-03T06:39:02.108Z level=INFO msg=\"waiting for pod to reach Succeeded state\" name=nvidia-smi-verify-mokka-aicr-stack-worker2",
+          "time=2026-08-03T06:39:02.348Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-03T06:39:02.764Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Pending waitingReason=ContainerCreating",
+          "time=2026-08-03T06:39:20.678Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-03T06:39:22.089Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Running",
+          "time=2026-08-03T06:39:23.174Z level=INFO msg=\"pod current phase\" name=nvidia-smi-verify-mokka-aicr-stack-worker2 status=Succeeded",
+          "time=2026-08-03T06:39:23.174Z level=INFO msg=\"pod successfully completed\" name=nvidia-smi-verify-mokka-aicr-stack-worker2",
+          "  mokka-aicr-stack-worker2: OK",
+          "Successfully verified GPU on all 2 nodes"
+        ]
+      },
+      {
+        "name": "dra-support",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found",
+        "stdout": [
+          "time=2026-08-03T06:39:32.808Z level=INFO msg=\"starting check\" name=dra-support",
+          "--- DRA driver namespace ---",
+          "Namespace: nvidia-dra-driver",
+          "Source:    resolved recipe componentRef nvidia-dra-driver-gpu",
+          "--- DRA API resources ---",
+          "Equivalent: kubectl api-resources --api-group=resource.k8s.io",
+          "",
+          "Served version: resource.k8s.io/v1",
+          "deviceclasses              DeviceClass            namespaced=false",
+          "resourceclaims             ResourceClaim          namespaced=true",
+          "resourceclaims/status      ResourceClaim          namespaced=true",
+          "resourceclaimtemplates     ResourceClaimTemplate  namespaced=true",
+          "resourceslices             ResourceSlice          namespaced=false",
+          "",
+          "--- DRA driver pods ---",
+          "Equivalent: kubectl get pods -n nvidia-dra-driver -o wide",
+          "",
+          "",
+          "time=2026-08-03T06:39:32.835Z level=ERROR msg=FAIL message=\"[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \\\"nvidia-dra-driver-gpu-controller\\\" not found\""
+        ]
+      },
+      {
+        "name": "accelerator-metrics",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "stdout": [
+          "time=2026-08-03T06:39:36.154Z level=INFO msg=\"starting check\" name=accelerator-metrics",
+          "--- DCGM Exporter Metrics (sample) ---",
+          "# HELP DCGM_FI_DEV_SM_CLOCK SM clock frequency (in MHz).",
+          "# TYPE DCGM_FI_DEV_SM_CLOCK gauge",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"0\",UUID=\"GPU-b200b200-0000-0000-0000-000000000000\",pci_bus_id=\"0000:0A:00.0\",device=\"nvidia0\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"1\",UUID=\"GPU-b200b200-0000-0000-0000-000000000001\",pci_bus_id=\"0000:0B:00.0\",device=\"nvidia1\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"2\",UUID=\"GPU-b200b200-0000-0000-0000-000000000002\",pci_bus_id=\"0000:4A:00.0\",device=\"nvidia2\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"3\",UUID=\"GPU-b200b200-0000-0000-0000-000000000003\",pci_bus_id=\"0000:4B:00.0\",device=\"nvidia3\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"4\",UUID=\"GPU-b200b200-0000-0000-0000-000000000004\",pci_bus_id=\"0000:8A:00.0\",device=\"nvidia4\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"5\",UUID=\"GPU-b200b200-0000-0000-0000-000000000005\",pci_bus_id=\"0000:8B:00.0\",device=\"nvidia5\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "... [truncated]",
+          "--- Required DCGM Metrics ---",
+          "  DCGM_FI_DEV_GPU_UTIL           FOUND",
+          "  DCGM_FI_DEV_FB_USED            FOUND",
+          "  DCGM_FI_DEV_GPU_TEMP           FOUND",
+          "  DCGM_FI_DEV_POWER_USAGE        FOUND"
+        ]
+      },
+      {
+        "name": "ai-service-metrics",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\"",
+        "stdout": [
+          "time=2026-08-03T06:39:51.612Z level=INFO msg=\"starting check\" name=ai-service-metrics",
+          "time=2026-08-03T06:39:51.626Z level=ERROR msg=FAIL message=\"[NOT_FOUND] no Prometheus service with port 9090 found in namespace \\\"monitoring\\\"\""
+        ]
+      },
+      {
+        "name": "gpu-operator-health",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[INTERNAL] ClusterPolicy state=notReady (want ready)",
+        "stdout": [
+          "time=2026-08-03T06:39:55.316Z level=INFO msg=\"starting check\" name=gpu-operator-health",
+          "time=2026-08-03T06:39:55.332Z level=ERROR msg=FAIL message=\"[INTERNAL] ClusterPolicy state=notReady (want ready)\""
+        ]
+      },
+      {
+        "name": "platform-health",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] platform health check failed (9 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvidia-dra-driver: not found\n  namespace nvsentinel: not found",
+        "stdout": [
+          "time=2026-08-03T06:39:59.226Z level=INFO msg=\"starting check\" name=platform-health",
+          "time=2026-08-03T06:39:59.266Z level=ERROR msg=FAIL message=\"[NOT_FOUND] platform health check failed (9 issues):\\n  namespace agentgateway-system: not found\\n  namespace cert-manager: not found\\n  namespace monitoring: not found\\n  namespace kai-scheduler: not found\\n  namespace nvidia-network-operator: not found\\n  namespace node-feature-discovery: not found\\n  namespace skyhook: not found\\n  namespace nvidia-dra-driver: not found\\n  namespace nvsentinel: not found\""
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aicr-sweep/results/base-gb200-kind-inference-stack/recipe.yaml
+++ b/tests/aicr-sweep/results/base-gb200-kind-inference-stack/recipe.yaml
@@ -1,0 +1,2021 @@
+apiVersion: aicr.run/v1alpha2
+componentRefs:
+  - chart: agentgateway
+    dependencyRefs:
+      - agentgateway-crds
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Agentgateway Health Check
+      #
+      # Validates that agentgateway is running and healthy in the agentgateway-system
+      # namespace. Checks that the agentgateway deployment has at least one available
+      # replica and that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # agentgateway deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: agentgateway
+                      namespace: agentgateway-system
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    manifestFiles:
+      - components/agentgateway/manifests/inference-gateway.yaml
+    name: agentgateway
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway/values.yaml
+    version: v1.3.1
+  - chart: agentgateway-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # agentgateway-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this component installs
+      # has reached the `Established=True` condition (CRD storage is up and
+      # the apiserver will accept CRs of those kinds).
+      #
+      # Scope: this component bundles BOTH the chart's agentgateway.dev/v1alpha1
+      # CRDs and the vendored Gateway API + Inference Extension manifests under
+      # recipes/components/agentgateway-crds/manifests/.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-gateway-api-crds-established
+            # Standard Gateway API CRDs vendored under
+            # manifests/gateway-api-crds.yaml. Verified against the in-tree
+            # manifest content.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gatewayclasses.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gateways.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: grpcroutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: httproutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: referencegrants.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-agentgateway-crds-established
+            # agentgateway.dev/v1alpha1 CRDs installed by the agentgateway-crds
+            # Helm chart.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaybackends.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewayparameters.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaypolicies.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-inference-extension-crds-established
+            # Gateway API Inference Extension CRDs vendored under
+            # manifests/inference-extension-crds.yaml.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencemodelrewrites.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferenceobjectives.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepoolimports.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    manifestFiles:
+      - components/agentgateway-crds/manifests/gateway-api-crds.yaml
+      - components/agentgateway-crds/manifests/inference-extension-crds.yaml
+    name: agentgateway-crds
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway-crds/values.yaml
+    version: v1.3.1
+  - chart: cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Cert Manager Health Check
+      #
+      # Validates that cert-manager is running and healthy in the cert-manager
+      # namespace. The chart deploys three Deployments — the controller
+      # (cert-manager), the CA injector (cert-manager-cainjector), and the
+      # webhook (cert-manager-webhook) — all of which must be available for
+      # the operator to issue / inject / validate certificates. The previous
+      # check only asserted the controller; this check covers all three to
+      # avoid silently passing while the webhook is down (which would block
+      # every Certificate/Issuer CR admission).
+      #
+      # Also asserts the three core CRDs are Established=True so the
+      # apiserver will accept CRs of those kinds (per #1222 / #660).
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: cert-manager-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: certificates.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: issuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterissuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-controller-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cainjector-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-cainjector
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-webhook-deployment
+            try:
+              # The webhook must be ready before any Certificate / Issuer CR
+              # can be admitted. Without this assert, a healthy controller
+              # with a dead webhook would still pass the check while the
+              # cluster silently rejects every cert-manager CR.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-webhook
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: cert-manager
+    namespace: cert-manager
+    source: https://charts.jetstack.io
+    type: Helm
+    valuesFile: components/cert-manager/values.yaml
+    version: v1.20.2
+  - chart: gpu-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # GPU Operator Health Check
+      #
+      # Validates the GPU operator stack:
+      # 1. The gpu-operator Deployment has at least one available replica.
+      # 2. The clusterpolicies.nvidia.com CRD is Established (apiserver will
+      #    accept the singleton ClusterPolicy CR).
+      # 3. The ClusterPolicy singleton named "cluster-policy" has reconciled
+      #    to status.state == "ready" — this is the deepest signal that the
+      #    full GPU stack (driver, toolkit, cuda, plugin DaemonSets, validators)
+      #    is healthy. Migrates the verifyClusterPolicyReady Go check that
+      #    PR #1235 task 7 deferred for assertion-equivalence proof.
+      # 4. No pods in unhealthy phases or stuck container-waiting states.
+      #
+      # The nvidia-operator-validator DaemonSet runs 4 sequential init
+      # containers (driver, toolkit, cuda, plugin) before reaching Running;
+      # the ClusterPolicy state assertion is the canonical post-reconcile
+      # signal that all four passed.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: gpu-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-cluster-policy-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterpolicies.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # gpu-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: gpu-operator
+                      namespace: gpu-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cluster-policy-ready
+            try:
+              # Deepest GPU readiness signal: ClusterPolicy singleton has
+              # reconciled to state=ready. Replaces the deferred
+              # verifyClusterPolicyReady Go check from PR #1235 task 7.
+              - assert:
+                  resource:
+                    apiVersion: nvidia.com/v1
+                    kind: ClusterPolicy
+                    metadata:
+                      name: cluster-policy
+                    status:
+                      state: ready
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: gpu-operator
+    namespace: gpu-operator
+    overrides:
+      daemonsets:
+        tolerations: []
+      dcgm:
+        enabled: false
+      dcgmExporter:
+        config:
+          create: false
+          data: ""
+          name: ""
+      devicePlugin:
+        env: []
+      driver:
+        enabled: false
+        rdma:
+          enabled: false
+      gdrcopy:
+        enabled: false
+      migManager:
+        enabled: false
+      operator:
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+      toolkit:
+        enabled: false
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/gpu-operator/values.yaml
+    version: v26.3.3
+  - chart: k8s-ephemeral-storage-metrics
+    dependencyRefs:
+      - kube-prometheus-stack
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # K8s Ephemeral Storage Metrics Health Check
+      #
+      # Validates that the k8s-ephemeral-storage-metrics Deployment is running and
+      # healthy in the monitoring namespace. Checks that the Deployment has at least
+      # one available replica and that no ephemeral storage metrics pods (selected by label)
+      # are stuck in Pending, Failed, or Unknown phases. Label selectors are used
+      # because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: k8s-ephemeral-storage-metrics-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the k8s-ephemeral-storage-metrics
+              # DaemonSet exists and has at least one ready pod.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: k8s-ephemeral-storage-metrics
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no ephemeral storage metrics pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: k8s-ephemeral-storage-metrics
+    namespace: monitoring
+    source: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
+    type: Helm
+    valuesFile: components/k8s-ephemeral-storage-metrics/values.yaml
+    version: 1.19.2
+  - chart: kai-scheduler
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # KAI Scheduler Health Check
+      #
+      # Validates that the KAI Scheduler is running and healthy in the kai-scheduler
+      # namespace. Checks that the kai-operator deployment has at least one
+      # available replica and that no pods in the namespace are stuck in Pending,
+      # Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kai-scheduler-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # kai-scheduler deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kai-operator
+                      namespace: kai-scheduler
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kai-scheduler
+    namespace: kai-scheduler
+    source: oci://ghcr.io/kai-scheduler/kai-scheduler
+    type: Helm
+    valuesFile: components/kai-scheduler/values.yaml
+    version: v0.14.1
+  - chart: kube-prometheus-stack
+    dependencyRefs:
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Kube Prometheus Stack Health Check
+      #
+      # Validates that the kube-prometheus-stack operator, its managed CRs, and
+      # associated workloads are running and healthy in the monitoring namespace:
+      #
+      # 1. The kube-prometheus-operator Deployment has at least one available replica.
+      # 2. The Prometheus CR (kube-prometheus-prometheus) reports Available=True.
+      #    This explicitly catches operator-level reconcile stalls (e.g., webhook
+      #    rejections) where a target StatefulSet might never be created at all.
+      # 3. The Alertmanager CR (kube-prometheus-alertmanager) reports Available=True.
+      # 4. The Prometheus StatefulSet (prometheus-kube-prometheus-prometheus) has
+      #    reached full rollout: readyReplicas >= replicas, with a replicas > 0
+      #    vacuous-pass guard so a missing StatefulSet does not silently pass.
+      # 5. The Alertmanager StatefulSet (alertmanager-kube-prometheus-alertmanager)
+      #    reaches the same full-rollout threshold.
+      # 6. No stack operator pods (label-scoped to app.kubernetes.io/name:
+      #    kube-prometheus-stack) are stuck in Pending, Failed, Unknown, or a
+      #    known-bad container-waiting reason (CrashLoopBackOff, ImagePullBackOff,
+      #    ErrImagePull, CreateContainerConfigError).
+      #
+      # StatefulSet and CR names are derived from fullnameOverride=kube-prometheus
+      # in recipes/components/kube-prometheus-stack/values.yaml. The prometheus-
+      # operator creates StatefulSets named <workload>-<cr-name>, and the chart
+      # renders CR names as <fullname>-<workload>. Names verified against
+      # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml and
+      # tests/chainsaw/ai-conformance/kind-common/assert-monitoring.yaml
+      # (both live-cluster-validated). Label selectors are used in the pod-health
+      # step because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kube-prometheus-stack-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the kube-prometheus-stack-operator
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kube-prometheus-operator
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-prometheus-cr-available
+            try:
+              # Assert the Prometheus CR has been reconciled by the operator.
+              # The prometheus-operator sets an Available condition on the CR once
+              # it has successfully reconciled the CR into a running StatefulSet.
+              # CR name kube-prometheus-prometheus derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -prometheus suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Prometheus
+                    metadata:
+                      name: kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-alertmanager-cr-available
+            try:
+              # Assert the Alertmanager CR has been reconciled by the operator.
+              # CR name kube-prometheus-alertmanager derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -alertmanager suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Alertmanager
+                    metadata:
+                      name: kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-prometheus-statefulset-ready
+            try:
+              # Assert the Prometheus StatefulSet created by the operator has
+              # reached full rollout. readyReplicas >= replicas ensures all pods
+              # are ready, not just some. The replicas > 0 guard prevents a
+              # vacuous pass when the StatefulSet is missing or has 0 replicas.
+              # StatefulSet name prometheus-kube-prometheus-prometheus is
+              # <workload>-<cr-name> per prometheus-operator convention, verified
+              # from tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: prometheus-kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-alertmanager-statefulset-ready
+            try:
+              # Assert the Alertmanager StatefulSet has reached full rollout.
+              # Same pattern as Prometheus above. StatefulSet name
+              # alertmanager-kube-prometheus-alertmanager is <workload>-<cr-name>
+              # per prometheus-operator convention, verified from
+              # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: alertmanager-kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus stack pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kube-prometheus-stack
+    namespace: monitoring
+    overrides:
+      alertmanager:
+        alertmanagerSpec:
+          resources:
+            limits:
+              cpu: 250m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+      defaultRules:
+        create: false
+      grafana:
+        enabled: false
+      prometheus:
+        prometheusSpec:
+          resources:
+            limits:
+              cpu: 1
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          retention: 7d
+          storageSpec:
+            emptyDir:
+              medium: ""
+              sizeLimit: 5Gi
+      prometheusOperator:
+        alertmanagerConfigNamespaces:
+          - monitoring
+        alertmanagerInstanceNamespaces:
+          - monitoring
+        livenessProbe:
+          failureThreshold: 10
+          timeoutSeconds: 10
+        prometheusInstanceNamespaces:
+          - monitoring
+        readinessProbe:
+          failureThreshold: 6
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        thanosRulerInstanceNamespaces:
+          - monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/kube-prometheus-stack/values.yaml
+    version: 84.4.0
+  - chart: network-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Network Operator Health Check
+      #
+      # Validates that the NVIDIA Network Operator is running and healthy in
+      # the nvidia-network-operator namespace. Also asserts
+      # nicclusterpolicies.mellanox.com is Established=True (verified against
+      # chart 26.4.1; re-verify on defaultVersion bump). Chart 26.4.1 also
+      # ships nicnodepolicies.mellanox.com, deliberately NOT asserted here:
+      # no in-tree recipe instantiates a CR against it, so it fails the same
+      # load-bearing-only bar the rest of this PR's assertions are held to.
+      # Checks that the
+      # network-operator deployment has at least one available replica and
+      # that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: network-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: nicclusterpolicies.mellanox.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # network-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: network-operator
+                      namespace: nvidia-network-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: network-operator
+    namespace: nvidia-network-operator
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/network-operator/values.yaml
+    version: 26.4.1
+  - chart: node-feature-discovery
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Node Feature Discovery Health Check
+      #
+      # Validates the standalone NFD deployment by checking:
+      # 1. NFD Master Deployment has at least one ready replica
+      # 2. NFD Worker DaemonSet has fully rolled out (desiredNumberScheduled > 0
+      #    and numberReady == desiredNumberScheduled, so partial failures don't pass)
+      # 3. NFD GC Deployment has at least one ready replica (gc.enable: true)
+      #
+      # Resource names: AICR deploys the kubernetes-sigs/node-feature-discovery
+      # chart under release name "nfd" (matching the ComponentRef Name in
+      # recipes/registry.yaml). The chart's fullname template prefixes the
+      # release name to the chart name when they don't overlap, yielding
+      # "nfd-node-feature-discovery-*" for the master Deployment, worker
+      # DaemonSet, and gc Deployment. If a deployer ever switches the release
+      # name to "node-feature-discovery", these asserts need updating in
+      # lockstep.
+      # 4. No pods in unhealthy phases (Pending, Failed, Unknown) or stuck in
+      #    Running with a known-unhealthy container waiting reason
+      #    (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+      #    CreateContainerConfigError)
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nfd-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-master-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-master
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-worker-daemonset
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nfd-node-feature-discovery-worker
+                      namespace: node-feature-discovery
+                    status:
+                      # Guard against vacuous pass when 0 nodes match the
+                      # DaemonSet: require at least one scheduled pod.
+                      (desiredNumberScheduled > `0`): true
+                      # Full rollout: every scheduled pod is ready. Combined with
+                      # the guard above, this rejects partial failures. We assert on
+                      # numberReady (always present in DaemonSetStatus) rather than
+                      # numberUnavailable, which is `omitempty` and disappears from
+                      # the status when zero — making `numberUnavailable == 0`
+                      # evaluate `null == 0` (false) on a fully-healthy DaemonSet.
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-gc-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-gc
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nfd
+    namespace: node-feature-discovery
+    source: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+    type: Helm
+    valuesFile: components/nfd/values.yaml
+    version: 0.19.0
+  - chart: nodewright
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Nodewright Operator Health Check
+      #
+      # Validates that the Nodewright Operator is running and healthy in the
+      # skyhook namespace:
+      # 1. skyhooks.skyhook.nvidia.com CRD Established=True (the apiserver
+      #    will accept Skyhook CRs that nodewright-customizations declares).
+      # 2. skyhook-operator-controller-manager Deployment has at least one
+      #    available replica.
+      # 3. No pods stuck in Pending/Failed/Unknown phases or known-bad
+      #    container-waiting states.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nodewright-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-skyhook-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: skyhooks.skyhook.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: skyhook-operator-controller-manager
+                      namespace: skyhook
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nodewright-operator
+    namespace: skyhook
+    overrides:
+      controllerManager:
+        manager:
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+    source: oci://ghcr.io/nvidia/nodewright/charts
+    type: Helm
+    valuesFile: components/nodewright-operator/values.yaml
+    version: v0.17.1
+  - chart: dra-driver-nvidia-gpu
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVIDIA DRA Driver GPU Health Check
+      #
+      # Validates that the NVIDIA DRA (Dynamic Resource Allocation) GPU driver
+      # is running and healthy in the nvidia-dra-driver namespace. The
+      # kubelet-plugin DaemonSet must roll out fully — numberReady ==
+      # desiredNumberScheduled (with desiredNumberScheduled > 0 as a guard).
+      # Previous check gated only on numberReady > 0, passing on partial
+      # failures; see #1222 and recipes/checks/nfd/health-check.yaml for
+      # the same rationale.
+      #
+      # Resource names: the DaemonSet name is release-derived
+      # (<release>-kubelet-plugin). AICR's release name is
+      # `nvidia-dra-driver-gpu` (matches ComponentRef Name in registry.yaml).
+      # If a deployer renames the release, this assert needs updating in
+      # lockstep — see verifyDRAKubeletPluginReady commentary in
+      # validators/deployment/expected_resources.go for why a chart-shape
+      # label would be a more robust selector.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvidia-dra-driver-gpu-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-kubelet-plugin-daemonset-fully-rolled-out
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nvidia-dra-driver-gpu-kubelet-plugin
+                      namespace: nvidia-dra-driver
+                    status:
+                      (desiredNumberScheduled > `0`): true
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvidia-dra-driver-gpu
+    namespace: nvidia-dra-driver
+    overrides:
+      nvidiaDriverRoot: /
+    source: oci://registry.k8s.io/dra-driver-nvidia/charts
+    type: Helm
+    valuesFile: components/nvidia-dra-driver-gpu/values.yaml
+    version: 0.4.1
+  - chart: nvsentinel
+    dependencyRefs:
+      - cert-manager
+      - gpu-operator
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVSentinel Health Check
+      #
+      # Validates that the NVSentinel labeler is running and healthy in
+      # the nvsentinel namespace. Checks that the labeler deployment has at
+      # least one available replica and that no pods in the
+      # namespace are stuck in Pending, Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvsentinel-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # nvsentinel-controller-manager deployment exists and has at least
+              # one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: labeler
+                      namespace: nvsentinel
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvsentinel
+    namespace: nvsentinel
+    overrides:
+      platformConnector:
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+    source: oci://ghcr.io/nvidia
+    type: Helm
+    valuesFile: components/nvsentinel/values.yaml
+    version: v1.9.0
+  - chart: prometheus-adapter
+    dependencyRefs:
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Prometheus Adapter Health Check
+      #
+      # Validates that the Prometheus Adapter is running and healthy in the
+      # monitoring namespace. Checks that the prometheus-adapter deployment has
+      # at least one available replica and that no prometheus adapter pods
+      # (selected by label) are stuck in Pending, Failed, or Unknown phases.
+      # Label selectors are used because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-adapter-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the prometheus-adapter
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: prometheus-adapter
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus adapter pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: prometheus-adapter
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-adapter/values.yaml
+    version: 5.3.0
+  - chart: prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # prometheus-operator-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this chart installs has
+      # reached the `Established=True` condition (CRD storage is up and the
+      # apiserver will accept CRs of those kinds).
+      #
+      # CRDs come from the upstream prometheus-community/prometheus-operator-crds
+      # chart pinned to 28.0.1 in recipes/registry.yaml. The 8 kinds under
+      # monitoring.coreos.com/v1 are enumerated in
+      # recipes/components/prometheus-operator-crds/values.yaml header:
+      # Alertmanager, AlertmanagerConfig, PodMonitor, Probe, Prometheus,
+      # PrometheusRule, ServiceMonitor, ThanosRuler. Plural names match the
+      # long-standing upstream prometheus-operator chart shape.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-operator-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-prometheus-operator-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagerconfigs.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: podmonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: probes.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheuses.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheusrules.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: servicemonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: thanosrulers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    name: prometheus-operator-crds
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-operator-crds/values.yaml
+    version: 28.0.1
+constraints:
+  - name: K8s.server.version
+    value: '>= 1.30'
+criteria:
+  accelerator: gb200
+  intent: inference
+  os: any
+  platform: any
+  service: kind
+deploymentOrder:
+  - agentgateway-crds
+  - cert-manager
+  - agentgateway
+  - nfd
+  - network-operator
+  - nodewright-operator
+  - prometheus-operator-crds
+  - kube-prometheus-stack
+  - gpu-operator
+  - k8s-ephemeral-storage-metrics
+  - kai-scheduler
+  - nvidia-dra-driver-gpu
+  - nvsentinel
+  - prometheus-adapter
+kind: RecipeResult
+metadata:
+  appliedOverlays:
+    - base
+    - monitoring-hpa
+    - gb200-any
+    - kind
+    - kind-inference
+  version: dev
+validation:
+  conformance:
+    checks:
+      - platform-health
+      - gpu-operator-health
+      - dra-support
+      - accelerator-metrics
+      - ai-service-metrics
+  deployment:
+    checks:
+      - operator-health
+      - expected-resources
+      - gpu-operator-version
+      - check-nvidia-smi
+    constraints:
+      - name: Deployment.gpu-operator.version
+        value: '>= v25.10.0'

--- a/tests/aicr-sweep/results/coverage.md
+++ b/tests/aicr-sweep/results/coverage.md
@@ -1,0 +1,331 @@
+# AICR check coverage under Mokka
+
+All evidence below is simulation provenance (`sim`). None of it was run on silicon.
+
+## Roll-up
+
+- Check results total: 210 (checks x cells)
+- A meaningful: 160  ·  B trivial: 10  ·  C hardware-dependent: 40  ·  G closable gap: 0
+- **Meaningful pre-silicon today: 76%** (A / total)
+- **Reachable once tracked gaps close: 76%** ((A + G) / total). Roadmap, not a current claim.
+- Of the A set, 100 are GPU-dependent (62% of A). The remainder run on any cluster, so Mokka is not what unlocks them.
+- Never reached a verdict (blocked or not-run): 197 (94%)
+
+### Why cells did not reach a verdict
+
+| Cause | Meaning | Count |
+|---|---|---|
+| BUDGET | host memory budget exhausted; cell not attempted. | 105 |
+| U | upstream dependency has not released what is needed. NOT a Mokka gap. | 21 |
+| X | AICR catalog has no recipe for the combination. NOT a Mokka gap. | 42 |
+
+## Cells
+
+### `base-gb200-kind-inference-stack`
+
+Recipe: service=kind accelerator=gb200 intent=inference · shape=stack workers=2 · status=ran
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | pass |  |  |
+| expected-resources | deployment | A | yes | not-run |  |  |
+| gpu-operator-version | deployment | A | no | fail |  |  |
+| check-nvidia-smi | deployment | A | yes | pass |  |  |
+| nccl-all-reduce-bw | performance | C | yes | not-run |  | check absent from run output |
+| nccl-all-reduce-bw-net | performance | C | yes | not-run |  | check absent from run output |
+| nccl-all-reduce-bw-nvls | performance | C | yes | not-run |  | check absent from run output |
+| inference-perf | performance | C | yes | not-run |  | check absent from run output |
+| dra-support | conformance | A | yes | fail |  |  |
+| gang-scheduling | conformance | A | no | not-run |  | check absent from run output |
+| accelerator-metrics | conformance | A | yes | pass |  |  |
+| ai-service-metrics | conformance | A | yes | fail |  |  |
+| inference-gateway | conformance | A | no | not-run |  | check absent from run output |
+| pod-autoscaling | conformance | B | yes | not-run |  | check absent from run output |
+| cluster-autoscaling | conformance | A | no | not-run |  | check absent from run output |
+| robust-controller | conformance | A | no | not-run |  | check absent from run output |
+| secure-accelerator-access | conformance | A | yes | not-run |  | check absent from run output |
+| slinky-slurm-health | conformance | A | yes | not-run |  | check absent from run output |
+| slinky-slurm-imex-channel | conformance | A | yes | not-run |  | check absent from run output |
+| gpu-operator-health | conformance | A | yes | fail |  |  |
+| platform-health | conformance | A | no | fail |  |  |
+
+### `base-gb200-kind-training-stack`
+
+Recipe: service=kind accelerator=gb200 intent=training · shape=stack workers=2 · status=blocked
+
+**Blocked (BUDGET):** Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available.
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | blocked | BUDGET |  |
+| expected-resources | deployment | A | yes | blocked | BUDGET |  |
+| gpu-operator-version | deployment | A | no | blocked | BUDGET |  |
+| check-nvidia-smi | deployment | A | yes | blocked | BUDGET |  |
+| nccl-all-reduce-bw | performance | C | yes | blocked | BUDGET |  |
+| nccl-all-reduce-bw-net | performance | C | yes | blocked | BUDGET |  |
+| nccl-all-reduce-bw-nvls | performance | C | yes | blocked | BUDGET |  |
+| inference-perf | performance | C | yes | blocked | BUDGET |  |
+| dra-support | conformance | A | yes | blocked | BUDGET |  |
+| gang-scheduling | conformance | A | no | blocked | BUDGET |  |
+| accelerator-metrics | conformance | A | yes | blocked | BUDGET |  |
+| ai-service-metrics | conformance | A | yes | blocked | BUDGET |  |
+| inference-gateway | conformance | A | no | blocked | BUDGET |  |
+| pod-autoscaling | conformance | B | yes | blocked | BUDGET |  |
+| cluster-autoscaling | conformance | A | no | blocked | BUDGET |  |
+| robust-controller | conformance | A | no | blocked | BUDGET |  |
+| secure-accelerator-access | conformance | A | yes | blocked | BUDGET |  |
+| slinky-slurm-health | conformance | A | yes | blocked | BUDGET |  |
+| slinky-slurm-imex-channel | conformance | A | yes | blocked | BUDGET |  |
+| gpu-operator-health | conformance | A | yes | blocked | BUDGET |  |
+| platform-health | conformance | A | no | blocked | BUDGET |  |
+
+### `base-h100-kind-inference-stack`
+
+Recipe: service=kind accelerator=h100 intent=inference · shape=stack workers=2 · status=blocked
+
+**Blocked (BUDGET):** Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage.
+
+Axes off base: accelerator=h100 (substitute for gb300)
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | blocked | BUDGET |  |
+| expected-resources | deployment | A | yes | blocked | BUDGET |  |
+| gpu-operator-version | deployment | A | no | blocked | BUDGET |  |
+| check-nvidia-smi | deployment | A | yes | blocked | BUDGET |  |
+| nccl-all-reduce-bw | performance | C | yes | blocked | BUDGET |  |
+| nccl-all-reduce-bw-net | performance | C | yes | blocked | BUDGET |  |
+| nccl-all-reduce-bw-nvls | performance | C | yes | blocked | BUDGET |  |
+| inference-perf | performance | C | yes | blocked | BUDGET |  |
+| dra-support | conformance | A | yes | blocked | BUDGET |  |
+| gang-scheduling | conformance | A | no | blocked | BUDGET |  |
+| accelerator-metrics | conformance | A | yes | blocked | BUDGET |  |
+| ai-service-metrics | conformance | A | yes | blocked | BUDGET |  |
+| inference-gateway | conformance | A | no | blocked | BUDGET |  |
+| pod-autoscaling | conformance | B | yes | blocked | BUDGET |  |
+| cluster-autoscaling | conformance | A | no | blocked | BUDGET |  |
+| robust-controller | conformance | A | no | blocked | BUDGET |  |
+| secure-accelerator-access | conformance | A | yes | blocked | BUDGET |  |
+| slinky-slurm-health | conformance | A | yes | blocked | BUDGET |  |
+| slinky-slurm-imex-channel | conformance | A | yes | blocked | BUDGET |  |
+| gpu-operator-health | conformance | A | yes | blocked | BUDGET |  |
+| platform-health | conformance | A | no | blocked | BUDGET |  |
+
+### `base-gb300-kind-inference-stack`
+
+Recipe: service=kind accelerator=gb300 intent=inference · shape=stack workers=2 · status=blocked
+
+**Blocked (X):** AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with "[INVALID_REQUEST] no recipe provides accelerator 'gb300'". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap.
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | blocked | X |  |
+| expected-resources | deployment | A | yes | blocked | X |  |
+| gpu-operator-version | deployment | A | no | blocked | X |  |
+| check-nvidia-smi | deployment | A | yes | blocked | X |  |
+| nccl-all-reduce-bw | performance | C | yes | blocked | X |  |
+| nccl-all-reduce-bw-net | performance | C | yes | blocked | X |  |
+| nccl-all-reduce-bw-nvls | performance | C | yes | blocked | X |  |
+| inference-perf | performance | C | yes | blocked | X |  |
+| dra-support | conformance | A | yes | blocked | X |  |
+| gang-scheduling | conformance | A | no | blocked | X |  |
+| accelerator-metrics | conformance | A | yes | blocked | X |  |
+| ai-service-metrics | conformance | A | yes | blocked | X |  |
+| inference-gateway | conformance | A | no | blocked | X |  |
+| pod-autoscaling | conformance | B | yes | blocked | X |  |
+| cluster-autoscaling | conformance | A | no | blocked | X |  |
+| robust-controller | conformance | A | no | blocked | X |  |
+| secure-accelerator-access | conformance | A | yes | blocked | X |  |
+| slinky-slurm-health | conformance | A | yes | blocked | X |  |
+| slinky-slurm-imex-channel | conformance | A | yes | blocked | X |  |
+| gpu-operator-health | conformance | A | yes | blocked | X |  |
+| platform-health | conformance | A | no | blocked | X |  |
+
+### `base-gb300-kind-training-stack`
+
+Recipe: service=kind accelerator=gb300 intent=training · shape=stack workers=2 · status=blocked
+
+**Blocked (X):** Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator.
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | blocked | X |  |
+| expected-resources | deployment | A | yes | blocked | X |  |
+| gpu-operator-version | deployment | A | no | blocked | X |  |
+| check-nvidia-smi | deployment | A | yes | blocked | X |  |
+| nccl-all-reduce-bw | performance | C | yes | blocked | X |  |
+| nccl-all-reduce-bw-net | performance | C | yes | blocked | X |  |
+| nccl-all-reduce-bw-nvls | performance | C | yes | blocked | X |  |
+| inference-perf | performance | C | yes | blocked | X |  |
+| dra-support | conformance | A | yes | blocked | X |  |
+| gang-scheduling | conformance | A | no | blocked | X |  |
+| accelerator-metrics | conformance | A | yes | blocked | X |  |
+| ai-service-metrics | conformance | A | yes | blocked | X |  |
+| inference-gateway | conformance | A | no | blocked | X |  |
+| pod-autoscaling | conformance | B | yes | blocked | X |  |
+| cluster-autoscaling | conformance | A | no | blocked | X |  |
+| robust-controller | conformance | A | no | blocked | X |  |
+| secure-accelerator-access | conformance | A | yes | blocked | X |  |
+| slinky-slurm-health | conformance | A | yes | blocked | X |  |
+| slinky-slurm-imex-channel | conformance | A | yes | blocked | X |  |
+| gpu-operator-health | conformance | A | yes | blocked | X |  |
+| platform-health | conformance | A | no | blocked | X |  |
+
+### `targeted-dra-installed`
+
+Recipe: service=kind accelerator=gb200 intent=inference · shape=stack workers=2 · status=ran
+
+Axes off base: nvidia-dra-driver-gpu=installed (base cell had none)
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | not-run |  | check absent from run output |
+| expected-resources | deployment | A | yes | not-run |  | check absent from run output |
+| gpu-operator-version | deployment | A | no | not-run |  | check absent from run output |
+| check-nvidia-smi | deployment | A | yes | not-run |  | check absent from run output |
+| nccl-all-reduce-bw | performance | C | yes | not-run |  | check absent from run output |
+| nccl-all-reduce-bw-net | performance | C | yes | not-run |  | check absent from run output |
+| nccl-all-reduce-bw-nvls | performance | C | yes | not-run |  | check absent from run output |
+| inference-perf | performance | C | yes | not-run |  | check absent from run output |
+| dra-support | conformance | A | yes | fail |  |  |
+| gang-scheduling | conformance | A | no | not-run |  | check absent from run output |
+| accelerator-metrics | conformance | A | yes | pass |  |  |
+| ai-service-metrics | conformance | A | yes | fail |  |  |
+| inference-gateway | conformance | A | no | not-run |  | check absent from run output |
+| pod-autoscaling | conformance | B | yes | not-run |  | check absent from run output |
+| cluster-autoscaling | conformance | A | no | not-run |  | check absent from run output |
+| robust-controller | conformance | A | no | not-run |  | check absent from run output |
+| secure-accelerator-access | conformance | A | yes | not-run |  | check absent from run output |
+| slinky-slurm-health | conformance | A | yes | not-run |  | check absent from run output |
+| slinky-slurm-imex-channel | conformance | A | yes | not-run |  | check absent from run output |
+| gpu-operator-health | conformance | A | yes | fail |  |  |
+| platform-health | conformance | A | no | fail |  |  |
+
+### `axis-nri-cdi`
+
+Recipe: service=kind accelerator=gb200 intent=inference · shape=stack workers=2 · status=blocked
+
+**Blocked (BUDGET):** Not attempted; host memory window exhausted after the base cell.
+
+Axes off base: nri.deviceInjectionMode=cdi (base is raw)
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | blocked | BUDGET |  |
+| expected-resources | deployment | A | yes | blocked | BUDGET |  |
+| gpu-operator-version | deployment | A | no | blocked | BUDGET |  |
+| check-nvidia-smi | deployment | A | yes | blocked | BUDGET |  |
+| nccl-all-reduce-bw | performance | C | yes | blocked | BUDGET |  |
+| nccl-all-reduce-bw-net | performance | C | yes | blocked | BUDGET |  |
+| nccl-all-reduce-bw-nvls | performance | C | yes | blocked | BUDGET |  |
+| inference-perf | performance | C | yes | blocked | BUDGET |  |
+| dra-support | conformance | A | yes | blocked | BUDGET |  |
+| gang-scheduling | conformance | A | no | blocked | BUDGET |  |
+| accelerator-metrics | conformance | A | yes | blocked | BUDGET |  |
+| ai-service-metrics | conformance | A | yes | blocked | BUDGET |  |
+| inference-gateway | conformance | A | no | blocked | BUDGET |  |
+| pod-autoscaling | conformance | B | yes | blocked | BUDGET |  |
+| cluster-autoscaling | conformance | A | no | blocked | BUDGET |  |
+| robust-controller | conformance | A | no | blocked | BUDGET |  |
+| secure-accelerator-access | conformance | A | yes | blocked | BUDGET |  |
+| slinky-slurm-health | conformance | A | yes | blocked | BUDGET |  |
+| slinky-slurm-imex-channel | conformance | A | yes | blocked | BUDGET |  |
+| gpu-operator-health | conformance | A | yes | blocked | BUDGET |  |
+| platform-health | conformance | A | no | blocked | BUDGET |  |
+
+### `axis-allocation-watcher-on`
+
+Recipe: service=kind accelerator=gb200 intent=inference · shape=stack workers=2 · status=blocked
+
+**Blocked (BUDGET):** Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction.
+
+Axes off base: allocationWatcher.enabled=true (base is false)
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | blocked | BUDGET |  |
+| expected-resources | deployment | A | yes | blocked | BUDGET |  |
+| gpu-operator-version | deployment | A | no | blocked | BUDGET |  |
+| check-nvidia-smi | deployment | A | yes | blocked | BUDGET |  |
+| nccl-all-reduce-bw | performance | C | yes | blocked | BUDGET |  |
+| nccl-all-reduce-bw-net | performance | C | yes | blocked | BUDGET |  |
+| nccl-all-reduce-bw-nvls | performance | C | yes | blocked | BUDGET |  |
+| inference-perf | performance | C | yes | blocked | BUDGET |  |
+| dra-support | conformance | A | yes | blocked | BUDGET |  |
+| gang-scheduling | conformance | A | no | blocked | BUDGET |  |
+| accelerator-metrics | conformance | A | yes | blocked | BUDGET |  |
+| ai-service-metrics | conformance | A | yes | blocked | BUDGET |  |
+| inference-gateway | conformance | A | no | blocked | BUDGET |  |
+| pod-autoscaling | conformance | B | yes | blocked | BUDGET |  |
+| cluster-autoscaling | conformance | A | no | blocked | BUDGET |  |
+| robust-controller | conformance | A | no | blocked | BUDGET |  |
+| secure-accelerator-access | conformance | A | yes | blocked | BUDGET |  |
+| slinky-slurm-health | conformance | A | yes | blocked | BUDGET |  |
+| slinky-slurm-imex-channel | conformance | A | yes | blocked | BUDGET |  |
+| gpu-operator-health | conformance | A | yes | blocked | BUDGET |  |
+| platform-health | conformance | A | no | blocked | BUDGET |  |
+
+### `axis-failure-injection-ecc`
+
+Recipe: service=kind accelerator=gb200 intent=inference · shape=stack workers=2 · status=blocked
+
+**Blocked (BUDGET):** Not attempted; host memory window exhausted after the base cell.
+
+Axes off base: gpu.failureInjection.mode=ecc_uncorrectable (base is off)
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | blocked | BUDGET |  |
+| expected-resources | deployment | A | yes | blocked | BUDGET |  |
+| gpu-operator-version | deployment | A | no | blocked | BUDGET |  |
+| check-nvidia-smi | deployment | A | yes | blocked | BUDGET |  |
+| nccl-all-reduce-bw | performance | C | yes | blocked | BUDGET |  |
+| nccl-all-reduce-bw-net | performance | C | yes | blocked | BUDGET |  |
+| nccl-all-reduce-bw-nvls | performance | C | yes | blocked | BUDGET |  |
+| inference-perf | performance | C | yes | blocked | BUDGET |  |
+| dra-support | conformance | A | yes | blocked | BUDGET |  |
+| gang-scheduling | conformance | A | no | blocked | BUDGET |  |
+| accelerator-metrics | conformance | A | yes | blocked | BUDGET |  |
+| ai-service-metrics | conformance | A | yes | blocked | BUDGET |  |
+| inference-gateway | conformance | A | no | blocked | BUDGET |  |
+| pod-autoscaling | conformance | B | yes | blocked | BUDGET |  |
+| cluster-autoscaling | conformance | A | no | blocked | BUDGET |  |
+| robust-controller | conformance | A | no | blocked | BUDGET |  |
+| secure-accelerator-access | conformance | A | yes | blocked | BUDGET |  |
+| slinky-slurm-health | conformance | A | yes | blocked | BUDGET |  |
+| slinky-slurm-imex-channel | conformance | A | yes | blocked | BUDGET |  |
+| gpu-operator-health | conformance | A | yes | blocked | BUDGET |  |
+| platform-health | conformance | A | no | blocked | BUDGET |  |
+
+### `axis-compute-domain-fabric`
+
+Recipe: service=kind accelerator=gb200 intent=training · shape=fabric workers=4 · status=blocked
+
+**Blocked (U):** The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap.
+
+Axes off base: imex.mockChannels.enabled=true, topology.domains=two cliques
+
+| Check | Phase | Bucket | GPU-dep | Outcome | Cause | Note |
+|---|---|---|---|---|---|---|
+| operator-health | deployment | A | yes | blocked | U |  |
+| expected-resources | deployment | A | yes | blocked | U |  |
+| gpu-operator-version | deployment | A | no | blocked | U |  |
+| check-nvidia-smi | deployment | A | yes | blocked | U |  |
+| nccl-all-reduce-bw | performance | C | yes | blocked | U |  |
+| nccl-all-reduce-bw-net | performance | C | yes | blocked | U |  |
+| nccl-all-reduce-bw-nvls | performance | C | yes | blocked | U |  |
+| inference-perf | performance | C | yes | blocked | U |  |
+| dra-support | conformance | A | yes | blocked | U |  |
+| gang-scheduling | conformance | A | no | blocked | U |  |
+| accelerator-metrics | conformance | A | yes | blocked | U |  |
+| ai-service-metrics | conformance | A | yes | blocked | U |  |
+| inference-gateway | conformance | A | no | blocked | U |  |
+| pod-autoscaling | conformance | B | yes | blocked | U |  |
+| cluster-autoscaling | conformance | A | no | blocked | U |  |
+| robust-controller | conformance | A | no | blocked | U |  |
+| secure-accelerator-access | conformance | A | yes | blocked | U |  |
+| slinky-slurm-health | conformance | A | yes | blocked | U |  |
+| slinky-slurm-imex-channel | conformance | A | yes | blocked | U |  |
+| gpu-operator-health | conformance | A | yes | blocked | U |  |
+| platform-health | conformance | A | no | blocked | U |  |
+

--- a/tests/aicr-sweep/results/dra-altprocdevices-evidence.log
+++ b/tests/aicr-sweep/results/dra-altprocdevices-evidence.log
@@ -1,0 +1,80 @@
+# Evidence: DRA driver v0.5.0 + altProcDevices closes the first run's cause-U block
+# Captured 2026-08-26, cell targeted-dra-installed, Mokka sha-57ef016.
+
+## What the first run said
+
+D-009 blocked axis-compute-domain-fabric as cause U: the DRA driver reads the
+nvidia-caps-imex-channels major out of /proc/devices, needs --set altProcDevices
+to look elsewhere, and that flag "is on the DRA driver's main branch and is in no
+release, including v25.12.0". True when written. No longer true.
+
+## What changed upstream
+
+k8s-dra-driver-gpu v0.5.0, released 2026-08-19, ships altProcDevices. Verified by
+reading the released chart, not the main branch:
+
+  deployments/helm/dra-driver-nvidia-gpu/values.yaml line 34:
+    altProcDevices: ""
+  with the doc comment "Used with mock NVML to inject fake
+  nvidia-caps-imex-channels entries so the compute-domain-kubelet-plugin can
+  initialize without a real kernel driver."
+
+Confirmed absent from v25.12.0's values.yaml (which has no proc or imex mention
+at all), so the first run's claim was correct for its pin.
+
+## Measured end to end
+
+Mokka rendered the substitute:
+
+  /var/lib/nvml-mock/imex/proc-devices
+    235 nvidia-caps-imex-channels
+    236 nvidia-caps
+
+DRA v0.5.0 consumed it. Both kubelet-plugin pods run BOTH containers:
+
+  nvidia-dra-driver-gpu-kubelet-plugin-77dsw -> compute-domains gpus
+  nvidia-dra-driver-gpu-kubelet-plugin-f8j7h -> compute-domains gpus
+  nvidia-dra-driver-gpu-controller-...       -> compute-domain
+
+12 ResourceSlice devices published. The first run's abort
+
+  error creating driver: failed to create device library: error getting nvcap
+  for IMEX channel '0': error getting device major: error parsing '/proc/devices'
+
+occurs ZERO times in 400 lines of driver logs. The only errors are an
+Unimplemented optional health-reporting API, which is benign.
+
+## Verdict flip
+
+  dra-support   v0.3.0 + DRA v25.12.0   FAILED
+                57ef016 + DRA v0.5.0    PASSED
+
+This is the ONLY verdict that moved in the whole re-run, and it moved for an
+upstream reason, not a Mokka one. Mokka's IMEX rendering already worked at
+v0.3.0; what was missing was a released consumer.
+
+## Caveat that must travel with this result
+
+The v0.5.0 chart was RENAMED: nvidia-dra-driver-gpu -> dra-driver-nvidia-gpu. Its
+default resource names are dra-driver-nvidia-gpu-controller, while AICR at
+0752ea14 looks for nvidia-dra-driver-gpu-controller (pkg/validator/v1/
+allocation_policy.go: draDriverGPUComponentName = "nvidia-dra-driver-gpu").
+Installed with chart defaults, dra-support fails NOT_FOUND on the name alone,
+whatever the driver is doing.
+
+This run therefore passed --set nameOverride=nvidia-dra-driver-gpu to restore the
+name AICR expects. That is an accommodation on the DRA side; AICR itself was not
+modified. Read the pass as "the mechanism works, and AICR can see it once the
+release is named the way AICR still expects", not as "v0.5.0 works with AICR out
+of the box". The rename is real drift and is worth raising on the AICR side.
+
+## Doc drift this creates in k8s-test-infra
+
+deployments/nvml-mock/helm/nvml-mock/values.yaml still says, in the imex section:
+
+  # NOTE: as of 2026-07-25 altProcDevices is on the DRA driver's main branch
+  # but is NOT in any release (absent at v25.12.0), so enabling this alone does
+  # not yet make ComputeDomains work with released artifacts. See
+  # NVIDIA/k8s-test-infra#498.
+
+That note is now stale and understates what Mokka can do. Issue #498 can close.

--- a/tests/aicr-sweep/results/ecc-injection-evidence.log
+++ b/tests/aicr-sweep/results/ecc-injection-evidence.log
@@ -1,0 +1,66 @@
+# Evidence: an injected uncorrectable ECC fault moves no AICR verdict
+# Captured 2026-08-26, cell axis-failure-injection-ecc, Mokka sha-57ef016.
+
+## The fault is real and active, verified before drawing any conclusion
+
+helm values in effect on the running release:
+
+  gpu:
+    failureInjection:
+      enabled: true
+      mode: ecc_uncorrectable
+      probability: 1
+    profile: gb200
+
+nvidia-smi against the mock, in cluster:
+
+  Attached GPUs : 4
+      ECC Mode
+          Volatile
+              SRAM Uncorrectable Parity  : 0
+              SRAM Uncorrectable SEC-DED : 0
+              DRAM Uncorrectable         : 6
+              SRAM Uncorrectable Parity  : 0
+              SRAM Uncorrectable SEC-DED : 0
+              DRAM Uncorrectable         : 9
+
+The GPUs still enumerate (nvidia-smi -L lists 4, rc=0), so this is a degraded
+GPU rather than an absent one, which is the scenario the cell is meant to model.
+
+## Result: no verdict moves
+
+All 9 dispatched checks are identical to the base cell.
+
+  operator-health       passed     accelerator-metrics   passed
+  expected-resources    other      ai-service-metrics    failed
+  gpu-operator-version  failed     gpu-operator-health   failed
+  check-nvidia-smi      passed     platform-health       failed
+  dra-support           failed
+
+check-nvidia-smi passes and accelerator-metrics passes, with 15 uncorrectable
+DRAM errors visible in NVML at that moment.
+
+## Reading it
+
+This is a discrimination test of the AICR check set, not of Mokka. Mokka's
+failure injection works end to end and is observable through NVML. What the
+result says is that the checks AICR dispatches for kind/gb200/inference do not
+read ECC state, so a GPU that is degraded but still enumerable is indistinguishable
+from a healthy one at this recipe. It says nothing about AICR checks that this
+recipe does not dispatch.
+
+## A trap worth recording
+
+The first attempt at this cell produced a DIFFERENT and much more flattering
+result: 1 passed, 7 failed, with check-nvidia-smi and accelerator-metrics both
+flipping to failed. That looked like clean evidence that AICR detects the fault.
+It was not. `--set gpu.failureInjection.probability=1.0` types 1.0 as a STRING,
+values.schema.json wants a number, and the Mokka install failed with
+
+  Error: INSTALLATION FAILED: values don't meet the specifications of the
+  schema(s) ... at '/gpu/failureInjection/probability': got string, want number
+
+The driver script logged the failure and carried on, so the cell ran against a
+cluster with no mock at all, and the two checks "flipped" only because there were
+no GPU nodes. Use --set-json for numeric values. The driver now aborts the cell
+when the Mokka install fails rather than measuring an empty cluster.

--- a/tests/aicr-sweep/results/gfd-sysfs-evidence.log
+++ b/tests/aicr-sweep/results/gfd-sysfs-evidence.log
@@ -1,0 +1,91 @@
+# Evidence: what #672 fixed, and what still blocks gpu-feature-discovery
+# Captured 2026-08-26 on a re-run of the base cell against nvml-mock sha-57ef016
+# (HEAD~1 of upstream/main), AICR held at the original pin 0752ea14 so Mokka is
+# the only axis that moved.
+
+## 1. #672 landed. The bus ID is now well formed.
+
+Differential probe, same config file, same command, only the image differs:
+
+  ghcr.io/nvidia/nvml-mock:0.3.0        Bus Id : 0000:01:00.0        (4-digit domain, the bug)
+  ghcr.io/nvidia/nvml-mock:sha-57ef016  Bus Id : 00000000:01:00.0    (8-digit domain, fixed)
+
+Live in the cluster, gb200 profile, 4 devices:
+
+  Attached GPUs : 4
+  Product Name  : NVIDIA GB200      Bus Id : 00000000:0A:00.0
+  Product Name  : NVIDIA GB200      Bus Id : 00000000:0B:00.0
+  Product Name  : NVIDIA GB200      Bus Id : 00000000:4A:00.0
+  Product Name  : NVIDIA GB200      Bus Id : 00000000:4B:00.0
+
+## 2. The consumer error changed, and that is the proof
+
+  v0.3.0      unable to read PCI device vendor id for :0a:00.0
+                open /sys/bus/pci/devices/:0a:00.0/vendor: no such file or directory
+  sha-57ef016 unable to read PCI device vendor id for 0000:0a:00.0
+                open /sys/bus/pci/devices/0000:0a:00.0/vendor: no such file or directory
+
+The BDF is now correct. The path is simply not there.
+
+## 3. Why it is still not there
+
+Mokka renders a correct and complete tree on the host:
+
+  /var/lib/nvml-mock/sys/bus/pci/devices/0000:0a:00.0/vendor  ->  0x10de
+
+but the entries under bus/pci/devices are RELATIVE SYMLINKS into a sibling subtree:
+
+  0000:0a:00.0 -> ../../../devices/pci0000:00/0000:0a:00.0
+  0000:0b:00.0 -> ../../../devices/pci0000:00/0000:0b:00.0
+  0000:4a:00.0 -> ../../../devices/pci0000:40/0000:4a:00.0
+  0000:4b:00.0 -> ../../../devices/pci0000:40/0000:4b:00.0
+
+gpu-feature-discovery mounts the REAL host /sys (hostPath: /sys), and the NRI
+plugin's overlay lands at /opt/nvml-mock, not on /sys. Two grafts were tried:
+
+  a) replace GFD's host-sys hostPath with /var/lib/nvml-mock/sys
+     -> RunContainerError. GFD also needs the real /sys (e.g. /sys/class/dmi).
+  b) mount only /var/lib/nvml-mock/sys/bus/pci/devices at /sys/bus/pci/devices
+     -> same "no such file or directory". The relative symlinks now resolve
+        against the REAL /sys/devices, where the mock devices do not exist.
+
+The tree is self-consistent and must be grafted coherently: both bus/pci and
+devices/ together. No chart value and no NRI injection does that for a GPU
+Operator operand today.
+
+## 4. Effect on the sweep
+
+ClusterPolicy still never reaches ready, so gpu-operator-health still fails, and
+the base cell's 9 dispatched verdicts are byte-identical to the v0.3.0 run:
+3 passed, 5 failed, 1 other. AICR's check reports only
+
+  [INTERNAL] ClusterPolicy state=notReady (want ready)
+
+so the check cannot distinguish "malformed BDF" from "sysfs tree not mounted".
+The fix is real and the verdict did not move. Both statements are true.
+
+## 5. This does NOT promote the GFD failure from K to G
+
+D-014 classified the GFD failure as K (an artifact of this sweep's stock-kind,
+no-toolkit configuration) rather than G (a Mokka gap), and said the call would
+change if the same cell failed with cdi.enabled=true and the toolkit installed.
+
+That reasoning survives #672. Checked against upstream/main:
+
+  - tests/e2e/VERSION-MATRIX.md states the GFD that CI exercises IS the GPU
+    Operator's operand, not the standalone gfd-mock.yaml DaemonSet. So the
+    green CI scenario really does cover the same component this sweep runs.
+  - tests/e2e/kind-gpu-operator-config.yaml differs from this sweep's cluster in
+    exactly the way D-014 named: enable_cdi = true, an nvidia runtime handler
+    bound to /usr/bin/nvidia-container-runtime, the toolkit installed after
+    cluster creation, and a single control-plane node.
+
+So the CDI path plausibly supplies the sysfs view that stock kind does not, and
+the distinguishing cell D-014 asked for has still not been run. The honest status
+is unchanged: NOT DISTINGUISHED, cause stays K.
+
+What #672 changes is only the diagnosis, not the classification. The "Mokka hands
+GFD a malformed bus ID" theory is now dead by measurement. What remains is a
+mount-visibility question, and D-014's experiment is still the one that answers
+it. It is now affordable: the host VM is 15.84 GiB, up from the 7.75 GiB that
+blocked it.

--- a/tests/aicr-sweep/results/hybrid-kwok-pinned/ctrf/validate-nocleanup.json
+++ b/tests/aicr-sweep/results/hybrid-kwok-pinned/ctrf/validate-nocleanup.json
@@ -1,0 +1,56 @@
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-08-03T19:13:15Z",
+  "generatedBy": "aicr",
+  "results": {
+    "tool": {
+      "name": "aicr",
+      "version": "dev"
+    },
+    "summary": {
+      "tests": 4,
+      "passed": 4,
+      "failed": 0,
+      "skipped": 0,
+      "pending": 0,
+      "other": 0,
+      "start": 1785784391525,
+      "stop": 1785784395710
+    },
+    "tests": [
+      {
+        "name": "operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ]
+      },
+      {
+        "name": "expected-resources",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ]
+      },
+      {
+        "name": "gpu-operator-version",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ]
+      },
+      {
+        "name": "check-nvidia-smi",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aicr-sweep/results/hybrid-kwok-pinned/ctrf/validate.json
+++ b/tests/aicr-sweep/results/hybrid-kwok-pinned/ctrf/validate.json
@@ -1,0 +1,96 @@
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-08-03T19:12:23Z",
+  "generatedBy": "aicr",
+  "results": {
+    "tool": {
+      "name": "aicr",
+      "version": "dev"
+    },
+    "summary": {
+      "tests": 9,
+      "passed": 9,
+      "failed": 0,
+      "skipped": 0,
+      "pending": 0,
+      "other": 0,
+      "start": 1785784339407,
+      "stop": 1785784348980
+    },
+    "tests": [
+      {
+        "name": "operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ]
+      },
+      {
+        "name": "expected-resources",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ]
+      },
+      {
+        "name": "gpu-operator-version",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ]
+      },
+      {
+        "name": "check-nvidia-smi",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ]
+      },
+      {
+        "name": "dra-support",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ]
+      },
+      {
+        "name": "accelerator-metrics",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ]
+      },
+      {
+        "name": "ai-service-metrics",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ]
+      },
+      {
+        "name": "gpu-operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ]
+      },
+      {
+        "name": "platform-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aicr-sweep/results/hybrid-kwok-pinned/recipe.yaml
+++ b/tests/aicr-sweep/results/hybrid-kwok-pinned/recipe.yaml
@@ -1,0 +1,2021 @@
+apiVersion: aicr.run/v1alpha2
+componentRefs:
+  - chart: agentgateway
+    dependencyRefs:
+      - agentgateway-crds
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Agentgateway Health Check
+      #
+      # Validates that agentgateway is running and healthy in the agentgateway-system
+      # namespace. Checks that the agentgateway deployment has at least one available
+      # replica and that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # agentgateway deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: agentgateway
+                      namespace: agentgateway-system
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    manifestFiles:
+      - components/agentgateway/manifests/inference-gateway.yaml
+    name: agentgateway
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway/values.yaml
+    version: v1.3.1
+  - chart: agentgateway-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # agentgateway-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this component installs
+      # has reached the `Established=True` condition (CRD storage is up and
+      # the apiserver will accept CRs of those kinds).
+      #
+      # Scope: this component bundles BOTH the chart's agentgateway.dev/v1alpha1
+      # CRDs and the vendored Gateway API + Inference Extension manifests under
+      # recipes/components/agentgateway-crds/manifests/.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-gateway-api-crds-established
+            # Standard Gateway API CRDs vendored under
+            # manifests/gateway-api-crds.yaml. Verified against the in-tree
+            # manifest content.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gatewayclasses.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gateways.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: grpcroutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: httproutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: referencegrants.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-agentgateway-crds-established
+            # agentgateway.dev/v1alpha1 CRDs installed by the agentgateway-crds
+            # Helm chart.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaybackends.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewayparameters.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaypolicies.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-inference-extension-crds-established
+            # Gateway API Inference Extension CRDs vendored under
+            # manifests/inference-extension-crds.yaml.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencemodelrewrites.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferenceobjectives.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepoolimports.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    manifestFiles:
+      - components/agentgateway-crds/manifests/gateway-api-crds.yaml
+      - components/agentgateway-crds/manifests/inference-extension-crds.yaml
+    name: agentgateway-crds
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway-crds/values.yaml
+    version: v1.3.1
+  - chart: cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Cert Manager Health Check
+      #
+      # Validates that cert-manager is running and healthy in the cert-manager
+      # namespace. The chart deploys three Deployments — the controller
+      # (cert-manager), the CA injector (cert-manager-cainjector), and the
+      # webhook (cert-manager-webhook) — all of which must be available for
+      # the operator to issue / inject / validate certificates. The previous
+      # check only asserted the controller; this check covers all three to
+      # avoid silently passing while the webhook is down (which would block
+      # every Certificate/Issuer CR admission).
+      #
+      # Also asserts the three core CRDs are Established=True so the
+      # apiserver will accept CRs of those kinds (per #1222 / #660).
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: cert-manager-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: certificates.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: issuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterissuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-controller-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cainjector-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-cainjector
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-webhook-deployment
+            try:
+              # The webhook must be ready before any Certificate / Issuer CR
+              # can be admitted. Without this assert, a healthy controller
+              # with a dead webhook would still pass the check while the
+              # cluster silently rejects every cert-manager CR.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-webhook
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: cert-manager
+    namespace: cert-manager
+    source: https://charts.jetstack.io
+    type: Helm
+    valuesFile: components/cert-manager/values.yaml
+    version: v1.20.2
+  - chart: gpu-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # GPU Operator Health Check
+      #
+      # Validates the GPU operator stack:
+      # 1. The gpu-operator Deployment has at least one available replica.
+      # 2. The clusterpolicies.nvidia.com CRD is Established (apiserver will
+      #    accept the singleton ClusterPolicy CR).
+      # 3. The ClusterPolicy singleton named "cluster-policy" has reconciled
+      #    to status.state == "ready" — this is the deepest signal that the
+      #    full GPU stack (driver, toolkit, cuda, plugin DaemonSets, validators)
+      #    is healthy. Migrates the verifyClusterPolicyReady Go check that
+      #    PR #1235 task 7 deferred for assertion-equivalence proof.
+      # 4. No pods in unhealthy phases or stuck container-waiting states.
+      #
+      # The nvidia-operator-validator DaemonSet runs 4 sequential init
+      # containers (driver, toolkit, cuda, plugin) before reaching Running;
+      # the ClusterPolicy state assertion is the canonical post-reconcile
+      # signal that all four passed.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: gpu-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-cluster-policy-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterpolicies.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # gpu-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: gpu-operator
+                      namespace: gpu-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cluster-policy-ready
+            try:
+              # Deepest GPU readiness signal: ClusterPolicy singleton has
+              # reconciled to state=ready. Replaces the deferred
+              # verifyClusterPolicyReady Go check from PR #1235 task 7.
+              - assert:
+                  resource:
+                    apiVersion: nvidia.com/v1
+                    kind: ClusterPolicy
+                    metadata:
+                      name: cluster-policy
+                    status:
+                      state: ready
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: gpu-operator
+    namespace: gpu-operator
+    overrides:
+      daemonsets:
+        tolerations: []
+      dcgm:
+        enabled: false
+      dcgmExporter:
+        config:
+          create: false
+          data: ""
+          name: ""
+      devicePlugin:
+        env: []
+      driver:
+        enabled: false
+        rdma:
+          enabled: false
+      gdrcopy:
+        enabled: false
+      migManager:
+        enabled: false
+      operator:
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+      toolkit:
+        enabled: false
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/gpu-operator/values.yaml
+    version: v26.3.3
+  - chart: k8s-ephemeral-storage-metrics
+    dependencyRefs:
+      - kube-prometheus-stack
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # K8s Ephemeral Storage Metrics Health Check
+      #
+      # Validates that the k8s-ephemeral-storage-metrics Deployment is running and
+      # healthy in the monitoring namespace. Checks that the Deployment has at least
+      # one available replica and that no ephemeral storage metrics pods (selected by label)
+      # are stuck in Pending, Failed, or Unknown phases. Label selectors are used
+      # because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: k8s-ephemeral-storage-metrics-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the k8s-ephemeral-storage-metrics
+              # DaemonSet exists and has at least one ready pod.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: k8s-ephemeral-storage-metrics
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no ephemeral storage metrics pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: k8s-ephemeral-storage-metrics
+    namespace: monitoring
+    source: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
+    type: Helm
+    valuesFile: components/k8s-ephemeral-storage-metrics/values.yaml
+    version: 1.19.2
+  - chart: kai-scheduler
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # KAI Scheduler Health Check
+      #
+      # Validates that the KAI Scheduler is running and healthy in the kai-scheduler
+      # namespace. Checks that the kai-operator deployment has at least one
+      # available replica and that no pods in the namespace are stuck in Pending,
+      # Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kai-scheduler-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # kai-scheduler deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kai-operator
+                      namespace: kai-scheduler
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kai-scheduler
+    namespace: kai-scheduler
+    source: oci://ghcr.io/kai-scheduler/kai-scheduler
+    type: Helm
+    valuesFile: components/kai-scheduler/values.yaml
+    version: v0.14.1
+  - chart: kube-prometheus-stack
+    dependencyRefs:
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Kube Prometheus Stack Health Check
+      #
+      # Validates that the kube-prometheus-stack operator, its managed CRs, and
+      # associated workloads are running and healthy in the monitoring namespace:
+      #
+      # 1. The kube-prometheus-operator Deployment has at least one available replica.
+      # 2. The Prometheus CR (kube-prometheus-prometheus) reports Available=True.
+      #    This explicitly catches operator-level reconcile stalls (e.g., webhook
+      #    rejections) where a target StatefulSet might never be created at all.
+      # 3. The Alertmanager CR (kube-prometheus-alertmanager) reports Available=True.
+      # 4. The Prometheus StatefulSet (prometheus-kube-prometheus-prometheus) has
+      #    reached full rollout: readyReplicas >= replicas, with a replicas > 0
+      #    vacuous-pass guard so a missing StatefulSet does not silently pass.
+      # 5. The Alertmanager StatefulSet (alertmanager-kube-prometheus-alertmanager)
+      #    reaches the same full-rollout threshold.
+      # 6. No stack operator pods (label-scoped to app.kubernetes.io/name:
+      #    kube-prometheus-stack) are stuck in Pending, Failed, Unknown, or a
+      #    known-bad container-waiting reason (CrashLoopBackOff, ImagePullBackOff,
+      #    ErrImagePull, CreateContainerConfigError).
+      #
+      # StatefulSet and CR names are derived from fullnameOverride=kube-prometheus
+      # in recipes/components/kube-prometheus-stack/values.yaml. The prometheus-
+      # operator creates StatefulSets named <workload>-<cr-name>, and the chart
+      # renders CR names as <fullname>-<workload>. Names verified against
+      # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml and
+      # tests/chainsaw/ai-conformance/kind-common/assert-monitoring.yaml
+      # (both live-cluster-validated). Label selectors are used in the pod-health
+      # step because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kube-prometheus-stack-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the kube-prometheus-stack-operator
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kube-prometheus-operator
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-prometheus-cr-available
+            try:
+              # Assert the Prometheus CR has been reconciled by the operator.
+              # The prometheus-operator sets an Available condition on the CR once
+              # it has successfully reconciled the CR into a running StatefulSet.
+              # CR name kube-prometheus-prometheus derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -prometheus suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Prometheus
+                    metadata:
+                      name: kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-alertmanager-cr-available
+            try:
+              # Assert the Alertmanager CR has been reconciled by the operator.
+              # CR name kube-prometheus-alertmanager derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -alertmanager suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Alertmanager
+                    metadata:
+                      name: kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-prometheus-statefulset-ready
+            try:
+              # Assert the Prometheus StatefulSet created by the operator has
+              # reached full rollout. readyReplicas >= replicas ensures all pods
+              # are ready, not just some. The replicas > 0 guard prevents a
+              # vacuous pass when the StatefulSet is missing or has 0 replicas.
+              # StatefulSet name prometheus-kube-prometheus-prometheus is
+              # <workload>-<cr-name> per prometheus-operator convention, verified
+              # from tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: prometheus-kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-alertmanager-statefulset-ready
+            try:
+              # Assert the Alertmanager StatefulSet has reached full rollout.
+              # Same pattern as Prometheus above. StatefulSet name
+              # alertmanager-kube-prometheus-alertmanager is <workload>-<cr-name>
+              # per prometheus-operator convention, verified from
+              # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: alertmanager-kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus stack pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kube-prometheus-stack
+    namespace: monitoring
+    overrides:
+      alertmanager:
+        alertmanagerSpec:
+          resources:
+            limits:
+              cpu: 250m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+      defaultRules:
+        create: false
+      grafana:
+        enabled: false
+      prometheus:
+        prometheusSpec:
+          resources:
+            limits:
+              cpu: 1
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          retention: 7d
+          storageSpec:
+            emptyDir:
+              medium: ""
+              sizeLimit: 5Gi
+      prometheusOperator:
+        alertmanagerConfigNamespaces:
+          - monitoring
+        alertmanagerInstanceNamespaces:
+          - monitoring
+        livenessProbe:
+          failureThreshold: 10
+          timeoutSeconds: 10
+        prometheusInstanceNamespaces:
+          - monitoring
+        readinessProbe:
+          failureThreshold: 6
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        thanosRulerInstanceNamespaces:
+          - monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/kube-prometheus-stack/values.yaml
+    version: 84.4.0
+  - chart: network-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Network Operator Health Check
+      #
+      # Validates that the NVIDIA Network Operator is running and healthy in
+      # the nvidia-network-operator namespace. Also asserts
+      # nicclusterpolicies.mellanox.com is Established=True (verified against
+      # chart 26.4.1; re-verify on defaultVersion bump). Chart 26.4.1 also
+      # ships nicnodepolicies.mellanox.com, deliberately NOT asserted here:
+      # no in-tree recipe instantiates a CR against it, so it fails the same
+      # load-bearing-only bar the rest of this PR's assertions are held to.
+      # Checks that the
+      # network-operator deployment has at least one available replica and
+      # that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: network-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: nicclusterpolicies.mellanox.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # network-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: network-operator
+                      namespace: nvidia-network-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: network-operator
+    namespace: nvidia-network-operator
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/network-operator/values.yaml
+    version: 26.4.1
+  - chart: node-feature-discovery
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Node Feature Discovery Health Check
+      #
+      # Validates the standalone NFD deployment by checking:
+      # 1. NFD Master Deployment has at least one ready replica
+      # 2. NFD Worker DaemonSet has fully rolled out (desiredNumberScheduled > 0
+      #    and numberReady == desiredNumberScheduled, so partial failures don't pass)
+      # 3. NFD GC Deployment has at least one ready replica (gc.enable: true)
+      #
+      # Resource names: AICR deploys the kubernetes-sigs/node-feature-discovery
+      # chart under release name "nfd" (matching the ComponentRef Name in
+      # recipes/registry.yaml). The chart's fullname template prefixes the
+      # release name to the chart name when they don't overlap, yielding
+      # "nfd-node-feature-discovery-*" for the master Deployment, worker
+      # DaemonSet, and gc Deployment. If a deployer ever switches the release
+      # name to "node-feature-discovery", these asserts need updating in
+      # lockstep.
+      # 4. No pods in unhealthy phases (Pending, Failed, Unknown) or stuck in
+      #    Running with a known-unhealthy container waiting reason
+      #    (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+      #    CreateContainerConfigError)
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nfd-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-master-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-master
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-worker-daemonset
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nfd-node-feature-discovery-worker
+                      namespace: node-feature-discovery
+                    status:
+                      # Guard against vacuous pass when 0 nodes match the
+                      # DaemonSet: require at least one scheduled pod.
+                      (desiredNumberScheduled > `0`): true
+                      # Full rollout: every scheduled pod is ready. Combined with
+                      # the guard above, this rejects partial failures. We assert on
+                      # numberReady (always present in DaemonSetStatus) rather than
+                      # numberUnavailable, which is `omitempty` and disappears from
+                      # the status when zero — making `numberUnavailable == 0`
+                      # evaluate `null == 0` (false) on a fully-healthy DaemonSet.
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-gc-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-gc
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nfd
+    namespace: node-feature-discovery
+    source: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+    type: Helm
+    valuesFile: components/nfd/values.yaml
+    version: 0.19.0
+  - chart: nodewright
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Nodewright Operator Health Check
+      #
+      # Validates that the Nodewright Operator is running and healthy in the
+      # skyhook namespace:
+      # 1. skyhooks.skyhook.nvidia.com CRD Established=True (the apiserver
+      #    will accept Skyhook CRs that nodewright-customizations declares).
+      # 2. skyhook-operator-controller-manager Deployment has at least one
+      #    available replica.
+      # 3. No pods stuck in Pending/Failed/Unknown phases or known-bad
+      #    container-waiting states.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nodewright-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-skyhook-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: skyhooks.skyhook.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: skyhook-operator-controller-manager
+                      namespace: skyhook
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nodewright-operator
+    namespace: skyhook
+    overrides:
+      controllerManager:
+        manager:
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+    source: oci://ghcr.io/nvidia/nodewright/charts
+    type: Helm
+    valuesFile: components/nodewright-operator/values.yaml
+    version: v0.17.1
+  - chart: dra-driver-nvidia-gpu
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVIDIA DRA Driver GPU Health Check
+      #
+      # Validates that the NVIDIA DRA (Dynamic Resource Allocation) GPU driver
+      # is running and healthy in the nvidia-dra-driver namespace. The
+      # kubelet-plugin DaemonSet must roll out fully — numberReady ==
+      # desiredNumberScheduled (with desiredNumberScheduled > 0 as a guard).
+      # Previous check gated only on numberReady > 0, passing on partial
+      # failures; see #1222 and recipes/checks/nfd/health-check.yaml for
+      # the same rationale.
+      #
+      # Resource names: the DaemonSet name is release-derived
+      # (<release>-kubelet-plugin). AICR's release name is
+      # `nvidia-dra-driver-gpu` (matches ComponentRef Name in registry.yaml).
+      # If a deployer renames the release, this assert needs updating in
+      # lockstep — see verifyDRAKubeletPluginReady commentary in
+      # validators/deployment/expected_resources.go for why a chart-shape
+      # label would be a more robust selector.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvidia-dra-driver-gpu-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-kubelet-plugin-daemonset-fully-rolled-out
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nvidia-dra-driver-gpu-kubelet-plugin
+                      namespace: nvidia-dra-driver
+                    status:
+                      (desiredNumberScheduled > `0`): true
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvidia-dra-driver-gpu
+    namespace: nvidia-dra-driver
+    overrides:
+      nvidiaDriverRoot: /
+    source: oci://registry.k8s.io/dra-driver-nvidia/charts
+    type: Helm
+    valuesFile: components/nvidia-dra-driver-gpu/values.yaml
+    version: 0.4.1
+  - chart: nvsentinel
+    dependencyRefs:
+      - cert-manager
+      - gpu-operator
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVSentinel Health Check
+      #
+      # Validates that the NVSentinel labeler is running and healthy in
+      # the nvsentinel namespace. Checks that the labeler deployment has at
+      # least one available replica and that no pods in the
+      # namespace are stuck in Pending, Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvsentinel-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # nvsentinel-controller-manager deployment exists and has at least
+              # one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: labeler
+                      namespace: nvsentinel
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvsentinel
+    namespace: nvsentinel
+    overrides:
+      platformConnector:
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+    source: oci://ghcr.io/nvidia
+    type: Helm
+    valuesFile: components/nvsentinel/values.yaml
+    version: v1.9.0
+  - chart: prometheus-adapter
+    dependencyRefs:
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Prometheus Adapter Health Check
+      #
+      # Validates that the Prometheus Adapter is running and healthy in the
+      # monitoring namespace. Checks that the prometheus-adapter deployment has
+      # at least one available replica and that no prometheus adapter pods
+      # (selected by label) are stuck in Pending, Failed, or Unknown phases.
+      # Label selectors are used because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-adapter-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the prometheus-adapter
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: prometheus-adapter
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus adapter pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: prometheus-adapter
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-adapter/values.yaml
+    version: 5.3.0
+  - chart: prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # prometheus-operator-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this chart installs has
+      # reached the `Established=True` condition (CRD storage is up and the
+      # apiserver will accept CRs of those kinds).
+      #
+      # CRDs come from the upstream prometheus-community/prometheus-operator-crds
+      # chart pinned to 28.0.1 in recipes/registry.yaml. The 8 kinds under
+      # monitoring.coreos.com/v1 are enumerated in
+      # recipes/components/prometheus-operator-crds/values.yaml header:
+      # Alertmanager, AlertmanagerConfig, PodMonitor, Probe, Prometheus,
+      # PrometheusRule, ServiceMonitor, ThanosRuler. Plural names match the
+      # long-standing upstream prometheus-operator chart shape.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-operator-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-prometheus-operator-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagerconfigs.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: podmonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: probes.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheuses.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheusrules.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: servicemonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: thanosrulers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    name: prometheus-operator-crds
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-operator-crds/values.yaml
+    version: 28.0.1
+constraints:
+  - name: K8s.server.version
+    value: '>= 1.30'
+criteria:
+  accelerator: gb200
+  intent: inference
+  os: any
+  platform: any
+  service: kind
+deploymentOrder:
+  - agentgateway-crds
+  - cert-manager
+  - agentgateway
+  - nfd
+  - network-operator
+  - nodewright-operator
+  - prometheus-operator-crds
+  - kube-prometheus-stack
+  - gpu-operator
+  - k8s-ephemeral-storage-metrics
+  - kai-scheduler
+  - nvidia-dra-driver-gpu
+  - nvsentinel
+  - prometheus-adapter
+kind: RecipeResult
+metadata:
+  appliedOverlays:
+    - base
+    - monitoring-hpa
+    - gb200-any
+    - kind
+    - kind-inference
+  version: dev
+validation:
+  conformance:
+    checks:
+      - platform-health
+      - gpu-operator-health
+      - dra-support
+      - accelerator-metrics
+      - ai-service-metrics
+  deployment:
+    checks:
+      - operator-health
+      - expected-resources
+      - gpu-operator-version
+      - check-nvidia-smi
+    constraints:
+      - name: Deployment.gpu-operator.version
+        value: '>= v25.10.0'

--- a/tests/aicr-sweep/results/hybrid-kwok-tainted/ctrf/validate-nocleanup.json
+++ b/tests/aicr-sweep/results/hybrid-kwok-tainted/ctrf/validate-nocleanup.json
@@ -1,0 +1,56 @@
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-08-03T19:11:34Z",
+  "generatedBy": "aicr",
+  "results": {
+    "tool": {
+      "name": "aicr",
+      "version": "dev"
+    },
+    "summary": {
+      "tests": 4,
+      "passed": 4,
+      "failed": 0,
+      "skipped": 0,
+      "pending": 0,
+      "other": 0,
+      "start": 1785784290226,
+      "stop": 1785784294382
+    },
+    "tests": [
+      {
+        "name": "operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ]
+      },
+      {
+        "name": "expected-resources",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ]
+      },
+      {
+        "name": "gpu-operator-version",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ]
+      },
+      {
+        "name": "check-nvidia-smi",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aicr-sweep/results/hybrid-kwok-tainted/ctrf/validate.json
+++ b/tests/aicr-sweep/results/hybrid-kwok-tainted/ctrf/validate.json
@@ -1,0 +1,96 @@
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-08-03T19:09:34Z",
+  "generatedBy": "aicr",
+  "results": {
+    "tool": {
+      "name": "aicr",
+      "version": "dev"
+    },
+    "summary": {
+      "tests": 9,
+      "passed": 9,
+      "failed": 0,
+      "skipped": 0,
+      "pending": 0,
+      "other": 0,
+      "start": 1785784169912,
+      "stop": 1785784179331
+    },
+    "tests": [
+      {
+        "name": "operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ]
+      },
+      {
+        "name": "expected-resources",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ]
+      },
+      {
+        "name": "gpu-operator-version",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ]
+      },
+      {
+        "name": "check-nvidia-smi",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "deployment"
+        ]
+      },
+      {
+        "name": "dra-support",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ]
+      },
+      {
+        "name": "accelerator-metrics",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ]
+      },
+      {
+        "name": "ai-service-metrics",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ]
+      },
+      {
+        "name": "gpu-operator-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ]
+      },
+      {
+        "name": "platform-health",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aicr-sweep/results/hybrid-kwok-tainted/recipe.yaml
+++ b/tests/aicr-sweep/results/hybrid-kwok-tainted/recipe.yaml
@@ -1,0 +1,2021 @@
+apiVersion: aicr.run/v1alpha2
+componentRefs:
+  - chart: agentgateway
+    dependencyRefs:
+      - agentgateway-crds
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Agentgateway Health Check
+      #
+      # Validates that agentgateway is running and healthy in the agentgateway-system
+      # namespace. Checks that the agentgateway deployment has at least one available
+      # replica and that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # agentgateway deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: agentgateway
+                      namespace: agentgateway-system
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: agentgateway-system
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    manifestFiles:
+      - components/agentgateway/manifests/inference-gateway.yaml
+    name: agentgateway
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway/values.yaml
+    version: v1.3.1
+  - chart: agentgateway-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # agentgateway-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this component installs
+      # has reached the `Established=True` condition (CRD storage is up and
+      # the apiserver will accept CRs of those kinds).
+      #
+      # Scope: this component bundles BOTH the chart's agentgateway.dev/v1alpha1
+      # CRDs and the vendored Gateway API + Inference Extension manifests under
+      # recipes/components/agentgateway-crds/manifests/.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: agentgateway-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-gateway-api-crds-established
+            # Standard Gateway API CRDs vendored under
+            # manifests/gateway-api-crds.yaml. Verified against the in-tree
+            # manifest content.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gatewayclasses.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: gateways.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: grpcroutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: httproutes.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: referencegrants.gateway.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-agentgateway-crds-established
+            # agentgateway.dev/v1alpha1 CRDs installed by the agentgateway-crds
+            # Helm chart.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaybackends.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewayparameters.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: agentgatewaypolicies.agentgateway.dev
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-inference-extension-crds-established
+            # Gateway API Inference Extension CRDs vendored under
+            # manifests/inference-extension-crds.yaml.
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencemodelrewrites.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferenceobjectives.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepoolimports.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: inferencepools.inference.networking.x-k8s.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    manifestFiles:
+      - components/agentgateway-crds/manifests/gateway-api-crds.yaml
+      - components/agentgateway-crds/manifests/inference-extension-crds.yaml
+    name: agentgateway-crds
+    namespace: agentgateway-system
+    source: oci://cr.agentgateway.dev/charts
+    type: Helm
+    valuesFile: components/agentgateway-crds/values.yaml
+    version: v1.3.1
+  - chart: cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Cert Manager Health Check
+      #
+      # Validates that cert-manager is running and healthy in the cert-manager
+      # namespace. The chart deploys three Deployments — the controller
+      # (cert-manager), the CA injector (cert-manager-cainjector), and the
+      # webhook (cert-manager-webhook) — all of which must be available for
+      # the operator to issue / inject / validate certificates. The previous
+      # check only asserted the controller; this check covers all three to
+      # avoid silently passing while the webhook is down (which would block
+      # every Certificate/Issuer CR admission).
+      #
+      # Also asserts the three core CRDs are Established=True so the
+      # apiserver will accept CRs of those kinds (per #1222 / #660).
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: cert-manager-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: certificates.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: issuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterissuers.cert-manager.io
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-controller-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cainjector-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-cainjector
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-webhook-deployment
+            try:
+              # The webhook must be ready before any Certificate / Issuer CR
+              # can be admitted. Without this assert, a healthy controller
+              # with a dead webhook would still pass the check while the
+              # cluster silently rejects every cert-manager CR.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: cert-manager-webhook
+                      namespace: cert-manager
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: cert-manager
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: cert-manager
+    namespace: cert-manager
+    source: https://charts.jetstack.io
+    type: Helm
+    valuesFile: components/cert-manager/values.yaml
+    version: v1.20.2
+  - chart: gpu-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # GPU Operator Health Check
+      #
+      # Validates the GPU operator stack:
+      # 1. The gpu-operator Deployment has at least one available replica.
+      # 2. The clusterpolicies.nvidia.com CRD is Established (apiserver will
+      #    accept the singleton ClusterPolicy CR).
+      # 3. The ClusterPolicy singleton named "cluster-policy" has reconciled
+      #    to status.state == "ready" — this is the deepest signal that the
+      #    full GPU stack (driver, toolkit, cuda, plugin DaemonSets, validators)
+      #    is healthy. Migrates the verifyClusterPolicyReady Go check that
+      #    PR #1235 task 7 deferred for assertion-equivalence proof.
+      # 4. No pods in unhealthy phases or stuck container-waiting states.
+      #
+      # The nvidia-operator-validator DaemonSet runs 4 sequential init
+      # containers (driver, toolkit, cuda, plugin) before reaching Running;
+      # the ClusterPolicy state assertion is the canonical post-reconcile
+      # signal that all four passed.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: gpu-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-cluster-policy-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: clusterpolicies.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # gpu-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: gpu-operator
+                      namespace: gpu-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-cluster-policy-ready
+            try:
+              # Deepest GPU readiness signal: ClusterPolicy singleton has
+              # reconciled to state=ready. Replaces the deferred
+              # verifyClusterPolicyReady Go check from PR #1235 task 7.
+              - assert:
+                  resource:
+                    apiVersion: nvidia.com/v1
+                    kind: ClusterPolicy
+                    metadata:
+                      name: cluster-policy
+                    status:
+                      state: ready
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: gpu-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: gpu-operator
+    namespace: gpu-operator
+    overrides:
+      daemonsets:
+        tolerations: []
+      dcgm:
+        enabled: false
+      dcgmExporter:
+        config:
+          create: false
+          data: ""
+          name: ""
+      devicePlugin:
+        env: []
+      driver:
+        enabled: false
+        rdma:
+          enabled: false
+      gdrcopy:
+        enabled: false
+      migManager:
+        enabled: false
+      operator:
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+      toolkit:
+        enabled: false
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/gpu-operator/values.yaml
+    version: v26.3.3
+  - chart: k8s-ephemeral-storage-metrics
+    dependencyRefs:
+      - kube-prometheus-stack
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # K8s Ephemeral Storage Metrics Health Check
+      #
+      # Validates that the k8s-ephemeral-storage-metrics Deployment is running and
+      # healthy in the monitoring namespace. Checks that the Deployment has at least
+      # one available replica and that no ephemeral storage metrics pods (selected by label)
+      # are stuck in Pending, Failed, or Unknown phases. Label selectors are used
+      # because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: k8s-ephemeral-storage-metrics-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the k8s-ephemeral-storage-metrics
+              # DaemonSet exists and has at least one ready pod.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: k8s-ephemeral-storage-metrics
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no ephemeral storage metrics pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: k8s-ephemeral-storage-metrics
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: k8s-ephemeral-storage-metrics
+    namespace: monitoring
+    source: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
+    type: Helm
+    valuesFile: components/k8s-ephemeral-storage-metrics/values.yaml
+    version: 1.19.2
+  - chart: kai-scheduler
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # KAI Scheduler Health Check
+      #
+      # Validates that the KAI Scheduler is running and healthy in the kai-scheduler
+      # namespace. Checks that the kai-operator deployment has at least one
+      # available replica and that no pods in the namespace are stuck in Pending,
+      # Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kai-scheduler-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # kai-scheduler deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kai-operator
+                      namespace: kai-scheduler
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: kai-scheduler
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kai-scheduler
+    namespace: kai-scheduler
+    source: oci://ghcr.io/kai-scheduler/kai-scheduler
+    type: Helm
+    valuesFile: components/kai-scheduler/values.yaml
+    version: v0.14.1
+  - chart: kube-prometheus-stack
+    dependencyRefs:
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Kube Prometheus Stack Health Check
+      #
+      # Validates that the kube-prometheus-stack operator, its managed CRs, and
+      # associated workloads are running and healthy in the monitoring namespace:
+      #
+      # 1. The kube-prometheus-operator Deployment has at least one available replica.
+      # 2. The Prometheus CR (kube-prometheus-prometheus) reports Available=True.
+      #    This explicitly catches operator-level reconcile stalls (e.g., webhook
+      #    rejections) where a target StatefulSet might never be created at all.
+      # 3. The Alertmanager CR (kube-prometheus-alertmanager) reports Available=True.
+      # 4. The Prometheus StatefulSet (prometheus-kube-prometheus-prometheus) has
+      #    reached full rollout: readyReplicas >= replicas, with a replicas > 0
+      #    vacuous-pass guard so a missing StatefulSet does not silently pass.
+      # 5. The Alertmanager StatefulSet (alertmanager-kube-prometheus-alertmanager)
+      #    reaches the same full-rollout threshold.
+      # 6. No stack operator pods (label-scoped to app.kubernetes.io/name:
+      #    kube-prometheus-stack) are stuck in Pending, Failed, Unknown, or a
+      #    known-bad container-waiting reason (CrashLoopBackOff, ImagePullBackOff,
+      #    ErrImagePull, CreateContainerConfigError).
+      #
+      # StatefulSet and CR names are derived from fullnameOverride=kube-prometheus
+      # in recipes/components/kube-prometheus-stack/values.yaml. The prometheus-
+      # operator creates StatefulSets named <workload>-<cr-name>, and the chart
+      # renders CR names as <fullname>-<workload>. Names verified against
+      # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml and
+      # tests/chainsaw/ai-conformance/kind-common/assert-monitoring.yaml
+      # (both live-cluster-validated). Label selectors are used in the pod-health
+      # step because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: kube-prometheus-stack-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the kube-prometheus-stack-operator
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: kube-prometheus-operator
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-prometheus-cr-available
+            try:
+              # Assert the Prometheus CR has been reconciled by the operator.
+              # The prometheus-operator sets an Available condition on the CR once
+              # it has successfully reconciled the CR into a running StatefulSet.
+              # CR name kube-prometheus-prometheus derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -prometheus suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Prometheus
+                    metadata:
+                      name: kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-alertmanager-cr-available
+            try:
+              # Assert the Alertmanager CR has been reconciled by the operator.
+              # CR name kube-prometheus-alertmanager derives from the chart's
+              # fullnameOverride=kube-prometheus + the chart's -alertmanager suffix.
+              - assert:
+                  resource:
+                    apiVersion: monitoring.coreos.com/v1
+                    kind: Alertmanager
+                    metadata:
+                      name: kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (conditions[?type == 'Available']):
+                        - status: "True"
+          - name: validate-prometheus-statefulset-ready
+            try:
+              # Assert the Prometheus StatefulSet created by the operator has
+              # reached full rollout. readyReplicas >= replicas ensures all pods
+              # are ready, not just some. The replicas > 0 guard prevents a
+              # vacuous pass when the StatefulSet is missing or has 0 replicas.
+              # StatefulSet name prometheus-kube-prometheus-prometheus is
+              # <workload>-<cr-name> per prometheus-operator convention, verified
+              # from tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: prometheus-kube-prometheus-prometheus
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-alertmanager-statefulset-ready
+            try:
+              # Assert the Alertmanager StatefulSet has reached full rollout.
+              # Same pattern as Prometheus above. StatefulSet name
+              # alertmanager-kube-prometheus-alertmanager is <workload>-<cr-name>
+              # per prometheus-operator convention, verified from
+              # tests/chainsaw/ai-conformance/common/assert-monitoring.yaml.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: StatefulSet
+                    metadata:
+                      name: alertmanager-kube-prometheus-alertmanager
+                      namespace: monitoring
+                    status:
+                      (replicas > `0`): true
+                      (readyReplicas >= replicas): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus stack pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: kube-prometheus-stack
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: kube-prometheus-stack
+    namespace: monitoring
+    overrides:
+      alertmanager:
+        alertmanagerSpec:
+          resources:
+            limits:
+              cpu: 250m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+      defaultRules:
+        create: false
+      grafana:
+        enabled: false
+      prometheus:
+        prometheusSpec:
+          resources:
+            limits:
+              cpu: 1
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          retention: 7d
+          storageSpec:
+            emptyDir:
+              medium: ""
+              sizeLimit: 5Gi
+      prometheusOperator:
+        alertmanagerConfigNamespaces:
+          - monitoring
+        alertmanagerInstanceNamespaces:
+          - monitoring
+        livenessProbe:
+          failureThreshold: 10
+          timeoutSeconds: 10
+        prometheusInstanceNamespaces:
+          - monitoring
+        readinessProbe:
+          failureThreshold: 6
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        thanosRulerInstanceNamespaces:
+          - monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/kube-prometheus-stack/values.yaml
+    version: 84.4.0
+  - chart: network-operator
+    dependencyRefs:
+      - nfd
+      - cert-manager
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Network Operator Health Check
+      #
+      # Validates that the NVIDIA Network Operator is running and healthy in
+      # the nvidia-network-operator namespace. Also asserts
+      # nicclusterpolicies.mellanox.com is Established=True (verified against
+      # chart 26.4.1; re-verify on defaultVersion bump). Chart 26.4.1 also
+      # ships nicnodepolicies.mellanox.com, deliberately NOT asserted here:
+      # no in-tree recipe instantiates a CR against it, so it fails the same
+      # load-bearing-only bar the rest of this PR's assertions are held to.
+      # Checks that the
+      # network-operator deployment has at least one available replica and
+      # that no pods in the namespace are stuck in Pending, Failed, or
+      # Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: network-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: nicclusterpolicies.mellanox.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # network-operator deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: network-operator
+                      namespace: nvidia-network-operator
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-network-operator
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: network-operator
+    namespace: nvidia-network-operator
+    source: https://helm.ngc.nvidia.com/nvidia
+    type: Helm
+    valuesFile: components/network-operator/values.yaml
+    version: 26.4.1
+  - chart: node-feature-discovery
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Node Feature Discovery Health Check
+      #
+      # Validates the standalone NFD deployment by checking:
+      # 1. NFD Master Deployment has at least one ready replica
+      # 2. NFD Worker DaemonSet has fully rolled out (desiredNumberScheduled > 0
+      #    and numberReady == desiredNumberScheduled, so partial failures don't pass)
+      # 3. NFD GC Deployment has at least one ready replica (gc.enable: true)
+      #
+      # Resource names: AICR deploys the kubernetes-sigs/node-feature-discovery
+      # chart under release name "nfd" (matching the ComponentRef Name in
+      # recipes/registry.yaml). The chart's fullname template prefixes the
+      # release name to the chart name when they don't overlap, yielding
+      # "nfd-node-feature-discovery-*" for the master Deployment, worker
+      # DaemonSet, and gc Deployment. If a deployer ever switches the release
+      # name to "node-feature-discovery", these asserts need updating in
+      # lockstep.
+      # 4. No pods in unhealthy phases (Pending, Failed, Unknown) or stuck in
+      #    Running with a known-unhealthy container waiting reason
+      #    (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+      #    CreateContainerConfigError)
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nfd-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-master-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-master
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-worker-daemonset
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nfd-node-feature-discovery-worker
+                      namespace: node-feature-discovery
+                    status:
+                      # Guard against vacuous pass when 0 nodes match the
+                      # DaemonSet: require at least one scheduled pod.
+                      (desiredNumberScheduled > `0`): true
+                      # Full rollout: every scheduled pod is ready. Combined with
+                      # the guard above, this rejects partial failures. We assert on
+                      # numberReady (always present in DaemonSetStatus) rather than
+                      # numberUnavailable, which is `omitempty` and disappears from
+                      # the status when zero — making `numberUnavailable == 0`
+                      # evaluate `null == 0` (false) on a fully-healthy DaemonSet.
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-gc-deployment
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: nfd-node-feature-discovery-gc
+                      namespace: node-feature-discovery
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Phase-based errors: Pending/Failed/Unknown.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      phase: Unknown
+              # Container-state errors: pods stuck in Running phase with a
+              # container in a known-bad waiting reason. Phase filtering alone
+              # misses CrashLoopBackOff/ImagePullBackOff because those pods
+              # typically remain in Running phase with unhealthy containers.
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: node-feature-discovery
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nfd
+    namespace: node-feature-discovery
+    source: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+    type: Helm
+    valuesFile: components/nfd/values.yaml
+    version: 0.19.0
+  - chart: nodewright
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Nodewright Operator Health Check
+      #
+      # Validates that the Nodewright Operator is running and healthy in the
+      # skyhook namespace:
+      # 1. skyhooks.skyhook.nvidia.com CRD Established=True (the apiserver
+      #    will accept Skyhook CRs that nodewright-customizations declares).
+      # 2. skyhook-operator-controller-manager Deployment has at least one
+      #    available replica.
+      # 3. No pods stuck in Pending/Failed/Unknown phases or known-bad
+      #    container-waiting states.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nodewright-operator-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-skyhook-crd-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: skyhooks.skyhook.nvidia.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+          - name: validate-deployment-exists
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: skyhook-operator-controller-manager
+                      namespace: skyhook
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: skyhook
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nodewright-operator
+    namespace: skyhook
+    overrides:
+      controllerManager:
+        manager:
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+    source: oci://ghcr.io/nvidia/nodewright/charts
+    type: Helm
+    valuesFile: components/nodewright-operator/values.yaml
+    version: v0.17.1
+  - chart: dra-driver-nvidia-gpu
+    dependencyRefs:
+      - gpu-operator
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVIDIA DRA Driver GPU Health Check
+      #
+      # Validates that the NVIDIA DRA (Dynamic Resource Allocation) GPU driver
+      # is running and healthy in the nvidia-dra-driver namespace. The
+      # kubelet-plugin DaemonSet must roll out fully — numberReady ==
+      # desiredNumberScheduled (with desiredNumberScheduled > 0 as a guard).
+      # Previous check gated only on numberReady > 0, passing on partial
+      # failures; see #1222 and recipes/checks/nfd/health-check.yaml for
+      # the same rationale.
+      #
+      # Resource names: the DaemonSet name is release-derived
+      # (<release>-kubelet-plugin). AICR's release name is
+      # `nvidia-dra-driver-gpu` (matches ComponentRef Name in registry.yaml).
+      # If a deployer renames the release, this assert needs updating in
+      # lockstep — see verifyDRAKubeletPluginReady commentary in
+      # validators/deployment/expected_resources.go for why a chart-shape
+      # label would be a more robust selector.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvidia-dra-driver-gpu-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-kubelet-plugin-daemonset-fully-rolled-out
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: DaemonSet
+                    metadata:
+                      name: nvidia-dra-driver-gpu-kubelet-plugin
+                      namespace: nvidia-dra-driver
+                    status:
+                      (desiredNumberScheduled > `0`): true
+                      (numberReady == desiredNumberScheduled): true
+          - name: validate-all-pods-healthy
+            try:
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvidia-dra-driver
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvidia-dra-driver-gpu
+    namespace: nvidia-dra-driver
+    overrides:
+      nvidiaDriverRoot: /
+    source: oci://registry.k8s.io/dra-driver-nvidia/charts
+    type: Helm
+    valuesFile: components/nvidia-dra-driver-gpu/values.yaml
+    version: 0.4.1
+  - chart: nvsentinel
+    dependencyRefs:
+      - cert-manager
+      - gpu-operator
+      - prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # NVSentinel Health Check
+      #
+      # Validates that the NVSentinel labeler is running and healthy in
+      # the nvsentinel namespace. Checks that the labeler deployment has at
+      # least one available replica and that no pods in the
+      # namespace are stuck in Pending, Failed, or Unknown phases.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: nvsentinel-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass on empty namespace: verify the
+              # nvsentinel-controller-manager deployment exists and has at least
+              # one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: labeler
+                      namespace: nvsentinel
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no pods are in unhealthy phases (Pending / Failed /
+              # Unknown) or stuck in Running phase with a known-bad
+              # container-waiting reason (CrashLoopBackOff,
+              # ImagePullBackOff, ErrImagePull, CreateContainerConfigError).
+              # Phase-only filtering misses CrashLoopBackOff because such
+              # pods typically remain in Running phase with an unhealthy
+              # container.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: nvsentinel
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: nvsentinel
+    namespace: nvsentinel
+    overrides:
+      platformConnector:
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+    source: oci://ghcr.io/nvidia
+    type: Helm
+    valuesFile: components/nvsentinel/values.yaml
+    version: v1.9.0
+  - chart: prometheus-adapter
+    dependencyRefs:
+      - kube-prometheus-stack
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # Prometheus Adapter Health Check
+      #
+      # Validates that the Prometheus Adapter is running and healthy in the
+      # monitoring namespace. Checks that the prometheus-adapter deployment has
+      # at least one available replica and that no prometheus adapter pods
+      # (selected by label) are stuck in Pending, Failed, or Unknown phases.
+      # Label selectors are used because monitoring is a shared namespace.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-adapter-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-deployment-exists
+            try:
+              # Guard against vacuous pass: verify the prometheus-adapter
+              # deployment exists and has at least one ready replica.
+              - assert:
+                  resource:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: prometheus-adapter
+                      namespace: monitoring
+                    status:
+                      (availableReplicas > `0`): true
+          - name: validate-all-pods-healthy
+            try:
+              # Assert no prometheus adapter pods are in unhealthy phases
+              # (Pending / Failed / Unknown) or stuck in Running phase
+              # with a known-bad container-waiting reason
+              # (CrashLoopBackOff, ImagePullBackOff, ErrImagePull,
+              # CreateContainerConfigError). Phase-only filtering misses
+              # CrashLoopBackOff because such pods typically remain in
+              # Running phase with an unhealthy container.
+              # Uses label selector because monitoring is a shared namespace.
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Pending
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Failed
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      phase: Unknown
+              # JMESPath projection (not single-element match): kyverno-json's
+              # sliceNode.Assert gates on exact slice length before per-element
+              # comparison, so a `containerStatuses: - state: ...` shape only
+              # matches single-container pods and silently passes sidecars. Use
+              # `containerStatuses[?...] | length(@) > 0` to fire on any
+              # container at any index. Parallel initContainerStatuses block
+              # below catches init-container failures (invisible to
+              # containerStatuses). Per PR #1245 review (@ArangoGutierrez).
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((containerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+              - error:
+                  resource:
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      namespace: monitoring
+                      labels:
+                        app.kubernetes.io/name: prometheus-adapter
+                    status:
+                      ((initContainerStatuses || `[]`)[?state.waiting.reason == 'CrashLoopBackOff' || state.waiting.reason == 'ImagePullBackOff' || state.waiting.reason == 'ErrImagePull' || state.waiting.reason == 'CreateContainerConfigError'] | length(@) > `0`): true
+    name: prometheus-adapter
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-adapter/values.yaml
+    version: 5.3.0
+  - chart: prometheus-operator-crds
+    healthCheckAsserts: |
+      # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+      #
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at
+      #
+      #     http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
+
+      # prometheus-operator-crds Health Check
+      #
+      # CRD-only component. Validates that every CRD this chart installs has
+      # reached the `Established=True` condition (CRD storage is up and the
+      # apiserver will accept CRs of those kinds).
+      #
+      # CRDs come from the upstream prometheus-community/prometheus-operator-crds
+      # chart pinned to 28.0.1 in recipes/registry.yaml. The 8 kinds under
+      # monitoring.coreos.com/v1 are enumerated in
+      # recipes/components/prometheus-operator-crds/values.yaml header:
+      # Alertmanager, AlertmanagerConfig, PodMonitor, Probe, Prometheus,
+      # PrometheusRule, ServiceMonitor, ThanosRuler. Plural names match the
+      # long-standing upstream prometheus-operator chart shape.
+      apiVersion: chainsaw.kyverno.io/v1alpha1
+      kind: Test
+      metadata:
+        name: prometheus-operator-crds-health-check
+      spec:
+        timeouts:
+          assert: 5m
+        steps:
+          - name: validate-prometheus-operator-crds-established
+            try:
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: alertmanagerconfigs.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: podmonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: probes.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheuses.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: prometheusrules.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: servicemonitors.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+              - assert:
+                  resource:
+                    apiVersion: apiextensions.k8s.io/v1
+                    kind: CustomResourceDefinition
+                    metadata:
+                      name: thanosrulers.monitoring.coreos.com
+                    status:
+                      (conditions[?type == 'Established']):
+                        - status: "True"
+    name: prometheus-operator-crds
+    namespace: monitoring
+    source: https://prometheus-community.github.io/helm-charts
+    type: Helm
+    valuesFile: components/prometheus-operator-crds/values.yaml
+    version: 28.0.1
+constraints:
+  - name: K8s.server.version
+    value: '>= 1.30'
+criteria:
+  accelerator: gb200
+  intent: inference
+  os: any
+  platform: any
+  service: kind
+deploymentOrder:
+  - agentgateway-crds
+  - cert-manager
+  - agentgateway
+  - nfd
+  - network-operator
+  - nodewright-operator
+  - prometheus-operator-crds
+  - kube-prometheus-stack
+  - gpu-operator
+  - k8s-ephemeral-storage-metrics
+  - kai-scheduler
+  - nvidia-dra-driver-gpu
+  - nvsentinel
+  - prometheus-adapter
+kind: RecipeResult
+metadata:
+  appliedOverlays:
+    - base
+    - monitoring-hpa
+    - gb200-any
+    - kind
+    - kind-inference
+  version: dev
+validation:
+  conformance:
+    checks:
+      - platform-health
+      - gpu-operator-health
+      - dra-support
+      - accelerator-metrics
+      - ai-service-metrics
+  deployment:
+    checks:
+      - operator-health
+      - expected-resources
+      - gpu-operator-version
+      - check-nvidia-smi
+    constraints:
+      - name: Deployment.gpu-operator.version
+        value: '>= v25.10.0'

--- a/tests/aicr-sweep/results/kwok-false-pass-evidence.log
+++ b/tests/aicr-sweep/results/kwok-false-pass-evidence.log
@@ -1,0 +1,58 @@
+# Evidence: KWOK nodes turn the AICR validator suite into a false pass
+# Captured 2026-08-03T19:14:36Z on the mokka-hybrid cluster.
+
+## Fleet
+total nodes: 253
+kwok (hollow) nodes: 250
+nvidia.com/gpu advertised fleet-wide: 2016
+
+## Baseline on the pure-Mokka cluster (same recipe, same AICR, no KWOK nodes)
+deployment phase: 9m0s, 2 passed / 1 failed / 1 inconclusive
+conformance phase: 5 selected, 1 passed / 4 failed
+
+## Same run with 250 KWOK nodes present
+deployment+conformance: 9 tests, 9 passed, 0 failed
+wall clock: deployment 4.2s, conformance 5.2s (vs 9m0s on the pure-Mokka cluster)
+
+## Where the validator pods actually ran (--no-cleanup, KWOK nodes tainted NoSchedule)
+aicr-check-nvidia-smi-5897be6f-6jxz8       kwok-gpu-0158         Succeeded
+aicr-expected-resources-bc7864cb-k2g5g     kwok-gpu-0169         Succeeded
+aicr-gpu-operator-version-1081b045-xqshm   kwok-gpu-0037         Succeeded
+aicr-operator-health-d60f7e59-ds784        kwok-gpu-0048         Succeeded
+aicr-validate-vkqcb (snapshot agent)       mokka-hybrid-worker   Succeeded
+
+## Proof no container ever executed
+containerStatuses for aicr-check-nvidia-smi (note empty imageID, started:false, startedAt==finishedAt):
+[{"image":"ghcr.io/nvidia/aicr-validators/deployment:latest","imageID":"","started":false,
+  "state":{"terminated":{"exitCode":0,"reason":"Completed",
+  "startedAt":"2026-08-03T19:11:33Z","finishedAt":"2026-08-03T19:11:33Z"}}}]
+
+kubectl logs on that pod:
+  Error from server (MethodNotAllowed): the server does not allow this method
+  on the requested resource ( pods/log ... )   <- no kubelet exists to serve logs
+
+## Why the pods land there despite the NoSchedule taint
+AICR validator Job pods carry a universal toleration. Observed on the live pod:
+  key=<empty> operator=Exists effect=<all>
+Source: pkg/validator/job/deployer_test.go:516 asserts the default is
+        Operator=Exists with Key="", i.e. tolerate every taint.
+
+## Why --node-selector does not mitigate it
+Observed: snapshot agent got the selector, validator Jobs did not.
+  aicr-validate-6qxk2                      nodeSelector={"aicr.run/real-node":"true"}
+  aicr-check-nvidia-smi-2bb73994-d9hc4     nodeSelector=NONE   -> ran on kwok-gpu-0213
+  aicr-expected-resources-345bc8fa-fqprd   nodeSelector=NONE   -> ran on kwok-gpu-0224
+  aicr-gpu-operator-version-32a497d6-fh5j2 nodeSelector=NONE   -> ran on kwok-gpu-0092
+  aicr-operator-health-72210902-5jxcg      nodeSelector=NONE   -> ran on kwok-gpu-0103
+Source: pkg/validator/job/deployer.go:66
+  "// NodeSelector is passed through to inner workloads via AICR_NODE_SELECTOR."
+  The flag reaches the validator container as an env var for workloads IT creates.
+  It is never applied to the validator Job's own pod spec.
+
+## The KWOK stage that manufactures the pass
+[{"key":".metadata.deletionTimestamp","operator":"DoesNotExist"},{"key":".status.phase","operator":"In","values":["Running"]},{"key":".metadata.ownerReferences.[].kind","operator":"In","values":["Job"]}]
+  Any Job-owned pod in phase Running is transitioned to Succeeded.
+
+## Control experiment: a pod that exits 7
+  on a REAL node  -> phase=Failed,    exitCode=7   (truth)
+  on a KWOK node  -> phase=Running -> Succeeded    (fabricated)

--- a/tests/aicr-sweep/results/pci-busid-evidence.log
+++ b/tests/aicr-sweep/results/pci-busid-evidence.log
@@ -1,0 +1,40 @@
+# Evidence: PCI bus ID reaches NVML consumers without its domain prefix
+# Captured 2026-08-03T06:46:23Z on the base sweep cluster.
+
+## What the gb200 profile declares (deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml)
+      bus_id: "0000:0A:00.0"
+      bus_id: "0000:0B:00.0"
+      bus_id: "0000:4A:00.0"
+      bus_id: "0000:4B:00.0"
+      bus_id: "0000:8A:00.0"
+      bus_id: "0000:8B:00.0"
+      bus_id: "0000:CA:00.0"
+      bus_id: "0000:CB:00.0"
+
+## What Mokka renders into the mock PCI sysfs tree (correct, domain present)
+0000:0a:00.0
+0000:0b:00.0
+0000:4a:00.0
+0000:4b:00.0
+0000:8a:00.0
+0000:8b:00.0
+0000:ca:00.0
+0000:cb:00.0
+
+## Consumer 1: NVIDIA DRA driver v25.12.0 (go-nvlib), drops dra.k8s.io/pcieRoot
+W0803 06:43:13.863421       1 nvlib.go:491] error getting PCIe root for device 0, continuing without attribute: invalid PCI Bus ID format: :0a:00.0
+W0803 06:43:13.863510       1 nvlib.go:491] error getting PCIe root for device 1, continuing without attribute: invalid PCI Bus ID format: :0b:00.0
+W0803 06:43:13.863550       1 nvlib.go:491] error getting PCIe root for device 2, continuing without attribute: invalid PCI Bus ID format: :4a:00.0
+W0803 06:43:13.863583       1 nvlib.go:491] error getting PCIe root for device 3, continuing without attribute: invalid PCI Bus ID format: :4b:00.0
+W0803 06:43:13.863632       1 nvlib.go:491] error getting PCIe root for device 4, continuing without attribute: invalid PCI Bus ID format: :8a:00.0
+W0803 06:43:13.863664       1 nvlib.go:491] error getting PCIe root for device 5, continuing without attribute: invalid PCI Bus ID format: :8b:00.0
+W0803 06:43:13.863706       1 nvlib.go:491] error getting PCIe root for device 6, continuing without attribute: invalid PCI Bus ID format: :ca:00.0
+W0803 06:43:13.863739       1 nvlib.go:491] error getting PCIe root for device 7, continuing without attribute: invalid PCI Bus ID format: :cb:00.0
+
+## Consumer 2: gpu-feature-discovery (GPU Operator v25.3.4), fails to start
+E0803 06:43:15.350642       1 main.go:127] error creating labeler: error creating resource labeler: unable to read PCI device vendor id for :0a:00.0: open /sys/bus/pci/devices/:0a:00.0/vendor: no such file or directory
+E0803 06:44:06.560097       1 main.go:127] error creating labeler: error creating resource labeler: unable to read PCI device vendor id for :0a:00.0: open /sys/bus/pci/devices/:0a:00.0/vendor: no such file or directory
+
+## Consumer 3 (separate cause, U not G): ComputeDomain kubelet plugin, /proc/devices
+Error: error creating driver: failed to create device library: error getting nvcap for IMEX channel '0': error getting device major: error parsing '/proc/devices': unexpected regex match: []
+Error: error creating driver: failed to create device library: error getting nvcap for IMEX channel '0': error getting device major: error parsing '/proc/devices': unexpected regex match: []

--- a/tests/aicr-sweep/results/report.json
+++ b/tests/aicr-sweep/results/report.json
@@ -1,0 +1,2658 @@
+{
+  "rollup": {
+    "total": 210,
+    "a": 160,
+    "b": 10,
+    "c": 40,
+    "g": 0,
+    "aGpuDependent": 100,
+    "blocked": 197,
+    "byCause": {
+      "BUDGET": 105,
+      "U": 21,
+      "X": 42
+    },
+    "byOutcome": {
+      "blocked": 168,
+      "fail": 9,
+      "not-run": 29,
+      "pass": 4
+    },
+    "suspect": 0
+  },
+  "cells": [
+    {
+      "cell": {
+        "id": "base-gb200-kind-inference-stack",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb200",
+          "intent": "inference"
+        },
+        "shape": "stack",
+        "workers": 2,
+        "notes": "The backbone cell. Mokka v0.3.0 gb200 profile over the NRI path, plus the real GPU Operator, device plugin, GFD and dcgm-exporter. AICR resolves this combination to a 14-component recipe over 5 overlays."
+      },
+      "versions": {
+        "mokka": "v0.3.0",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:0.3.0",
+        "mokkaDigest": "sha256:3b9bcf33d8bf442fe203062b78abeef7633172b4e589b23192e27edb6e81d3cc",
+        "chart": "oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock 0.3.0",
+        "chartDigest": "sha256:99e0de7e7c3292e9f814e15841c6c7a5bec8f64ce07620dd9f5c05ccb68b516e",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.1, 14 CPU, 7.75 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "ran",
+      "logsPointer": "tests/aicr-sweep/results/base-gb200-kind-inference-stack",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "message": "pod not found for Job aicr-expected-resources-906acd01: [NOT_FOUND] pod for job not found"
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[INTERNAL] GPU Operator version v25.3.4 does not satisfy constraint \"\u003e= v25.10.0\""
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found"
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\""
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[INTERNAL] ClusterPolicy state=notReady (want ready)"
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] platform health check failed (9 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvidia-dra-driver: not found\n  namespace nvsentinel: not found"
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "base-gb200-kind-training-stack",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb200",
+          "intent": "training"
+        },
+        "shape": "stack",
+        "workers": 2
+      },
+      "versions": {
+        "mokka": "v0.3.0",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:0.3.0",
+        "mokkaDigest": "sha256:3b9bcf33d8bf442fe203062b78abeef7633172b4e589b23192e27edb6e81d3cc",
+        "chart": "oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock 0.3.0",
+        "chartDigest": "sha256:99e0de7e7c3292e9f814e15841c6c7a5bec8f64ce07620dd9f5c05ccb68b516e",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.1, 14 CPU, 7.75 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "blocked",
+      "cause": "BUDGET",
+      "blockedWhy": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available.",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. The host Docker VM holds 7.75 GiB and the inference cell already consumed the window available for this sweep. The intent axis is a recipe-resolution difference, so this cell is expected to differ from the inference cell only in component set, not in Mokka behaviour. Re-run it first when more memory is available."
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "base-h100-kind-inference-stack",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "h100",
+          "intent": "inference"
+        },
+        "shape": "stack",
+        "workers": 2,
+        "axes": {
+          "accelerator": "h100 (substitute for gb300)"
+        }
+      },
+      "versions": {
+        "mokka": "v0.3.0",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:0.3.0",
+        "mokkaDigest": "sha256:3b9bcf33d8bf442fe203062b78abeef7633172b4e589b23192e27edb6e81d3cc",
+        "chart": "oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock 0.3.0",
+        "chartDigest": "sha256:99e0de7e7c3292e9f814e15841c6c7a5bec8f64ce07620dd9f5c05ccb68b516e",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.1, 14 CPU, 7.75 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "blocked",
+      "cause": "BUDGET",
+      "blockedWhy": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage.",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted, same memory window. This is the deliberate substitution for the brief's gb300 half of the base sweep: AICR has no gb300 accelerator, so h100 is the nearest second accelerator that both AICR and Mokka support on the kind service. It is a substitution and is never counted as gb300 coverage."
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "base-gb300-kind-inference-stack",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb300",
+          "intent": "inference"
+        },
+        "shape": "stack",
+        "workers": 2
+      },
+      "versions": {
+        "mokka": "v0.3.0",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:0.3.0",
+        "mokkaDigest": "sha256:3b9bcf33d8bf442fe203062b78abeef7633172b4e589b23192e27edb6e81d3cc",
+        "chart": "oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock 0.3.0",
+        "chartDigest": "sha256:99e0de7e7c3292e9f814e15841c6c7a5bec8f64ce07620dd9f5c05ccb68b516e",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.1, 14 CPU, 7.75 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "blocked",
+      "cause": "X",
+      "blockedWhy": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap.",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "AICR's recipe catalog at 0752ea14 has no gb300 accelerator. Verified by running the CLI, not by reading it: `aicr recipe --service kind --accelerator gb300 --intent inference` exits 2 with \"[INVALID_REQUEST] no recipe provides accelerator 'gb300'\". The catalog knows a100, b200, gb200, h100, h200, l40s and rtx-pro-6000. Mokka ships a gb300 profile; AICR has no accelerator to match it to. This is an AICR catalog gap, not a Mokka gap."
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "base-gb300-kind-training-stack",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb300",
+          "intent": "training"
+        },
+        "shape": "stack",
+        "workers": 2
+      },
+      "versions": {
+        "mokka": "v0.3.0",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:0.3.0",
+        "mokkaDigest": "sha256:3b9bcf33d8bf442fe203062b78abeef7633172b4e589b23192e27edb6e81d3cc",
+        "chart": "oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock 0.3.0",
+        "chartDigest": "sha256:99e0de7e7c3292e9f814e15841c6c7a5bec8f64ce07620dd9f5c05ccb68b516e",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.1, 14 CPU, 7.75 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "blocked",
+      "cause": "X",
+      "blockedWhy": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator.",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "X",
+          "provenance": "sim",
+          "message": "Same as base-gb300-kind-inference-stack: AICR has no gb300 accelerator."
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "targeted-dra-installed",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb200",
+          "intent": "inference"
+        },
+        "shape": "stack",
+        "workers": 2,
+        "axes": {
+          "nvidia-dra-driver-gpu": "installed (base cell had none)"
+        },
+        "notes": "Targeted follow-up to the base cell, suggested by its dra-support failure. Conformance phase only, re-run after installing nvidia-dra-driver-gpu 25.12.0 against the mock driver root. The DRA kubelet plugin published 16 devices across two ResourceSlices derived from the mock NVML, which is the GPU half of dra-support working. The check still fails: see the findings note for why that is cause U and not a Mokka gap."
+      },
+      "versions": {
+        "mokka": "v0.3.0",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:0.3.0",
+        "mokkaDigest": "sha256:3b9bcf33d8bf442fe203062b78abeef7633172b4e589b23192e27edb6e81d3cc",
+        "chart": "oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock 0.3.0",
+        "chartDigest": "sha256:99e0de7e7c3292e9f814e15841c6c7a5bec8f64ce07620dd9f5c05ccb68b516e",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.1, 14 CPU, 7.75 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "ran",
+      "logsPointer": "tests/aicr-sweep/results/targeted-dra-installed",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found"
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "pass",
+          "provenance": "sim"
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\""
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "not-run",
+          "provenance": "sim",
+          "note": "check absent from run output"
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[INTERNAL] ClusterPolicy state=notReady (want ready)"
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "fail",
+          "provenance": "sim",
+          "message": "[NOT_FOUND] platform health check failed (8 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvsentinel: not found"
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "axis-nri-cdi",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb200",
+          "intent": "inference"
+        },
+        "shape": "stack",
+        "workers": 2,
+        "axes": {
+          "nri.deviceInjectionMode": "cdi (base is raw)"
+        }
+      },
+      "versions": {
+        "mokka": "v0.3.0",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:0.3.0",
+        "mokkaDigest": "sha256:3b9bcf33d8bf442fe203062b78abeef7633172b4e589b23192e27edb6e81d3cc",
+        "chart": "oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock 0.3.0",
+        "chartDigest": "sha256:99e0de7e7c3292e9f814e15841c6c7a5bec8f64ce07620dd9f5c05ccb68b516e",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.1, 14 CPU, 7.75 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "blocked",
+      "cause": "BUDGET",
+      "blockedWhy": "Not attempted; host memory window exhausted after the base cell.",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "axis-allocation-watcher-on",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb200",
+          "intent": "inference"
+        },
+        "shape": "stack",
+        "workers": 2,
+        "axes": {
+          "allocationWatcher.enabled": "true (base is false)"
+        }
+      },
+      "versions": {
+        "mokka": "v0.3.0",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:0.3.0",
+        "mokkaDigest": "sha256:3b9bcf33d8bf442fe203062b78abeef7633172b4e589b23192e27edb6e81d3cc",
+        "chart": "oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock 0.3.0",
+        "chartDigest": "sha256:99e0de7e7c3292e9f814e15841c6c7a5bec8f64ce07620dd9f5c05ccb68b516e",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.1, 14 CPU, 7.75 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "blocked",
+      "cause": "BUDGET",
+      "blockedWhy": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction.",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted. Note in advance that any check reading GPU memory utilization as evidence of real work stays bucket B whatever this cell shows, because the allocation bytes are synthetic by construction."
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "axis-failure-injection-ecc",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb200",
+          "intent": "inference"
+        },
+        "shape": "stack",
+        "workers": 2,
+        "axes": {
+          "gpu.failureInjection.mode": "ecc_uncorrectable (base is off)"
+        }
+      },
+      "versions": {
+        "mokka": "v0.3.0",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:0.3.0",
+        "mokkaDigest": "sha256:3b9bcf33d8bf442fe203062b78abeef7633172b4e589b23192e27edb6e81d3cc",
+        "chart": "oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock 0.3.0",
+        "chartDigest": "sha256:99e0de7e7c3292e9f814e15841c6c7a5bec8f64ce07620dd9f5c05ccb68b516e",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.1, 14 CPU, 7.75 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "blocked",
+      "cause": "BUDGET",
+      "blockedWhy": "Not attempted; host memory window exhausted after the base cell.",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "BUDGET",
+          "provenance": "sim",
+          "message": "Not attempted; host memory window exhausted after the base cell."
+        }
+      ]
+    },
+    {
+      "cell": {
+        "id": "axis-compute-domain-fabric",
+        "recipe": {
+          "service": "kind",
+          "accelerator": "gb200",
+          "intent": "training"
+        },
+        "shape": "fabric",
+        "workers": 4,
+        "axes": {
+          "imex.mockChannels.enabled": "true",
+          "topology.domains": "two cliques"
+        }
+      },
+      "versions": {
+        "mokka": "v0.3.0",
+        "mokkaImage": "ghcr.io/nvidia/nvml-mock:0.3.0",
+        "mokkaDigest": "sha256:3b9bcf33d8bf442fe203062b78abeef7633172b4e589b23192e27edb6e81d3cc",
+        "chart": "oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock 0.3.0",
+        "chartDigest": "sha256:99e0de7e7c3292e9f814e15841c6c7a5bec8f64ce07620dd9f5c05ccb68b516e",
+        "profile": "gb200",
+        "kind": "v0.32.0",
+        "nodeImage": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+        "kubernetes": "v1.36.1 (containerd 2.3.1)",
+        "gpuOperator": "v25.3.4",
+        "dcgmExporter": "bundled with gpu-operator v25.3.4",
+        "aicr": "0752ea148aa1ae849cbef86ec59d0c970a582496",
+        "aicrImage": "ghcr.io/nvidia/aicr:latest",
+        "hostArch": "linux/arm64 (Docker Desktop VM on arm64 macOS)",
+        "hostContainerRuntime": "Docker 29.6.1, 14 CPU, 7.75 GiB VM"
+      },
+      "provenance": "sim",
+      "status": "blocked",
+      "cause": "U",
+      "blockedWhy": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap.",
+      "checks": [
+        {
+          "check": "operator-health",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "expected-resources",
+          "area": "control-plane",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "gpu-operator-version",
+          "area": "operator-install",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "check-nvidia-smi",
+          "area": "nvml-surface",
+          "phase": "deployment",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "nccl-all-reduce-bw",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "nccl-all-reduce-bw-net",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "nccl-all-reduce-bw-nvls",
+          "area": "nccl-nvlink-fabric",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "inference-perf",
+          "area": "ttft-throughput",
+          "phase": "performance",
+          "bucket": "C",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "dra-support",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "gang-scheduling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "accelerator-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "ai-service-metrics",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "inference-gateway",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "pod-autoscaling",
+          "area": "telemetry",
+          "phase": "conformance",
+          "bucket": "B",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "cluster-autoscaling",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "robust-controller",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "secure-accelerator-access",
+          "area": "scheduling",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "slinky-slurm-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "slinky-slurm-imex-channel",
+          "area": "dra",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "gpu-operator-health",
+          "area": "operator-install",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": true,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        },
+        {
+          "check": "platform-health",
+          "area": "control-plane",
+          "phase": "conformance",
+          "bucket": "A",
+          "gpuDependent": false,
+          "outcome": "blocked",
+          "cause": "U",
+          "provenance": "sim",
+          "message": "The NVIDIA DRA driver resolves the nvidia-caps-imex-channels device major out of /proc/devices and needs --set altProcDevices to read Mokka's substitute. That flag is on the DRA driver's main branch and is in no release, including v25.12.0, as the chart's own values.yaml records at lines 307-325. Mokka v0.3.0 already renders the IMEX surface, so this is an upstream release gap, not a Mokka gap."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/aicr-sweep/results/targeted-dra-installed/ctrf/validate.json
+++ b/tests/aicr-sweep/results/targeted-dra-installed/ctrf/validate.json
@@ -1,0 +1,121 @@
+{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.1",
+  "timestamp": "2026-08-03T06:42:47Z",
+  "generatedBy": "aicr",
+  "results": {
+    "tool": {
+      "name": "aicr",
+      "version": "dev"
+    },
+    "summary": {
+      "tests": 5,
+      "passed": 1,
+      "failed": 4,
+      "skipped": 0,
+      "pending": 0,
+      "other": 0,
+      "start": 1785739347637,
+      "stop": 1785739367636
+    },
+    "tests": [
+      {
+        "name": "dra-support",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \"nvidia-dra-driver-gpu-controller\" not found",
+        "stdout": [
+          "time=2026-08-03T06:42:28.815Z level=INFO msg=\"starting check\" name=dra-support",
+          "--- DRA driver namespace ---",
+          "Namespace: nvidia-dra-driver",
+          "Source:    resolved recipe componentRef nvidia-dra-driver-gpu",
+          "--- DRA API resources ---",
+          "Equivalent: kubectl api-resources --api-group=resource.k8s.io",
+          "",
+          "Served version: resource.k8s.io/v1",
+          "deviceclasses              DeviceClass            namespaced=false",
+          "resourceclaims             ResourceClaim          namespaced=true",
+          "resourceclaims/status      ResourceClaim          namespaced=true",
+          "resourceclaimtemplates     ResourceClaimTemplate  namespaced=true",
+          "resourceslices             ResourceSlice          namespaced=false",
+          "",
+          "--- DRA driver pods ---",
+          "Equivalent: kubectl get pods -n nvidia-dra-driver -o wide",
+          "",
+          "nvidia-dra-driver-gpu-kubelet-plugin-5bzcz       ready=1/1 phase=Running node=mokka-aicr-stack-worker",
+          "nvidia-dra-driver-gpu-kubelet-plugin-8t9bw       ready=1/1 phase=Running node=mokka-aicr-stack-worker2",
+          "",
+          "time=2026-08-03T06:42:28.843Z level=ERROR msg=FAIL message=\"[NOT_FOUND] deployment nvidia-dra-driver/nvidia-dra-driver-gpu-controller not found: deployments.apps \\\"nvidia-dra-driver-gpu-controller\\\" not found\""
+        ]
+      },
+      {
+        "name": "accelerator-metrics",
+        "status": "passed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "stdout": [
+          "time=2026-08-03T06:42:32.663Z level=INFO msg=\"starting check\" name=accelerator-metrics",
+          "--- DCGM Exporter Metrics (sample) ---",
+          "# HELP DCGM_FI_DEV_SM_CLOCK SM clock frequency (in MHz).",
+          "# TYPE DCGM_FI_DEV_SM_CLOCK gauge",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"0\",UUID=\"GPU-b200b200-0000-0000-0000-000000000000\",pci_bus_id=\"0000:0A:00.0\",device=\"nvidia0\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"1\",UUID=\"GPU-b200b200-0000-0000-0000-000000000001\",pci_bus_id=\"0000:0B:00.0\",device=\"nvidia1\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"2\",UUID=\"GPU-b200b200-0000-0000-0000-000000000002\",pci_bus_id=\"0000:4A:00.0\",device=\"nvidia2\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"3\",UUID=\"GPU-b200b200-0000-0000-0000-000000000003\",pci_bus_id=\"0000:4B:00.0\",device=\"nvidia3\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"4\",UUID=\"GPU-b200b200-0000-0000-0000-000000000004\",pci_bus_id=\"0000:8A:00.0\",device=\"nvidia4\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "DCGM_FI_DEV_SM_CLOCK{gpu=\"5\",UUID=\"GPU-b200b200-0000-0000-0000-000000000005\",pci_bus_id=\"0000:8B:00.0\",device=\"nvidia5\",modelName=\"NVIDIA GB200\",Hostname=\"mokka-aicr-stack-worker2\",DCGM_FI_DRIVER_VERSION=\"580.65.06\"} 345",
+          "... [truncated]",
+          "--- Required DCGM Metrics ---",
+          "  DCGM_FI_DEV_GPU_UTIL           FOUND",
+          "  DCGM_FI_DEV_FB_USED            FOUND",
+          "  DCGM_FI_DEV_GPU_TEMP           FOUND",
+          "  DCGM_FI_DEV_POWER_USAGE        FOUND"
+        ]
+      },
+      {
+        "name": "ai-service-metrics",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] no Prometheus service with port 9090 found in namespace \"monitoring\"",
+        "stdout": [
+          "time=2026-08-03T06:42:36.761Z level=INFO msg=\"starting check\" name=ai-service-metrics",
+          "time=2026-08-03T06:42:36.789Z level=ERROR msg=FAIL message=\"[NOT_FOUND] no Prometheus service with port 9090 found in namespace \\\"monitoring\\\"\""
+        ]
+      },
+      {
+        "name": "gpu-operator-health",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[INTERNAL] ClusterPolicy state=notReady (want ready)",
+        "stdout": [
+          "time=2026-08-03T06:42:40.758Z level=INFO msg=\"starting check\" name=gpu-operator-health",
+          "time=2026-08-03T06:42:40.773Z level=ERROR msg=FAIL message=\"[INTERNAL] ClusterPolicy state=notReady (want ready)\""
+        ]
+      },
+      {
+        "name": "platform-health",
+        "status": "failed",
+        "duration": 0,
+        "suite": [
+          "conformance"
+        ],
+        "message": "[NOT_FOUND] platform health check failed (8 issues):\n  namespace agentgateway-system: not found\n  namespace cert-manager: not found\n  namespace monitoring: not found\n  namespace kai-scheduler: not found\n  namespace nvidia-network-operator: not found\n  namespace node-feature-discovery: not found\n  namespace skyhook: not found\n  namespace nvsentinel: not found",
+        "stdout": [
+          "time=2026-08-03T06:42:44.711Z level=INFO msg=\"starting check\" name=platform-health",
+          "time=2026-08-03T06:42:44.737Z level=ERROR msg=FAIL message=\"[NOT_FOUND] platform health check failed (8 issues):\\n  namespace agentgateway-system: not found\\n  namespace cert-manager: not found\\n  namespace monitoring: not found\\n  namespace kai-scheduler: not found\\n  namespace nvidia-network-operator: not found\\n  namespace node-feature-discovery: not found\\n  namespace skyhook: not found\\n  namespace nvsentinel: not found\""
+        ]
+      }
+    ]
+  }
+}

--- a/tests/aicr-sweep/types.go
+++ b/tests/aicr-sweep/types.go
@@ -1,0 +1,221 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+// Bucket is the analytical judgment about what an AICR check proves when it runs
+// against a simulated cluster. The bucket comes from source evidence and is
+// reviewable independently of any run. The harness never edits a bucket from an
+// observed outcome, because a classification that moves to match the result is
+// not a classification.
+type Bucket string
+
+const (
+	// BucketA exercises real integration. Could plausibly fail for a real reason.
+	BucketA Bucket = "A"
+	// BucketB is green only because the mock answers the API. It would pass
+	// regardless of correctness, so it is not coverage. Recorded honestly
+	// because it bounds the claim.
+	BucketB Bucket = "B"
+	// BucketC is hardware-dependent and cannot be judged pre-silicon. These are
+	// why AICR-on-silicon remains the final readiness gate.
+	BucketC Bucket = "C"
+	// BucketG would be meaningful pre-silicon, but Mokka lacks the capability.
+	// Not hardware-dependent, therefore closable, therefore roadmap. Needs an
+	// issue.
+	BucketG Bucket = "G"
+)
+
+// Cause explains why a cell did not produce a usable verdict. It is deliberately
+// a separate axis from Bucket: a bucket says what a check would prove, a cause
+// says what stopped this particular run. Keeping them separate is what stops a
+// kind artifact from being reported as a Mokka gap.
+type Cause string
+
+const (
+	// CauseNone means the cell ran and reached a verdict.
+	CauseNone Cause = ""
+	// CauseK is a kind or single-host environment artifact. The check broke for
+	// a reason that would not occur on a real cluster. NOT a Mokka finding.
+	CauseK Cause = "K"
+	// CauseU is an upstream dependency gap: the capability exists in Mokka but
+	// a dependency has not released what is needed to consume it.
+	CauseU Cause = "U"
+	// CauseX is an AICR catalog gap: AICR has no recipe or accelerator for the
+	// requested combination, so there is nothing to run. Not a Mokka finding.
+	CauseX Cause = "X"
+	// CauseBudget means the cell was not attempted because the host ran out of
+	// memory budget. Recorded so the denominator stays honest.
+	CauseBudget Cause = "BUDGET"
+)
+
+// Outcome is the observed result of one check in one cell.
+type Outcome string
+
+const (
+	// OutcomePass means the suite reported a pass.
+	OutcomePass Outcome = "pass"
+	// OutcomeFail means the suite reported a failure.
+	OutcomeFail Outcome = "fail"
+	// OutcomeSkip means the suite deliberately skipped the check.
+	OutcomeSkip Outcome = "skip"
+	// OutcomeNotRun means no verdict was reached. A check absent from a run, or
+	// reported CTRF "pending" or "other", lands here. It is NEVER promoted to a
+	// pass: an incomplete run must degrade to "not run", not to a good number.
+	OutcomeNotRun Outcome = "not-run"
+	// OutcomeBlocked means the cell could not run at all. Carries a Cause.
+	OutcomeBlocked Outcome = "blocked"
+)
+
+// Provenance records whether evidence came from simulation or from silicon. The
+// two are never conflated, and every emitted record carries one.
+type Provenance string
+
+const (
+	// ProvenanceSim means the evidence came from a simulated GPU cluster.
+	ProvenanceSim Provenance = "sim"
+	// ProvenanceSilicon means the evidence came from real hardware.
+	ProvenanceSilicon Provenance = "silicon"
+)
+
+// Check is one AICR validation or conformance check, with the analytical bucket
+// it falls into when run against Mokka.
+type Check struct {
+	Name string `json:"name" yaml:"name"`
+	Area string `json:"area" yaml:"area"`
+	// Phase is the AICR validate phase: deployment, performance or conformance.
+	Phase string `json:"phase" yaml:"phase"`
+	// Bucket is the analytical classification. See Bucket.
+	Bucket Bucket `json:"bucket" yaml:"bucket"`
+	// GPUDependent records whether the check actually touches the GPU stack. A
+	// bucket-A check with GPUDependent false still moves left, but ANY cluster
+	// runs it, so Mokka is not what unlocks it. Keeping the split visible stops
+	// the headline A number from being inflated by pure control-plane checks.
+	GPUDependent bool `json:"gpuDependent" yaml:"gpuDependent"`
+	// Rationale states why this bucket, in prose a reviewer can attack.
+	Rationale string `json:"rationale" yaml:"rationale"`
+	// Evidence is the file:line in NVIDIA/aicr backing the rationale.
+	Evidence string `json:"evidence" yaml:"evidence"`
+	// GapIssue is the tracked issue URL for a bucket-G check. A bucket-G check
+	// without one fails catalog validation: an untracked gap is not a roadmap.
+	GapIssue string `json:"gapIssue,omitempty" yaml:"gapIssue,omitempty"`
+}
+
+// Catalog is the full analytical classification of the AICR check suite.
+type Catalog struct {
+	// Source identifies the AICR ref the catalog was derived from, so a reader
+	// can tell when it has drifted.
+	Source string  `json:"source" yaml:"source"`
+	Checks []Check `json:"checks" yaml:"checks"`
+}
+
+// RunTest is one check outcome as the AICR suite reported it.
+type RunTest struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Suite   string `json:"suite"`
+	Message string `json:"message"`
+}
+
+// RunResults is one AICR validate run, merged across phase reports.
+type RunResults struct {
+	Tests []RunTest `json:"tests"`
+}
+
+// Versions is the full version set recorded on every cell. Without it the
+// numbers are not reproducible.
+type Versions struct {
+	Mokka         string `json:"mokka"`
+	MokkaImage    string `json:"mokkaImage"`
+	MokkaDigest   string `json:"mokkaDigest,omitempty"`
+	Chart         string `json:"chart"`
+	ChartDigest   string `json:"chartDigest,omitempty"`
+	Profile       string `json:"profile"`
+	Kind          string `json:"kind"`
+	NodeImage     string `json:"nodeImage"`
+	Kubernetes    string `json:"kubernetes"`
+	GPUOperator   string `json:"gpuOperator,omitempty"`
+	DRADriver     string `json:"draDriver,omitempty"`
+	DCGMExporter  string `json:"dcgmExporter,omitempty"`
+	AICR          string `json:"aicr"`
+	AICRImage     string `json:"aicrImage,omitempty"`
+	HostArch      string `json:"hostArch"`
+	HostContainer string `json:"hostContainerRuntime,omitempty"`
+}
+
+// Cell is one point in the permutation matrix.
+type Cell struct {
+	// ID is a stable identifier, used as the results filename.
+	ID string `json:"id"`
+	// Recipe is the AICR recipe criteria that generated the recipe document.
+	Recipe RecipeCriteria `json:"recipe"`
+	// Shape is the cluster shape: "stack" or "fabric".
+	Shape string `json:"shape"`
+	// Workers is the worker node count.
+	Workers int `json:"workers"`
+	// Axes records which axis this cell varies off the base, and to what.
+	Axes map[string]string `json:"axes,omitempty"`
+	// Notes carries anything a reader needs to interpret the cell.
+	Notes string `json:"notes,omitempty"`
+}
+
+// RecipeCriteria is the input to `aicr recipe`.
+type RecipeCriteria struct {
+	Service     string `json:"service"`
+	Accelerator string `json:"accelerator"`
+	Intent      string `json:"intent"`
+	OS          string `json:"os,omitempty"`
+	Platform    string `json:"platform,omitempty"`
+}
+
+// CheckResult joins one catalog check with its observed outcome in one cell.
+type CheckResult struct {
+	Check      string     `json:"check"`
+	Area       string     `json:"area"`
+	Phase      string     `json:"phase"`
+	Bucket     Bucket     `json:"bucket"`
+	GPUDep     bool       `json:"gpuDependent"`
+	Outcome    Outcome    `json:"outcome"`
+	Cause      Cause      `json:"cause,omitempty"`
+	Provenance Provenance `json:"provenance"`
+	Message    string     `json:"message,omitempty"`
+	GapIssue   string     `json:"gapIssue,omitempty"`
+	// Suspect flags a result that contradicts its own classification: a
+	// hardware-dependent check reporting a pass without hardware. It is not an
+	// error, it is a signal that the check is weaker than its name suggests.
+	Suspect bool   `json:"suspect,omitempty"`
+	Note    string `json:"note,omitempty"`
+}
+
+// CellResult is the machine-readable record for one matrix cell.
+type CellResult struct {
+	Cell        Cell          `json:"cell"`
+	Versions    Versions      `json:"versions"`
+	Provenance  Provenance    `json:"provenance"`
+	Status      string        `json:"status"`
+	Cause       Cause         `json:"cause,omitempty"`
+	BlockedWhy  string        `json:"blockedWhy,omitempty"`
+	LogsPointer string        `json:"logsPointer,omitempty"`
+	StartedAt   string        `json:"startedAt,omitempty"`
+	Checks      []CheckResult `json:"checks"`
+	// Drift lists checks present in the run but absent from the catalog. They
+	// are reported rather than silently dropped.
+	Drift []string `json:"drift,omitempty"`
+}
+
+// Rollup is the aggregate coverage read across a set of cells.
+type Rollup struct {
+	Total int `json:"total"`
+	A     int `json:"a"`
+	B     int `json:"b"`
+	C     int `json:"c"`
+	G     int `json:"g"`
+	// AGPUDependent is the subset of A that actually touches the GPU stack.
+	// This is the number Mokka can claim credit for.
+	AGPUDependent int `json:"aGpuDependent"`
+	// Blocked counts checks that never reached a verdict, by cause.
+	Blocked   int             `json:"blocked"`
+	ByCause   map[Cause]int   `json:"byCause,omitempty"`
+	ByOutcome map[Outcome]int `json:"byOutcome,omitempty"`
+	Suspect   int             `json:"suspect"`
+}


### PR DESCRIPTION
## Problem

The 2026-07-25 POC (#503) answered whether AICR runs against Mokka at all. It could not answer the
question the AICR maintainer actually put on 2026-07-24:

> Does Mokka + AICR materially reduce GB200 bring-up time, or does it merely prove the stack deploys
> against mocked APIs?

Answering that needs a permutation matrix and a way to say what each check *proves* when no GPU is
present, not a single recipe and a pass count.

## Approach

A harness at `tests/aicr-sweep/` classifies every AICR check into A (meaningful), B (trivial),
C (hardware-dependent) or G (closable Mokka gap), and records a cause code for anything that did not
reach a verdict. Blocked cells stay in the denominator, so coverage cannot be inflated by deleting
the work that did not happen.

It is built so an incomplete run degrades to "not run" rather than to a favourable number. Seven
invariants each have a test that goes red if it regresses, and invariant 1 was mutation-checked:
flipping `OutcomeNotRun` to `OutcomePass` in `Classify` turns two tests red.

**Two runs are recorded, and both regenerate byte-identically:**

| Run | Cells | Results | Mokka |
|---|---|---|---|
| 2026-08-03 | `cells.yaml` | `results/` | `v0.3.0` |
| 2026-08-26 | `cells-57ef016.yaml` | `results-57ef016/` | `57ef01659` |

AICR is pinned to `0752ea14` in **both**, so Mokka is the only axis that moved between them. Verified
rather than assumed: the base cell's generated recipe is byte-identical across the two runs.

## What it found

**The re-run's headline is negative, and that is the point.** #672 fixed the PCI bus ID gap the first
run reported (`0000:01:00.0` to `00000000:01:00.0`, confirmed by a differential probe of the two
published images). `gpu-operator-health` did **not** move. GFD now receives a well-formed BDF and
still cannot read the vendor file, because Mokka's rendered PCI tree uses relative symlinks and is
not grafted onto GFD's `/sys`. Both statements are true at once, and AICR's check cannot tell them
apart: it only sees `ClusterPolicy state=notReady`.

**One verdict flipped.** `dra-support` passes now, because k8s-dra-driver-gpu v0.5.0 released
`altProcDevices` on 2026-08-19. D-009 had recorded that flag as unreleased, which was correct when
written. Mokka's IMEX rendering already worked at `v0.3.0`; a released consumer was what was missing.

**Coverage moved a long way.** 13 of 210 check-results reached a verdict in the first run; 53 in the
second. The `BUDGET` and `U` blocks are both zero. The largest single gain is the h100 cell, where
AICR dispatches 14 of 21 checks against 9 for gb200.

**Two cells the first run blocked were misattributed**, and this PR reclassifies them with CLI output
as evidence: both declare `intent=training`, which resolves no recipe on the `kind` service for
gb200. That is `X`, not `BUDGET`/`U`.

**Two consumers, one shape of problem.** GFD is dynamically linked and fails on a sysfs *path*.
AICR's own snapshot agent is a static `ko`-built Go binary with no `PT_INTERP`, so library
interception cannot reach it at all, and it fails on sysfs *content*. Raised by @giuliocalzo in
review and verified here against the published image. The common remedy is a filesystem graft, not
library interception.

**An injected uncorrectable ECC fault moves no verdict.** With the mock reporting 6 and 9 DRAM
Uncorrectable errors and all four GPUs still enumerating, every dispatched check is identical to the
base cell. That is a statement about which checks this recipe dispatches, not about Mokka.

## Testing done

```
go build ./tests/aicr-sweep/...
go test -race -count=1 ./tests/aicr-sweep/
golangci-lint run ./tests/aicr-sweep/...
go run ./tests/aicr-sweep -catalog ... -cells ... -results ...   # both runs
```

Build clean, tests pass, lint reports 0 issues, and both recorded runs regenerate byte-identical
`coverage.md` and `report.json`. Every number in the write-ups comes from that last command rather
than from memory.

## Known limits, stated rather than buried

- **Nothing here ran on silicon.** Every record carries `sim` provenance. Bucket C is non-empty by
  construction: 4 checks cannot be judged without hardware.
- **The chart came from the checkout, not from a release.** `Chart.yaml` on main is still `0.3.0`, so
  the published OCI chart does not carry the 60 commits under test. The image is the published
  `sha-57ef016`, so anyone can pull it by digest.
- **The GFD failure is still cause `K`, not `G`.** D-014 named the experiment that would settle it
  (run with `cdi.enabled=true` and the toolkit installed). It has not been run, the honest status is
  "not distinguished", and it is the single most valuable cell still outstanding.
- **`dra-support` needed `--set nameOverride`.** v0.5.0's chart was renamed, so its default resource
  names no longer match what AICR looks for. AICR itself was not modified.

## Breaking changes

None. This adds a test harness and documentation. No production code path changes.

## Relationship to other work

Supersedes and replaces #503, now closed. Its code had already landed on main via #541 and #542, and
the IMEX renderer it introduced now lives at `internal/imex/` after #729 relocated it. The
`preflight-workflow` diagram and the diagrams index are carried forward here; its harness and
2026-07-25 results are deliberately left behind, because that harness will not be in the tree and
those numbers could not be regenerated or checked. They remain reachable at `pull/503/head`.

Related: #502 tracks the coverage gaps, and its body still carries the July figures that this PR
supersedes. Not closing it here, since correcting those numbers is a separate call.
