### PR TITLE
docs: fix stale references found in the demo audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,12 @@ Use standalone for local development and CI pipelines.
 
 | Demo | Description |
 |------|-------------|
-| [Standalone](docs/demo/standalone/) | nvml-mock with FGO-style labels on Kind |
+| [Standalone](docs/demo/standalone/) | nvml-mock with FGO-style labels |
 | [With fake-gpu-operator](docs/demo/with-fgo/) | Full FGO + nvml-mock integration |
+| [Failure injection](docs/demo/failure-injection/) | ECC, lost and fallen-off-bus fault modes |
+| [Node-wide injection (NRI)](docs/demo/node-wide-injection/) | Ambient nvidia-smi with no GPU request |
+| [ComputeDomain](docs/demo/compute-domain/) | NVLink fabric identity with real nvidia-imex |
+| [NVSentinel](docs/demo/nv-sentinel/) | Thermal-margin detection, drain and auto-recovery |
 
 See [docs/demo/](docs/demo/) for the full list.
 

--- a/deployments/nvml-mock/helm/nvml-mock/templates/NOTES.txt
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/NOTES.txt
@@ -50,15 +50,34 @@ OPTION B: NVIDIA DRA Driver (requires DRA-enabled cluster)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-OPTION C: GPU Operator (UNTESTED — contributions welcome)
+OPTION C: GPU Operator
 
-  helm install gpu-operator nvidia/gpu-operator \
-    --set driver.enabled=false \
-    --set toolkit.enabled=true \
-    --set devicePlugin.enabled=true
+  The operator's driver and container-toolkit operands are replaced by
+  nvml-mock, so both are disabled and CDI carries the devices instead.
+  The overlay below carries that, plus the driver root the device plugin,
+  GFD and dcgm-exporter each need in their environment.
 
-  ⚠ This integration has no E2E test coverage. If you get it working,
-  please contribute the test back.
+  Cluster prerequisites (KIND): the node needs CDI enabled in containerd
+  and the nvidia runtime handler registered.
+  Walkthrough, including that containerd setup:
+    https://nvidia.github.io/k8s-test-infra/helm-chart/#quick-start-gpu-operator-on-kind
+
+  Install:
+    helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+    helm repo update
+
+    helm install gpu-operator nvidia/gpu-operator \
+      --namespace gpu-operator --create-namespace \
+      -f https://raw.githubusercontent.com/NVIDIA/k8s-test-infra/main/tests/e2e/gpu-operator-values.yaml \
+      --wait --timeout 600s
+
+  From a checkout, the local path tests/e2e/gpu-operator-values.yaml works too.
+
+  Verify the operands are running and GPUs are allocatable. The operands do
+  not tolerate the control-plane taint, so check every node, not just one:
+
+    kubectl -n gpu-operator get pods
+    kubectl get nodes -o 'custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 {{- if .Values.integrations.fakeGpuOperator.enabled }}

--- a/deployments/nvml-mock/helm/nvml-mock/templates/NOTES.txt
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/NOTES.txt
@@ -83,7 +83,7 @@ OPTION C: GPU Operator
 {{- if .Values.integrations.fakeGpuOperator.enabled }}
 
 fake-gpu-operator integration is enabled.
-6 profile ConfigMaps created. Discover them with:
+7 profile ConfigMaps created, one per GPU model. Discover them with:
 
   kubectl get cm -l run.ai/gpu-profile=true
 

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/notes_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/notes_test.yaml.snap
@@ -53,15 +53,34 @@ should match snapshot with b200 profile:
 
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-      OPTION C: GPU Operator (UNTESTED — contributions welcome)
+      OPTION C: GPU Operator
 
-        helm install gpu-operator nvidia/gpu-operator \
-          --set driver.enabled=false \
-          --set toolkit.enabled=true \
-          --set devicePlugin.enabled=true
+        The operator's driver and container-toolkit operands are replaced by
+        nvml-mock, so both are disabled and CDI carries the devices instead.
+        The overlay below carries that, plus the driver root the device plugin,
+        GFD and dcgm-exporter each need in their environment.
 
