### PR TITLE
docs(demo): state KUBECONFIG and Helm prerequisites on every demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,12 @@ Use standalone for local development and CI pipelines.
 
 | Demo | Description |
 |------|-------------|
-| [Standalone](docs/demo/standalone/) | nvml-mock with FGO-style labels on Kind |
+| [Standalone](docs/demo/standalone/) | nvml-mock with FGO-style labels |
 | [With fake-gpu-operator](docs/demo/with-fgo/) | Full FGO + nvml-mock integration |
+| [Failure injection](docs/demo/failure-injection/) | ECC, lost and fallen-off-bus fault modes |
+| [Node-wide injection (NRI)](docs/demo/node-wide-injection/) | Ambient nvidia-smi with no GPU request |
+| [ComputeDomain](docs/demo/compute-domain/) | NVLink fabric identity with real nvidia-imex |
+| [NVSentinel](docs/demo/nv-sentinel/) | Thermal-margin detection, drain and auto-recovery |
 
 See [docs/demo/](docs/demo/) for the full list.
 

--- a/deployments/nvml-mock/helm/nvml-mock/templates/NOTES.txt
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/NOTES.txt
@@ -50,15 +50,34 @@ OPTION B: NVIDIA DRA Driver (requires DRA-enabled cluster)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-OPTION C: GPU Operator (UNTESTED — contributions welcome)
+OPTION C: GPU Operator
 
-  helm install gpu-operator nvidia/gpu-operator \
-    --set driver.enabled=false \
-    --set toolkit.enabled=true \
-    --set devicePlugin.enabled=true
+  The operator's driver and container-toolkit operands are replaced by
+  nvml-mock, so both are disabled and CDI carries the devices instead.
+  The overlay below carries that, plus the driver root the device plugin,
+  GFD and dcgm-exporter each need in their environment.
 
-  ⚠ This integration has no E2E test coverage. If you get it working,
-  please contribute the test back.
+  Cluster prerequisites (KIND): the node needs CDI enabled in containerd
+  and the nvidia runtime handler registered.
+  Walkthrough, including that containerd setup:
+    https://nvidia.github.io/k8s-test-infra/helm-chart/#quick-start-gpu-operator-on-kind
+
+  Install:
+    helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+    helm repo update
+
+    helm install gpu-operator nvidia/gpu-operator \
+      --namespace gpu-operator --create-namespace \
+      -f https://raw.githubusercontent.com/NVIDIA/k8s-test-infra/main/tests/e2e/gpu-operator-values.yaml \
+      --wait --timeout 600s
+
+  From a checkout, the local path tests/e2e/gpu-operator-values.yaml works too.
+
+  Verify the operands are running and GPUs are allocatable. The operands do
+  not tolerate the control-plane taint, so check every node, not just one:
+
+    kubectl -n gpu-operator get pods
+    kubectl get nodes -o 'custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 {{- if .Values.integrations.fakeGpuOperator.enabled }}

--- a/deployments/nvml-mock/helm/nvml-mock/templates/NOTES.txt
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/NOTES.txt
@@ -83,7 +83,7 @@ OPTION C: GPU Operator
 {{- if .Values.integrations.fakeGpuOperator.enabled }}
 
 fake-gpu-operator integration is enabled.
-6 profile ConfigMaps created. Discover them with:
+7 profile ConfigMaps created, one per GPU model. Discover them with:
 
   kubectl get cm -l run.ai/gpu-profile=true
 

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/notes_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/notes_test.yaml.snap
@@ -53,15 +53,34 @@ should match snapshot with b200 profile:
 
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-      OPTION C: GPU Operator (UNTESTED — contributions welcome)
+      OPTION C: GPU Operator
 
-        helm install gpu-operator nvidia/gpu-operator \
-          --set driver.enabled=false \
-          --set toolkit.enabled=true \
-          --set devicePlugin.enabled=true
+        The operator's driver and container-toolkit operands are replaced by
+        nvml-mock, so both are disabled and CDI carries the devices instead.
+        The overlay below carries that, plus the driver root the device plugin,
+        GFD and dcgm-exporter each need in their environment.
 
