### PR TITLE
fix(chart): correct GPU Operator flags in NOTES.txt

### DIFF
--- a/deployments/nvml-mock/helm/nvml-mock/templates/NOTES.txt
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/NOTES.txt
@@ -50,15 +50,34 @@ OPTION B: NVIDIA DRA Driver (requires DRA-enabled cluster)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-OPTION C: GPU Operator (UNTESTED — contributions welcome)
+OPTION C: GPU Operator
 
-  helm install gpu-operator nvidia/gpu-operator \
-    --set driver.enabled=false \
-    --set toolkit.enabled=true \
-    --set devicePlugin.enabled=true
+  The operator's driver and container-toolkit operands are replaced by
+  nvml-mock, so both are disabled and CDI carries the devices instead.
+  The overlay below carries that, plus the driver root the device plugin,
+  GFD and dcgm-exporter each need in their environment.
 
-  ⚠ This integration has no E2E test coverage. If you get it working,
-  please contribute the test back.
+  Cluster prerequisites (KIND): the node needs CDI enabled in containerd
+  and the nvidia runtime handler registered.
+  Walkthrough, including that containerd setup:
+    https://nvidia.github.io/k8s-test-infra/helm-chart/#quick-start-gpu-operator-on-kind
+
+  Install:
+    helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+    helm repo update
+
+    helm install gpu-operator nvidia/gpu-operator \
+      --namespace gpu-operator --create-namespace \
+      -f https://raw.githubusercontent.com/NVIDIA/k8s-test-infra/main/tests/e2e/gpu-operator-values.yaml \
+      --wait --timeout 600s
+
+  From a checkout, the local path tests/e2e/gpu-operator-values.yaml works too.
+
+  Verify the operands are running and GPUs are allocatable. The operands do
+  not tolerate the control-plane taint, so check every node, not just one:
+
+    kubectl -n gpu-operator get pods
+    kubectl get nodes -o 'custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 {{- if .Values.integrations.fakeGpuOperator.enabled }}

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/notes_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/notes_test.yaml.snap
@@ -53,15 +53,34 @@ should match snapshot with b200 profile:
 
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-      OPTION C: GPU Operator (UNTESTED — contributions welcome)
+      OPTION C: GPU Operator
 
-        helm install gpu-operator nvidia/gpu-operator \
-          --set driver.enabled=false \
-          --set toolkit.enabled=true \
-          --set devicePlugin.enabled=true
+        The operator's driver and container-toolkit operands are replaced by
+        nvml-mock, so both are disabled and CDI carries the devices instead.
+        The overlay below carries that, plus the driver root the device plugin,
+        GFD and dcgm-exporter each need in their environment.
 
-        ⚠ This integration has no E2E test coverage. If you get it working,
-        please contribute the test back.
+        Cluster prerequisites (KIND): the node needs CDI enabled in containerd
+        and the nvidia runtime handler registered.
+        Walkthrough, including that containerd setup:
+          https://nvidia.github.io/k8s-test-infra/helm-chart/#quick-start-gpu-operator-on-kind
+
+        Install:
+          helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+          helm repo update
+
+          helm install gpu-operator nvidia/gpu-operator \
+            --namespace gpu-operator --create-namespace \
+            -f https://raw.githubusercontent.com/NVIDIA/k8s-test-infra/main/tests/e2e/gpu-operator-values.yaml \
+            --wait --timeout 600s
+
+        From a checkout, the local path tests/e2e/gpu-operator-values.yaml works too.
+
+        Verify the operands are running and GPUs are allocatable. The operands do
+        not tolerate the control-plane taint, so check every node, not just one:
+
+          kubectl -n gpu-operator get pods
+          kubectl get nodes -o 'custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
 
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -123,15 +142,34 @@ should match snapshot with default values:
 
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-      OPTION C: GPU Operator (UNTESTED — contributions welcome)
+      OPTION C: GPU Operator
 
-        helm install gpu-operator nvidia/gpu-operator \
-          --set driver.enabled=false \
-          --set toolkit.enabled=true \
-          --set devicePlugin.enabled=true
+        The operator's driver and container-toolkit operands are replaced by
+        nvml-mock, so both are disabled and CDI carries the devices instead.
+        The overlay below carries that, plus the driver root the device plugin,
+        GFD and dcgm-exporter each need in their environment.
 
-        ⚠ This integration has no E2E test coverage. If you get it working,
-        please contribute the test back.
+        Cluster prerequisites (KIND): the node needs CDI enabled in containerd
+        and the nvidia runtime handler registered.
+        Walkthrough, including that containerd setup:
+          https://nvidia.github.io/k8s-test-infra/helm-chart/#quick-start-gpu-operator-on-kind
+
+        Install:
+          helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+          helm repo update
+
+          helm install gpu-operator nvidia/gpu-operator \
+            --namespace gpu-operator --create-namespace \
+            -f https://raw.githubusercontent.com/NVIDIA/k8s-test-infra/main/tests/e2e/gpu-operator-values.yaml \
+            --wait --timeout 600s
+
+        From a checkout, the local path tests/e2e/gpu-operator-values.yaml works too.
+
+        Verify the operands are running and GPUs are allocatable. The operands do
+        not tolerate the control-plane taint, so check every node, not just one:
+
+          kubectl -n gpu-operator get pods
+          kubectl get nodes -o 'custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
 
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/deployments/nvml-mock/helm/nvml-mock/tests/notes_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/notes_test.yaml
@@ -79,3 +79,26 @@ tests:
           pattern: "OPTION B: NVIDIA DRA Driver"
       - matchRegexRaw:
           pattern: "OPTION C: GPU Operator"
