### PR TITLE
feat(demo): run portable demos on the current kube context

### DIFF
--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -9,6 +9,13 @@ and say so in their own README. All of them need Helm 3.8+
 (<https://helm.sh/docs/intro/install/>). No cluster? Start with the
 [quick start](../quickstart.md).
 
+Run one nvml-mock demo per cluster at a time. The chart's hostPath mounts are
+scoped by neither release nor namespace and the DaemonSet tolerates every
+node, so two of these releases collide on per-node host state even from
+different namespaces. The standalone and failure-injection demos refuse to
+install over each other (exit `4`), because the shared mock config left behind
+is what any real GPU workload on those nodes goes on to read.
+
 ## Available Demos
 
 ### Node-wide injection (NRI)
@@ -28,9 +35,9 @@ walkthrough.
 
 ### Standalone
 
-Deploy nvml-mock with FGO-style GPU labels on a Kind cluster. No external
-GPU operator is required -- nvml-mock generates the labels and ConfigMaps
-itself.
+Deploy nvml-mock with FGO-style GPU labels on the cluster your current
+context points at. No external GPU operator is required -- nvml-mock
+generates the labels and ConfigMaps itself.
 
 **Requirements:** KUBECONFIG, Helm 3.8+, kubectl
 
@@ -50,8 +57,9 @@ See [with-fgo/README.md](with-fgo/README.md) for the step-by-step guide.
 
 ### Failure injection
 
-Dedicated cluster (`nvml-mock-failure-demo`) that deploys nvml-mock with
-GPU failure injection enabled and verifies the engine actually trips
+Deploys nvml-mock into your current context with GPU failure injection
+enabled (`BUILD_LOCAL=true` uses a dedicated `nvml-mock-failure-demo`
+cluster instead) and verifies the engine actually trips
 the configured fault. Exercises all four modes end to end as four
 scenarios (`healthy`, `ecc_uncorrectable`, `lost`, `fallen_off_bus`),
 upgrading the running release into each one and asserting the result

--- a/docs/demo/failure-injection/README.md
+++ b/docs/demo/failure-injection/README.md
@@ -1,16 +1,70 @@
 # nvml-mock Failure-Injection Demo
 
-End-to-end walkthrough of the GPU failure-injection feature on a
-dedicated Kind cluster. Unlike [`../standalone/`](../standalone/README.md), this
+End-to-end walkthrough of the GPU failure-injection feature on the cluster
+your current context points at. Unlike [`../standalone/`](../standalone/README.md), this
 demo exercises every supported failure mode (`healthy` →
 `ecc_uncorrectable` → `lost` → `fallen_off_bus`) by re-deploying the
 chart between scenarios with `helm upgrade --reuse-values`, and
 asserts each mode's expected behaviour against `nvidia-smi` output
 inside the pod.
 
-The demo lives in its own cluster (`nvml-mock-failure-demo`) so it
-never collides with the standalone demo or any other nvml-mock
-deployment. The Kind topology itself is the shared
+With `BUILD_LOCAL=true` the demo gets its own cluster
+(`nvml-mock-failure-demo`), which is the only configuration that fully
+isolates it from the standalone demo.
+
+On the default path it shares whatever cluster you point it at, so it installs
+a release called `nvml-mock-failure` into a namespace of its own,
+`mokka-failure` (override with `NAMESPACE=...`), both distinct from the
+standalone demo's `nvml-mock` in `mokka`. The release name is what does the
+real work here, for the reason below; the namespace just keeps the two demos'
+namespaced objects from interleaving.
+
+> **Do not point `NAMESPACE=` at the standalone demo's namespace.** The demo
+> refuses to install if the other demo's release is already there, and exits
+> `4`. That refusal exists because **the two demos share per-node host state
+> whatever namespace they use.** Both DaemonSets mount the same hostPaths,
+> `/var/lib/nvml-mock`, `/var/run/cdi`, `/run/nvidia` and the NFD features
+> directory, and none of those is scoped by release or by namespace.
+>
+> Measured on a live cluster: after a co-located run, the single shared
+> `/var/lib/nvml-mock/driver/config/config.yaml`, which the CDI spec at
+> `/var/run/cdi/nvidia.yaml` points `MOCK_NVML_CONFIG` at, was left reading
+> `failure: {after_calls: 1, mode: fallen_off_bus, code: 79}`.
+>
+> The two demos' own pods do not notice, because each mounts its own
+> ConfigMap. **Any real GPU workload scheduled on those nodes does**: it
+> silently consumes the failure-injected config, which is precisely what this
+> mock exists to provide honestly. Both demos exit `0` while that happens,
+> which is why the refusal is a hard stop rather than a warning.
+>
+> `DEMO_ASSUME_YES=true` overrides it. If you use that, treat the affected
+> nodes as dirty until one of the demos is reinstalled on its own.
+
+**A namespace alone cannot separate the two demos, so the release name does
+the work.** The chart creates a ClusterRole and a ClusterRoleBinding named
+after the release (`templates/rbac.yaml`), and those are cluster-scoped: with
+both demos installing a release called `nvml-mock`, the second one fails
+outright, before creating anything, with
+
+```
+Error: unable to continue with install: ClusterRole "nvml-mock" in namespace ""
+exists and cannot be imported into the current release: invalid ownership
+metadata; annotation validation error: key "meta.helm.sh/release-namespace"
+must equal "mokka-failure": current value is "mokka"
+```
+
+That is why this demo's release is **`nvml-mock-failure`**, not `nvml-mock`.
+The namespace split is still needed, but it is the release name that keeps the
+cluster-scoped objects apart.
+
+**Even with both, this is not isolation.** The chart's hostPath mounts are
+fixed and release-independent (`/var/lib/nvml-mock`, `/var/run/cdi`,
+`/run/nvidia`, and the NFD features directory), and it ships `nodeSelector: {}`
+with `tolerations: [{operator: Exists}]`, so both DaemonSets land on every node
+and write the same per-node host state whatever they are called. Do not run
+this demo and the standalone demo against the same cluster at the same time.
+
+The Kind topology itself is the shared
 [`../kind.yaml`](../kind.yaml) (1 control-plane + 3 workers with
 FGO-style labels) — failure injection doesn't need its own topology.
 
@@ -26,14 +80,60 @@ FGO-style labels) — failure injection doesn't need its own topology.
 > **No cluster yet?** The [quick start](../../quickstart.md) creates a
 > throwaway one with Kind in about a minute, then come back here.
 
-Docker and Kind are needed only if you want to build the image from source
-(`BUILD_LOCAL=true`); the default path pulls the published image.
+Docker and Kind are needed only for `BUILD_LOCAL=true`, which builds the image
+from source and side-loads it into a Kind cluster named
+`nvml-mock-failure-demo`, creating that cluster if it is missing. The default
+path pulls the published image and never creates or deletes a cluster.
+
+### First run on a cold cluster is slow
+
+The image is about 100 MB. On a cluster that has never pulled it, a measured
+cold pull took **roughly 8 minutes per node**, so the demo waits up to **15
+minutes** rather than the 2 it used to. It prints a notice before installing;
+a long silence there is the pull, not a hang.
+
+A first install pulls on all nodes at once on its own, because a fresh
+DaemonSet creates every pod immediately. The demo also sets
+`updateStrategy.rollingUpdate.maxUnavailable=100%`, which matters on **re-runs**:
+the chart's 25% default turns a rolling update on an existing release back
+into one node at a time.
+
+Raise the budget on a slow link:
+
+```bash
+HELM_TIMEOUT=30m ./run.sh
+```
+
+Note that `ghcr.io/nvidia/nvml-mock:latest` is a floating tag, so a cluster
+holding an older cached `:latest` can run a build that does not match this
+chart. Pin `NVML_MOCK_IMAGE` to a released tag if you need a fixed pairing.
 
 ## What the script does
 
-1. (Re)creates the dedicated Kind cluster (idempotent: an existing
-   `nvml-mock-failure-demo` cluster is reused).
-2. Builds and loads the `nvml-mock:failure-demo` image.
+1. Announces the target: context, API server, node count, and the namespace
+   the workload lands in. Unless that target is a throwaway Kind cluster (a
+   `kind-*` context whose API server is loopback, since the name alone proves
+   nothing), it asks you to type the context name back before installing
+   anything. The chart runs a privileged DaemonSet with hostPath mounts, so
+   nothing is installed until the target is confirmed.
+
+   It **fails closed** when nobody can answer: a non-interactive run against
+   anything but a throwaway cluster exits `4` rather than installing
+   unattended. Set `DEMO_ASSUME_YES=true` to proceed deliberately without a
+   terminal.
+
+   Exit codes: `2` no usable cluster, `3` missing or too-old tooling, `4`
+   confirmation declined, impossible, refused because another nvml-mock demo is
+   already installed anywhere on the cluster, or refused because helm could not
+   list releases to rule that out, `5` a configuration the chart cannot
+   express (a digest-pinned `NVML_MOCK_IMAGE`).
+
+   Every subsequent `kubectl` and `helm` call is pinned to both the context
+   **and** the namespace it announced.
+2. With `BUILD_LOCAL=true` only: creates the `nvml-mock-failure-demo` Kind
+   cluster if missing, then builds and loads the `nvml-mock:failure-demo`
+   image. Otherwise it uses `ghcr.io/nvidia/nvml-mock:latest` (override with
+   `NVML_MOCK_IMAGE`).
 3. **Scenario 1 — healthy baseline**. Installs with
    `gpu.failureInjection.enabled=false` and asserts:
    * the rendered ConfigMap has **no** `failure:` block,
@@ -141,5 +241,12 @@ For the full per-mode behaviour contract see
 ## Clean up
 
 ```bash
+# Default path: the cluster was already yours, so only remove the release.
+# The -n and --kube-context are load-bearing. Without them helm resolves the
+# release from whatever context and namespace happen to be current, which on
+# a shared cluster is how this can delete the standalone demo's release.
+helm uninstall nvml-mock-failure -n mokka-failure --kube-context <your-context>
+
+# BUILD_LOCAL=true also created a cluster, so tear that down too:
 kind delete cluster --name nvml-mock-failure-demo
 ```

--- a/docs/demo/failure-injection/run.sh
+++ b/docs/demo/failure-injection/run.sh
@@ -5,9 +5,10 @@
 #
 # End-to-end demo of nvml-mock GPU failure injection.
 #
-# Spins up a dedicated Kind cluster (so it never collides with the
-# standalone demo), then walks the deployment through four scenarios
-# via `helm upgrade --reuse-values`:
+# Installs into the cluster your current kubectl context points at
+# (BUILD_LOCAL=true instead builds the image and side-loads it into a
+# dedicated Kind cluster of its own), then walks the deployment through
+# four scenarios via `helm upgrade --reuse-values`:
 #
 #   1. healthy            - baseline, all NVML calls succeed.
 #   2. ecc_uncorrectable  - device stays addressable; ECC counters
@@ -27,22 +28,61 @@
 
 set -euo pipefail
 
+# shellcheck source=../lib/preflight.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)/preflight.sh"
+
 ###############################################################################
 # Configuration
 ###############################################################################
 CLUSTER_NAME="nvml-mock-failure-demo"
-# Kind creates a kubeconfig context named "kind-<cluster>". Pin every kubectl
-# and helm call to it so the demo never operates on whatever context happens to
-# be current (which could be a real cluster).
-KUBE_CONTEXT="kind-${CLUSTER_NAME}"
-IMAGE_NAME="nvml-mock:failure-demo"
-RELEASE_NAME="nvml-mock"
+# BUILD_LOCAL=true builds the image from source and side-loads it into a Kind
+# cluster, creating that cluster if it is missing. It is the ONLY path that
+# needs Docker and Kind. The default installs the published image into the
+# cluster your current context already points at, and never creates one.
+: "${BUILD_LOCAL:=false}"
+: "${LOCAL_IMAGE:=nvml-mock:failure-demo}"
+# Populated only on the BUILD_LOCAL path, when the demo switches contexts.
+PRIOR_CONTEXT=""
+# Resolved by demo::preflight below. This demo previously ran 11 bare kubectl
+# call sites and two helm calls with no --kube-context, so on its
+# cluster-reuse branch it installed into whatever context happened to be
+# current, silently. Every one is now pinned to the context the preflight
+# announced and, off Kind, made you confirm.
+KUBE_CONTEXT=""
+# MUST differ from the standalone demo's release name. The chart creates a
+# ClusterRole and ClusterRoleBinding named after the release
+# (templates/rbac.yaml), and those are CLUSTER-scoped, so a namespace cannot
+# separate them. With both demos on "nvml-mock" the second install dies with:
+#   Error: unable to continue with install: ClusterRole "nvml-mock" in
+#   namespace "" exists and cannot be imported into the current release:
+#   invalid ownership metadata; annotation validation error: key
+#   "meta.helm.sh/release-namespace" must equal "mokka-failure": current
+#   value is "mokka"
+# The release name contains the chart name, so nvml-mock.fullname collapses to
+# exactly this string and every derived object is "nvml-mock-failure*".
+RELEASE_NAME="nvml-mock-failure"
+# Deploy into a namespace of its own, distinct from the standalone demo's
+# "mokka". The distinct RELEASE_NAME above is what keeps the two demos'
+# cluster-scoped objects apart; this keeps their namespaced objects apart too,
+# so `kubectl -n mokka get all` shows one demo rather than both interleaved.
+#
+# Overriding this to "mokka" no longer produces a helm ownership error, since
+# the releases now have different names, so the two demos would simply
+# co-locate. They still share per-node host state either way, so do not run
+# both against one cluster at the same time.
+: "${NAMESPACE:=mokka-failure}"
 CHART_PATH="deployments/nvml-mock/helm/nvml-mock"
 # The chart names its rendered ConfigMap "<fullname>-config" (see
-# templates/configmap.yaml). For RELEASE_NAME=nvml-mock the helm
-# fullname helper short-circuits to the release name, so the
-# ConfigMap is just "nvml-mock-config".
+# templates/configmap.yaml). The fullname helper short-circuits to the
+# release name whenever the release name contains the chart name, which
+# ours does, so the ConfigMap is "nvml-mock-failure-config".
 CONFIGMAP_NAME="${RELEASE_NAME}-config"
+# Pods carry app.kubernetes.io/name=<CHART name> and
+# app.kubernetes.io/instance=<RELEASE name> (templates/_helpers.tpl,
+# nvml-mock.selectorLabels). Selecting on name alone would match the
+# standalone demo's pods too on a shared cluster, and would match NOTHING
+# once the release stopped being called "nvml-mock". Pin the instance.
+POD_SELECTOR="app.kubernetes.io/name=nvml-mock,app.kubernetes.io/instance=${RELEASE_NAME}"
 # Number of GPUs that nvidia-smi reports inside the daemonset pod. We
 # DON'T pass --set gpu.count=... because that only affects the
 # host-side CDI spec produced by the cdi simulator — the in-pod config mounted