-        ⚠ This integration has no E2E test coverage. If you get it working,
-        please contribute the test back.
+        Cluster prerequisites (KIND): the node needs CDI enabled in containerd
+        and the nvidia runtime handler registered.
+        Walkthrough, including that containerd setup:
+          https://nvidia.github.io/k8s-test-infra/helm-chart/#quick-start-gpu-operator-on-kind
+
+        Install:
+          helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+          helm repo update
+
+          helm install gpu-operator nvidia/gpu-operator \
+            --namespace gpu-operator --create-namespace \
+            -f https://raw.githubusercontent.com/NVIDIA/k8s-test-infra/main/tests/e2e/gpu-operator-values.yaml \
+            --wait --timeout 600s
+
+        From a checkout, the local path tests/e2e/gpu-operator-values.yaml works too.
+
+        Verify the operands are running and GPUs are allocatable. The operands do
+        not tolerate the control-plane taint, so check every node, not just one:
+
+          kubectl -n gpu-operator get pods
+          kubectl get nodes -o 'custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
 
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -123,15 +142,34 @@ should match snapshot with default values:
 
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-      OPTION C: GPU Operator (UNTESTED — contributions welcome)
+      OPTION C: GPU Operator
 
-        helm install gpu-operator nvidia/gpu-operator \
-          --set driver.enabled=false \
-          --set toolkit.enabled=true \
-          --set devicePlugin.enabled=true
+        The operator's driver and container-toolkit operands are replaced by
+        nvml-mock, so both are disabled and CDI carries the devices instead.
+        The overlay below carries that, plus the driver root the device plugin,
+        GFD and dcgm-exporter each need in their environment.
 
-        ⚠ This integration has no E2E test coverage. If you get it working,
-        please contribute the test back.
+        Cluster prerequisites (KIND): the node needs CDI enabled in containerd
+        and the nvidia runtime handler registered.
+        Walkthrough, including that containerd setup:
+          https://nvidia.github.io/k8s-test-infra/helm-chart/#quick-start-gpu-operator-on-kind
+
+        Install:
+          helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+          helm repo update
+
+          helm install gpu-operator nvidia/gpu-operator \
+            --namespace gpu-operator --create-namespace \
+            -f https://raw.githubusercontent.com/NVIDIA/k8s-test-infra/main/tests/e2e/gpu-operator-values.yaml \
+            --wait --timeout 600s
+
+        From a checkout, the local path tests/e2e/gpu-operator-values.yaml works too.
+
+        Verify the operands are running and GPUs are allocatable. The operands do
+        not tolerate the control-plane taint, so check every node, not just one:
+
+          kubectl -n gpu-operator get pods
+          kubectl get nodes -o 'custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
 
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/deployments/nvml-mock/helm/nvml-mock/tests/notes_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/notes_test.yaml
@@ -79,3 +79,26 @@ tests:
           pattern: "OPTION B: NVIDIA DRA Driver"
       - matchRegexRaw:
           pattern: "OPTION C: GPU Operator"
+
+  # Guards the OPTION C fix. The printed install must keep pointing at the
+  # overlay the demo and docs use (tests/e2e/gpu-operator-values.yaml, which
+  # currently matches the one CI installs through Tilt, though nothing
+  # enforces that), must keep waiting for the operands, and must never go back
+  # to the --set form that told users toolkit.enabled=true. The last two
+  # asserts cover contracts the snapshot alone would guard, and `helm unittest
+  # -u` launders a snapshot regression away without anyone noticing.
+  - it: should install the GPU Operator from the tested values overlay
+    asserts:
+      - matchRegexRaw:
+          pattern: "-f https://raw\\.githubusercontent\\.com/NVIDIA/k8s-test-infra/main/tests/e2e/gpu-operator-values\\.yaml"
+      # --wait is bounded to the OPTION C section rather than pinned to a
+      # timeout value: [^\u2501] cannot cross the box rule that separates
+      # sections, so OPTION B's own --wait line cannot satisfy this.
+      - matchRegexRaw:
+          pattern: "OPTION C: GPU Operator[^\u2501]*--wait"
+      - notMatchRegexRaw:
+          pattern: "--set toolkit\\.enabled"
+      - notMatchRegexRaw:
+          pattern: "Verified in CI"
+      - matchRegexRaw:
+          pattern: "nvidia\\.github\\.io/k8s-test-infra/helm-chart/#quick-start-gpu-operator-on-kind"

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,7 +1,13 @@
 # nvml-mock Demos
 
