### PR TITLE
chore(greptile): tune AI review output to the project's review standards

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,96 @@
+{
+  "strictness": 3,
+  "commentTypes": [
+    "logic"
+  ],
+  "triggerOnUpdates": true,
+  "triggerOnDrafts": false,
+  "statusCheck": true,
+  "hideFooter": true,
+  "shouldUpdateDescription": false,
+  "ignorePatterns": "vendor/\ntests/mocknvml/vendor/\nLICENSES/\n**/zz_generated*.go\n",
+  "summarySection": {
+    "included": true,
+    "collapsible": false,
+    "defaultOpen": true
+  },
+  "issuesTableSection": {
+    "included": false
+  },
+  "confidenceScoreSection": {
+    "included": false
+  },
+  "sequenceDiagramSection": {
+    "included": false
+  },
+  "instructions": "Write about the code, never about the review. Do not describe your own pass over the change: no \"I checked\", no \"the changes look good\", no \"nothing blocking remains\", no \"this pull request appears safe to merge\", and no counting of your own findings. Do not name the tooling or any configuration file behind the review.\n\nState each finding in one or two sentences: what breaks, then what to do about it. Name the symbol, invariant, or test involved, because that specificity is what makes a comment worth reading and what makes it read as a person who looked at the change. Do not put a severity word or tag in the comment text. Do not repeat an inline comment in the summary; the summary carries only findings that have no inline anchor.\n\nDo not use emojis, em dashes, or filler adjectives. When nothing blocks the change, open with one short sentence naming what this change specifically improves. A sentence that would fit any pull request adds nothing.",
+  "rules": [
+    {
+      "id": "nvml-bridge-types",
+      "rule": "When a change adds a new nvml entry point to vendor/github.com/NVIDIA/go-nvml/pkg/nvml/nvml.go, pkg/gpu/mocknvml/bridge/stubs_generated.go must be regenerated with `make gen`, and pkg/gpu/mocknvml/bridge/nvml_types.h must gain the matching C type definitions by hand with full field layouts rather than opaque forward declarations. The generator does not touch that header. A stale stubs_generated.go omits the //export directives for the new entry points, and the shared library still links because -buildmode=c-shared does not pass --no-undefined, so build, vet, test and lint all stay green. The failure appears only when a consumer dlopens the library with RTLD_NOW.",
+      "scope": [
+        "pkg/gpu/mocknvml/bridge/**",
+        "vendor/github.com/NVIDIA/go-nvml/**"
+      ],
+      "severity": "high"
+    },
+    {
+      "id": "nvml-busid-signedness",
+      "rule": "The element type of nvml.PciInfo.BusId alternates between [32]uint8 and [32]int8 across go-nvml regenerations. A loop that copies a bus ID must cast to the element type of the vendored struct rather than a hard-coded uint8 or int8, or the package stops type-checking on the next dependency bump.",
+      "scope": [
+        "pkg/gpu/mocknvml/**"
+      ],
+      "severity": "high"
+    },
+    {
+      "id": "list-index-access",
+      "rule": "Do not select an element from a Kubernetes list response or any other collection with unspecified order by position, such as .Items[0] or items[N]. Match on Name or UID, or sort before indexing. Positional access passes locally and fails once the API returns the same set in a different order.",
+      "scope": [
+        "**/*.go"
+      ],
+      "severity": "high"
+    },
+    {
+      "id": "test-discrimination",
+      "rule": "Each assertion must compare against a literal or a value derived independently of the code under test. Recomputing the implementation's own logic inside the test asserts nothing. Flag a test that would still pass if the body of the function it covers were replaced with an empty return or a zero value, and flag a table case whose expected value is produced by calling the subject.",
+      "scope": [
+        "**/*_test.go"
+      ],
+      "severity": "high"
+    },
+    {
+      "id": "helm-chart-version-coupling",
+      "rule": "A change to the chart version in Chart.yaml also requires regenerated helm-unittest snapshots and updated helm.sh/chart label assertions in the chart tests. Flag a version bump that arrives without those matching test updates, and name `make helm-tests` as the check that would catch it.",
+      "scope": [
+        "deployments/**"
+      ],
+      "severity": "medium"
+    },
+    {
+      "id": "workflow-tag-paths-filter",
+      "rule": "In a workflow triggered on push, do not combine a tags filter with a paths filter in the same on.push block. A tag push carries no file diff, so the paths filter suppresses the run and the tag-triggered job never fires.",
+      "scope": [
+        ".github/workflows/**"
+      ],
+      "severity": "high"
+    },
+    {
+      "id": "comment-intent",
+      "rule": "A code comment must explain why the code does what it does, where that reason is not obvious from the code itself. Flag a comment that restates what the following line does, and flag a comment that narrates the change being made rather than the long-lived behaviour a future reader needs.",
+      "scope": [
+        "**/*.go"
+      ],
+      "severity": "medium"
+    },
+    {
+      "id": "rbac-and-secrets",
+      "rule": "Flag an RBAC rule that introduces a wildcard verb, resource, or apiGroup, and flag any credential, token, or private key committed as a literal value. Name the specific permission and the ServiceAccount or workload it binds to. Host path mounts and privileged containers are expected in this project because it simulates device driver state, so raise those only when a change widens access beyond what the surrounding workload already holds.",
+      "scope": [
+        "deployments/**",
+        "internal/**",
+        "cmd/**"
+      ],
+      "severity": "high"
+    }
+  ]
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,22 @@
+{
+  "files": [
+    {
+      "path": "AGENTS.md",
+      "description": "Project principles, tech stack, and the commands a change is expected to pass. Go 1.26, testify/require for assertions, `make lint-fix` and `make test` for Go changes, `make helm-tests` for chart changes. Also states that code comments explain why rather than what."
+    },
+    {
+      "path": "CONTRIBUTING.md",
+      "description": "Contribution workflow and the commit and pull request conventions this repository expects."
+    },
+    {
+      "path": ".golangci.yml",
+      "description": "The exact linter set that already runs on every pull request. Treat every finding these linters produce as already reported, and do not raise it again in review.",
+      "scope": ["**/*.go"]
+    },
+    {
+      "path": "docs/architecture.md",
+      "description": "How the simulated driver layers fit together, for judging whether a change sits at the right layer.",
+      "scope": ["internal/**", "pkg/**", "cmd/**"]
+    }
+  ]
+}

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,41 @@
+# What not to raise
+
+Findings that any of the checks below already produce are noise on a pull
+request: they arrive twice, and the second copy trains reviewers to skim.
+
+`golangci-lint` runs on every pull request in this repository with `revive`,
+`staticcheck` (all checks), `testifylint` (enable-all), `cyclop`, `nestif`,
+`bodyclose`, `contextcheck`, `errname`, `exhaustive`, `misspell`, `nolintlint`,
+`perfsprint`, `prealloc`, `predeclared`, `asasalint`, `unconvert`,
+`usestdlibvars` and `loggercheck`. It lints `e2e` and `integration`
+tag-guarded sources too. Do not raise anything inside that scope, including:
+
+- Formatting, import order, unused variables, type errors. The compiler and
+  `gofmt` reject these before review.
+- Test assertion style, `require` against `assert`, expected and actual
+  argument order. `testifylint` runs with every check enabled.
+- Cyclomatic complexity and nesting depth.
+- Unclosed response bodies, context that is not propagated, misspellings,
+  stale `//nolint` directives.
+
+Also leave these alone:
+
+- Problems on lines this change did not touch. Report only what the diff
+  introduces or makes newly reachable.
+- Nitpicks that a senior engineer would not stop a merge for.
+- Missing tests or documentation, unless `AGENTS.md` asks for them.
+- Anything silenced in code by a `//nolint` directive that carries an
+  explanation. `nolintlint` requires both a specific linter and a reason, so a
+  directive that survives lint was deliberate.
+- Choices that are plainly part of the stated purpose of the change.
+
+# Weighing a finding before posting it
+
+Post a finding when you can name the input that reaches it and the behaviour
+that results. A reader should be able to act on the comment without asking a
+follow-up question.
+
+Hold a finding back when it rests on a guess about code you cannot see in the
+diff, when the same defect already has a comment elsewhere in this review, or
+when the only supporting argument is that a different structure would read
+better. Two symptoms of one defect are one comment, not two.

--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,10 @@ test-mockpcisysfs: mockpcisysfs-shim ## Run mockpcisysfs integration tests
 test-nvidia-imex-shim: build ## Run nvidia-imex-shim integration tests
 	@$(GO_CMD) test -v ./shims/nvidia-imex-shim/...
 
+.PHONY: verify-greptile
+verify-greptile: ## Validate the .greptile review configuration
+	@bash hack/verify-greptile-config.sh
+
 .PHONY: helm-tests
 helm-tests: ## Run the nvml-mock chart unit test suite
 	helm unittest $(HELM_CHART_DIR)

--- a/hack/verify-greptile-config.sh
+++ b/hack/verify-greptile-config.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Copyright 2026 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Validate the .greptile/ review configuration.
+#
+# The failure this exists to catch: a rule `scope` glob, or a files.json path,
+# that stops matching anything after a package move or a rename. Greptile fails
+# open on both, so the rule simply stops applying and no error is reported
+# anywhere. Without this check that drift is invisible until someone notices a
+# class of review comment has quietly disappeared.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+python3 - "${REPO_ROOT}" <<'PY'
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+cfg_dir = root / ".greptile"
+failures = []
+checks = 0
+
+
+def check(ok, label, detail=""):
+    global checks
+    checks += 1
+    if ok:
+        print(f"  ok    {label}")
+    else:
+        print(f"  FAIL  {label}{(': ' + detail) if detail else ''}")
+        failures.append(label)
+
+
+def glob_to_re(pat):
+    """Translate a glob to a regex with correct ** and / semantics."""
+    out, i = [], 0
+    while i < len(pat):
+        if pat.startswith("**/", i):
+            out.append("(?:.*/)?")
+            i += 3
+        elif pat.startswith("**", i):
+            out.append(".*")
+            i += 2
+        elif pat[i] == "*":
+            out.append("[^/]*")
+            i += 1
+        elif pat[i] == "?":
+            out.append("[^/]")
+            i += 1
+        else:
+            out.append(re.escape(pat[i]))
+            i += 1
+    return re.compile("^" + "".join(out) + "$")
+
+
+tracked = subprocess.run(
+    ["git", "ls-files"], cwd=root, capture_output=True, text=True, check=True
+).stdout.splitlines()
+print(f"tracked files: {len(tracked)}\n")
+
+print("JSON parses:")
+docs = {}
+for name in ("config.json", "files.json"):
+    path = cfg_dir / name
+    try:
+        docs[name] = json.loads(path.read_text())
+        check(True, f".greptile/{name} is valid JSON")
+    except Exception as exc:
+        check(False, f".greptile/{name} is valid JSON", str(exc))
+
+if len(docs) != 2:
+    print("\ncannot continue without both JSON documents")
+    sys.exit(1)
+
+cfg = docs["config.json"]
+rules = cfg.get("rules", [])
+
+print("\nrule shape:")
+check(bool(rules), "config.json declares at least one rule")
+ids = [r.get("id") for r in rules]
+check(all(ids), "every rule carries an id", f"ids={ids}")
+check(len(ids) == len(set(ids)), "rule ids are unique", f"ids={ids}")
+for r in rules:
+    rid = r.get("id", "<no id>")
+    check(bool(r.get("rule", "").strip()), f"rule {rid} has non-empty text")
+    check(
+        r.get("severity") in ("low", "medium", "high"),
+        f"rule {rid} severity is low|medium|high",
+        repr(r.get("severity")),
+    )
+
+print("\nrule scope globs match tracked files:")
+for r in rules:
+    rid = r.get("id", "<no id>")
+    for pat in r.get("scope", []):
+        rx = glob_to_re(pat)
+        n = sum(1 for f in tracked if rx.match(f))
+        check(n > 0, f"rule {rid} scope {pat!r} matches {n} file(s)", "matches nothing")
+
+print("\nfiles.json context paths exist:")
+files_doc = docs["files.json"]
+check(isinstance(files_doc, dict) and "files" in files_doc,
+      "files.json is an object with a 'files' key")
+for entry in files_doc.get("files", []):
+    p = entry.get("path", "")
+    check((root / p).is_file(), f"context file {p!r} exists")
+    for pat in entry.get("scope", []):
+        rx = glob_to_re(pat)
+        n = sum(1 for f in tracked if rx.match(f))
+        check(n > 0, f"context {p!r} scope {pat!r} matches {n} file(s)", "matches nothing")
+
+print("\nignorePatterns refer to real paths:")
+raw = cfg.get("ignorePatterns", "")
+check(isinstance(raw, str), "ignorePatterns is a string in .gitignore syntax",
+      f"got {type(raw).__name__}")
+for line in [l.strip() for l in str(raw).splitlines() if l.strip()]:
+    if line.startswith("**"):
+        rx = glob_to_re(line)
+        n = sum(1 for f in tracked if rx.match(f))
+        ok, detail = n > 0, "matches no tracked file"
+    else:
+        target = root / line.rstrip("/")
+        n = 1 if target.exists() else 0
+        ok, detail = target.exists(), "path does not exist"
+    check(ok, f"ignore {line!r} resolves ({n})", detail)
+
+print("\ntone guard on the config text itself:")
+banned = {"—": "em dash"}
+for name in ("config.json", "files.json", "rules.md"):
+    text = (cfg_dir / name).read_text()
+    hits = [lbl for ch, lbl in banned.items() if ch in text]
+    emoji = [c for c in text if 0x1F300 <= ord(c) <= 0x1FAFF or 0x2600 <= ord(c) <= 0x27BF]
+    check(not hits and not emoji, f"{name} carries no em dash or emoji",
+          f"{hits} {emoji}")
+
+print(f"\n{checks - len(failures)}/{checks} checks passed")
+if failures:
+    print(f"FAILED: {len(failures)}")
+    sys.exit(1)
+print("OK")
+PY


### PR DESCRIPTION
## What This PR Does

Adds a `.greptile/` configuration directory so the Greptile bot reviews this
repository the way a maintainer would.

- `config.json` turns off the generated wrapper around each review (tool
  header, confidence score, changed-files table, rendered flowchart, footer),
  sets `strictness: 3` with `commentTypes: ["logic"]`, and carries eight
  glob-scoped project rules.
- `rules.md` states what Greptile should not raise, listing the linters that
  already run on every pull request.
- `files.json` points the reviewer at `AGENTS.md`, `CONTRIBUTING.md`,
  `.golangci.yml` and `docs/architecture.md`.
- `hack/verify-greptile-config.sh` plus `make verify-greptile` validate the
  configuration.

Nothing about merge gating changes. `statusCheck` is on so a review leaves a
visible check, but it is not added to the required-checks list, and
auto-approval is off, so a human still holds the approve bit.

## Why

Greptile output on a recent pull request carried a summary header, a
confidence score, a changed-files table and a flowchart around a single
substantive finding. That finding was good and named the symbols involved;
the wrapper around it was what made it easy to miss.

The `strictness` and `commentTypes` settings keep Greptile off ground
`golangci-lint` already covers. That linter set is wide here (revive,
staticcheck with all checks, testifylint with enable-all, cyclop, nestif,
bodyclose, contextcheck and others), so a second probabilistic pass over the
same ground yields duplicate comments and trains reviewers to skim.

The eight rules encode failures that build, vet, test and lint were all green
for at the time. The clearest is the bridge rule: a go-nvml bump that adds an
NVML entry point needs `make gen` and a hand-added C type in `nvml_types.h`,
and a stale `stubs_generated.go` still links under `-buildmode=c-shared`, so
the break appears only when a consumer dlopens the library with `RTLD_NOW`.

The verifier exists because Greptile fails open on a rule scope that stops
matching. After a package move the rule quietly stops applying and nothing
reports it. The check fails when a scope glob or a context path matches
nothing. It earned its place while this branch was being written: it caught
three ignore patterns pointing at gitignored directories that can never appear
in a diff, and one (`**/*_generated.go`) that would have hidden
`pkg/gpu/mocknvml/bridge/stubs_generated.go` from the rule that needs to see it.

## Testing

Run against the final commit:

- `make test` passes.
- `make lint` passes: golangci-lint reports 0 issues, govulncheck reports no
  vulnerabilities the code calls.
- `make verify-greptile` passes 49 of 49 checks.
- `make gen` produces no diff, so generated code is unaffected.
- The verifier was mutation-tested. A dead scope glob, invalid JSON, an
  inserted em dash and an invalid severity each turn it red, and the
  unmutated tree stays green.

Behaviour is not yet verified against a live review. Greptile reads
configuration from the source branch of a pull request, so this pull request
is itself the first test of the settings.

## Breaking Changes

None. No existing source is modified; the Makefile gains one standalone
target.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`go test -v -race ./...`)
- [x] Linter passes (`make lint-fix`)
- [x] New code has SPDX license headers
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (if user-facing change)

## Open question for reviewers

`ignorePatterns` is documented as a string in `.gitignore` syntax in the
`greptile.json` reference but is not typed in the `.greptile/` reference. If
Greptile comments on a file under `vendor/`, the field wants an array instead
and this is a one-line fix.