@@ -64,13 +104,12 @@ KIND_CONFIG="${REPO_ROOT}/docs/demo/kind.yaml"
 # value on stdout (e.g. upgrade_and_recycle -> pod name) stay safe to
 # use inside command substitution.
 info()    { printf '\n==> %s\n' "$*" >&2; }
+# Pin every kubectl call to the context the preflight resolved and announced,
+# so nothing can redirect the demo to a cluster the reader never saw.
+kubectl_ctx() { command kubectl --context "${KUBE_CONTEXT}" -n "${NAMESPACE}" "$@"; }
 sub()     { printf '    %s\n' "$*" >&2; }
 ok()      { printf '    \xE2\x9C\x93 %s\n' "$*" >&2; }   # ✓
 fail()    { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
-
-# Wrap kubectl so every call is pinned to the demo's kind context without
-# repeating --context at each call site. helm keeps --kube-context inline.
-kubectl_ctx() { command kubectl --context "${KUBE_CONTEXT}" "$@"; }
 
 # wait_for_pod: wait for the DaemonSet rollout to settle and echo the
 # name of a Running pod we can exec into for verification.
@@ -80,8 +119,9 @@ kubectl_ctx() { command kubectl --context "${KUBE_CONTEXT}" "$@"; }
 # Filtering on status.phase=Running keeps us from accidentally execing
 # into a pod that's on its way out.
 wait_for_pod() {
-  kubectl_ctx rollout status "daemonset/${RELEASE_NAME}" --timeout=90s >/dev/null
-  kubectl_ctx get pods -l "app.kubernetes.io/name=${RELEASE_NAME}" \
+  kubectl_ctx rollout status "daemonset/${RELEASE_NAME}" \
+    --timeout="$(demo::install_timeout)" >/dev/null
+  kubectl_ctx get pods -l "${POD_SELECTOR}" \
     --field-selector=status.phase=Running \
     -o jsonpath='{.items[0].metadata.name}'
 }
@@ -108,15 +148,16 @@ upgrade_and_recycle() {
   shift
   sub "helm upgrade -> ${label}"
   helm upgrade "${RELEASE_NAME}" "${REPO_ROOT}/${CHART_PATH}" \
-  --kube-context "${KUBE_CONTEXT}" \
+    --kube-context "${KUBE_CONTEXT}" \
+    --namespace "${NAMESPACE}" \
     --reuse-values "$@" \
-    --wait --timeout 120s >/dev/null
+    --wait --timeout "$(demo::install_timeout)" >/dev/null
   # Synchronous delete: the chart pins terminationGracePeriodSeconds
   # to a low value (see values.yaml), so the default --wait=true
   # blocks just long enough for pods to disappear before rollout
   # status checks the new generation. --ignore-not-found keeps the
   # call idempotent if the previous scenario already evicted them.
-  kubectl_ctx delete pods -l "app.kubernetes.io/name=${RELEASE_NAME}" \
+  kubectl_ctx delete pods -l "${POD_SELECTOR}" \
     --ignore-not-found >/dev/null
   wait_for_pod
 }
@@ -135,24 +176,64 @@ assert_configmap_contains() {
 }
 
 ###############################################################################
-# Step 1 -- Create / reuse the Kind cluster
+# Step 1 -- Resolve the target cluster
+#
+# BUILD_LOCAL=true owns a Kind cluster: it creates one if missing and switches
+# to it, because a locally built image can only be side-loaded into a cluster
+# this script controls. Otherwise nothing is created and the demo installs
+# into whatever context is already current, which demo::preflight announces
+# and, unless it is a loopback Kind cluster, makes you confirm.
 ###############################################################################
-info "Creating Kind cluster: ${CLUSTER_NAME}"
-if kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
-  sub "Cluster already exists, reusing it"
-else
-  kind create cluster --name "${CLUSTER_NAME}" --config="${KIND_CONFIG}"
+if [[ "${BUILD_LOCAL}" == "true" ]]; then
+  # Before creating anything: a missing docker or kind here would otherwise
+  # surface as a raw "command not found" after a cluster already existed.
+  demo::require_build_tools
+  # Remember where the reader was BEFORE anything can move them. `kind create
+  # cluster` switches the current context as a side effect, so capturing after
+  # the block below would record the cluster this run just made and the summary
+  # would have nothing to put back.
+  PRIOR_CONTEXT="$(command kubectl config current-context 2>/dev/null || true)"
+  info "Creating Kind cluster: ${CLUSTER_NAME}"
+  if kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
+    sub "Cluster already exists, reusing it"
+  else
+    kind create cluster --name "${CLUSTER_NAME}" --config="${KIND_CONFIG}"
+  fi
+  command kubectl config use-context "kind-${CLUSTER_NAME}"
 fi
 
-###############################################################################
-# Step 2 -- Build + load the image
-###############################################################################
-info "Building image: ${IMAGE_NAME}"
-docker build -t "${IMAGE_NAME}" \
-  -f "${REPO_ROOT}/deployments/nvml-mock/Dockerfile" "${REPO_ROOT}"
+# Tell the preflight where the workload lands so its announcement, which is
+# the one thing the reader confirms, names the namespace too.
+# shellcheck disable=SC2034  # read by demo::preflight in ../lib/preflight.sh
+DEMO_NAMESPACE="${NAMESPACE}"
+demo::preflight
+# The standalone demo's release. Co-locating the two corrupts shared per-node
+# host state that no namespace or release name scopes.
+demo::require_no_sibling_release "nvml-mock" "${RELEASE_NAME}"
+KUBE_CONTEXT="${DEMO_KUBE_CONTEXT}"
+IMAGE_NAME="$(demo::image_ref)"
 
-info "Loading image into Kind"
-kind load docker-image "${IMAGE_NAME}" --name "${CLUSTER_NAME}"
+# Split "repo:tag" for the chart's two separate values. Shared with the
+# standalone demo, and it rejects digest refs the chart cannot express.
+# `exit` inside $() only leaves the subshell, so propagate the code explicitly
+# rather than relying on set -e to notice the failed assignment.
+IMAGE_PARTS="$(demo::image_parts "${IMAGE_NAME}")" || exit $?
+IMAGE_REPO="${IMAGE_PARTS%|*}"
+IMAGE_TAG="${IMAGE_PARTS#*|}"
+
+###############################################################################
+# Step 2 -- Build + load the image (BUILD_LOCAL only)
+###############################################################################
+if [[ "${BUILD_LOCAL}" == "true" ]]; then
+  info "Building image: ${IMAGE_NAME}"
+  docker build -t "${IMAGE_NAME}" \
+    -f "${REPO_ROOT}/deployments/nvml-mock/Dockerfile" "${REPO_ROOT}"
+
+  info "Loading image into Kind"
+  kind load docker-image "${IMAGE_NAME}" --name "${CLUSTER_NAME}"
+else
+  info "Using published image: ${IMAGE_NAME} (set BUILD_LOCAL=true to build from source)"
+fi
 
 ###############################################################################
 # Scenario 1 -- Healthy baseline
@@ -160,15 +241,17 @@ kind load docker-image "${IMAGE_NAME}" --name "${CLUSTER_NAME}"
 # The first install is the only one without --reuse-values; from here
 # on every scenario diffs against this baseline.
 info "Scenario 1: healthy baseline (failureInjection.enabled=false)"
+demo::announce_pull "${IMAGE_NAME}"
 helm upgrade --install "${RELEASE_NAME}" "${REPO_ROOT}/${CHART_PATH}" \
   --kube-context "${KUBE_CONTEXT}" \
-  --set image.repository=nvml-mock \
-  --set image.tag=failure-demo \
+  --namespace "${NAMESPACE}" --create-namespace \
+  --set-string "image.repository=${IMAGE_REPO}" \
+  --set-string "image.tag=${IMAGE_TAG}" \
   --set gpu.profile=h100 \
   --set gpu.failureInjection.enabled=false \
   --set-string updateStrategy.rollingUpdate.maxUnavailable=100% \
   --set terminationGracePeriodSeconds=1 \
-  --wait --timeout 120s >/dev/null
+  --wait --timeout "$(demo::install_timeout)" >/dev/null
 
 POD=$(wait_for_pod)
 sub "DaemonSet pod ready: ${POD}"
@@ -317,6 +400,24 @@ fi
 ###############################################################################
 # Summary
 ###############################################################################
+# Only the BUILD_LOCAL path creates a cluster, so only it offers to delete
+# one. On the default path the cluster was already yours.
+# The uninstall MUST carry -n and --kube-context. Without them helm resolves
+# the release from the reader's current context and namespace, which on a
+# shared cluster is how this teardown would delete the standalone demo's
+# release instead of this one.
+UNINSTALL="helm uninstall ${RELEASE_NAME} -n ${NAMESPACE} --kube-context ${KUBE_CONTEXT}"
+if [[ "${BUILD_LOCAL}" == "true" ]]; then
+  TEARDOWN="kind delete cluster --name ${CLUSTER_NAME}"
+  if [[ -n "${PRIOR_CONTEXT}" && "${PRIOR_CONTEXT}" != "${KUBE_CONTEXT}" ]]; then
+    TEARDOWN="${TEARDOWN}
+    kubectl config use-context ${PRIOR_CONTEXT}   # this run switched your context"
+  fi
+else
+  TEARDOWN="${UNINSTALL}
+    (this run did not create a cluster, so nothing here deletes one)"
+fi
+
 cat <<EOF
 
 ==> All four failure-injection scenarios verified.
@@ -333,6 +434,11 @@ cat <<EOF
     surface 'Xid 79' / mark the GPU Unhealthy on their own when run
     against this cluster.
 
+==> Target cluster
+    context  : ${KUBE_CONTEXT}
+    namespace: ${NAMESPACE}
+    image    : ${IMAGE_NAME}
+
 ==> Tear down
-    kind delete cluster --name ${CLUSTER_NAME}
+    ${TEARDOWN}
 EOF

--- a/docs/demo/lib/preflight.sh
+++ b/docs/demo/lib/preflight.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared preflight for the portable nvml-mock demos.
+#
+# These demos install into the cluster your current context points at, which
+# is a deliberate change from the older behaviour of pinning a kind context.
+# The confirmation below is what replaces that pin: the chart installs a
+# privileged DaemonSet with hostPath mounts, so an accidental run against a
+# real cluster is worth one keystroke to prevent.
+#
+# Exit codes are contract, asserted by preflight_test.sh:
+#   2  no usable cluster
+#   3  missing or too-old tooling
+#   4  refusing to install: confirmation declined, a non-interactive run
+#      against a cluster that is not a throwaway one, the other demo's
+#      release already present anywhere on the cluster, or helm unable to
+#      list releases to rule that out
+#   5  configuration this chart cannot express (a digest-pinned image)
+#
+# Written for bash 3.2 (stock macOS): no mapfile, no associative arrays,
+# no ${var,,}.
+
+DEMO_EXIT_NO_CLUSTER=2
+DEMO_EXIT_NO_TOOL=3
+DEMO_EXIT_DECLINED=4
+DEMO_EXIT_BAD_CONFIG=5
+
+# Set by demo::preflight to the context it announced and confirmed. Callers
+# pin every kubectl and helm call to it, so a kubeconfig that changes under
+# the demo cannot redirect the install to a cluster the reader never saw.
+DEMO_KUBE_CONTEXT=""
+
+# Set by demo::preflight to the namespace that was current for that context
+# BEFORE the demo touched anything, or "default" when the context pins none.
+# standalone/demo.sh prints it as a truthful undo hint instead of assuming the
+# reader was on "default".
+DEMO_PRIOR_NAMESPACE=""
+
+# Set by demo::preflight to the cluster's node count. The demos use it to tell
+# the reader how long a cold image pull is going to take.
+DEMO_NODE_COUNT=""
+
+demo::die() {
+    echo "ERROR: $*" >&2
+}
+
+demo::require_tool() {
+    local tool="$1" url="$2"
+    if ! command -v "${tool}" >/dev/null 2>&1; then
+        demo::die "${tool} not found on PATH. Install it: ${url}"
+        exit "${DEMO_EXIT_NO_TOOL}"
+    fi
+}
+
+demo::require_helm_version() {
+    local raw major minor
+    raw="$(helm version --short 2>/dev/null)"
+    major="$(printf '%s' "${raw}" | sed -n 's/^v\{0,1\}\([0-9][0-9]*\)\.\([0-9][0-9]*\).*/\1/p')"
+    minor="$(printf '%s' "${raw}" | sed -n 's/^v\{0,1\}\([0-9][0-9]*\)\.\([0-9][0-9]*\).*/\2/p')"
+    if [ -z "${major}" ] || [ -z "${minor}" ]; then
+        demo::die "could not parse a version from 'helm version --short' output: '${raw}'"
+        exit "${DEMO_EXIT_NO_TOOL}"
+    fi
+    # 3.8 is the DOCUMENTED project minimum (docs/quickstart.md), not a
+    # measured one. Rendering this chart under 3.2.4, 3.5.4, 3.6.3, 3.7.2 and
+    # 3.8.2 puts the real floor at 3.6: anything older dies with "parse error
+    # at (nvml-mock/templates/_helpers.tpl:156): unclosed action", while 3.6.3
+    # and 3.8.2 produce byte-identical output. The check stays at 3.8 so the
+    # demos agree with the documented number rather than quietly inventing a
+    # second one.
+    if [ "${major}" -lt 3 ] || { [ "${major}" -eq 3 ] && [ "${minor}" -lt 8 ]; }; then
+        # Do NOT say "the chart is served from an OCI registry" here. That is true
+        # only for the published-chart path in docs/quickstart.md and the with-fgo
+        # demo; the portable demos install from the local chart directory, and
+        # nothing else in this repo asserts a 3.8 floor (both Chart.yaml files
+        # constrain only kubeVersion, and CI's setup-helm pins no version).
+        demo::die "helm ${raw} is older than 3.8, the minimum documented in docs/quickstart.md: https://helm.sh/docs/intro/install/"
+        exit "${DEMO_EXIT_NO_TOOL}"
+    fi
+}
+
+# Tools the BUILD_LOCAL path needs. Called by the demos BEFORE they create a
+# cluster, because demo::preflight runs after that block and a missing docker
+# or kind would otherwise surface as a raw "command not found" partway
+# through, having already created a cluster.
+demo::require_build_tools() {
+    demo::require_tool kubectl "https://kubernetes.io/docs/tasks/tools/"
+    demo::require_tool docker "https://docs.docker.com/get-docker/"
+    demo::require_tool kind "https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
+}
+
+# Seam for the interactive check. Overridable so preflight_test.sh can drive
+# the confirmation path (and therefore exit code 4) without allocating a pty;
+# production callers never touch it.
+demo::is_tty() {
+    [ -t 0 ]
+}
+
+# A "throwaway" cluster is one it is safe to install a privileged DaemonSet
+# into without asking. A kind-* NAME alone does not prove that: a context is
+# just a label, and `kubectl config rename-context prod kind-prod` would buy
+# a silent pass. Require the API server to be loopback as well, which is what
+# actually distinguishes a local Kind node from a remote cluster.
+#
+# $1 = context name, $2 = API server URL
+demo::is_throwaway() {
+    local ctx="$1" server="$2"
+    case "${ctx}" in
+        kind-*) ;;
+        *) return 1 ;;
+    esac
+    case "${server}" in
+        https://127.0.0.1:* | http://127.0.0.1:* | \
+        https://localhost:* | http://localhost:* | \
+        "https://[::1]:"* | "http://[::1]:"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+demo::preflight() {
+    demo::require_tool kubectl "https://kubernetes.io/docs/tasks/tools/"
+    demo::require_tool helm "https://helm.sh/docs/intro/install/"
+    demo::require_helm_version
+
+    # Belt and braces: the demos already call demo::require_build_tools before
+    # their cluster block, but re-check here so any other caller of the
+    # library gets the documented exit 3 too.
+    if [ "${BUILD_LOCAL:-false}" = "true" ]; then
+        demo::require_build_tools
+    fi
+
+    local ctx server nodes ns answer
+    ctx="$(kubectl config current-context 2>/dev/null)" || ctx=""
+    if [ -z "${ctx}" ]; then
+        demo::die "no current kubectl context. This demo installs into the cluster your KUBECONFIG points at. To create a throwaway one, follow the quickstart: docs/quickstart.md"
+        exit "${DEMO_EXIT_NO_CLUSTER}"
+    fi
+
+    if ! kubectl cluster-info >/dev/null 2>&1; then
+        demo::die "context '${ctx}' is set but its API server is not reachable. Fix your KUBECONFIG, or create a throwaway cluster with the quickstart: docs/quickstart.md"
+        exit "${DEMO_EXIT_NO_CLUSTER}"
+    fi
+
+    # Callers run under `set -euo pipefail`, where a failing command
+    # substitution would abort the demo with kubectl's exit code instead of
+    # the documented one. These two lines are cosmetic, so degrade instead.
+    server="$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null)" || server="unknown"
+    nodes="$(kubectl get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ')" || nodes="unknown"
+
+    # The namespace the privileged DaemonSet actually lands in is the one
+    # thing a reader most needs to confirm, so announce it rather than only
+    # the cluster. DEMO_NAMESPACE is set by each demo before calling us.
+    ns="$(kubectl config view --minify -o jsonpath='{.contexts[0].context.namespace}' 2>/dev/null)" || ns=""
+    DEMO_PRIOR_NAMESPACE="${ns:-default}"
+    # shellcheck disable=SC2034  # read by the demos that source this file
+    DEMO_NODE_COUNT="${nodes}"
+
+    printf 'Target for a privileged DaemonSet with hostPath mounts:\n'
+    printf '  context   : %s\n  server    : %s\n  nodes     : %s\n  namespace : %s\n' \
+        "${ctx}" "${server}" "${nodes}" \
+        "${DEMO_NAMESPACE:-${DEMO_PRIOR_NAMESPACE}}"
+
+    # shellcheck disable=SC2034  # read by the demos that source this file
+    DEMO_KUBE_CONTEXT="${ctx}"
+
+    if demo::is_throwaway "${ctx}" "${server}"; then
+        return 0
+    fi
+
+    if [ "${DEMO_ASSUME_YES:-false}" = "true" ]; then
+        echo "Not a throwaway Kind cluster; DEMO_ASSUME_YES=true, proceeding without confirmation."
+        return 0
+    fi
+
+    # Fail closed when nobody can answer. A non-interactive run (a CI job, a
+    # wrapper script, `./demo.sh </dev/null`) previously installed into any
+    # context with no confirmation at all, which is the accident this guard
+    # exists to prevent. Loopback Kind contexts still pass above, so
+    # automation against a throwaway cluster keeps working untouched.
+    if ! demo::is_tty; then
+        demo::die "refusing to install into '${ctx}' non-interactively: it is not a throwaway Kind cluster and stdin is not a TTY, so the confirmation cannot be answered. Re-run on a terminal, or set DEMO_ASSUME_YES=true to proceed deliberately."
+        exit "${DEMO_EXIT_DECLINED}"
+    fi
+
+    printf '\nThis is not a throwaway Kind cluster. The demo installs a privileged\n'
+    printf 'DaemonSet with hostPath mounts into the cluster above.\n'
+    printf "Type the context name to continue: "
+    # EOF (Ctrl-D) leaves answer empty rather than aborting the caller with
+    # read's exit code, so a declined confirmation still reports code 4.
+    read -r answer || answer=""
+    if [ "${answer}" != "${ctx}" ]; then
+        demo::die "confirmation did not match '${ctx}'; aborting without changing anything"
+        exit "${DEMO_EXIT_DECLINED}"
+    fi
+    return 0
+}
+
+# How long to let `helm --wait` run.
+#
+# The old value was 120s, which cannot be met on the cluster this path exists
+# to serve. Measured on a cold 4-node cluster, pulling
+# ghcr.io/nvidia/nvml-mock:latest (about 100 MB) took 7m58s on one node, and
+# helm gave up after two minutes:
+#
+#   Error: UPGRADE FAILED: resource DaemonSet/mokka/nvml-mock not ready.
+#   status: InProgress, message: Updated: 1/4 ... context deadline exceeded
+#
+# 15m covers that measurement with roughly 2x headroom. On a bandwidth-limited
+# link, where concurrent pulls share one pipe rather than each getting their
+# own, raise it: HELM_TIMEOUT=30m ./demo.sh
+#
+# A note on maxUnavailable, because the obvious explanation is wrong. It gates
+# UPDATES, not creation: a fresh DaemonSet creates all of its pods at once
+# whatever the setting is, so the parallel pulls on a first install come free
+# from the DaemonSet controller, not from the override. Measured directly:
+# at the chart default of 25% a fresh 4-node DaemonSet still created all four
+# pods in the same second, while a rolling update serialised them (08:44:43,
+# :46, :50, :52) and only went parallel at 100% (all four at 08:44:56). The
+# override is still load-bearing, just for re-runs against a cluster that
+# already has the release, and for failure-injection, whose three
+# `helm upgrade --reuse-values` scenarios are all rolling updates.
+demo::install_timeout() {
+    echo "${HELM_TIMEOUT:-15m}"
+}
+
+# Tell the reader why the next few minutes are silent. A first run against a
+# cluster that has never pulled this image looks identical to a hang.
+demo::announce_pull() {
+    local image="$1"
+    printf 'Installing %s across %s node(s), waiting up to %s.\n' \
+        "${image}" "${DEMO_NODE_COUNT:-?}" "$(demo::install_timeout)"
+    printf 'A cluster that has not cached this image pulls about 100 MB per\n'
+    printf 'node first, which took ~8 minutes per node when measured. All\n'
+    printf 'nodes pull at once, so this is minutes of silence, not a hang.\n'
+    printf 'Raise it with HELM_TIMEOUT=30m if your link is slow.\n'
+}
+
+# Refuse to install alongside the other demo's release in the same namespace.
+#
+# The selector pinning keeps each demo's KUBECTL calls on its own pods, but it
+# cannot keep them off each other's HOST state, and nothing in the chart can.
+# Both DaemonSets mount the same non-release-scoped hostPaths
+# (/var/lib/nvml-mock, /var/run/cdi, /run/nvidia, and the NFD features dir),
+# so co-locating them leaves one demo's config in those paths and the other's
+# overwritten. Measured on a live cluster: after a co-located run, the single
+# shared /var/lib/nvml-mock/driver/config/config.yaml that the CDI spec at
+# /var/run/cdi/nvidia.yaml points MOCK_NVML_CONFIG at read
+#
+#   failure: {after_calls: 1, mode: fallen_off_bus, code: 79}
+#
+# The demos' own pods do not notice, because each mounts its own ConfigMap.
+# Any REAL GPU workload scheduled on that node does: it silently consumes the
+# failure-injected config, which is the entire thing this mock exists to
+# provide honestly. Both scripts exited 0 while that happened.
+#
+# Exit code 4, the same "refusing to install" code the confirmation path uses,
+# and overridable the same way with DEMO_ASSUME_YES=true.
+#
+# $1 = the sibling demo's release name, $2 = this demo's release name
+demo::require_no_sibling_release() {
+    local sibling="$1" mine="$2" found="" sibling_ns=""
+
+    # Cluster-wide, not --namespace: the three demos default to different
+    # namespaces (mokka, mokka-failure, mokka-operator), so a namespace-scoped
+    # lookup searches the one place the sibling cannot be and the guard never
+    # fires for the arrangement it was written for. What it protects is
+    # per-node hostPath state, which no namespace scopes anyway.
+    #
+    # An empty cluster is not an error here: helm lists nothing and we
+    # proceed. A helm that cannot list at all is a different case. The guard
+    # then cannot rule the sibling out, and nothing downstream will: helm
+    # installs a second, differently-named release into the same namespace
+    # without complaint, which is the whole reason this check exists. Returning
+    # success on a check that could not run makes the guard indistinguishable
+    # from a deleted one, so refuse with the same code a seen collision uses,
+    # overridable the same way.
+    if ! found="$(helm list --kube-context "${DEMO_KUBE_CONTEXT}"             --all-namespaces 2>/dev/null)"; then
+        if [ "${DEMO_ASSUME_YES:-false}" = "true" ]; then
+            echo "WARNING: could not list releases in this cluster to check for a co-located demo." >&2
+            echo "WARNING: DEMO_ASSUME_YES=true, continuing anyway. If '${sibling}' is installed" >&2
+            echo "WARNING: there, the two demos share per-node host state and the mock config" >&2
+            echo "WARNING: left on these nodes will be whichever demo wrote last." >&2
+            return 0
+        fi
+        demo::die "refusing to install '${mine}': could not list releases in this cluster, so the '${sibling}' demo cannot be ruled out.
+
+Both demos mount the same per-node hostPaths (/var/lib/nvml-mock, /var/run/cdi,
+/run/nvidia, and the NFD features directory), and helm installs this release
+alongside '${sibling}' without complaint, so a co-located run leaves the shared
+mock config in whichever state the last one wrote.
+
+Check your permissions on that namespace, or set DEMO_ASSUME_YES=true to
+proceed deliberately."
+        exit "${DEMO_EXIT_DECLINED}"
+    fi
+
+    # Not --short: that returns names only, and a sibling found in its own
+    # default namespace then gets an uninstall command naming THIS demo's
+    # namespace, which cannot remove it. helm's table puts NAME first and
+    # NAMESPACE second, and matching $1 exactly both skips the header row and
+    # keeps "nvml-mock" from matching "nvml-mock-failure".
+    sibling_ns="$(printf '%s
+' "${found}" | awk -v rel="${sibling}" '$1 == rel { print $2; exit }')"
+    if [ -z "${sibling_ns}" ]; then
+        return 0
+    fi
+
+    if [ "${DEMO_ASSUME_YES:-false}" = "true" ]; then
+        echo "WARNING: '${sibling}' is already installed in namespace '${sibling_ns}'." >&2
+        echo "WARNING: DEMO_ASSUME_YES=true, continuing anyway. The two demos share" >&2
+        echo "WARNING: per-node host state, so the mock config left on these nodes" >&2
+        echo "WARNING: will be whichever demo wrote last." >&2
+        return 0
+    fi
+
+    demo::die "refusing to install '${mine}' into namespace '${DEMO_NAMESPACE}': the '${sibling}' demo is already installed in namespace '${sibling_ns}'.
+
+Both demos mount the same per-node hostPaths (/var/lib/nvml-mock, /var/run/cdi,
+/run/nvidia, and the NFD features directory), and those are not scoped by
+release or namespace. Running them together leaves the shared mock config in
+whichever state the last one wrote, so a real GPU workload on these nodes can
+silently read a failure-injected config while both demos report success.
+
+Use a different namespace, a different cluster, or uninstall the other demo:
+  helm uninstall ${sibling} -n ${sibling_ns} --kube-context ${DEMO_KUBE_CONTEXT}
+Set DEMO_ASSUME_YES=true to override deliberately."
+    exit "${DEMO_EXIT_DECLINED}"
+}
+
+# The exact command that undoes the one persistent change a demo makes outside
+# the cluster: setting the context's default namespace. Lives here, rather than
+# being formatted at each call site, so it is a unit the tests can assert on
+# directly. It restores the namespace that was current BEFORE the demo ran, so
+# a reader working in "team-a" is sent back to "team-a" and not to "default".
+demo::namespace_undo_hint() {
+    echo "kubectl config set-context ${DEMO_KUBE_CONTEXT} --namespace=${DEMO_PRIOR_NAMESPACE}"
+}
+
+# Image to install. Defaults to the published image so the demo works on a
+# cluster you cannot side-load into; BUILD_LOCAL=true opts into the older
+# build-and-kind-load path, which stays Kind-only by nature.
+demo::image_ref() {
+    if [ "${BUILD_LOCAL:-false}" = "true" ]; then
+        echo "${LOCAL_IMAGE:-nvml-mock:demo}"
+    else
+        echo "${NVML_MOCK_IMAGE:-ghcr.io/nvidia/nvml-mock:latest}"
+    fi
+}
+
+# Split an image reference into the chart's separate image.repository and
+# image.tag values, echoed as "<repo>|<tag>". NVML_MOCK_IMAGE is documented as
+# overridable, so three shapes reach this:
+#   nvml-mock:demo          -> repo=nvml-mock         tag=demo
+#   registry:5000/nvml-mock -> repo=registry:5000/... tag=latest
+#     (that colon is a port, not a tag: it precedes the last slash)
+#   repo@sha256:<hex>       -> rejected, see below
+#
+# The chart renders the image as "{{ .Values.image.repository }}:{{
+# .Values.image.tag }}" (templates/daemonset.yaml, nri-daemonset.yaml) and has
+# no image.digest value, so a digest ref cannot be expressed through it at
+# all: splitting on its colon would yield the repo "...@sha256" and the tag
+# "<hex>", rendering an invalid reference that fails at pull time with a
+# confusing error. Reject it here with an actionable message instead.
+demo::image_parts() {
+    local ref="$1" repo tag tail
+    case "${ref}" in
+        *@sha256:*)
+            demo::die "image reference '${ref}' pins a digest, which this chart cannot express: it builds the image as repository:tag and has no image.digest value. Use a tag, or install the chart directly with a digest-aware values file."
+            exit "${DEMO_EXIT_BAD_CONFIG}"
+            ;;
+    esac
+    repo="${ref}"
+    tag="latest"
+    tail="${ref##*:}"
+    case "${tail}" in
+        "${ref}" | */*) : ;;
+        *) repo="${ref%:*}"; tag="${tail}" ;;
+    esac
+    echo "${repo}|${tag}"
+}

--- a/docs/demo/lib/preflight_test.sh
+++ b/docs/demo/lib/preflight_test.sh
@@ -1,0 +1,778 @@
+#!/usr/bin/env bash
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# Drives demo::preflight through PATH shims. Every case asserts the exact
+# documented exit code, so a guard that stops discriminating goes red.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="${SCRIPT_DIR}/preflight.sh"
+FAILURES=0
+
+# Build a shim directory. Each shim is a real executable on PATH, so this
+# exercises the same lookup the demo does rather than stubbing a function.
+make_shims() {
+    # Abort loudly rather than limping on. A sandbox that denies writes under
+    # $TMPDIR makes mktemp fail, and every later case then fails against an
+    # empty SHIMDIR, producing a page of red that has nothing to do with the
+    # code under test. Fail once, with the reason.
+    SHIMDIR="$(mktemp -d 2>/dev/null)" || SHIMDIR=""
+    if [ -z "${SHIMDIR}" ] || [ ! -d "${SHIMDIR}" ]; then
+        echo "FATAL: mktemp -d failed (TMPDIR=${TMPDIR:-unset}). Cannot build" >&2
+        echo "       PATH shims, so no case below would mean anything. This is" >&2
+        echo "       usually a sandbox denying writes under TMPDIR." >&2
+        exit 1
+    fi
+    KIND_MARKER="${SHIMDIR}/kind-was-called"
+    cat >"${SHIMDIR}/kind" <<EOF
+#!/usr/bin/env bash
+touch "${KIND_MARKER}"
+exit 0
+EOF
+    chmod +x "${SHIMDIR}/kind"
+}
+
+# $1 = version string, $2 = newline-separated releases `helm list --short`
+# should report (default: none).
+# $2 is the whole cluster, one "RELEASE NAMESPACE" pair per line. The shim
+# renders helm's real table, header included, because the code under test parses
+# columns out of it: a shim emitting bare names would let a NAME-only query pass
+# and hide the wrong-namespace defect. --namespace filters, so a query that
+# narrows back cannot still see a sibling living elsewhere.
+write_helm() {
+    cat >"${SHIMDIR}/helm" <<EOF
+#!/usr/bin/env bash
+[ "\$1" = "version" ] && { echo "$1"; exit 0; }
+if [ "\$1" = "list" ]; then
+    all=false; ns=""; prev=""
+    for arg in "\$@"; do
+        [ "\$arg" = "--all-namespaces" ] && all=true
+        [ "\$prev" = "--namespace" ] && ns="\$arg"
+        prev="\$arg"
+    done
+    printf 'NAME\tNAMESPACE\tREVISION\tUPDATED\tSTATUS\tCHART\tAPP VERSION\n'
+    while read -r _rel _ns; do
+        [ -z "\$_rel" ] && continue
+        if [ "\$all" = "true" ] || [ "\$_ns" = "\$ns" ]; then
+            printf '%s\t%s\t1\t2026-09-07\tdeployed\tnvml-mock-0.1.0\t0.1.0\n' "\$_rel" "\$_ns"
+        fi
+    done <<'RELEASES'
+${2:-}
+RELEASES
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "${SHIMDIR}/helm"
+}
+
+# A helm whose `list` fails outright, while `version` still answers, so the
+# preflight reaches the co-location guard and the guard gets no answer.
+write_helm_list_broken() {
+    cat >"${SHIMDIR}/helm" <<EOF
+#!/usr/bin/env bash
+[ "\$1" = "version" ] && { echo "$1"; exit 0; }
+[ "\$1" = "list" ] && exit 1
+exit 0
+EOF
+    chmod +x "${SHIMDIR}/helm"
+}
+
+# $1 = current-context output ("" means none), $2 = cluster-info exit code,
+# $3 = API server URL (default loopback, i.e. a real local Kind node),
+# $4 = the context's namespace ("" means the context pins none).
+#
+# `config view` has to discriminate on the jsonpath, because the preflight
+# asks it for the server AND for the namespace. A shim that answered both with
+# one string would make the namespace assertion pass on the server URL.
+write_kubectl() {
+    local server="${3:-https://127.0.0.1:6443}" ns="${4:-}"
+    cat >"${SHIMDIR}/kubectl" <<EOF
+#!/usr/bin/env bash
+all="\$*"
+case "\$1 \$2" in
+  "config current-context") [ -n "$1" ] && { echo "$1"; exit 0; } || exit 1 ;;
+  "cluster-info "*|"cluster-info") exit $2 ;;
+  "get nodes") echo "node1 Ready"; exit 0 ;;
+  "config view")
+      case "\${all}" in
+        *cluster.server*)     echo "${server}" ;;
+        *context.namespace*)  echo "${ns}" ;;
+      esac
+      exit 0 ;;
+esac
+exit 0
+EOF
+    chmod +x "${SHIMDIR}/kubectl"
+}
+
+write_docker() {
+    cat >"${SHIMDIR}/docker" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "${SHIMDIR}/docker"
+}
+
+# stdout and stderr are captured SEPARATELY, then concatenated into "out".
+# Keeping them apart matters: the announcement goes to stdout and every
+# refusal goes to stderr via demo::die, so a check that reads the combined
+# stream can pass on the announcement while the refusal message is empty.
+# check_stdout / check_stderr read the isolated streams.
+_capture() {
+    cat "${SHIMDIR}/stdout" "${SHIMDIR}/err" >"${SHIMDIR}/out"
+}
+
+run_preflight() {
+    env PATH="${SHIMDIR}:/usr/bin:/bin" "$@" \
+        bash -c "source '${LIB}'; demo::preflight" </dev/null \
+        >"${SHIMDIR}/stdout" 2>"${SHIMDIR}/err"
+    local rc=$?
+    _capture
+    echo "${rc}"
+}
+
+# Runs demo::preflight and then evaluates $1 in the SAME shell, so a case can
+# assert on the variables the library exports to its callers.
+run_preflight_post() {
+    local post="$1"
+    shift
+    env PATH="${SHIMDIR}:/usr/bin:/bin" "$@" \
+        bash -c "source '${LIB}'; demo::preflight; ${post}" </dev/null \
+        >"${SHIMDIR}/stdout" 2>"${SHIMDIR}/err"
+    local rc=$?
+    _capture
+    echo "${rc}"
+}
+
+# Same, but drives the interactive branch: $1 is fed on stdin and $2 is a
+# prelude evaluated after the library is sourced, used to override
+# demo::is_tty. Overriding that one function is what makes exit code 4
+# reachable without allocating a pty; everything else stays the real code.
+run_preflight_prompt() {
+    local stdin_text="$1" prelude="$2"
+    shift 2
+    printf '%s\n' "${stdin_text}" \
+        | env PATH="${SHIMDIR}:/usr/bin:/bin" "$@" \
+            bash -c "source '${LIB}'; ${prelude}; demo::preflight" \
+            >"${SHIMDIR}/stdout" 2>"${SHIMDIR}/err"
+    local rc=$?
+    _capture
+    echo "${rc}"
+}
+
+FORCE_TTY='demo::is_tty() { return 0; }'
+
+# demo::image_parts is a pure function, so drive it directly. run_image_parts
+# echoes the EXIT CODE (for the digest rejection); image_parts_value echoes
+# the "repo|tag" it produced.
+run_image_parts() {
+    env PATH="${SHIMDIR}:/usr/bin:/bin" \
+        bash -c "source '${LIB}'; demo::image_parts \"\$1\"" _ "$1" \
+        >"${SHIMDIR}/stdout" 2>"${SHIMDIR}/err"
+    local rc=$?
+    _capture
+    echo "${rc}"
+}
+
+image_parts_value() {
+    env PATH="${SHIMDIR}:/usr/bin:/bin" \
+        bash -c "source '${LIB}'; demo::image_parts \"\$1\"" _ "$1" 2>/dev/null
+}
+
+check() {
+    local name="$1" expected="$2" actual="$3"
+    if [ "${expected}" != "${actual}" ]; then
+        echo "FAIL ${name}: expected exit ${expected}, got ${actual}"
+        sed 's/^/      /' "${SHIMDIR}/out"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "ok   ${name}"
+    fi
+}
+
+check_output() {
+    local name="$1" needle="$2"
+    if ! grep -q "${needle}" "${SHIMDIR}/out"; then
+        echo "FAIL ${name}: output did not mention '${needle}'"
+        sed 's/^/      /' "${SHIMDIR}/out"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "ok   ${name}"
+    fi
+}
+
+# Stream-scoped variants. check_output reads the combined stream and is kept
+# for assertions where the stream genuinely does not matter.
+check_stream() {
+    local name="$1" stream="$2" needle="$3"
+    if ! grep -q "${needle}" "${SHIMDIR}/${stream}"; then
+        echo "FAIL ${name}: ${stream} did not contain '${needle}'"
+        echo "      --- stdout ---"; sed 's/^/      /' "${SHIMDIR}/stdout"
+        echo "      --- stderr ---"; sed 's/^/      /' "${SHIMDIR}/err"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "ok   ${name}"
+    fi
+}
+
+check_stdout() { check_stream "$1" stdout "$2"; }
+check_stderr() { check_stream "$1" err "$2"; }
+
+check_output_absent() {
+    local name="$1" needle="$2"
+    if grep -q "${needle}" "${SHIMDIR}/out"; then
+        echo "FAIL ${name}: output should not have mentioned '${needle}'"
+        sed 's/^/      /' "${SHIMDIR}/out"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "ok   ${name}"
+    fi
+}
+
+# Case 0: PATH hygiene, a precondition for case 1. "Missing kubectl exits 3"
+# only proves something if kubectl is genuinely unreachable under the test
+# PATH. On a host where kubectl is installed in /usr/bin, case 1 would pass
+# for the wrong reason, so assert the precondition instead of assuming it.
+make_shims
+if env PATH="${SHIMDIR}:/usr/bin:/bin" bash -c 'command -v kubectl' >/dev/null 2>&1; then
+    echo "FAIL test PATH still resolves kubectl, so case 1 cannot discriminate"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "ok   kubectl is genuinely unreachable under the test PATH"
+fi
+
+# Case 1: kubectl missing entirely.
+make_shims; write_helm "v3.8.0+g1234"
+check "missing kubectl exits 3" 3 "$(run_preflight)"
+check_stderr "missing kubectl names the tool" "kubectl not found on PATH"
+
+# Case 2: helm too old for OCI.
+make_shims; write_helm "v3.7.2+g1234"; write_kubectl "kind-demo" 0
+check "helm 3.7 exits 3" 3 "$(run_preflight)"
+check_stderr "helm 3.7 links install docs" "helm.sh/docs/intro/install"
+
+# Case 3: helm 3.8 is accepted (boundary, must NOT be rejected).
+make_shims; write_helm "v3.8.0+g1234"; write_kubectl "kind-demo" 0
+check "helm 3.8 is accepted" 0 "$(run_preflight)"
+
+# Case 4: helm 4.x is accepted.
+make_shims; write_helm "v4.2.4+g3900f43"; write_kubectl "kind-demo" 0
+check "helm 4.x is accepted" 0 "$(run_preflight)"
+
+# Case 5: no current context at all.
+make_shims; write_helm "v3.8.0+g1234"; write_kubectl "" 0
+check "no context exits 2" 2 "$(run_preflight)"
+check_stderr "no context points at quickstart" "quickstart"
+
+# Case 6: context exists but the API server is unreachable.
+make_shims; write_helm "v3.8.0+g1234"; write_kubectl "kind-demo" 1
+check "unreachable cluster exits 2" 2 "$(run_preflight)"
+
+# Case 7: the discriminating guard. A healthy kind context must succeed
+# WITHOUT the preflight ever shelling out to kind. If a future edit makes the
+# demo create a cluster behind the reader's back, the marker file appears and
+# this goes red.
+make_shims; write_helm "v3.8.0+g1234"; write_kubectl "kind-demo" 0
+rc="$(run_preflight)"
+check "healthy kind context exits 0" 0 "${rc}"
+if [ -e "${KIND_MARKER}" ]; then
+    echo "FAIL preflight must not invoke kind"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "ok   preflight did not invoke kind"
+fi
+
+# Case 8: a non-throwaway context with no TTY FAILS CLOSED. This used to
+# proceed, which meant `./demo.sh </dev/null`, a wrapper script or a CI job
+# installed a privileged DaemonSet into a production context with no
+# confirmation whatsoever.
+make_shims; write_helm "v3.8.0+g1234"; write_kubectl "prod-cluster" 0
+check "non-throwaway + no TTY fails closed with 4" 4 "$(run_preflight)"
+# Read stderr ONLY, and match a phrase from the refusal sentence itself. The
+# previous form read the combined stream for "prod-cluster", which the
+# announcement on stdout already prints, so emptying demo::die left it green.
+check_stderr "fail-closed refusal names the context" "refusing to install into 'prod-cluster'"
+check_stderr "fail-closed names the deliberate override" "DEMO_ASSUME_YES=true to proceed deliberately"
+
+# Case 9: DEMO_ASSUME_YES is honored.
+make_shims; write_helm "v3.8.0+g1234"; write_kubectl "prod-cluster" 0
+check "DEMO_ASSUME_YES proceeds" 0 "$(run_preflight DEMO_ASSUME_YES=true)"
+
+###############################################################################
+# Cases 10-19 exist because cases 1-9 do not discriminate the branches they
+# cover. Two were proven inert by deleting the code they nominally test and
+# watching the suite stay green; each is now paired with a mutation that turns
+# it red. See the report for both repros.
+###############################################################################
+
+# Case 10: the confirmation path is reachable and announces itself.
+make_shims; write_helm "v3.8.0+g1234"; write_kubectl "prod-cluster" 0
+check "non-throwaway on a TTY prompts, declining exits 4" 4 \
+    "$(run_preflight_prompt "not-the-context" "${FORCE_TTY}")"
+check_stdout "prompt says it is not a throwaway cluster" "not a throwaway Kind cluster"
+check_stderr "declined confirmation says nothing was changed" "aborting without changing anything"
+
+# Case 11: the converse. A loopback kind context must NOT be treated as
+# unrecognized, on a TTY or otherwise.
+make_shims; write_helm "v3.8.0+g1234"; write_kubectl "kind-demo" 0
+check "loopback kind context exits 0" 0 "$(run_preflight)"
+check_output_absent "loopback kind context is not challenged" "not a throwaway Kind cluster"
+
+# Case 12: typing the context name back proceeds.
+make_shims; write_helm "v3.8.0+g1234"; write_kubectl "prod-cluster" 0
+check "typing the context name proceeds" 0 \
+    "$(run_preflight_prompt "prod-cluster" "${FORCE_TTY}")"
+
+# Case 13: a loopback kind context on a TTY must NOT prompt. Stdin carries a
+# wrong answer, so if the throwaway branch is ever dropped this exits 4.
+make_shims; write_helm "v3.8.0+g1234"; write_kubectl "kind-demo" 0
+check "loopback kind context on a TTY does not prompt" 0 \
+    "$(run_preflight_prompt "not-the-context" "${FORCE_TTY}")"
+check_output_absent "loopback kind context asks for no confirmation" "Type the context name"
+
+# Case 14: DEMO_ASSUME_YES, for real this time. Case 9 cannot fail: with
+# stdin at /dev/null the fail-closed branch is what it actually exercised,
+# so DELETING the whole assume-yes branch left the suite 24/24 green. Forcing
+# a TTY and supplying a WRONG answer means only the assume-yes branch can
+# produce exit 0 here: without it the answer is compared and rejected as 4.
+make_shims; write_helm "v3.8.0+g1234"; write_kubectl "prod-cluster" 0
+check "DEMO_ASSUME_YES skips the prompt on a TTY" 0 \
+    "$(run_preflight_prompt "wrong-answer-entirely" "${FORCE_TTY}" DEMO_ASSUME_YES=true)"
+check_output_absent "DEMO_ASSUME_YES asks nothing" "Type the context name"
+
+# Case 15: a kind-* NAME is not proof of a throwaway cluster.
+# `kubectl config rename-context prod kind-prod` must not buy a silent pass,
+# so a kind-* name pointing at a REMOTE server takes the confirmation path.
+make_shims; write_helm "v3.8.0+g1234"
+write_kubectl "kind-prod" 0 "https://k8s.prod.example.com:6443"
+check "kind-* name with a remote server is challenged" 4 "$(run_preflight)"
+check_stderr "remote kind-* is named in the refusal" "refusing to install into 'kind-prod'"
+
+# Case 16: and the corroboration is the SERVER, not merely a non-loopback
+# string. localhost and ::1 are throwaway too.
+make_shims; write_helm "v3.8.0+g1234"
+write_kubectl "kind-demo" 0 "https://localhost:6443"
+check "kind-* on localhost is throwaway" 0 "$(run_preflight)"
+make_shims; write_helm "v3.8.0+g1234"
+write_kubectl "kind-demo" 0 "https://[::1]:6443"
+check "kind-* on ::1 is throwaway" 0 "$(run_preflight)"
+
+# Case 17: the announcement names the namespace the DaemonSet lands in. That
+# is the one thing the reader confirms, and it used to be absent entirely.
+make_shims; write_helm "v3.8.0+g1234"; write_kubectl "kind-demo" 0
+check "announcement exits 0" 0 "$(run_preflight DEMO_NAMESPACE=mokka-failure)"
+check_stdout "announcement names the target namespace" "namespace : mokka-failure"
+
+# Case 18: BUILD_LOCAL=true reports missing build tooling as the documented
+# exit 3, rather than a raw "command not found" after creating a cluster.
+make_shims; write_helm "v3.8.0+g1234"; write_kubectl "kind-demo" 0; write_docker
+rm -f "${SHIMDIR}/kind"
+check "BUILD_LOCAL without kind exits 3" 3 "$(run_preflight BUILD_LOCAL=true)"
+check_stderr "missing kind names the tool" "kind not found on PATH"
+
+# Case 19: a digest-pinned image is rejected. The chart renders
+# "{{ repository }}:{{ tag }}" and has no image.digest, so splitting on the
+# digest's colon would render an invalid reference that only fails at pull
+# time. Exit 5 is the documented code for config the chart cannot express.
+make_shims
+check "digest ref is rejected with 5" 5 "$(run_image_parts 'ghcr.io/nvidia/nvml-mock@sha256:abc123')"
+check_stderr "digest rejection explains why" "cannot express"
+check "tag ref splits" "nvml-mock|demo" "$(image_parts_value 'nvml-mock:demo')"
+check "registry port is not mistaken for a tag" "registry:5000/nvml-mock|latest" \
+    "$(image_parts_value 'registry:5000/nvml-mock')"
+check "published default splits" "ghcr.io/nvidia/nvml-mock|latest" \
+    "$(image_parts_value 'ghcr.io/nvidia/nvml-mock:latest')"
+
+###############################################################################
+# Cases 20-24 close gaps the round-1 suite left open. Each was found by
+# deleting the thing it covers and watching 39/39 stay green.
+###############################################################################
+
+# Case 20: the announcement must actually name the cluster. This is the whole
+# point of the guard: it tells a reader which cluster is about to receive a
+# privileged hostPath DaemonSet. Deleting the context from that line was
+# invisible to every other check. Server and node count were equally
+# uncovered, so assert all three, on stdout, where the announcement lives.
+make_shims; write_helm "v3.8.0+g1234"
+write_kubectl "kind-demo" 0 "https://127.0.0.1:6443"
+check "announcement exits 0" 0 "$(run_preflight)"
+check_stdout "announcement names the context" "context   : kind-demo"
+check_stdout "announcement names the server" "server    : https://127.0.0.1:6443"
+check_stdout "announcement names the node count" "nodes     : 1"
+
+# Case 21: the prior namespace is captured from the context, not assumed to
+# be "default", and it reaches both the announcement and the undo hint. A
+# reader working in "team-a" must be sent back to "team-a".
+make_shims; write_helm "v3.8.0+g1234"
+write_kubectl "kind-demo" 0 "https://127.0.0.1:6443" "team-a"
+check "prior-namespace run exits 0" 0 \
+    "$(run_preflight_post 'echo "UNDO: $(demo::namespace_undo_hint)"')"
+check_stdout "announcement shows the context's own namespace" "namespace : team-a"
+check_stdout "undo hint restores the prior namespace" "UNDO: kubectl config set-context kind-demo --namespace=team-a"
+
+# Case 22: a context that pins no namespace falls back to "default", so the
+# undo hint stays correct rather than empty.
+make_shims; write_helm "v3.8.0+g1234"
+write_kubectl "kind-demo" 0 "https://127.0.0.1:6443" ""
+check "no-prior-namespace run exits 0" 0 \
+    "$(run_preflight_post 'echo "UNDO: $(demo::namespace_undo_hint)"')"
+check_stdout "unset namespace falls back to default" "UNDO: kubectl config set-context kind-demo --namespace=default"
+
+# Case 23: DEMO_KUBE_CONTEXT is what pins every downstream kubectl and helm
+# call, so an empty one would silently un-pin the whole demo.
+make_shims; write_helm "v3.8.0+g1234"
+write_kubectl "kind-demo" 0 "https://127.0.0.1:6443"
+check "context-export run exits 0" 0 \
+    "$(run_preflight_post 'echo "EXPORTED:[${DEMO_KUBE_CONTEXT}]"')"
+check_stdout "DEMO_KUBE_CONTEXT is exported to callers" "EXPORTED:\[kind-demo\]"
+
+# Case 24: helm is required, not just kubectl. PATH hygiene first, for the
+# same reason as case 0: on a host with helm in /usr/bin this would otherwise
+# pass for the wrong reason.
+make_shims
+if env PATH="${SHIMDIR}:/usr/bin:/bin" bash -c 'command -v helm' >/dev/null 2>&1; then
+    echo "FAIL test PATH still resolves helm, so the next case cannot discriminate"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "ok   helm is genuinely unreachable under the test PATH"
+fi
+write_kubectl "kind-demo" 0
+check "missing helm exits 3" 3 "$(run_preflight)"
+check_stderr "missing helm names the tool" "helm not found on PATH"
+
+###############################################################################
+# Cases 25-26 cover two failures that 53 passing checks missed entirely,
+# because both only appear against a real API server. They are static
+# assertions about the two demo scripts rather than about the library, which
+# is the cheapest place to catch either regression.
+###############################################################################
+
+STANDALONE="${SCRIPT_DIR}/../standalone/demo.sh"
+FAILURE_INJECTION="${SCRIPT_DIR}/../failure-injection/run.sh"
+
+# EVERY script-level guard below reads this, never the raw file. A guard that
+# greps the whole file passes when the code it checks is commented out, since
+# the comment still carries the literal. That defect class was found twice in
+# this suite, so it is now structurally impossible to reintroduce one guard at
+# a time: there is a single stripped view and all the guards share it.
+code_lines() {
+    grep -v '^[[:space:]]*#' "$1"
+}
+
+# Both scripts, every time. Checking one and not its sibling is the same
+# asymmetry that shipped the original defect, mirrored into the guards.
+DEMO_SCRIPTS="${STANDALONE} ${FAILURE_INJECTION}"
+
+for f in ${DEMO_SCRIPTS}; do
+    if [ ! -f "${f}" ]; then
+        echo "FAIL demo script not found: ${f}"
+        FAILURES=$((FAILURES + 1))
+    fi
+done
+
+# Prove the stripped view actually differs from the raw file, so a future edit
+# that makes code_lines a no-op cannot quietly disarm every guard at once.
+_raw_n="$(wc -l < "${FAILURE_INJECTION}" | tr -d ' ')"
+_code_n="$(code_lines "${FAILURE_INJECTION}" | wc -l | tr -d ' ')"
+if [ "${_code_n}" -lt "${_raw_n}" ]; then
+    echo "ok   code_lines strips comments (${_raw_n} raw -> ${_code_n} code)"
+else
+    echo "FAIL code_lines is not stripping anything, so every guard below is blind to commented-out code"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# Case 25: the two demos must not collide on a shared cluster.
+#
+# A namespace cannot separate them. The chart creates a ClusterRole and a
+# ClusterRoleBinding named after the release (templates/rbac.yaml), and those
+# are cluster-scoped, so with both demos on RELEASE_NAME=nvml-mock the second
+# install dies with "ClusterRole \"nvml-mock\" in namespace \"\" exists and
+# cannot be imported into the current release". Distinct release names are the
+# actual mechanism; distinct namespaces are necessary but not sufficient.
+FI_RELEASE="$(code_lines "${FAILURE_INJECTION}" | sed -n 's/^RELEASE_NAME="\([^"]*\)".*/\1/p' | head -1)"
+SA_RELEASE="$(code_lines "${STANDALONE}"        | sed -n 's/^RELEASE_NAME="\([^"]*\)".*/\1/p' | head -1)"
+FI_NS="$(code_lines "${FAILURE_INJECTION}" | sed -n 's/^: "${NAMESPACE:=\([^}]*\)}".*/\1/p' | head -1)"
+SA_NS="$(code_lines "${STANDALONE}"        | sed -n 's/^: "${NAMESPACE:=\([^}]*\)}".*/\1/p' | head -1)"
+
+if [ -z "${FI_RELEASE}" ] || [ -z "${SA_RELEASE}" ]; then
+    echo "FAIL could not extract release names (FI='${FI_RELEASE}' SA='${SA_RELEASE}')"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "ok   extracted release names (FI='${FI_RELEASE}' SA='${SA_RELEASE}')"
+fi
+check "demo release names differ (cluster-scoped RBAC would collide)" \
+    "differ" "$([ "${FI_RELEASE}" != "${SA_RELEASE}" ] && echo differ || echo same)"
+check "demo namespaces differ" \
+    "differ" "$([ "${FI_NS}" != "${SA_NS}" ] && echo differ || echo same)"
+
+# Every derived name follows the release name through nvml-mock.fullname,
+# which collapses to the release name only when the release name contains the
+# chart name. If either stopped containing it, fullname would become
+# "<release>-nvml-mock" and CONFIGMAP_NAME / daemonset/<release> would both
+# point at objects that do not exist. Checked for BOTH releases: asserting it
+# of one and not the other is how P8 slipped through.
+for _pair in "standalone:${SA_RELEASE}" "failure-injection:${FI_RELEASE}"; do
+    _who="${_pair%%:*}"; _rel="${_pair#*:}"
+    case "${_rel}" in
+        *nvml-mock*) echo "ok   ${_who} release '${_rel}' keeps fullname collapsed" ;;
+        *) echo "FAIL ${_who} release '${_rel}' does not contain the chart name, so nvml-mock.fullname would not collapse to it"
+           FAILURES=$((FAILURES + 1)) ;;
+    esac
+done
+
+for f in ${DEMO_SCRIPTS}; do
+    base="$(basename "$(dirname "${f}")")"
+
+    # --- release-name derivation -------------------------------------------
+    if code_lines "${f}" | grep -q '^RELEASE_NAME='; then
+        echo "ok   ${base} defines RELEASE_NAME"
+    else
+        echo "FAIL ${base} must define RELEASE_NAME and derive from it"
+        FAILURES=$((FAILURES + 1))
+    fi
+
+    # No literal release name in a resource reference, in EITHER script.
+    # `daemonset/nvml-mock` in run.sh waits on the other demo's DaemonSet.
+    if code_lines "${f}" | grep -qE 'daemonset/[a-z]|helm uninstall [a-z]|helm upgrade --install [a-z]'; then
+        echo "FAIL ${base} hardcodes a release name in a resource reference"
+        code_lines "${f}" | grep -nE 'daemonset/[a-z]|helm uninstall [a-z]|helm upgrade --install [a-z]' | sed 's/^/      /'
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "ok   ${base} hardcodes no release name in resource references"
+    fi
+
+    # --- pod selectors ------------------------------------------------------
+    if code_lines "${f}" | grep -q 'app.kubernetes.io/instance=${RELEASE_NAME}'; then
+        echo "ok   ${base} pins pods by instance, not just chart name"
+    else
+        echo "FAIL ${base} must select pods by app.kubernetes.io/instance=\${RELEASE_NAME}"
+        FAILURES=$((FAILURES + 1))
+    fi
+
+    # Any code line naming the chart-name label MUST also carry the instance
+    # label. Matching on the presence of both, rather than on a trailing
+    # space, is what closes the end-of-line variant.
+    if code_lines "${f}" | grep 'app\.kubernetes\.io/name=' | grep -qv 'instance='; then
+        echo "FAIL ${base}: has a chart-name selector with no instance pin"
+        code_lines "${f}" | grep -n 'app\.kubernetes\.io/name=' | grep -v 'instance=' | sed 's/^/      /'
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "ok   ${base} has no chart-name-only pod selector"
+    fi
+
+    # --- install budget -----------------------------------------------------
+    # Count the helm calls and require EVERY one to wait on the shared budget.
+    # Comparing --wait against --timeout alone passes when both drop by one,
+    # which is how a single un-budgeted `helm upgrade --reuse-values` hid.
+    n_helm="$(code_lines "${f}" | grep -c '^[[:space:]]*helm upgrade')"
+    n_wait="$(code_lines "${f}" | grep -c -- '--wait')"
+    n_budget="$(code_lines "${f}" | grep -c -- '--timeout "$(demo::install_timeout)"')"
+    if [ "${n_helm}" -lt 1 ]; then
+        echo "FAIL ${base}: no helm upgrade call found at all"
+        FAILURES=$((FAILURES + 1))
+    elif [ "${n_wait}" != "${n_helm}" ] || [ "${n_budget}" != "${n_helm}" ]; then
+        echo "FAIL ${base}: ${n_helm} helm call(s) but ${n_wait} --wait and ${n_budget} using demo::install_timeout"
+        code_lines "${f}" | grep -nE 'helm upgrade|--wait|--timeout' | sed 's/^/      /'
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "ok   ${base}: all ${n_helm} helm call(s) wait on demo::install_timeout"
+    fi
+
+    if code_lines "${f}" | grep -qE -- '--timeout[= ]"?[0-9]+[hms]'; then
+        echo "FAIL ${base}: carries a hardcoded --timeout duration instead of the shared budget"
+        code_lines "${f}" | grep -nE -- '--timeout[= ]"?[0-9]+[hms]' | sed 's/^/      /'
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "ok   ${base} hardcodes no --timeout duration"
+    fi
+
+    # --- image values -------------------------------------------------------
+    # helm --set runs its value through YAML type inference, so image.tag=1.0
+    # reaches the chart as the float 1 and a tag of "null" as null. Tags and
+    # repositories are always strings. Counting both spellings, rather than
+    # grepping for the wrong one, keeps this from passing on a script that sets
+    # no image at all.
+    n_img="$(code_lines "${f}" | grep -cE -- '--set(-string)? "image\.(tag|repository)=')"
+    n_imgstr="$(code_lines "${f}" | grep -cE -- '--set-string "image\.(tag|repository)=')"
+    if [ "${n_img}" -lt 1 ]; then
+        echo "ok   ${base} sets no image values inline"
+    elif [ "${n_img}" != "${n_imgstr}" ]; then
+        echo "FAIL ${base}: ${n_img} inline image value(s) but only ${n_imgstr} use --set-string, so a tag like 1.0 is type-coerced"
+        code_lines "${f}" | grep -nE -- '--set "image\.' | sed 's/^/      /'
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "ok   ${base}: all ${n_img} image value(s) use --set-string"
+    fi
+
+    # --- context restore ordering -------------------------------------------
+    # `kind create cluster` switches the current context as a side effect, so
+    # PRIOR_CONTEXT has to be read before it runs. Captured after, it records
+    # the cluster this run just made, the summary's PRIOR_CONTEXT != KUBE_CONTEXT
+    # test then compares a value with itself, and the reader is never told how
+    # to get back. Comparing line numbers, rather than checking both are
+    # present, is what makes this an ordering assertion.
+    _create_ln="$(code_lines "${f}" | grep -n 'kind create cluster' | head -1 | cut -d: -f1)"
+    _prior_ln="$(code_lines "${f}" | grep -n 'PRIOR_CONTEXT="\$(' | head -1 | cut -d: -f1)"
+    if [ -z "${_create_ln}" ]; then
+        echo "ok   ${base} creates no cluster, so there is no ordering to check"
+    elif [ -z "${_prior_ln}" ]; then
+        echo "FAIL ${base}: runs 'kind create cluster' but never captures PRIOR_CONTEXT"
+        FAILURES=$((FAILURES + 1))
+    elif [ "${_prior_ln}" -lt "${_create_ln}" ]; then
+        echo "ok   ${base} captures PRIOR_CONTEXT before creating a cluster"
+    else
+        echo "FAIL ${base}: captures PRIOR_CONTEXT at code line ${_prior_ln}, after 'kind create cluster' at ${_create_ln}, so the restore hint names the cluster this run made"
+        FAILURES=$((FAILURES + 1))
+    fi
+
+    if code_lines "${f}" | grep -q -- '--set-string updateStrategy.rollingUpdate.maxUnavailable=100%'; then
+        echo "ok   ${base} rolls every node at once on re-runs"
+    else
+        echo "FAIL ${base} must pass --set-string updateStrategy.rollingUpdate.maxUnavailable=100%"
+        FAILURES=$((FAILURES + 1))
+    fi
+
+    # --- notices and refusals ----------------------------------------------
+    if code_lines "${f}" | grep -q 'demo::announce_pull'; then
+        echo "ok   ${base} announces the pull before installing"
+    else
+        echo "FAIL ${base} must call demo::announce_pull before its first install"
+        FAILURES=$((FAILURES + 1))
+    fi
+
+    if code_lines "${f}" | grep -q 'demo::require_no_sibling_release'; then
+        echo "ok   ${base} refuses to co-locate with the other demo"
+    else
+        echo "FAIL ${base} must call demo::require_no_sibling_release before installing"
+        FAILURES=$((FAILURES + 1))
+    fi
+done
+
+# Each demo must name the OTHER demo's release, not its own, or the check is a
+# no-op that can never fire.
+if code_lines "${STANDALONE}" | grep -q 'demo::require_no_sibling_release "nvml-mock-failure"'; then
+    echo "ok   standalone watches for the failure-injection release"
+else
+    echo "FAIL standalone must pass the failure-injection release name as the sibling"
+    FAILURES=$((FAILURES + 1))
+fi
+if code_lines "${FAILURE_INJECTION}" | grep -q 'demo::require_no_sibling_release "nvml-mock"'; then
+    echo "ok   failure-injection watches for the standalone release"
+else
+    echo "FAIL failure-injection must pass the standalone release name as the sibling"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# Case 30: the co-location refusal. Selector pinning keeps each demo's kubectl
+# calls on its own pods, but nothing scopes the hostPaths both DaemonSets
+# mount, so a co-located run leaves the shared mock config failure-injected and
+# any real GPU workload on those nodes reads it. Both demos exited 0 while that
+# happened on a live cluster, which is why this refuses rather than warns.
+run_sibling() {
+    local sibling="$1" mine="$2"
+    shift 2
+    env PATH="${SHIMDIR}:/usr/bin:/bin" "$@" \
+        bash -c "source '${LIB}'; demo::preflight >/dev/null; demo::require_no_sibling_release '${sibling}' '${mine}'" \
+        </dev/null >"${SHIMDIR}/stdout" 2>"${SHIMDIR}/err"
+    local rc=$?
+    _capture
+    echo "${rc}"
+}
+
+# The sibling IS installed in the demo's own namespace: refuse with 4.
+make_shims; write_kubectl "kind-demo" 0 "https://127.0.0.1:6443"
+write_helm "v3.8.0+g1234" "nvml-mock mokka
+cert-manager mokka"
+check "co-located sibling refuses with 4" 4 \
+    "$(run_sibling nvml-mock nvml-mock-failure DEMO_NAMESPACE=mokka)"
+check_stderr "refusal names the sibling release" "the 'nvml-mock' demo is already installed"
+check_stderr "refusal explains the shared host state" "/var/lib/nvml-mock"
+check_stderr "refusal offers a way out" "helm uninstall nvml-mock -n mokka"
+
+# The sibling is NOT there: proceed. Without this the check could be a
+# constant refusal and the case above would still pass.
+make_shims; write_kubectl "kind-demo" 0 "https://127.0.0.1:6443"
+write_helm "v3.8.0+g1234" "cert-manager mokka-failure
+ingress-nginx mokka-failure"
+check "no sibling present proceeds" 0 \
+    "$(run_sibling nvml-mock nvml-mock-failure DEMO_NAMESPACE=mokka-failure)"
+
+# An empty namespace proceeds too.
+make_shims; write_kubectl "kind-demo" 0 "https://127.0.0.1:6443"
+write_helm "v3.8.0+g1234" ""
+check "empty namespace proceeds" 0 \
+    "$(run_sibling nvml-mock nvml-mock-failure DEMO_NAMESPACE=mokka-failure)"
+
+# A release whose name merely CONTAINS the sibling's must not trip it: the
+# match is exact, so "nvml-mock-failure" does not read as "nvml-mock".
+make_shims; write_kubectl "kind-demo" 0 "https://127.0.0.1:6443"
+write_helm "v3.8.0+g1234" "nvml-mock-failure mokka-failure"
+check "similarly named release does not false-positive" 0 \
+    "$(run_sibling nvml-mock nvml-mock-failure DEMO_NAMESPACE=mokka-failure)"
+
+# DEMO_ASSUME_YES overrides, consistent with the rest of the preflight, but
+# says what it is overriding.
+make_shims; write_kubectl "kind-demo" 0 "https://127.0.0.1:6443"
+write_helm "v3.8.0+g1234" "nvml-mock mokka"
+check "DEMO_ASSUME_YES overrides the refusal" 0 \
+    "$(run_sibling nvml-mock nvml-mock-failure DEMO_NAMESPACE=mokka DEMO_ASSUME_YES=true)"
+check_stderr "override still warns about shared host state" "share"
+
+# A helm that cannot list cannot rule out a co-located demo. Both demos mount
+# the same unscoped hostPaths, and helm installs a second, differently-named
+# release alongside the first without complaint, so nothing downstream catches
+# the collision this guard exists to prevent. Returning success when the check
+# could not run makes the guard indistinguishable from a deleted one, so an
+# unreadable namespace refuses with the same code as a seen collision.
+make_shims; write_kubectl "kind-demo" 0 "https://127.0.0.1:6443"
+write_helm_list_broken "v3.8.0+g1234"
+check "unlistable namespace refuses with 4" 4 \
+    "$(run_sibling nvml-mock nvml-mock-failure DEMO_NAMESPACE=mokka)"
+check_stderr "unlistable namespace is reported" "could not list releases"
+check_stderr "refusal names the sibling it could not rule out" "the 'nvml-mock' demo cannot be ruled out"
+check_stderr "refusal offers the documented override" "DEMO_ASSUME_YES=true"
+
+# The override still proceeds. Without this the case above could be a constant
+# refusal and would still pass: same failing helm, opposite outcome.
+make_shims; write_kubectl "kind-demo" 0 "https://127.0.0.1:6443"
+write_helm_list_broken "v3.8.0+g1234"
+check "DEMO_ASSUME_YES proceeds despite the unlistable namespace" 0 \
+    "$(run_sibling nvml-mock nvml-mock-failure DEMO_NAMESPACE=mokka DEMO_ASSUME_YES=true)"
+check_stderr "override says the check could not run" "could not list releases"
+
+# Case 33: the sibling lives in a DIFFERENT namespace, which is the shipped
+# arrangement. standalone defaults to mokka, failure-injection to
+# mokka-failure and with-gpu-operator to mokka-operator, so a lookup scoped to
+# the installing demo's own namespace searches the one place the sibling cannot
+# be, and the guard never fires for the case it was written for. The shim
+# reveals this release only to an --all-namespaces query, so narrowing the
+# query back turns this case red.
+make_shims; write_kubectl "kind-demo" 0 "https://127.0.0.1:6443"
+write_helm "v3.8.0+g1234" "nvml-mock mokka"
+check "sibling in another namespace refuses with 4" 4 \
+    "$(run_sibling nvml-mock nvml-mock-failure DEMO_NAMESPACE=mokka-failure)"
+check_stderr "cross-namespace refusal names the sibling" "the 'nvml-mock' demo is already installed"
+# The whole point of reading the namespace out of the listing. This demo installs
+# into mokka-failure; the sibling lives in mokka. A refusal that echoed
+# DEMO_NAMESPACE would print an uninstall command for mokka-failure, where the
+# offending release is not, so the reader would run it, see nothing removed, and
+# be stuck. The trailing space keeps "mokka" from matching "mokka-failure".
+check_stderr "cross-namespace refusal names the SIBLING's namespace" "already installed in namespace 'mokka'"
+check_stderr "cross-namespace uninstall targets the sibling's namespace" "helm uninstall nvml-mock -n mokka "
+
+# A cluster with no sibling in any namespace still proceeds, so the case above
+# cannot be a constant refusal produced by the wider query.
+make_shims; write_kubectl "kind-demo" 0 "https://127.0.0.1:6443"
+write_helm "v3.8.0+g1234" "cert-manager other
+ingress-nginx other"
+check "no sibling in any namespace proceeds" 0 \
+    "$(run_sibling nvml-mock nvml-mock-failure DEMO_NAMESPACE=mokka-failure)"
+
+if [ "${FAILURES}" -ne 0 ]; then
+    echo "${FAILURES} failure(s)"
+    exit 1
+fi
+echo "all preflight tests passed"

--- a/docs/demo/standalone/README.md
+++ b/docs/demo/standalone/README.md
@@ -1,7 +1,8 @@
 # Standalone nvml-mock Demo
 
-This demo deploys nvml-mock on a local Kind cluster with FGO-style labels
-enabled. It does not require any external GPU operator -- nvml-mock itself
+This demo deploys nvml-mock with FGO-style labels enabled into the cluster
+your current context points at. It does not require any external GPU operator
+-- nvml-mock itself
 generates the GPU profile ConfigMaps, the fake InfiniBand sysfs tree, and
 the node labels that downstream consumers expect.
 
@@ -17,20 +18,85 @@ the node labels that downstream consumers expect.
 > **No cluster yet?** The [quick start](../../quickstart.md) creates a
 > throwaway one with Kind in about a minute, then come back here.
 
-Docker and Kind are needed only if you want to build the image from source
-(`BUILD_LOCAL=true`); the default path pulls the published image.
+> **One nvml-mock demo per cluster at a time.** The chart's hostPath mounts
+> (`/var/lib/nvml-mock`, `/var/run/cdi`, `/run/nvidia`, the NFD features
+> directory) are scoped by neither release nor namespace, and the DaemonSet
+> tolerates every node, so two nvml-mock releases write the same per-node host
+> state even from different namespaces. The demo refuses to install with exit
+> `4` if the [failure-injection demo](../failure-injection/README.md) is
+> already present anywhere on the cluster.
+>
+> This matters beyond the demos: the shared
+> `/var/lib/nvml-mock/driver/config/config.yaml` is what the CDI spec points
+> `MOCK_NVML_CONFIG` at, so after a co-located run **any real GPU workload on
+> those nodes reads whichever config was written last**, which may be a
+> failure-injected one. Each demo's own pods mount their own ConfigMap and so
+> look fine throughout.
+
+Docker and Kind are needed only for `BUILD_LOCAL=true`, which builds the image
+from source and side-loads it into a Kind cluster named `nvml-mock-demo`,
+creating that cluster if it is missing. The default path pulls the published
+image and never creates or deletes a cluster.
+
+### First run on a cold cluster is slow
+
+The image is about 100 MB. On a cluster that has never pulled it, a measured
+cold pull took **roughly 8 minutes per node**, so the demo waits up to **15
+minutes** rather than the 2 it used to. It prints a notice before installing;
+a long silence there is the pull, not a hang.
+
+A first install pulls on all nodes at once on its own, because a fresh
+DaemonSet creates every pod immediately. The demo also sets
+`updateStrategy.rollingUpdate.maxUnavailable=100%`, which matters on **re-runs**:
+the chart's 25% default turns a rolling update on an existing release back
+into one node at a time.
+
+Raise the budget on a slow link:
+
+```bash
+HELM_TIMEOUT=30m ./demo.sh
+```
+
+Note that `ghcr.io/nvidia/nvml-mock:latest` is a floating tag, so a cluster
+holding an older cached `:latest` can run a build that does not match this
+chart. Pin `NVML_MOCK_IMAGE` to a released tag if you need a fixed pairing.
 
 ## What it does
 
-1. Creates a Kind cluster (`nvml-mock-demo`: 1 control-plane, 3 workers).
-2. Builds the `nvml-mock:demo` container image from the repository root.
-3. Loads the image into the Kind cluster.
-4. Installs the nvml-mock Helm chart into a dedicated `mokka`
+1. Announces the target: context, API server, node count, and the namespace
+   the workload lands in. Unless that target is a throwaway Kind cluster, it
+   then asks you to type the context name back before installing anything.
+   The chart runs a privileged DaemonSet with hostPath mounts, so this is the
+   guard that replaced the old hardcoded Kind context.
+
+   "Throwaway" means the context is named `kind-*` **and** its API server is
+   loopback. The name alone is not enough: `kubectl config rename-context prod
+   kind-prod` would otherwise buy a silent pass.
+
+   It **fails closed** when nobody can answer. A non-interactive run (a CI
+   job, a wrapper script, `./demo.sh </dev/null`) against anything but a
+   throwaway cluster exits `4` rather than installing unattended. To proceed
+   deliberately without a terminal, set `DEMO_ASSUME_YES=true`:
+
+   ```bash
+   DEMO_ASSUME_YES=true ./demo.sh
+   ```
+
+   Exit codes: `2` no usable cluster, `3` missing or too-old tooling, `4`
+   confirmation declined, impossible, refused because another nvml-mock demo is
+   already installed anywhere on the cluster, or refused because helm could not
+   list releases to rule that out, `5` a configuration the chart cannot
+   express (a digest-pinned `NVML_MOCK_IMAGE`).
+2. With `BUILD_LOCAL=true` only: creates the `nvml-mock-demo` Kind cluster
+   (1 control-plane, 3 workers) if missing, builds the `nvml-mock:demo` image
+   from the repository root, and loads it into that cluster. Otherwise it uses
+   `ghcr.io/nvidia/nvml-mock:latest` (override with `NVML_MOCK_IMAGE`).
+3. Installs the nvml-mock Helm chart into a dedicated `mokka`
    namespace (override with `NAMESPACE=...`) with
    `integrations.fakeGpuOperator.enabled=true`, an H100 profile, and 8 GPUs
    per node. The demo sets this namespace as the current context default so the
    validation helpers resolve pods in it.
-5. Verifies the deployment:
+4. Verifies the deployment:
    - DaemonSet pods are running on all workers.
    - Seven GPU profile ConfigMaps are created, one per GPU model.
    - `nvidia-smi` runs successfully inside a pod.
@@ -45,18 +111,37 @@ Docker and Kind are needed only if you want to build the image from source
      [`tests/e2e/validate-iblinkinfo.sh`](https://github.com/NVIDIA/k8s-test-infra/blob/main/tests/e2e/validate-iblinkinfo.sh).
    - Node labels are present.
 
+   One check is Kind-only: the NVLink / NVSwitch topology assertion runs the
+   host-driver-root `nvidia-smi` through `docker exec` on the node container,
+   so it is skipped, not failed, when the node is not a local Kind container.
+
 ## Quick start
 
 ```bash
+# Installs into your current context, using the published image.
 ./demo.sh
+
+# Or build from source and side-load into a throwaway Kind cluster:
+BUILD_LOCAL=true ./demo.sh
 ```
 
 ## Clean up
 
 ```bash
-# Remove just the release (keeps the cluster):
-helm uninstall nvml-mock -n mokka --kube-context kind-nvml-mock-demo
+# Remove just the release (keeps the cluster). The -n and --kube-context are
+# load-bearing: without them helm resolves the release from whatever context
+# and namespace happen to be current, which is not necessarily where the demo
+# installed it. The demo prints this line with both filled in.
+helm uninstall nvml-mock -n mokka --kube-context <your-context>
 
-# Or tear down the whole cluster:
+# The demo set the namespace default on your context. It prints the exact
+# command to restore whatever was there before; it does NOT assume "default".
+kubectl config set-context <your-context> --namespace=<your-previous-namespace>
+```
+
+If you ran with `BUILD_LOCAL=true`, that run also created the Kind cluster, so
+tear it down too:
+
+```bash
 kind delete cluster --name nvml-mock-demo
 ```

--- a/docs/demo/standalone/demo.sh
+++ b/docs/demo/standalone/demo.sh
@@ -5,6 +5,9 @@
 
 set -euo pipefail
 
+# shellcheck source=../lib/preflight.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)/preflight.sh"
+
 ###############################################################################
 # Configuration
 #
@@ -20,11 +23,26 @@ set -euo pipefail
 # further edits.
 ###############################################################################
 CLUSTER_NAME="nvml-mock-demo"
-# Kind creates a kubeconfig context named "kind-<cluster>". Pin every kubectl
-# and helm call to it so the demo never operates on whatever context happens to
-# be current (which could be a real cluster).
-KUBE_CONTEXT="kind-${CLUSTER_NAME}"
-IMAGE_NAME="nvml-mock:demo"
+# Every object this demo creates derives from RELEASE_NAME. The chart's
+# ClusterRole and ClusterRoleBinding are named after the release and are
+# CLUSTER-scoped (templates/rbac.yaml), so a demo that hardcodes its release
+# name in several places is one edit away from colliding with the
+# failure-injection demo, which installs "nvml-mock-failure".
+RELEASE_NAME="nvml-mock"
+# Pods carry app.kubernetes.io/name=<CHART name> and
+# app.kubernetes.io/instance=<RELEASE name> (templates/_helpers.tpl,
+# nvml-mock.selectorLabels). Selecting on the chart name alone matches BOTH
+# demos' pods when they share a namespace, and combined with jsonpath
+# .items[0] that means exec'ing into the other demo's pod. Pin the instance.
+POD_SELECTOR="app.kubernetes.io/name=nvml-mock,app.kubernetes.io/instance=${RELEASE_NAME}"
+# The demo used to hardcode KUBE_CONTEXT="kind-${CLUSTER_NAME}" so it could
+# never operate on whatever context happened to be current. It now installs
+# into the current context on purpose, so demo::preflight carries that guard
+# instead: it prints the target context, server, node count and namespace,
+# and unless the target is a loopback Kind cluster it requires the context
+# name typed back, or DEMO_ASSUME_YES=true when there is no terminal to
+# answer on. Resolved below, then every kubectl and helm call is pinned to it.
+KUBE_CONTEXT=""
 CHART_PATH="deployments/nvml-mock/helm/nvml-mock"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 : "${GPU_PROFILE:=h100}"
@@ -33,9 +51,20 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 # current context's default so the validate-*.sh helpers (which exec into pods
 # without a -n flag) target it too.
 : "${NAMESPACE:=mokka}"
+# BUILD_LOCAL=true builds the image from source and side-loads it into a Kind
+# cluster, creating that cluster if it is missing. It is the ONLY path that
+# needs Docker and Kind, because there is no portable way to side-load an
+# image into a cluster you do not control. The default installs the published
+# image into the cluster your current context already points at, and never
+# creates or deletes a cluster.
+: "${BUILD_LOCAL:=false}"
+: "${LOCAL_IMAGE:=nvml-mock:demo}"
 # FORCE_RECREATE=true tears down an existing cluster of the same name and
-# recreates it; otherwise an existing cluster is reused as-is.
+# recreates it; otherwise an existing cluster is reused as-is. Only meaningful
+# alongside BUILD_LOCAL=true, since that is the only path that owns a cluster.
 : "${FORCE_RECREATE:=false}"
+# Populated only on the BUILD_LOCAL path, when the demo switches contexts.
+PRIOR_CONTEXT=""
 
 PROFILE_YAML="${REPO_ROOT}/${CHART_PATH}/profiles/${GPU_PROFILE}.yaml"
 if [[ ! -f "${PROFILE_YAML}" ]]; then
@@ -67,73 +96,122 @@ IB_ENABLED=$(awk '
 info() { echo "==> $*"; }
 fail() { echo "ERROR: $*" >&2; exit 1; }
 
-# Wrap kubectl so every call is pinned to the demo's kind context without
-# repeating --context at each call site. helm keeps --kube-context inline
-# (there is only one invocation). The external validate-*.sh helpers still
-# rely on the context's default namespace set after the helm install below.
+# Wrap kubectl so every call is pinned to the context the preflight resolved
+# and announced, without repeating --context at each call site. helm keeps
+# --kube-context inline (there is only one invocation). The external
+# validate-*.sh helpers still rely on the context's default namespace set
+# after the helm install below.
 kubectl_ctx() { command kubectl --context "${KUBE_CONTEXT}" "$@"; }
 
 ###############################################################################
-# Step 1 -- Create a Kind cluster
+# Step 1 -- Resolve the target cluster
 #
-# Reuse an existing cluster of the same name unless FORCE_RECREATE=true, in
-# which case tear it down first and create a fresh one.
+# BUILD_LOCAL=true owns a Kind cluster: it creates one if missing (reusing an
+# existing cluster of the same name unless FORCE_RECREATE=true) and switches
+# to it, because a locally built image can only be side-loaded into a cluster
+# this script controls. Otherwise nothing is created and the demo installs
+# into whatever context is already current, which demo::preflight announces
+# and, unless it is a loopback Kind cluster, makes you confirm.
 ###############################################################################
-if kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
-  if [[ "${FORCE_RECREATE}" == "true" ]]; then
-    info "Kind cluster '${CLUSTER_NAME}' exists; FORCE_RECREATE=true -> deleting it"
-    kind delete cluster --name "${CLUSTER_NAME}"
+if [[ "${BUILD_LOCAL}" == "true" ]]; then
+  # Before creating anything: a missing docker or kind here would otherwise
+  # surface as a raw "command not found" after a cluster already existed.
+  demo::require_build_tools
+  # Remember where the reader was BEFORE anything can move them. `kind create
+  # cluster` switches the current context as a side effect, so capturing after
+  # the block below would record the cluster this run just made and the summary
+  # would have nothing to put back.
+  PRIOR_CONTEXT="$(command kubectl config current-context 2>/dev/null || true)"
+  if kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
+    if [[ "${FORCE_RECREATE}" == "true" ]]; then
+      info "Kind cluster '${CLUSTER_NAME}' exists; FORCE_RECREATE=true -> deleting it"
+      kind delete cluster --name "${CLUSTER_NAME}"
+      info "Creating Kind cluster: ${CLUSTER_NAME}"
+      kind create cluster --name "${CLUSTER_NAME}" --config="$REPO_ROOT/docs/demo/kind.yaml"
+    else
+      info "Reusing existing Kind cluster '${CLUSTER_NAME}' (set FORCE_RECREATE=true to recreate)"
+    fi
+  else
     info "Creating Kind cluster: ${CLUSTER_NAME}"
     kind create cluster --name "${CLUSTER_NAME}" --config="$REPO_ROOT/docs/demo/kind.yaml"
-  else
-    info "Reusing existing Kind cluster '${CLUSTER_NAME}' (set FORCE_RECREATE=true to recreate)"
   fi
-else
-  info "Creating Kind cluster: ${CLUSTER_NAME}"
-  kind create cluster --name "${CLUSTER_NAME}" --config="$REPO_ROOT/docs/demo/kind.yaml"
+  command kubectl config use-context "kind-${CLUSTER_NAME}"
 fi
 
-###############################################################################
-# Step 2 -- Build the nvml-mock image
-###############################################################################
-info "Building image: ${IMAGE_NAME}"
-docker build -t "${IMAGE_NAME}" -f "${REPO_ROOT}/deployments/nvml-mock/Dockerfile" "${REPO_ROOT}"
+# Tell the preflight where the workload lands so its announcement, which is
+# the one thing the reader confirms, names the namespace too.
+# shellcheck disable=SC2034  # read by demo::preflight in ../lib/preflight.sh
+DEMO_NAMESPACE="${NAMESPACE}"
+demo::preflight
+# The failure-injection demo's release. Co-locating the two corrupts shared
+# per-node host state that no namespace or release name scopes.
+demo::require_no_sibling_release "nvml-mock-failure" "${RELEASE_NAME}"
+KUBE_CONTEXT="${DEMO_KUBE_CONTEXT}"
+IMAGE_NAME="$(demo::image_ref)"
+
+# Split "repo:tag" for the chart's two separate values. Shared with the
+# failure-injection demo, and it rejects digest refs the chart cannot express.
+# `exit` inside $() only leaves the subshell, so propagate the code explicitly
+# rather than relying on set -e to notice the failed assignment.
+IMAGE_PARTS="$(demo::image_parts "${IMAGE_NAME}")" || exit $?
+IMAGE_REPO="${IMAGE_PARTS%|*}"
+IMAGE_TAG="${IMAGE_PARTS#*|}"
 
 ###############################################################################
-# Step 3 -- Load image into Kind
+# Step 2 -- Build the nvml-mock image (BUILD_LOCAL only)
 ###############################################################################
-info "Loading image into Kind cluster"
-kind load docker-image "${IMAGE_NAME}" --name "${CLUSTER_NAME}"
+if [[ "${BUILD_LOCAL}" == "true" ]]; then
+  info "Building image: ${IMAGE_NAME}"
+  docker build -t "${IMAGE_NAME}" -f "${REPO_ROOT}/deployments/nvml-mock/Dockerfile" "${REPO_ROOT}"
+
+  ###############################################################################
+  # Step 3 -- Load image into Kind (BUILD_LOCAL only)
+  ###############################################################################
+  info "Loading image into Kind cluster"
+  kind load docker-image "${IMAGE_NAME}" --name "${CLUSTER_NAME}"
+else
+  info "Using published image: ${IMAGE_NAME} (set BUILD_LOCAL=true to build from source)"
+fi
 
 ###############################################################################
 # Step 4 -- Install nvml-mock via Helm
 ###############################################################################
-info "Installing nvml-mock Helm chart (profile=${GPU_PROFILE}, count=${GPU_COUNT}, namespace=${NAMESPACE})"
-helm upgrade --install nvml-mock "${REPO_ROOT}/${CHART_PATH}" \
+info "Installing ${RELEASE_NAME} Helm chart (profile=${GPU_PROFILE}, count=${GPU_COUNT}, namespace=${NAMESPACE})"
+demo::announce_pull "${IMAGE_NAME}"
+# maxUnavailable=100% matters on RE-RUNS, not on a first install: a fresh
+# DaemonSet creates every pod at once regardless, so it is the rolling update
+# on a second run that would otherwise serialise four multi-minute image
+# pulls at the chart's 25% default. See demo::install_timeout.
+helm upgrade --install "${RELEASE_NAME}" "${REPO_ROOT}/${CHART_PATH}" \
   --kube-context "${KUBE_CONTEXT}" \
   --namespace "${NAMESPACE}" --create-namespace \
-  --set image.repository=nvml-mock \
-  --set image.tag=demo \
+  --set-string "image.repository=${IMAGE_REPO}" \
+  --set-string "image.tag=${IMAGE_TAG}" \
   --set integrations.fakeGpuOperator.enabled=true \
   --set "gpu.profile=${GPU_PROFILE}" \
   --set "gpu.count=${GPU_COUNT}" \
   --set gpu.dynamicMetrics.enabled=true \
-  --wait --timeout 120s
+  --set-string updateStrategy.rollingUpdate.maxUnavailable=100% \
+  --wait --timeout "$(demo::install_timeout)"
 
 # Make the demo namespace the context default so the validate-*.sh helpers
-# (which run `kubectl exec <pod>` without -n) resolve pods in it. Pin the
-# kind-${CLUSTER_NAME} context explicitly (not --current): on the
-# cluster-reuse branch nothing has switched contexts, so --current could
-# silently repoint an unrelated kubeconfig's default namespace. This context
-# is torn down with the cluster.
-info "Setting default namespace to ${NAMESPACE} for the kind-${CLUSTER_NAME} context"
-command kubectl config set-context "kind-${CLUSTER_NAME}" --namespace="${NAMESPACE}"
+# (which run `kubectl exec <pod>` without -n) resolve pods in it. Name the
+# context explicitly (not --current) so this always writes to the context the
+# preflight announced, even if something repoints the kubeconfig mid-run.
+#
+# This edits your kubeconfig. It is the one persistent change the demo makes
+# outside the cluster, so it says how to undo it, restoring the namespace that
+# was actually current beforehand rather than assuming it was "default": a
+# reader working in "team-a" would otherwise be moved silently.
+info "Setting default namespace to ${NAMESPACE} for the '${KUBE_CONTEXT}' context"
+command kubectl config set-context "${KUBE_CONTEXT}" --namespace="${NAMESPACE}"
+info "  undo with: $(demo::namespace_undo_hint)"
 
 ###############################################################################
 # Step 5 -- Verify: DaemonSet rollout
 ###############################################################################
 info "Waiting for DaemonSet rollout"
-kubectl_ctx -n "${NAMESPACE}" rollout status daemonset/nvml-mock --timeout=60s
+kubectl_ctx -n "${NAMESPACE}" rollout status "daemonset/${RELEASE_NAME}" --timeout="$(demo::install_timeout)"
 
 ###############################################################################
 # Step 6 -- Verify: Profile ConfigMaps
@@ -151,7 +229,7 @@ info "Found ${CM_COUNT} profile ConfigMap(s)"
 # Step 7 -- Verify: nvidia-smi
 ###############################################################################
 info "Running nvidia-smi inside a DaemonSet pod"
-POD=$(kubectl_ctx -n "${NAMESPACE}" get pods -l app.kubernetes.io/name=nvml-mock -o jsonpath='{.items[0].metadata.name}')
+POD=$(kubectl_ctx -n "${NAMESPACE}" get pods -l "${POD_SELECTOR}" -o jsonpath='{.items[0].metadata.name}')
 kubectl_ctx -n "${NAMESPACE}" exec "${POD}" -- nvidia-smi
 
 ###############################################################################
@@ -163,10 +241,22 @@ kubectl_ctx -n "${NAMESPACE}" exec "${POD}" -- nvidia-smi
 # enumerate links for NVLink profiles. It runs the host-driver-root nvidia-smi
 # via `docker exec` on the Kind node, so resolve the node container (== the
 # Kubernetes node name in Kind) from the pod we just exec'd into.
+#
+# It therefore only works when the node really is a Kind container on this
+# host. On any other cluster the node is not a local docker container, so
+# skip rather than aborting a run that has already installed successfully.
 ###############################################################################
-info "Validating NVLink / NVSwitch topology"
 NODE_CONTAINER=$(kubectl_ctx -n "${NAMESPACE}" get pod "${POD}" -o jsonpath='{.spec.nodeName}')
-"${REPO_ROOT}/tests/e2e/validate-nvlink.sh" "${NODE_CONTAINER}" "${GPU_PROFILE}" "${GPU_COUNT}"
+NVLINK_STATUS="validated (profile=${GPU_PROFILE})"
+if command -v docker >/dev/null 2>&1 && docker inspect "${NODE_CONTAINER}" >/dev/null 2>&1; then
+  info "Validating NVLink / NVSwitch topology"
+  "${REPO_ROOT}/tests/e2e/validate-nvlink.sh" "${NODE_CONTAINER}" "${GPU_PROFILE}" "${GPU_COUNT}"
+else
+  NVLINK_STATUS="skipped (node '${NODE_CONTAINER}' is not a local Kind container)"
+  info "Skipping NVLink / NVSwitch validation: it runs the host-driver-root"
+  info "  nvidia-smi via 'docker exec' on the Kind node, which needs a local"
+  info "  Kind cluster. ${NVLINK_STATUS}"
+fi
 
 ###############################################################################
 # Step 8 -- Verify: InfiniBand mock (libibmocksys.so + mock-ib render)
@@ -272,11 +362,11 @@ if [[ "${IB_ENABLED}" == "true" ]]; then
   IB_PODS=()
   while IFS= read -r ib_pod; do
     [[ -n "${ib_pod}" ]] && IB_PODS+=("${ib_pod}")
-  done < <(kubectl_ctx -n "${NAMESPACE}" get pods -l app.kubernetes.io/name=nvml-mock \
+  done < <(kubectl_ctx -n "${NAMESPACE}" get pods -l "${POD_SELECTOR}" \
     --field-selector=status.phase=Running \
     -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
   if [[ "${#IB_PODS[@]}" -lt 2 ]]; then
-    fail "Expected at least 2 running nvml-mock pods for cross-node ibping, found ${#IB_PODS[@]}"
+    fail "Expected at least 2 running ${RELEASE_NAME} pods for cross-node ibping, found ${#IB_PODS[@]}"
   fi
   SERVER_POD="${IB_PODS[0]}"
   CLIENT_POD="${IB_PODS[1]}"
@@ -304,14 +394,15 @@ WORKERS=($(kubectl_ctx get nodes --no-headers -o custom-columns=":metadata.name"
 ###############################################################################
 echo
 info "Demo complete."
-info "  Cluster   : ${CLUSTER_NAME}"
+info "  Context   : ${KUBE_CONTEXT}"
+info "  Image     : ${IMAGE_NAME}"
 info "  Namespace : ${NAMESPACE}"
 info "  Profile   : ${GPU_PROFILE} (gpu.count=${GPU_COUNT})"
 info "  Workers   : ${#WORKERS[@]}"
 info "  ConfigMaps: ${CM_COUNT}"
 info "  Mock HCAs : ${HCA_COUNT} per pod"
 info "  PCI devs  : ${PCI_DEV_COUNT} across ${ROOT_COUNT} root complex(es)"
-info "  NVLink    : topo -m + nvlink validated (profile=${GPU_PROFILE})"
+info "  NVLink    : topo -m + nvlink ${NVLINK_STATUS}"
 if [[ "${IB_ENABLED}" == "true" ]]; then
   info "  ibping    : cross-node OK (${SERVER_POD} -> ${CLIENT_POD})"
   info "  ibv_devinfo / iblinkinfo: validated (profile=${GPU_PROFILE})"
@@ -320,5 +411,15 @@ else
   info "  ibv_devinfo / iblinkinfo: skipped"
 fi
 info ""
-info "To uninstall the release: helm uninstall nvml-mock -n ${NAMESPACE}"
-info "To tear down: kind delete cluster --name ${CLUSTER_NAME}"
+info "To uninstall the release: helm uninstall ${RELEASE_NAME} -n ${NAMESPACE} --kube-context ${KUBE_CONTEXT}"
+info "To restore your context's default namespace:"
+info "  $(demo::namespace_undo_hint)"
+if [[ "${BUILD_LOCAL}" == "true" ]]; then
+  info "To tear down the cluster this run owns: kind delete cluster --name ${CLUSTER_NAME}"
+  if [[ -n "${PRIOR_CONTEXT}" && "${PRIOR_CONTEXT}" != "${KUBE_CONTEXT}" ]]; then
+    info "This run switched your current context. To switch back:"
+    info "  kubectl config use-context ${PRIOR_CONTEXT}"
+  fi
+else
+  info "The cluster was already yours, so nothing here deletes it."
+fi

--- a/docs/demo/with-fgo/README.md
+++ b/docs/demo/with-fgo/README.md
@@ -28,10 +28,26 @@ shim.
 > **No cluster yet?** The [quick start](../../quickstart.md) creates a
 > throwaway one with Kind in about a minute, then come back here.
 
-Docker and Kind are needed only if you want to build the image from source
-(`BUILD_LOCAL=true`); the default path pulls the published image.
+This guide has no script, so there is no `BUILD_LOCAL` switch to set, and no
+`DEMO_ASSUME_YES` either: the scripted demos run a preflight that announces
+the target cluster and makes you confirm it before installing a privileged
+DaemonSet, but here you are running `helm` yourself. Nothing checks the
+target on your behalf, so confirm it before Step 3:
 
-## Step 1 -- Create a Kind cluster
+```bash
+kubectl config current-context
+kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}'
+```
+
+Docker and Kind are needed only for two optional steps you can skip on a
+cluster you already have: Step 1, which creates a throwaway Kind cluster, and
+Step 2, which builds the image from source. Skip both and Step 3 installs the
+published image.
+
+## Step 1 (Optional) -- Create a Kind cluster
+
+Skip this if your `KUBECONFIG` already points at a cluster whose nodes carry
+the two pool labels listed above.
 
 ```bash
 kind create cluster --name nvml-mock-fgo-demo --config=docs/demo/kind.yaml
@@ -48,6 +64,15 @@ kind load docker-image nvml-mock:demo --name nvml-mock-fgo-demo
 
 ## Step 3 -- Install nvml-mock
 
+The image is about 100 MB and a cold pull was measured at roughly 8 minutes
+per node, so `--wait` gets a 15-minute budget below rather than the 2 minutes
+this guide used to show. A long silence there is the pull, not a hang. A first
+install already pulls on every node at once; `maxUnavailable=100%` is there so
+a later `helm upgrade` does not fall back to rolling one node at a time.
+`ghcr.io/nvidia/nvml-mock:latest` is also a floating tag: a cluster holding an
+older cached `:latest` can run a build that does not match this chart, so pin
+a released tag if you need a fixed pairing.
+
 ```bash
 helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --kube-context kind-nvml-mock-fgo-demo \
@@ -55,7 +80,8 @@ helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
   --set gpu.profile=h100 \
   --set gpu.count=8 \
   --set "nodeSelector.run\.ai/simulated-gpu-node-pool=integration" \
-  --wait --timeout 120s
+  --set-string updateStrategy.rollingUpdate.maxUnavailable=100% \
+  --wait --timeout 15m
 ```
 
 > **Tip:** To use the locally built image from Step 2, add `--set image.repository=nvml-mock --set image.tag=demo` to the command above.
@@ -69,7 +95,7 @@ Follow the official FGO installation instructions. A minimal example:
 helm upgrade --install gpu-operator  oci://ghcr.io/run-ai/fake-gpu-operator/fake-gpu-operator \
   --kube-context kind-nvml-mock-fgo-demo \
   -n gpu-operator --create-namespace \
-  --wait --timeout 120s  -f - <<EOF
+  --wait --timeout 15m  -f - <<EOF
 topology:
     nodePools:
       integration:


### PR DESCRIPTION
## Problem

The portable demos each created their own Kind cluster and side-loaded a locally built
image, so a reader who already had a cluster had no supported path. #763 documented the
KUBECONFIG-first contract; this makes it true.

`standalone/demo.sh` also hardcoded its kube context, with a comment saying the pin
existed so the demo could never touch "a real cluster". Removing that pin means
replacing the safety it provided, and `failure-injection/run.sh` had no context pinning
at all: eleven bare `kubectl` calls and a `helm upgrade --install` with no
`--kube-context`.

## Approach

`docs/demo/lib/preflight.sh` provides `demo::preflight`, which resolves the current
context, refuses when there is no usable cluster, prints the target (context, server,
node count, namespace) and, for a context that is not a throwaway, requires the context
name typed back. A context counts as throwaway only when its name matches `kind-*` AND
its server is loopback, because the name alone is a user-chosen label and
`kubectl config rename-context prod kind-prod` would otherwise skip the confirmation.
A non-TTY run against a non-throwaway context fails closed with exit 4 unless
`DEMO_ASSUME_YES=true`, so a wrapper script or CI job cannot install a privileged
hostPath DaemonSet into production silently.

Exit codes are contract and asserted: 2 no usable cluster, 3 missing or too-old tooling,
4 refusal, 5 an image reference the chart cannot express.

Three defects found by running this against a real cluster rather than by reading it:

- `--wait --timeout 120s` could not absorb a cold image pull, measured at 7m58s per node
  rolled one node at a time. Both scripts now wait `HELM_TIMEOUT` (default 15m), pass
  `maxUnavailable=100%`, and warn before a first pull.
- The two demos shared release name `nvml-mock`, and the chart creates a cluster-scoped
  ClusterRole named from the release, so the second install failed on ownership metadata
  regardless of namespace. failure-injection is now release `nvml-mock-failure` in
  `mokka-failure`.
- That rename exposed a latent bug: the pod selector used `app.kubernetes.io/name`,
  which carries the CHART name, where `app.kubernetes.io/instance` carries the release.
  It was correct only while the two strings happened to be equal. Both scripts now pin
  both labels.

## Testing

- `docs/demo/lib/preflight_test.sh`: 90 checks, green under `/bin/bash` 3.2.57 (macOS
  ships 3.2, so the scripts avoid bash 4 builtins). Guards read comment-stripped code,
  because a grep satisfied by a commented-out line is not a guard.
- Mutation-tested throughout: 13 single-concern mutants, each a printed diff touching
  only its subject, zero survivors. Against the previous revision, 7 of 8 equivalent
  mutants survived.
- Live cluster, cold: portable path exit 0 in 78s and again in 91s on a second run, all
  four nodes pulling in parallel, against a 15m budget.
- Live cluster, collision: both demos installed, both releases deployed with distinct
  ClusterRoles, and standalone provably untouched (identical pod names, RESTARTS 0,
  unchanged generation, still reporting 8 healthy GPUs while the failure release
  reported `[GPU is lost]`).

## Known limitation, deliberately not hidden

Separate release names and namespaces stop the two releases adopting each other. They do
not isolate the demos: the chart's hostPaths are release-independent and mounted
writable, and it tolerates every taint, so two demos on one cluster share per-node host
state. A live run confirmed a co-located pair leaves the shared mock config in a
failure-injected state that a real workload on that node would then read.

`demo::require_no_sibling_release` refuses when the other demo's release is present in
the target namespace. That refusal is namespace-scoped while the hazard is node-scoped,
so two demos in different namespaces on one cluster are documented rather than refused.
The durable fix is in the chart, by scoping those hostPaths to the release or adding a
node selector, and is out of scope here.

## Breaking changes

The portable demos install into your current context instead of a cluster they create.
`BUILD_LOCAL=true` restores the previous build-and-side-load behaviour.

## Stack

PR 4 of 5, stacked on #763. GitHub shows the cumulative diff because a cross-fork PR
cannot use a fork branch as its base; the change belonging to this PR is its last
commit. Merge #761, #762 and #763 first.
