### PR TITLE
feat(node-agent): Mokka Node Agent NVLink simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plugin aborts at startup, and without the channel nodes containerd refuses to
   admit a pod carrying a compute-domain CDI spec. Gated on
   `imex.mockChannels.enabled`. (#TBD)
+- The node agent gains an `nvlink` simulator that stages the cluster
+  ComputeDomain topology document into the node overlay, subsuming that phase of
+  `setup.sh`. Topology edits now reach workloads without a DaemonSet restart,
+  and disabling topology removes the staged document. (#750)
 - `host.Host.Mknod` centralises privileged character-device creation, so
   `gpudriver` and `imex` share one primitive rather than each carrying its own
   copy of the `mknod`-then-`chmod` sequence. (#TBD)

--- a/cmd/node-agent/main.go
+++ b/cmd/node-agent/main.go
@@ -68,6 +68,12 @@ func startCommand() *cli.Command {
 				Sources: cli.EnvVars("MOKKA_AGENT_CONFIG"),
 			},
 			&cli.StringFlag{
+				Name:    "topology",
+				Value:   "/etc/nvml-mock/topology/topology.yaml",
+				Usage:   "path to the cluster ComputeDomain topology document; the chart mounts it only when topology is enabled",
+				Sources: cli.EnvVars("MOKKA_AGENT_TOPOLOGY"),
+			},
+			&cli.StringFlag{
 				Name:    "host-root",
 				Value:   "/host",
 				Sources: cli.EnvVars("MOKKA_AGENT_HOST_ROOT"),
@@ -155,7 +161,7 @@ func runStart(ctx context.Context, cmd *cli.Command) error {
 				Fabric:  cmd.Bool("ib-fabric"),
 			}),
 		},
-		Source:          source.NewFileSource(configPath, log),
+		Source:          source.NewFileSource(configPath, cmd.String("topology"), log),
 		Host:            host.New(cmd.String("host-root")),
 		Log:             log,
 		ShutdownTimeout: shutdownTimeout,

--- a/cmd/node-agent/main.go
+++ b/cmd/node-agent/main.go
@@ -13,6 +13,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/NVIDIA/k8s-test-infra/internal/agent/imex"
+	"github.com/NVIDIA/k8s-test-infra/internal/agent/nvlink"
+	"github.com/NVIDIA/k8s-test-infra/internal/agent/pcibus"
 	"github.com/urfave/cli/v3"
 	"golang.org/x/sync/errgroup"
 
@@ -23,15 +26,13 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/internal/agent/health"
 	"github.com/NVIDIA/k8s-test-infra/internal/agent/host"
 	"github.com/NVIDIA/k8s-test-infra/internal/agent/ib"
-	"github.com/NVIDIA/k8s-test-infra/internal/agent/imex"
-	"github.com/NVIDIA/k8s-test-infra/internal/agent/pcibus"
 	"github.com/NVIDIA/k8s-test-infra/internal/agent/source"
 	"github.com/NVIDIA/k8s-test-infra/internal/logging"
 )
 
 func main() {
 	if err := newCLI().Run(context.Background(), os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "node-agent: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "node-agent: %v\n", err)
 		os.Exit(1)
 	}
 }
@@ -141,17 +142,18 @@ func runStart(ctx context.Context, cmd *cli.Command) error {
 	a := agent.New(agent.Config{
 		Simulators: []agent.Simulator{
 			gpudriver.New(),
+			pcibus.New(),
+			cdi.New(),
+			imex.New(),
+			nvlink.New(),
 			fabricmanager.New(fabricmanager.Options{
 				InitDelay: cmd.Duration("fabricmanager-init-delay"),
 			}),
-			pcibus.New(),
-			imex.New(),
 			ib.New(ib.Options{
 				Mode:    ibMode,
 				TCPPort: cmd.Int("ib-fabric-port"),
 				Fabric:  cmd.Bool("ib-fabric"),
 			}),
-			cdi.New(),
 		},
 		Source:          source.NewFileSource(configPath, log),
 		Host:            host.New(cmd.String("host-root")),

--- a/cmd/node-agent/main.go
+++ b/cmd/node-agent/main.go
@@ -69,8 +69,7 @@ func startCommand() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:    "topology",
-				Value:   "/etc/nvml-mock/topology/topology.yaml",
-				Usage:   "path to the cluster ComputeDomain topology document; the chart mounts it only when topology is enabled",
+				Usage:   "path to the cluster ComputeDomain topology document; unset where the cluster declares no topology",
 				Sources: cli.EnvVars("MOKKA_AGENT_TOPOLOGY"),
 			},
 			&cli.StringFlag{

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -237,6 +237,13 @@ spec:
               readOnly: true
             - name: host-nfd-features
               mountPath: /host/etc/kubernetes/node-feature-discovery/features.d
+            {{- if .Values.topology.enabled }}
+            # Source for the topology document the nvlink simulator stages into
+            # the overlay, where the NRI plugin points workloads at it.
+            - name: gpu-topology
+              mountPath: /etc/nvml-mock/topology
+              readOnly: true
+            {{- end }}
             {{- if $fmEnabled }}
             # The agent writes the marker the nvml-mock container reads, and it
             # reaches host paths through /host.

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -152,6 +152,9 @@ spec:
             - /usr/local/bin/node-agent
             - start
             - --config=/etc/nvml-mock/config.yaml
+            # Absent unless topology.enabled, which is what retracts the
+            # document the nvlink simulator staged for workloads.
+            - --topology=/etc/nvml-mock/topology/topology.yaml
             - --host-root=/host
             - --health-addr=:9091
             - --log-level={{ .Values.nodeAgent.logging.level }}

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -152,9 +152,11 @@ spec:
             - /usr/local/bin/node-agent
             - start
             - --config=/etc/nvml-mock/config.yaml
-            # Absent unless topology.enabled, which is what retracts the
-            # document the nvlink simulator staged for workloads.
+            {{- if .Values.topology.enabled }}
+            # Names the gpu-topology mount below. Leaving it unset is what
+            # retracts the document the nvlink simulator staged for workloads.
             - --topology=/etc/nvml-mock/topology/topology.yaml
+            {{- end }}
             - --host-root=/host
             - --health-addr=:9091
             - --log-level={{ .Values.nodeAgent.logging.level }}

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -81,7 +81,6 @@ should match snapshot with all overrides:
                 - /usr/local/bin/node-agent
                 - start
                 - --config=/etc/nvml-mock/config.yaml
-                - --topology=/etc/nvml-mock/topology/topology.yaml
                 - --host-root=/host
                 - --health-addr=:9091
                 - --log-level=info
@@ -263,7 +262,6 @@ should match snapshot with b200 profile:
                 - /usr/local/bin/node-agent
                 - start
                 - --config=/etc/nvml-mock/config.yaml
-                - --topology=/etc/nvml-mock/topology/topology.yaml
                 - --host-root=/host
                 - --health-addr=:9091
                 - --log-level=info
@@ -435,7 +433,6 @@ should match snapshot with default values:
                 - /usr/local/bin/node-agent
                 - start
                 - --config=/etc/nvml-mock/config.yaml
-                - --topology=/etc/nvml-mock/topology/topology.yaml
                 - --host-root=/host
                 - --health-addr=:9091
                 - --log-level=info

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -81,6 +81,7 @@ should match snapshot with all overrides:
                 - /usr/local/bin/node-agent
                 - start
                 - --config=/etc/nvml-mock/config.yaml
+                - --topology=/etc/nvml-mock/topology/topology.yaml
                 - --host-root=/host
                 - --health-addr=:9091
                 - --log-level=info
@@ -262,6 +263,7 @@ should match snapshot with b200 profile:
                 - /usr/local/bin/node-agent
                 - start
                 - --config=/etc/nvml-mock/config.yaml
+                - --topology=/etc/nvml-mock/topology/topology.yaml
                 - --host-root=/host
                 - --health-addr=:9091
                 - --log-level=info
@@ -433,6 +435,7 @@ should match snapshot with default values:
                 - /usr/local/bin/node-agent
                 - start
                 - --config=/etc/nvml-mock/config.yaml
+                - --topology=/etc/nvml-mock/topology/topology.yaml
                 - --host-root=/host
                 - --health-addr=:9091
                 - --log-level=info

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -784,6 +784,23 @@ tests:
             mountPath: /etc/nvml-mock/topology
             readOnly: true
 
+  # The flag and the mount have to name the same path, or the agent watches a
+  # file the chart never places there.
+  - it: should point the node agent at the mounted topology document
+    set:
+      topology:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].command
+          content: --topology=/etc/nvml-mock/topology/topology.yaml
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: gpu-topology
+            mountPath: /etc/nvml-mock/topology
+            readOnly: true
+
   - it: should not mount the topology ConfigMap when disabled
     asserts:
       - notContains:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -803,6 +803,10 @@ tests:
 
   - it: should not mount the topology ConfigMap when disabled
     asserts:
+      # An unset --topology is what tells the agent this cluster declares none.
+      - notContains:
+          path: spec.template.spec.containers[1].command
+          content: --topology=/etc/nvml-mock/topology/topology.yaml
       - notContains:
           path: spec.template.spec.containers[1].volumeMounts
           content:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -763,6 +763,40 @@ tests:
             name: MOCK_FABRICMANAGER_STATE_DIR
             value: /var/lib/nvml-mock/fabric-state
 
+  # ── ComputeDomain topology ──────────────────────────────────────────
+  - it: should mount the topology ConfigMap into both readers when enabled
+    set:
+      topology:
+        enabled: true
+    asserts:
+      # nvml-mock: the engine reads it for `kubectl exec nvidia-smi -q`.
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: gpu-topology
+            mountPath: /etc/nvml-mock/topology
+      # node-agent: the nvlink simulator stages it into the overlay, where the
+      # NRI plugin points workloads at it.
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: gpu-topology
+            mountPath: /etc/nvml-mock/topology
+            readOnly: true
+
+  - it: should not mount the topology ConfigMap when disabled
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: gpu-topology
+            mountPath: /etc/nvml-mock/topology
+            readOnly: true
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: gpu-topology
+
   - it: should wire fabricmanager state dir into both containers when enabled
     set:
       fabricmanager:

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -225,9 +225,9 @@ terminationGracePeriodSeconds: 2
 # pkg/gpu/mocknvml/engine/fabric.go and issue NVIDIA/k8s-test-infra#304.
 topology:
   enabled: false
-  # Cluster-level topology document (consumed only by the mock NVML
-  # engine). Each node must appear in exactly one clique within one
-  # domain. Example:
+  # Cluster-level topology document, read by the mock NVML engine and staged
+  # for workloads by the node agent. Each node must appear in exactly one
+  # clique within one domain. Example:
   # domains:
   #   - name: "test-domain-1"
   #     uuid: "00000000-0000-0000-0000-000000000001"

--- a/deployments/nvml-mock/scripts/setup.sh
+++ b/deployments/nvml-mock/scripts/setup.sh
@@ -39,19 +39,6 @@ mkdir -p "$HOST/run"
 # back to the pristine profile config.
 rm -f "$CONFIG_DIR/overrides.yaml" "$DRIVER_ROOT/config/overrides.yaml"
 
-# 6b. Stage the cluster-level ComputeDomain topology document into the overlay
-#     tree so node-wide NRI injection can surface per-node fabric identity.
-#     The daemon mounts the topology ConfigMap at /etc/nvml-mock/topology when
-#     topology.enabled=true; the NRI plugin bind-mounts $HOST at the container
-#     overlay path and injects MOCK_TOPOLOGY_CONFIG pointing here (plus the
-#     node's NODE_NAME) so the mock NVML engine's applyTopologyOverlay() rewrites
-#     each GPU's clique_id / cluster_uuid. No-op when topology is disabled.
-if [ -f /etc/nvml-mock/topology/topology.yaml ]; then
-  mkdir -p "$HOST/topology"
-  cp /etc/nvml-mock/topology/topology.yaml "$HOST/topology/topology.yaml"
-  echo "Staged ComputeDomain topology overlay at $HOST/topology/topology.yaml"
-fi
-
 # 7. Label node with nvidia.com/gpu.present (requires RBAC: get+patch on nodes).
 if command -v kubectl >/dev/null 2>&1; then
   kubectl label node "$NODE_NAME" nvidia.com/gpu.present=true --overwrite || true

--- a/internal/agent/nvlink/nvlink.go
+++ b/internal/agent/nvlink/nvlink.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/NVIDIA/k8s-test-infra/internal/agent"
 	"github.com/NVIDIA/k8s-test-infra/internal/agent/host"
+	"github.com/NVIDIA/k8s-test-infra/internal/fsutil"
 )
 
 const name = "nvlink"
@@ -46,17 +47,26 @@ func (s *Simulator) Name() string { return name }
 // Ready reports whether the last Stage call completed without error.
 func (s *Simulator) Ready() bool { return s.ready.Load() }
 
-// Stage copies the topology document into the overlay. Absence of the source is
-// not an error: the chart mounts it only when topology is enabled, and a fabric
-// without a declared topology simply keeps the profile's own clique defaults.
+// Stage copies the topology document into the overlay. An absent source retracts
+// it: the chart mounts the ConfigMap only when topology is enabled, and a fabric
+// without a declared topology keeps the profile's own clique defaults.
 func (s *Simulator) Stage(_ context.Context, h *host.Host, _ *agent.State) error {
 	s.ready.Store(false)
 
 	if _, err := os.Stat(sourcePath); err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		// The overlay is on a host mount that outlives the pod, and the NRI
+		// plugin injects MOCK_TOPOLOGY_CONFIG for any container while the file
+		// is there, so a retracted topology has to take the document with it.
+		if err := fsutil.Remove(h.RootPath(overlayRel)); err != nil {
+			return err
+		}
 		s.ready.Store(true)
 		return nil
 	}
-	if err := h.CopyFile(sourcePath, h.RootPath(overlayRel), 0o644); err != nil {
+	if err := fsutil.Copy(sourcePath, h.RootPath(overlayRel), 0o644); err != nil {
 		return err
 	}
 
@@ -70,5 +80,5 @@ func (s *Simulator) Discard(_ context.Context, h *host.Host) error {
 	if !s.ready.Load() {
 		return nil
 	}
-	return h.Remove(h.RootPath(overlayRel))
+	return fsutil.Remove(h.RootPath(overlayRel))
 }

--- a/internal/agent/nvlink/nvlink.go
+++ b/internal/agent/nvlink/nvlink.go
@@ -7,7 +7,6 @@ package nvlink
 
 import (
 	"context"
-	"os"
 	"sync/atomic"
 
 	"github.com/NVIDIA/k8s-test-infra/internal/agent"
@@ -21,10 +20,6 @@ const name = "nvlink"
 // bind-mounts the overlay root into workloads and points MOCK_TOPOLOGY_CONFIG
 // at this path within it.
 const overlayRel = "topology/topology.yaml"
-
-// sourcePath is the chart's topology ConfigMap mount. A package var so tests
-// can point it at a fixture.
-var sourcePath = "/etc/nvml-mock/topology/topology.yaml"
 
 var _ agent.Simulator = (*Simulator)(nil)
 
@@ -47,16 +42,13 @@ func (s *Simulator) Name() string { return name }
 // Ready reports whether the last Stage call completed without error.
 func (s *Simulator) Ready() bool { return s.ready.Load() }
 
-// Stage copies the topology document into the overlay. An absent source retracts
-// it: the chart mounts the ConfigMap only when topology is enabled, and a fabric
-// without a declared topology keeps the profile's own clique defaults.
-func (s *Simulator) Stage(_ context.Context, h *host.Host, _ *agent.State) error {
+// Stage writes the topology document into the overlay. An empty document
+// retracts it: the chart mounts the ConfigMap only when topology is enabled,
+// and a fabric without a declared topology keeps the profile's clique defaults.
+func (s *Simulator) Stage(_ context.Context, h *host.Host, state *agent.State) error {
 	s.ready.Store(false)
 
-	if _, err := os.Stat(sourcePath); err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
+	if len(state.TopologyRaw) == 0 {
 		// The overlay is on a host mount that outlives the pod, and the NRI
 		// plugin injects MOCK_TOPOLOGY_CONFIG for any container while the file
 		// is there, so a retracted topology has to take the document with it.
@@ -66,7 +58,7 @@ func (s *Simulator) Stage(_ context.Context, h *host.Host, _ *agent.State) error
 		s.ready.Store(true)
 		return nil
 	}
-	if err := fsutil.Copy(sourcePath, h.RootPath(overlayRel), 0o644); err != nil {
+	if err := fsutil.Write(h.RootPath(overlayRel), state.TopologyRaw, 0o644); err != nil {
 		return err
 	}
 

--- a/internal/agent/nvlink/nvlink.go
+++ b/internal/agent/nvlink/nvlink.go
@@ -1,0 +1,74 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// Package nvlink stages the ComputeDomain topology document, which gives each
+// node its NVLink fabric identity.
+package nvlink
+
+import (
+	"context"
+	"os"
+	"sync/atomic"
+
+	"github.com/NVIDIA/k8s-test-infra/internal/agent"
+	"github.com/NVIDIA/k8s-test-infra/internal/agent/host"
+)
+
+const name = "nvlink"
+
+// overlayRel must match the NRI plugin's defaultTopologyRelPath: the plugin
+// bind-mounts the overlay root into workloads and points MOCK_TOPOLOGY_CONFIG
+// at this path within it.
+const overlayRel = "topology/topology.yaml"
+
+// sourcePath is the chart's topology ConfigMap mount. A package var so tests
+// can point it at a fixture.
+var sourcePath = "/etc/nvml-mock/topology/topology.yaml"
+
+var _ agent.Simulator = (*Simulator)(nil)
+
+// Simulator copies the cluster topology document into the node overlay so
+// NRI-injected workloads can read it.
+//
+// The document is cluster-wide and lists every node's domain and clique; the
+// mock NVML engine selects this node's entry by NODE_NAME when it loads. That
+// is why this stages the file whole rather than compiling a per-node view.
+type Simulator struct {
+	ready atomic.Bool
+}
+
+// New returns an nvlink Simulator.
+func New() *Simulator { return &Simulator{} }
+
+// Name returns the simulator's stable identifier.
+func (s *Simulator) Name() string { return name }
+
+// Ready reports whether the last Stage call completed without error.
+func (s *Simulator) Ready() bool { return s.ready.Load() }
+
+// Stage copies the topology document into the overlay. Absence of the source is
+// not an error: the chart mounts it only when topology is enabled, and a fabric
+// without a declared topology simply keeps the profile's own clique defaults.
+func (s *Simulator) Stage(_ context.Context, h *host.Host, _ *agent.State) error {
+	s.ready.Store(false)
+
+	if _, err := os.Stat(sourcePath); err != nil {
+		s.ready.Store(true)
+		return nil
+	}
+	if err := h.CopyFile(sourcePath, h.RootPath(overlayRel), 0o644); err != nil {
+		return err
+	}
+
+	s.ready.Store(true)
+	return nil
+}
+
+// Discard removes the staged document. It is a no-op when Stage never
+// completed successfully.
+func (s *Simulator) Discard(_ context.Context, h *host.Host) error {
+	if !s.ready.Load() {
+		return nil
+	}
+	return h.Remove(h.RootPath(overlayRel))
+}

--- a/internal/agent/nvlink/nvlink.go
+++ b/internal/agent/nvlink/nvlink.go
@@ -7,7 +7,6 @@ package nvlink
 
 import (
 	"context"
-	"os"
 	"sync/atomic"
 
 	"github.com/NVIDIA/k8s-test-infra/internal/agent"
@@ -21,10 +20,6 @@ const name = "nvlink"
 // bind-mounts the overlay root into workloads and points MOCK_TOPOLOGY_CONFIG
 // at this path within it.
 const overlayRel = "topology/topology.yaml"
-
-// sourcePath is the chart's topology ConfigMap mount. A package var so tests
-// can point it at a fixture.
-var sourcePath = "/etc/nvml-mock/topology/topology.yaml"
 
 var _ agent.Simulator = (*Simulator)(nil)
 
@@ -47,26 +42,25 @@ func (s *Simulator) Name() string { return name }
 // Ready reports whether the last Stage call completed without error.
 func (s *Simulator) Ready() bool { return s.ready.Load() }
 
-// Stage copies the topology document into the overlay. An absent source retracts
-// it: the chart mounts the ConfigMap only when topology is enabled, and a fabric
-// without a declared topology keeps the profile's own clique defaults.
-func (s *Simulator) Stage(_ context.Context, h *host.Host, _ *agent.State) error {
+// Stage writes the topology document into the overlay. An empty document
+// retracts it: the chart mounts the ConfigMap only when topology is enabled,
+// and a fabric without a declared topology keeps the profile's clique defaults.
+func (s *Simulator) Stage(_ context.Context, h *host.Host, state *agent.State) error {
 	s.ready.Store(false)
 
-	if _, err := os.Stat(sourcePath); err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
+	if len(state.TopologyRaw) == 0 {
 		// The overlay is on a host mount that outlives the pod, and the NRI
 		// plugin injects MOCK_TOPOLOGY_CONFIG for any container while the file
 		// is there, so a retracted topology has to take the document with it.
 		if err := fsutil.Remove(h.RootPath(overlayRel)); err != nil {
 			return err
 		}
+
 		s.ready.Store(true)
 		return nil
 	}
-	if err := fsutil.Copy(sourcePath, h.RootPath(overlayRel), 0o644); err != nil {
+
+	if err := fsutil.Write(h.RootPath(overlayRel), state.TopologyRaw, 0o644); err != nil {
 		return err
 	}
 
@@ -74,11 +68,7 @@ func (s *Simulator) Stage(_ context.Context, h *host.Host, _ *agent.State) error
 	return nil
 }
 
-// Discard removes the staged document. It is a no-op when Stage never
-// completed successfully.
+// Discard removes the staged document.
 func (s *Simulator) Discard(_ context.Context, h *host.Host) error {
-	if !s.ready.Load() {
-		return nil
-	}
 	return fsutil.Remove(h.RootPath(overlayRel))
 }

--- a/internal/agent/nvlink/nvlink_test.go
+++ b/internal/agent/nvlink/nvlink_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package nvlink
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/k8s-test-infra/internal/agent"
+	"github.com/NVIDIA/k8s-test-infra/internal/agent/host"
+)
+
+const doc = `domains:
+  - uuid: 6f0e1b8a-0000-4000-8000-000000000001
+    cliques:
+      - id: 1
+        nodes: [worker-0, worker-1]
+`
+
+// withSource points the simulator at a fixture instead of the chart's mount.
+func withSource(t *testing.T, contents string) {
+	t.Helper()
+	orig := sourcePath
+	t.Cleanup(func() { sourcePath = orig })
+
+	if contents == "" {
+		sourcePath = filepath.Join(t.TempDir(), "absent.yaml")
+		return
+	}
+	p := filepath.Join(t.TempDir(), "topology.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(contents), 0o644))
+	sourcePath = p
+}
+
+// The NRI plugin bind-mounts the overlay root and points workloads at this
+// relative path, so the layout is a contract rather than a detail.
+func TestStage_CopiesDocumentToTheNRIPath(t *testing.T) {
+	withSource(t, doc)
+	h := host.New(t.TempDir())
+	s := New()
+
+	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	require.True(t, s.Ready())
+
+	got, err := os.ReadFile(h.RootPath("topology/topology.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, doc, string(got), "the document must be staged verbatim")
+}
+
+// The engine selects this node's clique by NODE_NAME at load time, so every
+// node stages the whole cluster document unchanged.
+func TestStage_StagesEveryNodesEntry(t *testing.T) {
+	withSource(t, doc)
+	h := host.New(t.TempDir())
+
+	require.NoError(t, New().Stage(context.Background(), h, &agent.State{}))
+	got, err := os.ReadFile(h.RootPath("topology/topology.yaml"))
+	require.NoError(t, err)
+	require.Contains(t, string(got), "worker-0")
+	require.Contains(t, string(got), "worker-1")
+}
+
+// The chart mounts the ConfigMap only when topology is enabled.
+func TestStage_NoOpWithoutTopology(t *testing.T) {
+	withSource(t, "")
+	h := host.New(t.TempDir())
+	s := New()
+
+	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	require.True(t, s.Ready(), "a node without topology is ready, not pending")
+	require.NoFileExists(t, h.RootPath("topology/topology.yaml"))
+}
+
+func TestStage_IsIdempotent(t *testing.T) {
+	withSource(t, doc)
+	h := host.New(t.TempDir())
+	s := New()
+
+	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	first, err := os.ReadFile(h.RootPath("topology/topology.yaml"))
+	require.NoError(t, err)
+
+	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	second, err := os.ReadFile(h.RootPath("topology/topology.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+}
+
+// A ConfigMap edit must reach workloads without a pod restart.
+func TestStage_PicksUpAnEditedDocument(t *testing.T) {
+	withSource(t, doc)
+	h := host.New(t.TempDir())
+	s := New()
+	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+
+	updated := doc + "      - id: 2\n        nodes: [worker-2]\n"
+	require.NoError(t, os.WriteFile(sourcePath, []byte(updated), 0o644))
+	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+
+	got, err := os.ReadFile(h.RootPath("topology/topology.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, updated, string(got))
+}
+
+func TestDiscard_RemovesTheDocument(t *testing.T) {
+	withSource(t, doc)
+	h := host.New(t.TempDir())
+	s := New()
+	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+
+	require.NoError(t, s.Discard(context.Background(), h))
+	require.NoFileExists(t, h.RootPath("topology/topology.yaml"))
+}
+
+func TestDiscard_NoOpBeforeStage(t *testing.T) {
+	require.NoError(t, New().Discard(context.Background(), host.New(t.TempDir())))
+}

--- a/internal/agent/nvlink/nvlink_test.go
+++ b/internal/agent/nvlink/nvlink_test.go
@@ -6,7 +6,6 @@ package nvlink
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,29 +21,23 @@ const doc = `domains:
         nodes: [worker-0, worker-1]
 `
 
-// withSource points the simulator at a fixture instead of the chart's mount.
-func withSource(t *testing.T, contents string) {
-	t.Helper()
-	orig := sourcePath
-	t.Cleanup(func() { sourcePath = orig })
-
+// stateWith returns the State the source compiles for a node whose cluster
+// declares topology; an empty document is a node whose cluster does not.
+func stateWith(contents string) *agent.State {
 	if contents == "" {
-		sourcePath = filepath.Join(t.TempDir(), "absent.yaml")
-		return
+		return &agent.State{}
 	}
-	p := filepath.Join(t.TempDir(), "topology.yaml")
-	require.NoError(t, os.WriteFile(p, []byte(contents), 0o644))
-	sourcePath = p
+	return &agent.State{TopologyRaw: []byte(contents)}
 }
 
 // The NRI plugin bind-mounts the overlay root and points workloads at this
 // relative path, so the layout is a contract rather than a detail.
-func TestStage_CopiesDocumentToTheNRIPath(t *testing.T) {
-	withSource(t, doc)
+func TestStage_WritesDocumentToTheNRIPath(t *testing.T) {
+	t.Parallel()
 	h := host.New(t.TempDir())
 	s := New()
 
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	require.NoError(t, s.Stage(context.Background(), h, stateWith(doc)))
 	require.True(t, s.Ready())
 
 	got, err := os.ReadFile(h.RootPath("topology/topology.yaml"))
@@ -55,10 +48,10 @@ func TestStage_CopiesDocumentToTheNRIPath(t *testing.T) {
 // The engine selects this node's clique by NODE_NAME at load time, so every
 // node stages the whole cluster document unchanged.
 func TestStage_StagesEveryNodesEntry(t *testing.T) {
-	withSource(t, doc)
+	t.Parallel()
 	h := host.New(t.TempDir())
 
-	require.NoError(t, New().Stage(context.Background(), h, &agent.State{}))
+	require.NoError(t, New().Stage(context.Background(), h, stateWith(doc)))
 	got, err := os.ReadFile(h.RootPath("topology/topology.yaml"))
 	require.NoError(t, err)
 	require.Contains(t, string(got), "worker-0")
@@ -67,85 +60,85 @@ func TestStage_StagesEveryNodesEntry(t *testing.T) {
 
 // The chart mounts the ConfigMap only when topology is enabled.
 func TestStage_NoOpWithoutTopology(t *testing.T) {
-	withSource(t, "")
+	t.Parallel()
 	h := host.New(t.TempDir())
 	s := New()
 
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	require.NoError(t, s.Stage(context.Background(), h, stateWith("")))
 	require.True(t, s.Ready(), "a node without topology is ready, not pending")
 	require.NoFileExists(t, h.RootPath("topology/topology.yaml"))
 }
 
 func TestStage_IsIdempotent(t *testing.T) {
-	withSource(t, doc)
+	t.Parallel()
 	h := host.New(t.TempDir())
 	s := New()
 
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	require.NoError(t, s.Stage(context.Background(), h, stateWith(doc)))
 	first, err := os.ReadFile(h.RootPath("topology/topology.yaml"))
 	require.NoError(t, err)
 
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	require.NoError(t, s.Stage(context.Background(), h, stateWith(doc)))
 	second, err := os.ReadFile(h.RootPath("topology/topology.yaml"))
 	require.NoError(t, err)
 	require.Equal(t, first, second)
 }
 
-// A ConfigMap edit must reach workloads without a pod restart.
+// A ConfigMap edit reaches workloads through a reconcile, without a pod restart.
 func TestStage_PicksUpAnEditedDocument(t *testing.T) {
-	withSource(t, doc)
+	t.Parallel()
 	h := host.New(t.TempDir())
 	s := New()
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	require.NoError(t, s.Stage(context.Background(), h, stateWith(doc)))
 
 	updated := doc + "      - id: 2\n        nodes: [worker-2]\n"
-	require.NoError(t, os.WriteFile(sourcePath, []byte(updated), 0o644))
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	require.NoError(t, s.Stage(context.Background(), h, stateWith(updated)))
 
 	got, err := os.ReadFile(h.RootPath("topology/topology.yaml"))
 	require.NoError(t, err)
 	require.Equal(t, updated, string(got))
 }
 
-func TestDiscard_RemovesTheDocument(t *testing.T) {
-	withSource(t, doc)
+// The overlay is on a host mount that outlives the pod, so a topology withdrawn
+// from the cluster must not leave workloads on an obsolete clique.
+func TestStage_RetractsAWithdrawnDocument(t *testing.T) {
+	t.Parallel()
 	h := host.New(t.TempDir())
 	s := New()
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	require.NoError(t, s.Stage(context.Background(), h, stateWith(doc)))
+
+	require.NoError(t, s.Stage(context.Background(), h, stateWith("")))
+
+	require.True(t, s.Ready(), "a retracted topology is ready, not pending")
+	require.NoFileExists(t, h.RootPath("topology/topology.yaml"))
+}
+
+func TestDiscard_RemovesTheDocument(t *testing.T) {
+	t.Parallel()
+	h := host.New(t.TempDir())
+	s := New()
+	require.NoError(t, s.Stage(context.Background(), h, stateWith(doc)))
+
+	require.NoError(t, s.Discard(context.Background(), h))
+	require.NoFileExists(t, h.RootPath("topology/topology.yaml"))
+}
+
+// Cleanup ownership is independent of the last Stage result: a reconcile that
+// fails after an earlier one staged the document clears readiness, and the
+// document is still on a host mount that outlives the pod.
+func TestDiscard_RemovesTheDocumentWhenNotReady(t *testing.T) {
+	t.Parallel()
+	h := host.New(t.TempDir())
+	s := New()
+	require.NoError(t, s.Stage(context.Background(), h, stateWith(doc)))
+
+	s.ready.Store(false) // what a failed reconcile leaves behind
 
 	require.NoError(t, s.Discard(context.Background(), h))
 	require.NoFileExists(t, h.RootPath("topology/topology.yaml"))
 }
 
 func TestDiscard_NoOpBeforeStage(t *testing.T) {
+	t.Parallel()
 	require.NoError(t, New().Discard(context.Background(), host.New(t.TempDir())))
-}
-
-// The overlay is on a host mount that outlives the pod, so a topology withdrawn
-// between two agent lifetimes must not leave workloads on an obsolete clique.
-func TestStage_RetractsAWithdrawnDocument(t *testing.T) {
-	withSource(t, doc)
-	h := host.New(t.TempDir())
-	s := New()
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
-
-	require.NoError(t, os.Remove(sourcePath))
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
-
-	require.True(t, s.Ready(), "a retracted topology is ready, not pending")
-	require.NoFileExists(t, h.RootPath("topology/topology.yaml"))
-}
-
-// A source that cannot be stat'd at all is a broken mount, not a node without
-// topology; reporting ready would hide it behind plausible clique defaults.
-func TestStage_PropagatesAnUnreadableSource(t *testing.T) {
-	orig := sourcePath
-	t.Cleanup(func() { sourcePath = orig })
-	notADir := filepath.Join(t.TempDir(), "topology.yaml")
-	require.NoError(t, os.WriteFile(notADir, nil, 0o644))
-	sourcePath = filepath.Join(notADir, "topology.yaml")
-
-	s := New()
-	require.Error(t, s.Stage(context.Background(), host.New(t.TempDir()), &agent.State{}))
-	require.False(t, s.Ready())
 }

--- a/internal/agent/nvlink/nvlink_test.go
+++ b/internal/agent/nvlink/nvlink_test.go
@@ -6,7 +6,6 @@ package nvlink
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,29 +21,23 @@ const doc = `domains:
         nodes: [worker-0, worker-1]
 `
 
-// withSource points the simulator at a fixture instead of the chart's mount.
-func withSource(t *testing.T, contents string) {
-	t.Helper()
-	orig := sourcePath
-	t.Cleanup(func() { sourcePath = orig })
-
+// stateWith returns the State the source compiles for a node whose cluster
+// declares topology; an empty document is a node whose cluster does not.
+func stateWith(contents string) *agent.State {
 	if contents == "" {
-		sourcePath = filepath.Join(t.TempDir(), "absent.yaml")
-		return
+		return &agent.State{}
 	}
-	p := filepath.Join(t.TempDir(), "topology.yaml")
-	require.NoError(t, os.WriteFile(p, []byte(contents), 0o644))
-	sourcePath = p
+	return &agent.State{TopologyRaw: []byte(contents)}
 }
 
 // The NRI plugin bind-mounts the overlay root and points workloads at this
 // relative path, so the layout is a contract rather than a detail.
-func TestStage_CopiesDocumentToTheNRIPath(t *testing.T) {
-	withSource(t, doc)
+func TestStage_WritesDocumentToTheNRIPath(t *testing.T) {
+	t.Parallel()
 	h := host.New(t.TempDir())
 	s := New()
 
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	require.NoError(t, s.Stage(context.Background(), h, stateWith(doc)))
 	require.True(t, s.Ready())
 
 	got, err := os.ReadFile(h.RootPath("topology/topology.yaml"))
@@ -55,10 +48,10 @@ func TestStage_CopiesDocumentToTheNRIPath(t *testing.T) {
 // The engine selects this node's clique by NODE_NAME at load time, so every
 // node stages the whole cluster document unchanged.
 func TestStage_StagesEveryNodesEntry(t *testing.T) {
-	withSource(t, doc)
+	t.Parallel()
 	h := host.New(t.TempDir())
 
-	require.NoError(t, New().Stage(context.Background(), h, &agent.State{}))
+	require.NoError(t, New().Stage(context.Background(), h, stateWith(doc)))
 	got, err := os.ReadFile(h.RootPath("topology/topology.yaml"))
 	require.NoError(t, err)
 	require.Contains(t, string(got), "worker-0")
@@ -67,85 +60,70 @@ func TestStage_StagesEveryNodesEntry(t *testing.T) {
 
 // The chart mounts the ConfigMap only when topology is enabled.
 func TestStage_NoOpWithoutTopology(t *testing.T) {
-	withSource(t, "")
+	t.Parallel()
 	h := host.New(t.TempDir())
 	s := New()
 
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	require.NoError(t, s.Stage(context.Background(), h, stateWith("")))
 	require.True(t, s.Ready(), "a node without topology is ready, not pending")
 	require.NoFileExists(t, h.RootPath("topology/topology.yaml"))
 }
 
 func TestStage_IsIdempotent(t *testing.T) {
-	withSource(t, doc)
+	t.Parallel()
 	h := host.New(t.TempDir())
 	s := New()
 
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	require.NoError(t, s.Stage(context.Background(), h, stateWith(doc)))
 	first, err := os.ReadFile(h.RootPath("topology/topology.yaml"))
 	require.NoError(t, err)
 
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	require.NoError(t, s.Stage(context.Background(), h, stateWith(doc)))
 	second, err := os.ReadFile(h.RootPath("topology/topology.yaml"))
 	require.NoError(t, err)
 	require.Equal(t, first, second)
 }
 
-// A ConfigMap edit must reach workloads without a pod restart.
+// A ConfigMap edit reaches workloads through a reconcile, without a pod restart.
 func TestStage_PicksUpAnEditedDocument(t *testing.T) {
-	withSource(t, doc)
+	t.Parallel()
 	h := host.New(t.TempDir())
 	s := New()
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	require.NoError(t, s.Stage(context.Background(), h, stateWith(doc)))
 
 	updated := doc + "      - id: 2\n        nodes: [worker-2]\n"
-	require.NoError(t, os.WriteFile(sourcePath, []byte(updated), 0o644))
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	require.NoError(t, s.Stage(context.Background(), h, stateWith(updated)))
 
 	got, err := os.ReadFile(h.RootPath("topology/topology.yaml"))
 	require.NoError(t, err)
 	require.Equal(t, updated, string(got))
 }
 
-func TestDiscard_RemovesTheDocument(t *testing.T) {
-	withSource(t, doc)
+// The overlay is on a host mount that outlives the pod, so a topology withdrawn
+// from the cluster must not leave workloads on an obsolete clique.
+func TestStage_RetractsAWithdrawnDocument(t *testing.T) {
+	t.Parallel()
 	h := host.New(t.TempDir())
 	s := New()
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+	require.NoError(t, s.Stage(context.Background(), h, stateWith(doc)))
+
+	require.NoError(t, s.Stage(context.Background(), h, stateWith("")))
+
+	require.True(t, s.Ready(), "a retracted topology is ready, not pending")
+	require.NoFileExists(t, h.RootPath("topology/topology.yaml"))
+}
+
+func TestDiscard_RemovesTheDocument(t *testing.T) {
+	t.Parallel()
+	h := host.New(t.TempDir())
+	s := New()
+	require.NoError(t, s.Stage(context.Background(), h, stateWith(doc)))
 
 	require.NoError(t, s.Discard(context.Background(), h))
 	require.NoFileExists(t, h.RootPath("topology/topology.yaml"))
 }
 
 func TestDiscard_NoOpBeforeStage(t *testing.T) {
+	t.Parallel()
 	require.NoError(t, New().Discard(context.Background(), host.New(t.TempDir())))
-}
-
-// The overlay is on a host mount that outlives the pod, so a topology withdrawn
-// between two agent lifetimes must not leave workloads on an obsolete clique.
-func TestStage_RetractsAWithdrawnDocument(t *testing.T) {
-	withSource(t, doc)
-	h := host.New(t.TempDir())
-	s := New()
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
-
-	require.NoError(t, os.Remove(sourcePath))
-	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
-
-	require.True(t, s.Ready(), "a retracted topology is ready, not pending")
-	require.NoFileExists(t, h.RootPath("topology/topology.yaml"))
-}
-
-// A source that cannot be stat'd at all is a broken mount, not a node without
-// topology; reporting ready would hide it behind plausible clique defaults.
-func TestStage_PropagatesAnUnreadableSource(t *testing.T) {
-	orig := sourcePath
-	t.Cleanup(func() { sourcePath = orig })
-	notADir := filepath.Join(t.TempDir(), "topology.yaml")
-	require.NoError(t, os.WriteFile(notADir, nil, 0o644))
-	sourcePath = filepath.Join(notADir, "topology.yaml")
-
-	s := New()
-	require.Error(t, s.Stage(context.Background(), host.New(t.TempDir()), &agent.State{}))
-	require.False(t, s.Ready())
 }

--- a/internal/agent/nvlink/nvlink_test.go
+++ b/internal/agent/nvlink/nvlink_test.go
@@ -120,3 +120,32 @@ func TestDiscard_RemovesTheDocument(t *testing.T) {
 func TestDiscard_NoOpBeforeStage(t *testing.T) {
 	require.NoError(t, New().Discard(context.Background(), host.New(t.TempDir())))
 }
+
+// The overlay is on a host mount that outlives the pod, so a topology withdrawn
+// between two agent lifetimes must not leave workloads on an obsolete clique.
+func TestStage_RetractsAWithdrawnDocument(t *testing.T) {
+	withSource(t, doc)
+	h := host.New(t.TempDir())
+	s := New()
+	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+
+	require.NoError(t, os.Remove(sourcePath))
+	require.NoError(t, s.Stage(context.Background(), h, &agent.State{}))
+
+	require.True(t, s.Ready(), "a retracted topology is ready, not pending")
+	require.NoFileExists(t, h.RootPath("topology/topology.yaml"))
+}
+
+// A source that cannot be stat'd at all is a broken mount, not a node without
+// topology; reporting ready would hide it behind plausible clique defaults.
+func TestStage_PropagatesAnUnreadableSource(t *testing.T) {
+	orig := sourcePath
+	t.Cleanup(func() { sourcePath = orig })
+	notADir := filepath.Join(t.TempDir(), "topology.yaml")
+	require.NoError(t, os.WriteFile(notADir, nil, 0o644))
+	sourcePath = filepath.Join(notADir, "topology.yaml")
+
+	s := New()
+	require.Error(t, s.Stage(context.Background(), host.New(t.TempDir()), &agent.State{}))
+	require.False(t, s.Ready())
+}

--- a/internal/agent/source/file.go
+++ b/internal/agent/source/file.go
@@ -119,10 +119,14 @@ func (f *FileSource) send(ctx context.Context, ch chan<- agent.Update, u agent.U
 	}
 }
 
-// readTopology returns the cluster topology document, or nil when no topology
-// ConfigMap is mounted. Other read failures surface as errors, because a nil
-// document retracts the one already staged on this node.
+// readTopology returns the cluster topology document, or nil where the node has
+// none — an unset path or an unmounted ConfigMap. Other read failures surface as
+// errors, because a nil document retracts the one already staged on this node.
 func readTopology(path string) ([]byte, error) {
+	if path == "" {
+		return nil, nil
+	}
+
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return nil, nil

--- a/internal/agent/source/file.go
+++ b/internal/agent/source/file.go
@@ -32,26 +32,29 @@ func envIntOrDefault(key string, def int) int {
 
 const defaultPollInterval = 5 * time.Second
 
-// FileSource watches a YAML config file and emits State updates on change.
-// It polls the config directory so ConfigMap atomic ..data symlink swaps
-// are detected correctly — watching the file itself would pin the replaced inode.
+// FileSource watches the profile and the cluster topology document and emits a
+// State update when either changes. It polls the containing directories so
+// ConfigMap atomic ..data symlink swaps are detected correctly — watching a file
+// itself would pin the replaced inode.
 type FileSource struct {
 	configPath   string
+	topologyPath string
 	pollInterval time.Duration
 	log          *slog.Logger
 }
 
-// NewFileSource returns a FileSource that watches configPath for changes.
-func NewFileSource(configPath string, log *slog.Logger) *FileSource {
+// NewFileSource returns a FileSource that watches configPath and topologyPath.
+func NewFileSource(configPath, topologyPath string, log *slog.Logger) *FileSource {
 	return &FileSource{
 		configPath:   configPath,
+		topologyPath: topologyPath,
 		pollInterval: defaultPollInterval,
 		log:          log,
 	}
 }
 
 // Watch sends the current State immediately and then pushes updates whenever
-// the config file content changes. The channel is closed when ctx is done.
+// either watched document changes. The channel is closed when ctx is done.
 func (f *FileSource) Watch(ctx context.Context) <-chan agent.Update {
 	ch := make(chan agent.Update, 1)
 	go f.run(ctx, ch)
@@ -86,7 +89,13 @@ func (f *FileSource) poll(ctx context.Context, ch chan<- agent.Update, lastHash 
 		return
 	}
 
-	h := sha256.Sum256(data)
+	topology, err := readTopology(f.topologyPath)
+	if err != nil {
+		f.send(ctx, ch, agent.Update{Err: err, At: time.Now()})
+		return
+	}
+
+	h := inputsHash(data, topology)
 	if h == *lastHash {
 		return // content unchanged
 	}
@@ -98,6 +107,7 @@ func (f *FileSource) poll(ctx context.Context, ch chan<- agent.Update, lastHash 
 		return
 	}
 	state.ConfigRaw = data
+	state.TopologyRaw = topology
 	f.log.Info("state updated from config", "config", f.configPath)
 	f.send(ctx, ch, agent.Update{State: state, At: time.Now()})
 }
@@ -107,6 +117,29 @@ func (f *FileSource) send(ctx context.Context, ch chan<- agent.Update, u agent.U
 	case ch <- u:
 	case <-ctx.Done():
 	}
+}
+
+// readTopology returns the cluster topology document, or nil when no topology
+// ConfigMap is mounted. Other read failures surface as errors, because a nil
+// document retracts the one already staged on this node.
+func readTopology(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read topology: %w", err)
+	}
+
+	return data, nil
+}
+
+// inputsHash digests both documents so an edit to either is a change. Hashing
+// the fixed-width sums keeps a byte from shifting across the boundary.
+func inputsHash(config, topology []byte) [32]byte {
+	c, t := sha256.Sum256(config), sha256.Sum256(topology)
+
+	return sha256.Sum256(append(c[:], t[:]...))
 }
 
 // compileState parses raw YAML config bytes and builds the agent State.

--- a/internal/agent/source/file_test.go
+++ b/internal/agent/source/file_test.go
@@ -387,6 +387,19 @@ func TestFileSource_TopologyRemovalTriggersAReconcile(t *testing.T) {
 	require.Empty(t, u.State.TopologyRaw)
 }
 
+// The chart omits --topology where the cluster declares none, so an unset path
+// carries the same meaning as an unmounted ConfigMap.
+func TestFileSource_UnsetTopologyPathIsEmptyNotAnError(t *testing.T) {
+	f, _ := sourceWith(t, topologyDoc)
+	f.topologyPath = ""
+
+	var hash [32]byte
+	u := pollOnce(t, f, &hash)
+	require.NotNil(t, u)
+	require.NoError(t, u.Err)
+	require.Empty(t, u.State.TopologyRaw)
+}
+
 // A topology that cannot be read is a broken mount, not a cluster without
 // topology; emitting an empty document would retract every node's overlay.
 func TestFileSource_ReportsAnUnreadableTopology(t *testing.T) {

--- a/internal/agent/source/file_test.go
+++ b/internal/agent/source/file_test.go
@@ -5,6 +5,7 @@ package source
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -75,7 +76,7 @@ func TestFileSource_EmitsInitialState(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	fs := NewFileSource(configs[0], slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	fs := NewFileSource(configs[0], filepath.Join(t.TempDir(), "topology.yaml"), slog.New(slog.NewTextHandler(os.Stdout, nil)))
 	ch := fs.Watch(ctx)
 
 	u := <-ch
@@ -286,4 +287,115 @@ func TestCompileNetwork_AppliesDefaults(t *testing.T) {
 	require.NotEmpty(t, net.PortState)
 	require.NotEmpty(t, net.PhysState)
 	require.Positive(t, net.RateGbps)
+}
+
+const topologyDoc = `domains:
+  - uuid: 6f0e1b8a-0000-4000-8000-000000000001
+    cliques:
+      - id: 1
+        nodes: [worker-0]
+`
+
+// sourceWith returns a FileSource over a gb200 profile and a topology path that
+// the caller can create, edit, or leave absent.
+func sourceWith(t *testing.T, topology string) (*FileSource, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	profile, err := os.ReadFile("../../../pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml")
+	require.NoError(t, err)
+	configPath := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, profile, 0o600))
+
+	topologyPath := filepath.Join(dir, "topology.yaml")
+	if topology != "" {
+		require.NoError(t, os.WriteFile(topologyPath, []byte(topology), 0o600))
+	}
+
+	return NewFileSource(configPath, topologyPath, slog.New(slog.NewTextHandler(io.Discard, nil))), topologyPath
+}
+
+// poll is what the ticker calls, so driving it directly exercises the same
+// change detection the running agent sees without waiting on the interval.
+func pollOnce(t *testing.T, f *FileSource, lastHash *[32]byte) *agent.Update {
+	t.Helper()
+
+	ch := make(chan agent.Update, 1)
+	f.poll(context.Background(), ch, lastHash)
+	select {
+	case u := <-ch:
+		return &u
+	default:
+		return nil
+	}
+}
+
+// The topology document reaches simulators through State, so nvlink never has
+// to read the ConfigMap mount itself.
+func TestFileSource_CarriesTheTopologyDocument(t *testing.T) {
+	f, _ := sourceWith(t, topologyDoc)
+
+	var hash [32]byte
+	u := pollOnce(t, f, &hash)
+	require.NotNil(t, u)
+	require.NoError(t, u.Err)
+	require.Equal(t, topologyDoc, string(u.State.TopologyRaw))
+}
+
+// The chart mounts the ConfigMap only when topology is enabled, so an absent
+// document is an ordinary state, and it is what retracts a staged overlay.
+func TestFileSource_AbsentTopologyIsEmptyNotAnError(t *testing.T) {
+	f, _ := sourceWith(t, "")
+
+	var hash [32]byte
+	u := pollOnce(t, f, &hash)
+	require.NotNil(t, u)
+	require.NoError(t, u.Err)
+	require.Empty(t, u.State.TopologyRaw)
+}
+
+// Editing the topology alone must reconcile: nothing in the profile changes, so
+// hashing the profile by itself would leave workloads on the previous clique.
+func TestFileSource_TopologyEditTriggersAReconcile(t *testing.T) {
+	f, topologyPath := sourceWith(t, topologyDoc)
+
+	var hash [32]byte
+	require.NotNil(t, pollOnce(t, f, &hash), "initial poll emits")
+	require.Nil(t, pollOnce(t, f, &hash), "an unchanged pair emits nothing")
+
+	updated := topologyDoc + "      - id: 2\n        nodes: [worker-1]\n"
+	require.NoError(t, os.WriteFile(topologyPath, []byte(updated), 0o600))
+
+	u := pollOnce(t, f, &hash)
+	require.NotNil(t, u, "a topology edit must emit an update")
+	require.NoError(t, u.Err)
+	require.Equal(t, updated, string(u.State.TopologyRaw))
+}
+
+// Deleting the ConfigMap is the retraction path, and it has to reconcile too.
+func TestFileSource_TopologyRemovalTriggersAReconcile(t *testing.T) {
+	f, topologyPath := sourceWith(t, topologyDoc)
+
+	var hash [32]byte
+	require.NotNil(t, pollOnce(t, f, &hash))
+
+	require.NoError(t, os.Remove(topologyPath))
+
+	u := pollOnce(t, f, &hash)
+	require.NotNil(t, u, "a withdrawn topology must emit an update")
+	require.NoError(t, u.Err)
+	require.Empty(t, u.State.TopologyRaw)
+}
+
+// A topology that cannot be read is a broken mount, not a cluster without
+// topology; emitting an empty document would retract every node's overlay.
+func TestFileSource_ReportsAnUnreadableTopology(t *testing.T) {
+	f, topologyPath := sourceWith(t, topologyDoc)
+	f.topologyPath = filepath.Join(topologyPath, "topology.yaml") // a file, not a directory
+
+	var hash [32]byte
+	u := pollOnce(t, f, &hash)
+	require.NotNil(t, u)
+	require.Error(t, u.Err)
+	require.Nil(t, u.State)
 }

--- a/internal/agent/state.go
+++ b/internal/agent/state.go
@@ -24,6 +24,11 @@ type State struct {
 	// the static hardware model, Runtime carries operational overrides (GPU_COUNT,
 	// faults, fabric) written by GPU_COUNT env, MEP-0001 CP, and nvml-mock-ctl.
 	ConfigRaw []byte
+	// TopologyRaw holds the cluster ComputeDomain topology document verbatim.
+	// It stays raw because the document describes every node and the mock NVML
+	// engine picks this node's entry by NODE_NAME at load time, so there is no
+	// per-node view for the agent to compile.
+	TopologyRaw []byte
 }
 
 // NodeMeta carries node identity fields.


### PR DESCRIPTION
## What This PR Does

Ported NVLink simulator. topology.yaml file now triggers FileSource reconciliation. 

Since it's just contains of moving one topology.yaml file under the proper location we may find a better place for this code potentially completely eliminating NVLink as a simulator. However, for now, for the sake of compliance with the existing logic, we keep it as a simulator.

## Why

A part of MEP0003.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`go test -v -race ./...`)
- [x] Linter passes (`make lint-fix`)
- [x] New code has SPDX license headers
- [ ] Documentation updated (if applicable)
- [x] CHANGELOG.md updated (if user-facing change)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>