+
+  # Guards the OPTION C fix. The printed install must keep pointing at the
+  # overlay the demo and docs use (tests/e2e/gpu-operator-values.yaml, which
+  # currently matches the one CI installs through Tilt, though nothing
+  # enforces that), must keep waiting for the operands, and must never go back
+  # to the --set form that told users toolkit.enabled=true. The last two
+  # asserts cover contracts the snapshot alone would guard, and `helm unittest
+  # -u` launders a snapshot regression away without anyone noticing.
+  - it: should install the GPU Operator from the tested values overlay
+    asserts:
+      - matchRegexRaw:
+          pattern: "-f https://raw\\.githubusercontent\\.com/NVIDIA/k8s-test-infra/main/tests/e2e/gpu-operator-values\\.yaml"
+      # --wait is bounded to the OPTION C section rather than pinned to a
+      # timeout value: [^\u2501] cannot cross the box rule that separates
+      # sections, so OPTION B's own --wait line cannot satisfy this.
+      - matchRegexRaw:
+          pattern: "OPTION C: GPU Operator[^\u2501]*--wait"
+      - notMatchRegexRaw:
+          pattern: "--set toolkit\\.enabled"
+      - notMatchRegexRaw:
+          pattern: "Verified in CI"
+      - matchRegexRaw:
+          pattern: "nvidia\\.github\\.io/k8s-test-infra/helm-chart/#quick-start-gpu-operator-on-kind"


### PR DESCRIPTION
## Problem

The chart's post-install NOTES print a GPU Operator command that does not work:

```
helm install gpu-operator nvidia/gpu-operator \
  --set driver.enabled=false \
  --set toolkit.enabled=true \
  --set devicePlugin.enabled=true
```

A user following it hit `Init:Error` on `nvidia-container-toolkit-daemonset`, with the
validator reporting `open /run/nvidia/driver/sys/bus/pci/devices: no such file or
directory` and pointing at `DISABLE_DEV_CHAR_SYMLINK_CREATION`, which is one of the
nine operand environment settings the `--set` form omits entirely.

Three separate defects in that block:

1. `toolkit.enabled=true` contradicts the configuration we actually verify.
   `tests/e2e/gpu-operator-values.yaml` sets `toolkit.enabled=false` and drives CDI.
2. It claimed the integration was UNTESTED. The `e2e-gpu-operator` job has covered it
   across six GPU profiles for some time.
3. It cannot carry what the install needs. The operands require
   `NVIDIA_DRIVER_ROOT=/var/lib/nvml-mock/driver`, and the validator needs
   `DRIVER_INSTALL_DIR`, `LD_LIBRARY_PATH`, `DISABLE_DEV_CHAR_SYMLINK_CREATION`,
   `NVIDIA_VISIBLE_DEVICES` and `WITH_WORKLOAD=false`. None fit a short flag list.

Two further problems found while fixing it: `--set validator.cuda.env[0].value="false"`
sends a boolean into ClusterPolicy's string `env` field, and the unquoted `env[0]` is a
zsh glob, so on a default macOS shell the whole command line aborts with
`no matches found` and nothing runs at all.

## Approach

Print a values-file form instead of a flag list, referencing
`tests/e2e/gpu-operator-values.yaml` by absolute URL so it is reachable by a reader who
installed the chart from the OCI registry and has no checkout. Drop the UNTESTED
banner. Add `--wait --timeout 600s` and a verification step, matching how the other two
options end. Mention the Kind containerd prerequisites and point at the demo for setup.

The verification command deliberately scans every node rather than `.items[0]`: the
Operator's operands do not tolerate the control-plane taint, so a single-node check
returns empty on a healthy install.

## Testing

- `make helm-tests`: 175/175 tests, 15/15 snapshots.
- Four assertions added to `notes_test.yaml`, because the previous assertion matched the
  substring `OPTION C: GPU Operator` and therefore passed against the old, broken block.
  Each new assertion was mutation-checked: restoring the parent blob makes them fail
  individually, and a mutant that removes only `--wait` from this section (leaving
  OPTION B's) fails exactly one of them.
- The `helm install ... -f <raw URL>` form was confirmed to fetch (rc=0), with a 404 on a
  bogus sibling path as the control.

## Breaking changes

None. Documentation output only.

## Stack

This is PR 1 of 3. It is the base of the stack and can merge on its own.