-This directory contains end-to-end demos showing how to deploy nvml-mock on a
-local Kind cluster.
+End-to-end demos for nvml-mock.
+
+Most run on any Kubernetes cluster: point your `KUBECONFIG` at one and go.
+Two of them (node-wide injection and ComputeDomain) need containerd NRI
+enabled on every node, so they provision a dedicated Kind cluster instead,
+and say so in their own README. All of them need Helm 3.8+
+(<https://helm.sh/docs/intro/install/>). No cluster? Start with the
+[quick start](../quickstart.md).
 
 ## Available Demos
 
@@ -11,7 +17,7 @@ Dedicated cluster (`nvml-mock-node-wide-demo`) with containerd NRI enabled.
 Installs the `nvml-mock-nri` DaemonSet and proves a plain pod can run
 `nvidia-smi` without GPU requests, annotations, or pod-spec mutation.
 
-**Requirements:** Docker, Kind, Helm
+**Requirements:** Docker, Kind, Helm 3.8+, kubectl (creates its own cluster)
 
 ```bash
 cd node-wide-injection && ./run.sh
@@ -26,7 +32,7 @@ Deploy nvml-mock with FGO-style GPU labels on a Kind cluster. No external
 GPU operator is required -- nvml-mock generates the labels and ConfigMaps
 itself.
 
-**Requirements:** Docker, Kind, Helm
+**Requirements:** KUBECONFIG, Helm 3.8+, kubectl
 
 ```bash
 cd standalone && ./demo.sh
@@ -38,7 +44,7 @@ Full integration with Run:ai's fake-gpu-operator. nvml-mock handles the
 "integration" node pool (real NVML shim) while FGO handles the "scale" pool
 (lightweight fake shim).
 
-**Requirements:** Docker, Kind, Helm, fake-gpu-operator Helm chart
+**Requirements:** KUBECONFIG, Helm 3.8+, kubectl, fake-gpu-operator Helm chart
 
 See [with-fgo/README.md](with-fgo/README.md) for the step-by-step guide.
 
@@ -51,7 +57,7 @@ scenarios (`healthy`, `ecc_uncorrectable`, `lost`, `fallen_off_bus`),
 upgrading the running release into each one and asserting the result
 against `nvidia-smi` output.
 
-**Requirements:** Docker, Kind, Helm
+**Requirements:** KUBECONFIG, Helm 3.8+, kubectl
 
 ```bash
 cd failure-injection && ./run.sh
@@ -72,7 +78,7 @@ the real protocol, not a simulation. Concludes with a `helm upgrade`
 that rebinds every node into a new clique without rebuilding the
 image.
 
-**Requirements:** Docker, Kind, Helm, kubectl, jq
+**Requirements:** Docker, Kind, Helm 3.8+, kubectl, jq (creates its own cluster)
 
 ```bash
 cd compute-domain && ./run.sh
@@ -92,7 +98,7 @@ margin crossing via DCGM + the metadata-collector's slowdown offset,
 reschedules to the healthy worker), and then **auto-recovers** — cooling the GPU
 uncordons the node automatically, with no DCGM restart.
 