-        ⚠ This integration has no E2E test coverage. If you get it working,
-        please contribute the test back.
+        Cluster prerequisites (KIND): the node needs CDI enabled in containerd
+        and the nvidia runtime handler registered.
+        Walkthrough, including that containerd setup:
+          https://nvidia.github.io/k8s-test-infra/helm-chart/#quick-start-gpu-operator-on-kind
+
+        Install:
+          helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+          helm repo update
+
+          helm install gpu-operator nvidia/gpu-operator \
+            --namespace gpu-operator --create-namespace \
+            -f https://raw.githubusercontent.com/NVIDIA/k8s-test-infra/main/tests/e2e/gpu-operator-values.yaml \
+            --wait --timeout 600s
+
+        From a checkout, the local path tests/e2e/gpu-operator-values.yaml works too.
+
+        Verify the operands are running and GPUs are allocatable. The operands do
+        not tolerate the control-plane taint, so check every node, not just one:
+
+          kubectl -n gpu-operator get pods
+          kubectl get nodes -o 'custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
 
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -123,15 +142,34 @@ should match snapshot with default values:
 
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-      OPTION C: GPU Operator (UNTESTED — contributions welcome)
+      OPTION C: GPU Operator
 
-        helm install gpu-operator nvidia/gpu-operator \
-          --set driver.enabled=false \
-          --set toolkit.enabled=true \
-          --set devicePlugin.enabled=true
+        The operator's driver and container-toolkit operands are replaced by
+        nvml-mock, so both are disabled and CDI carries the devices instead.
+        The overlay below carries that, plus the driver root the device plugin,
+        GFD and dcgm-exporter each need in their environment.
 
-        ⚠ This integration has no E2E test coverage. If you get it working,
-        please contribute the test back.
+        Cluster prerequisites (KIND): the node needs CDI enabled in containerd
+        and the nvidia runtime handler registered.
+        Walkthrough, including that containerd setup:
+          https://nvidia.github.io/k8s-test-infra/helm-chart/#quick-start-gpu-operator-on-kind
+
+        Install:
+          helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+          helm repo update
+
+          helm install gpu-operator nvidia/gpu-operator \
+            --namespace gpu-operator --create-namespace \
+            -f https://raw.githubusercontent.com/NVIDIA/k8s-test-infra/main/tests/e2e/gpu-operator-values.yaml \
+            --wait --timeout 600s
+
+        From a checkout, the local path tests/e2e/gpu-operator-values.yaml works too.
+
+        Verify the operands are running and GPUs are allocatable. The operands do
+        not tolerate the control-plane taint, so check every node, not just one:
+
+          kubectl -n gpu-operator get pods
+          kubectl get nodes -o 'custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
 
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/deployments/nvml-mock/helm/nvml-mock/tests/notes_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/notes_test.yaml
@@ -79,3 +79,26 @@ tests:
           pattern: "OPTION B: NVIDIA DRA Driver"
       - matchRegexRaw:
           pattern: "OPTION C: GPU Operator"
+
+  # Guards the OPTION C fix. The printed install must keep pointing at the
+  # overlay the demo and docs use (tests/e2e/gpu-operator-values.yaml, which
+  # currently matches the one CI installs through Tilt, though nothing
+  # enforces that), must keep waiting for the operands, and must never go back
+  # to the --set form that told users toolkit.enabled=true. The last two
+  # asserts cover contracts the snapshot alone would guard, and `helm unittest
+  # -u` launders a snapshot regression away without anyone noticing.
+  - it: should install the GPU Operator from the tested values overlay
+    asserts:
+      - matchRegexRaw:
+          pattern: "-f https://raw\\.githubusercontent\\.com/NVIDIA/k8s-test-infra/main/tests/e2e/gpu-operator-values\\.yaml"
+      # --wait is bounded to the OPTION C section rather than pinned to a
+      # timeout value: [^\u2501] cannot cross the box rule that separates
+      # sections, so OPTION B's own --wait line cannot satisfy this.
+      - matchRegexRaw:
+          pattern: "OPTION C: GPU Operator[^\u2501]*--wait"
+      - notMatchRegexRaw:
+          pattern: "--set toolkit\\.enabled"
+      - notMatchRegexRaw:
+          pattern: "Verified in CI"
+      - matchRegexRaw:
+          pattern: "nvidia\\.github\\.io/k8s-test-infra/helm-chart/#quick-start-gpu-operator-on-kind"

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -46,9 +46,10 @@ See [with-fgo/README.md](with-fgo/README.md) for the step-by-step guide.
 
 Dedicated cluster (`nvml-mock-failure-demo`) that deploys nvml-mock with
 GPU failure injection enabled and verifies the engine actually trips