-**Requirements:** Docker, Kind, Helm, kubectl (jq optional)
+**Requirements:** Docker, Kind, Helm 3.8+, kubectl (jq optional; creates its own cluster)
 
 ```bash
 cd nv-sentinel && ./run.sh

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -46,9 +46,10 @@ See [with-fgo/README.md](with-fgo/README.md) for the step-by-step guide.
 
 Dedicated cluster (`nvml-mock-failure-demo`) that deploys nvml-mock with
 GPU failure injection enabled and verifies the engine actually trips
-the configured fault. Demonstrates `ecc_uncorrectable` end-to-end and
-prints copy-pasteable commands to switch the running release into
-`lost` / `fallen_off_bus` mode.
+the configured fault. Exercises all four modes end to end as four
+scenarios (`healthy`, `ecc_uncorrectable`, `lost`, `fallen_off_bus`),
+upgrading the running release into each one and asserting the result
+against `nvidia-smi` output.
 
 **Requirements:** Docker, Kind, Helm
 

--- a/docs/demo/compute-domain/README.md
+++ b/docs/demo/compute-domain/README.md
@@ -29,6 +29,10 @@ own 4-worker Kind topology
 
 ## Prerequisites
 
+> **This demo creates its own Kind cluster.** It needs containerd NRI enabled
+> on every node, which cannot be assumed on an existing cluster, so it ignores
+> your current `KUBECONFIG` context and will not touch it.
+
 The demo expects the following tools on `$PATH`:
 
 | Tool      | Tested version | Notes |
@@ -39,6 +43,12 @@ The demo expects the following tools on `$PATH`:
 | `helm`    | v3.13+ (v4 works) | Chart install + `helm upgrade --reuse-values`. |
 | `bash`    | 3.2+           | `run.sh` uses `set -euo pipefail` — no bash 4+ features. |
 | `jq`      | any recent     | Scenario 2 parses `nvidia-imex-ctl -N -j` JSON. |
+
+Install Helm at the version the table above pins, from the official docs:
+<https://helm.sh/docs/intro/install/>
+
+New to Mokka? The [quick start](../../quickstart.md) is the fastest way to see
+simulated GPUs before running this demo.
 
 ## What the script does
 

--- a/docs/demo/failure-injection/README.md
+++ b/docs/demo/failure-injection/README.md
@@ -14,6 +14,21 @@ deployment. The Kind topology itself is the shared
 [`../kind.yaml`](../kind.yaml) (1 control-plane + 3 workers with
 FGO-style labels) — failure injection doesn't need its own topology.
 
+## Prerequisites
+
+- **A Kubernetes cluster and a valid `KUBECONFIG`.** This demo installs into
+  whatever cluster your current context points at. Check yours with
+  `kubectl config current-context`.
+- **Helm 3.8 or newer.** Install it from the official docs:
+  <https://helm.sh/docs/intro/install/>
+- `kubectl`, matching your cluster version.
+
+> **No cluster yet?** The [quick start](../../quickstart.md) creates a
+> throwaway one with Kind in about a minute, then come back here.
+
+Docker and Kind are needed only if you want to build the image from source
+(`BUILD_LOCAL=true`); the default path pulls the published image.
+
 ## What the script does
 
 1. (Re)creates the dedicated Kind cluster (idempotent: an existing

--- a/docs/demo/node-wide-injection/README.md
+++ b/docs/demo/node-wide-injection/README.md
@@ -13,12 +13,18 @@ delivered ambiently through NRI instead of the nvml-mock DaemonSet pod.
 
 ## Prerequisites
 
-Install these tools locally before running the demo:
+> **This demo creates its own Kind cluster.** It needs containerd NRI enabled
+> on every node, which cannot be assumed on an existing cluster, so it ignores
+> your current `KUBECONFIG` context and will not touch it.
 
-- `docker`
-- `kind`
-- `kubectl`
-- `helm`
+- **Docker**, with the daemon running.
+- **Kind**, to provision the demo's dedicated cluster.
+- **Helm 3.8 or newer.** Install it from the official docs:
+  <https://helm.sh/docs/intro/install/>
+- `kubectl`.
+
+New to Mokka? The [quick start](../../quickstart.md) is the fastest way to see
+simulated GPUs before running this demo.
 
 ## How ComputeDomain identity reaches injected pods
 

--- a/docs/demo/nv-sentinel/README.md
+++ b/docs/demo/nv-sentinel/README.md
@@ -52,16 +52,27 @@ One control-plane + two workers:
 When one worker's GPU overheats, NVSentinel cordons/drains it and the sample GPU
 workload reschedules onto the second, healthy worker.
 
-## Requirements
+## Prerequisites
 
-- Docker, [Kind](https://kind.sigs.k8s.io/), Helm, `kubectl`
-- `jq` (optional — only used to pretty-print node conditions)
+> **This demo creates its own Kind cluster.** It pins a two-worker topology and
+> specific node labels, so it provisions its own cluster rather than using your
+> current `KUBECONFIG` context, and it will not touch it.
+
+- **Docker**, with the daemon running.
+- **Kind**, to provision the demo's dedicated cluster.
+- **Helm 3.8 or newer.** Install it from the official docs:
+  <https://helm.sh/docs/intro/install/>
+- `kubectl`.
+- `jq` (optional, only used to pretty-print node conditions).
 - Network access to `ghcr.io` (NVSentinel chart), `helm.ngc.nvidia.com`
   (GPU Operator), `public.ecr.aws` (MongoDB), and `nvidia.github.io`
   (container-toolkit packages).
 - An `arm64` or `amd64` host. The demo runs a standalone MongoDB
   (`public.ecr.aws/docker/library/mongo:8.0.3`) instead of the chart's bundled
   Bitnami MongoDB, so it works on Apple Silicon too (see below).
+
+New to Mokka? The [quick start](../../quickstart.md) is the fastest way to see
+simulated GPUs before running this demo.
 
 ## Run it
 

--- a/docs/demo/nv-sentinel/gpu-operator-values.yaml
+++ b/docs/demo/nv-sentinel/gpu-operator-values.yaml
@@ -3,7 +3,7 @@
 #
 # GPU Operator values for the NVSentinel thermal-margin demo (mock GPUs on Kind).
 #
-# This mirrors tests/e2e/go/assets/gpu-operator-values.yaml with ONE key
+# This mirrors tests/e2e/gpu-operator-values.yaml with ONE key
 # difference: the standalone DCGM (nv-hostengine) DaemonSet is ENABLED so it
 # publishes the "nvidia-dcgm" Service on :5555 that NVSentinel's GPU Health
 # Monitor polls (global.dcgm.mode=operator-service). The repo's e2e disables it

--- a/docs/demo/standalone/README.md
+++ b/docs/demo/standalone/README.md
@@ -17,7 +17,7 @@ the node labels that downstream consumers expect.
    validation helpers resolve pods in it.
 5. Verifies the deployment:
    - DaemonSet pods are running on all workers.
-   - Six GPU profile ConfigMaps are created (one per profile field group).
+   - Seven GPU profile ConfigMaps are created, one per GPU model.
    - `nvidia-smi` runs successfully inside a pod.
    - `ibstat` lists 8 simulated ConnectX-7 NDR HCAs (see
      [`internal/ib/README.md`](https://github.com/NVIDIA/k8s-test-infra/blob/main/internal/ib/README.md)).

--- a/docs/demo/standalone/README.md
+++ b/docs/demo/standalone/README.md
@@ -5,6 +5,21 @@ enabled. It does not require any external GPU operator -- nvml-mock itself
 generates the GPU profile ConfigMaps, the fake InfiniBand sysfs tree, and
 the node labels that downstream consumers expect.
 
+## Prerequisites
+
+- **A Kubernetes cluster and a valid `KUBECONFIG`.** This demo installs into
+  whatever cluster your current context points at. Check yours with
+  `kubectl config current-context`.
+- **Helm 3.8 or newer.** Install it from the official docs:
+  <https://helm.sh/docs/intro/install/>
+- `kubectl`, matching your cluster version.
+
+> **No cluster yet?** The [quick start](../../quickstart.md) creates a
+> throwaway one with Kind in about a minute, then come back here.
+
+Docker and Kind are needed only if you want to build the image from source
+(`BUILD_LOCAL=true`); the default path pulls the published image.
+
 ## What it does
 
 1. Creates a Kind cluster (`nvml-mock-demo`: 1 control-plane, 3 workers).

--- a/docs/demo/with-fgo/README.md
+++ b/docs/demo/with-fgo/README.md
@@ -7,12 +7,29 @@ shim.
 
 ## Prerequisites
 
-- Docker
-- Kind
-- Helm
-- kubectl
-- fake-gpu-operator Helm chart (see
-  [Run:ai fake-gpu-operator docs](https://github.com/run-ai/fake-gpu-operator))
+- **A Kubernetes cluster and a valid `KUBECONFIG`.** This demo installs into
+  whatever cluster your current context points at. Check yours with
+  `kubectl config current-context`.
+- **Helm 3.8 or newer.** The chart is served from an OCI registry, which
+  needs 3.8+. Install it from the official docs:
+  <https://helm.sh/docs/intro/install/>
+- `kubectl`, matching your cluster version.
+- The fake-gpu-operator Helm chart (see
+  [Run:ai fake-gpu-operator docs](https://github.com/run-ai/fake-gpu-operator)).
+- **Nodes labelled for both pools.** This demo splits work across two node
+  pools, so you need at least one node labelled
+  `run.ai/simulated-gpu-node-pool=integration` (Step 3 pins nvml-mock there)
+  and at least one labelled `run.ai/simulated-gpu-node-pool=scale` (Step 4
+  gives that pool to FGO). A cluster missing either label silently produces no
+  pods for that pool, and Helm reports no error.
+  [`../kind.yaml`](../kind.yaml) labels one worker `integration` and two
+  `scale`.
+
+> **No cluster yet?** The [quick start](../../quickstart.md) creates a
+> throwaway one with Kind in about a minute, then come back here.
+
+Docker and Kind are needed only if you want to build the image from source
+(`BUILD_LOCAL=true`); the default path pulls the published image.
 
 ## Step 1 -- Create a Kind cluster
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ though real hardware were present. No physical NVIDIA GPU is required.
 
 -   **Demos**
 
-    Six runnable walkthroughs, from a standalone install to NVSentinel health
+    Runnable walkthroughs, from a standalone install to NVSentinel health
     monitoring.
 
     [Browse demos](demo/README.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,17 @@ Get Mock NVML running in 5 minutes.
 
 ## Kubernetes (Recommended)
 
-Requires Docker, `kind`, `kubectl`, and Helm 3.8+ (for OCI registry support).
+This path creates a throwaway cluster with Kind. If you already have a
+cluster, skip the `kind create cluster` line and the rest works against your
+current `KUBECONFIG` context.
+
+Requires:
+
+- **Helm 3.8 or newer** (the chart is served from an OCI registry):
+  <https://helm.sh/docs/intro/install/>
+- `kubectl`
+- Docker and [Kind](https://kind.sigs.k8s.io/), only for the throwaway
+  cluster below
 
 ```bash
 kind create cluster --name mokka


### PR DESCRIPTION
## Problem

Every demo listed Docker and Kind as its prerequisites, but never the two things a
reader actually needs first: a cluster their `KUBECONFIG` points at, and Helm. Kind was
presented as the platform rather than as one convenient way to get a cluster, so a
reader who already has a cluster had no stated path, and a reader with no cluster had
no pointer to the quick start.

## Approach

Each demo now opens with the prerequisites it really has, worded per tier:

- **Portable** (`standalone`, `failure-injection`, `with-fgo`): a valid `KUBECONFIG`,
  Helm 3.8+ linked to <https://helm.sh/docs/intro/install/>, and a "no cluster yet?"
  pointer to the quick start.
- **Kind-bound** (`node-wide-injection`, `compute-domain`, `nv-sentinel`): these create
  their own cluster and now say so in the first thing you read, instead of leaving it to
  be discovered mid-run. The first two need containerd NRI enabled on every node, which
  cannot be assumed on an existing cluster; `nv-sentinel` pins a two-worker topology and
  specific node labels. Verified against each demo's kind config and `run.sh`.

`docs/quickstart.md` gains the same prerequisites, and the demo index now describes the
two tiers instead of asserting that every demo runs on a local Kind cluster.

Two accuracy fixes fell out of review:

- The Helm floor was originally justified as "the chart is served from an OCI registry".
  That is true only for `with-fgo` and the quick start; the other demos install from the
  local chart path. Rather than invent a second reason, those pages now state the
  requirement without one, matching what two of them already did. `compute-domain`
  defers to its own tool-version table, which pins v3.13+.
- `with-fgo` needs at least one node labelled
  `run.ai/simulated-gpu-node-pool=integration` and one labelled `=scale`. Without them
  the DaemonSets schedule nowhere and Helm reports no error, because `--wait` treats a
  DaemonSet with zero desired pods as ready. `docs/demo/kind.yaml` provides both.

## Testing

Documentation only; no script changed in this PR. Verified that all six demo READMEs
carry the KUBECONFIG prerequisite, the official Helm install link and the quick-start
pointer, that `docs/quickstart.md` carries the first two, and that all seven added
relative links resolve. `make docs` exits 0, so the strict site build accepts them.

## Breaking changes

None.

## Notes for reviewers

The portable demos still create their own Kind cluster today; a follow-up PR makes their
scripts honour the current context behind a preflight that announces the target cluster
and namespace before installing a privileged DaemonSet. Until that lands, these three
READMEs describe the intended contract ahead of the implementation, which is called out
in the follow-up rather than hidden.

## Stack

PR 3 of 3, stacked on #762. GitHub shows the cumulative diff because cross-fork PRs
cannot use a fork branch as their base; **the change belonging to this PR is its last
commit**, `docs(demo): state KUBECONFIG and Helm prerequisites on every demo`. Merge
#761 then #762 first.