-the configured fault. Demonstrates `ecc_uncorrectable` end-to-end and
-prints copy-pasteable commands to switch the running release into
-`lost` / `fallen_off_bus` mode.
+the configured fault. Exercises all four modes end to end as four
+scenarios (`healthy`, `ecc_uncorrectable`, `lost`, `fallen_off_bus`),
+upgrading the running release into each one and asserting the result
+against `nvidia-smi` output.
 
 **Requirements:** Docker, Kind, Helm
 

--- a/docs/demo/nv-sentinel/gpu-operator-values.yaml
+++ b/docs/demo/nv-sentinel/gpu-operator-values.yaml
@@ -3,7 +3,7 @@
 #
 # GPU Operator values for the NVSentinel thermal-margin demo (mock GPUs on Kind).
 #
-# This mirrors tests/e2e/go/assets/gpu-operator-values.yaml with ONE key
+# This mirrors tests/e2e/gpu-operator-values.yaml with ONE key
 # difference: the standalone DCGM (nv-hostengine) DaemonSet is ENABLED so it
 # publishes the "nvidia-dcgm" Service on :5555 that NVSentinel's GPU Health
 # Monitor polls (global.dcgm.mode=operator-service). The repo's e2e disables it

--- a/docs/demo/standalone/README.md
+++ b/docs/demo/standalone/README.md
@@ -17,7 +17,7 @@ the node labels that downstream consumers expect.
    validation helpers resolve pods in it.
 5. Verifies the deployment:
    - DaemonSet pods are running on all workers.
-   - Six GPU profile ConfigMaps are created (one per profile field group).
+   - Seven GPU profile ConfigMaps are created, one per GPU model.
    - `nvidia-smi` runs successfully inside a pod.
    - `ibstat` lists 8 simulated ConnectX-7 NDR HCAs (see
      [`internal/ib/README.md`](https://github.com/NVIDIA/k8s-test-infra/blob/main/internal/ib/README.md)).

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ though real hardware were present. No physical NVIDIA GPU is required.
 
 -   **Demos**
 
-    Six runnable walkthroughs, from a standalone install to NVSentinel health
+    Runnable walkthroughs, from a standalone install to NVSentinel health
     monitoring.
 
     [Browse demos](demo/README.md)


### PR DESCRIPTION
## Problem

A documentation audit of this repo turned up statements the tree contradicts. This PR
fixes the ones found in and around the demos:

- `docs/demo/nv-sentinel/gpu-operator-values.yaml` cited
  `tests/e2e/go/assets/gpu-operator-values.yaml` as the file it mirrors. That path does
  not exist; the overlay is at `tests/e2e/gpu-operator-values.yaml`.
- `README.md` listed two of the six demos.
- `docs/index.md` hard-coded "Six runnable walkthroughs", which goes stale every time a
  demo is added.
- The chart's own NOTES and `docs/demo/standalone/README.md` both promised **6** profile
  ConfigMaps. Seven ship, one per GPU model (`a100 b200 gb200 gb300 h100 l40s t4`), and
  the README additionally described them as "one per profile field group", which is not
  what they are. This was observed by actually running the standalone demo, not by
  reading.
- `docs/demo/README.md` said the failure-injection demo "prints copy-pasteable commands"
  for the `lost` and `fallen_off_bus` modes. The script executes both itself, as
  scenarios 3 and 4.

## Approach

Correct each statement against what the tree actually does. The ConfigMap count was
re-derived by rendering the chart with the fake-gpu-operator integration enabled rather
than by trusting the number in the bug report.

## Testing

- `helm template --set integrations.fakeGpuOperator.enabled=true` renders exactly seven
  ConfigMaps labelled `run.ai/gpu-profile`, confirming the corrected count.
- `make helm-tests` green, `make docs` exits 0.

Worth flagging for a follow-up: the NOTES line carrying that count sits inside
`{{- if .Values.integrations.fakeGpuOperator.enabled }}`, and no test enables that
integration, so the whole branch renders in no snapshot. `helm unittest -u` was a
verified no-op here, which is why no snapshot change accompanies the NOTES edit. The
count itself is guarded by `tests/integrations_fgo_test.yaml`, but the prose is not.

## Breaking changes

None. Documentation only.

## Stack

PR 2 of 3, stacked on #761. GitHub shows the cumulative diff because cross-fork PRs
cannot use a fork branch as their base; **the change belonging to this PR is its last
commit**, `docs: fix stale references found in the demo audit`. Merge #761 first.
