### PR TITLE
fix(mocknvml): reset GPUs through nvidia-smi --gpu-reset instead of segfaulting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- mocknvml: `nvidia-smi --gpu-reset` (`-r`) segfaulted instead of resetting a
+  GPU. The fault was in the mock's own internal export-table dispatcher, not in
+  `nvidia-smi`: the catch-all for per-device calls ends by writing a zero count
+  through `arg1`, and on slot 197 — reached only while resetting — `arg1` carries
+  no count. Because that write sits ahead of the debug print, the fault produced
+  no log line of its own, so the trace stopped mid-sequence and the crash looked
+  like `nvidia-smi` dying on driver state a mock cannot supply. Returning before
+  the write is the whole fix; the reset then completes entirely in-process, so an
+  operator reaching for the most common GPU remediation no longer gets a bare
+  exit 139 with no output at all.
+  The reset is now also a real operation rather than a refusal. Slot 20 calls
+  into Go and clears the device's injected overrides under the same flock
+  `nvml-mock-ctl` takes — the same mutation as `nvml-mock-ctl reset --gpu <n>` —
+  so a remediation controller or runbook that already reaches for the standard
+  GPU reset works unmodified against the mock, and the NVSentinel demo's
+  heal-and-uncordon step can be driven either way. Scope follows `nvidia-smi`,
+  which calls the slot once per targeted GPU: `-i <n>` clears one device and a
+  bare `--gpu-reset` walks every device, reporting each one. Two consequences
+  follow from it being per-device and are documented in `docs/nvml-mock-ctl.md`:
+  state injected with `--gpu all` lives in a shared bucket that no per-device
+  reset clears (matching `reset --gpu <n>`, so `reset --gpu all` is still needed
+  for it), and resetting a GPU with nothing injected leaves `overrides.yaml`
+  untouched, so a reset on a healthy GPU cannot fail on a read-only mount.
 - mocknvml: `Max Customer Boost Clocks` in `nvidia-smi -q` now reports the
   profile's `clocks.graphics_max` instead of `N/A`. Both NVML entry points that
   can answer the row were generated stubs — the dedicated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,38 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- mocknvml: `nvidia-smi --gpu-reset` (`-r`) segfaulted instead of resetting a
-  GPU. The fault was in the mock's own internal export-table dispatcher, not in
-  `nvidia-smi`: the catch-all for per-device calls ends by writing a zero count
-  through `arg1`, and on slot 197 — reached only while resetting — `arg1` carries
-  no count. Because that write sits ahead of the debug print, the fault produced
-  no log line of its own, so the trace stopped mid-sequence and the crash looked
-  like `nvidia-smi` dying on driver state a mock cannot supply. Returning before
-  the write is the whole fix; the reset then completes entirely in-process, so an
-  operator reaching for the most common GPU remediation no longer gets a bare
-  exit 139 with no output at all.
-  The reset is now also a real operation rather than a refusal. Slot 20 calls
-  into Go and clears the device's injected overrides under the same flock
-  `nvml-mock-ctl` takes — the same mutation as `nvml-mock-ctl reset --gpu <n>` —
-  so a remediation controller or runbook that already reaches for the standard
-  GPU reset works unmodified against the mock, and the NVSentinel demo's
-  heal-and-uncordon step can be driven either way. Scope follows `nvidia-smi`,
-  which calls the slot once per targeted GPU: `-i <n>` clears one device and a
-  bare `--gpu-reset` walks every device, reporting each one. Two consequences
-  follow from it being per-device and are documented in `docs/nvml-mock-ctl.md`:
-  state injected with `--gpu all` lives in a shared bucket that no per-device
-  reset clears (matching `reset --gpu <n>`, so `reset --gpu all` is still needed
-  for it), and resetting a GPU with nothing injected leaves `overrides.yaml`
-  untouched, so a reset on a healthy GPU never depends on the overrides being
-  writable.
-  The reset also works from an injected consumer container, not just from the
-  nvml-mock pod, which is where a remediation controller actually runs it.
-  Clearing a bucket rewrites `overrides.yaml`, and both injection paths mounted
-  the config directory read-only: the write failed with `EROFS` on exactly the
-  GPUs that had state to clear, while healthy ones reported success through the
-  no-write path above. CDI now binds that directory `rw`, and the NRI plugin
-  layers a writable bind over it on top of the still-read-only overlay, so the
-  mock library and `nvidia-smi` themselves stay immutable inside the container.
+- mocknvml: `nvidia-smi --gpu-reset` (`-r`) now resets a GPU instead of
+  segfaulting. The mock's export-table dispatcher ended every per-device call by
+  writing a zero count through `arg1`, which the reset slots do not carry, so the
+  most common GPU remediation died with a bare exit 139. The reset is also a real
+  operation now: it clears the device's injected overrides under the same flock
+  as `nvml-mock-ctl reset --gpu <n>`, so an existing remediation controller or
+  runbook works unmodified against the mock. It runs from an injected consumer
+  container as well as the nvml-mock pod — CDI and NRI mount the config directory
+  writable for it, while the mock library and `nvidia-smi` stay read-only.
+  `-i <n>` resets one GPU, a bare `--gpu-reset` every device. Two consequences,
+  documented in `docs/nvml-mock-ctl.md`: state injected with `--gpu all` still
+  needs `reset --gpu all`, and resetting a GPU with nothing injected rewrites
+  nothing.
 - mocknvml: `Max Customer Boost Clocks` in `nvidia-smi -q` now reports the
   profile's `clocks.graphics_max` instead of `N/A`. Both NVML entry points that
   can answer the row were generated stubs — the dedicated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   state injected with `--gpu all` lives in a shared bucket that no per-device
   reset clears (matching `reset --gpu <n>`, so `reset --gpu all` is still needed
   for it), and resetting a GPU with nothing injected leaves `overrides.yaml`
-  untouched, so a reset on a healthy GPU cannot fail on a read-only mount.
+  untouched, so a reset on a healthy GPU never depends on the overrides being
+  writable.
+  The reset also works from an injected consumer container, not just from the
+  nvml-mock pod, which is where a remediation controller actually runs it.
+  Clearing a bucket rewrites `overrides.yaml`, and both injection paths mounted
+  the config directory read-only: the write failed with `EROFS` on exactly the
+  GPUs that had state to clear, while healthy ones reported success through the
+  no-write path above. CDI now binds that directory `rw`, and the NRI plugin
+  layers a writable bind over it on top of the still-read-only overlay, so the
+  mock library and `nvidia-smi` themselves stay immutable inside the container.
 - mocknvml: `Max Customer Boost Clocks` in `nvidia-smi -q` now reports the
   profile's `clocks.graphics_max` instead of `N/A`. Both NVML entry points that
   can answer the row were generated stubs — the dedicated

--- a/docs/nvml-mock-ctl.md
+++ b/docs/nvml-mock-ctl.md
@@ -395,8 +395,16 @@ at a time:
   `all:` bucket. State injected with `--gpu all` needs
   `nvml-mock-ctl reset --gpu all`.
 - Resetting a GPU that has nothing injected leaves `overrides.yaml` untouched
-  (no write, no lock), so a reset on a healthy GPU cannot fail on a read-only
-  overrides mount.
+  (no write, no lock), so a reset on a healthy GPU never depends on the overrides
+  being writable.
+
+The reset works from an injected consumer container as well as from the nvml-mock
+pod, which is what lets a remediation controller run it where the workload sees
+the GPU. Clearing a bucket rewrites `overrides.yaml` under an flock, so the config
+directory is bind-mounted writable into injected containers (the driver library
+and `nvidia-smi` itself stay read-only). Mounted read-only it would fail with
+`GPU Reset couldn't run` on exactly the GPUs that had state to clear, while
+healthy ones reported success through the no-write path above.
 
 ## Reset semantics
 

--- a/docs/nvml-mock-ctl.md
+++ b/docs/nvml-mock-ctl.md
@@ -375,11 +375,35 @@ prints `no active overrides`.
 `--gpu` clears **everything** (equivalent to `reset --gpu all`). State reverts to
 the pristine profile within one TTL.
 
+### Reset via `nvidia-smi`
+
+`nvidia-smi --gpu-reset` (`-r`) performs the same reset, so a remediation
+controller or a runbook that already reaches for the standard GPU reset works
+unmodified against the mock:
+
+```bash
+kubectl -n mokka exec "$POD" -- nvidia-smi -r -i 0   # same as: reset --gpu 0
+kubectl -n mokka exec "$POD" -- nvidia-smi -r        # every GPU, one at a time
+```
+
+It reports per GPU (`GPU 00000000:0A:00.0 was successfully reset.`) and exits 0.
+
+Two differences from the CLI follow from nvidia-smi driving the reset one device
+at a time:
+
+- A bare `-r` resets each GPU individually, so it does **not** clear the shared
+  `all:` bucket. State injected with `--gpu all` needs
+  `nvml-mock-ctl reset --gpu all`.
+- Resetting a GPU that has nothing injected leaves `overrides.yaml` untouched
+  (no write, no lock), so a reset on a healthy GPU cannot fail on a read-only
+  overrides mount.
+
 ## Reset semantics
 
 | Action | Effect on runtime overrides | Result |
 | ------ | --------------------------- | ------ |
 | `nvml-mock-ctl reset [--gpu <t>]` | clears the targeted bucket(s) from `overrides.yaml` | device(s) revert to pristine profile within one TTL |
+| `nvidia-smi --gpu-reset [-i <idx>]` | clears the same per-device bucket(s) — see [via nvidia-smi](#reset-via-nvidia-smi) | device(s) revert to pristine profile within one TTL |
 | `nvml-mock-ctl fail --gpu <t> --mode healthy` | removes just the `failure` block for the target | that device recovers within one TTL; other overrides stay |
 | `nvml-mock-ctl fabric-health --gpu <t> healthy` | clears just the fabric health conditions for the target | that device's fabric reports healthy within one TTL; other overrides stay |
 | DaemonSet pod restart | `setup.sh` deletes `overrides.yaml` on startup | **all** overrides wiped; back to pristine profile |

--- a/internal/agent/cdi/spec.go
+++ b/internal/agent/cdi/spec.go
@@ -77,10 +77,18 @@ func buildNvidiaSpec(state *agent.State) cdiSpec {
 			},
 			// Bind the config directory (not just config.yaml) so atomic renames
 			// by nvml-mock-ctl's overrides.yaml writes are visible inside the container.
+			//
+			// Writable because the container also resets through it: the mock
+			// serves `nvidia-smi --gpu-reset` by clearing the device's bucket from
+			// overrides.yaml, which takes an flock and rewrites the file. Read-only
+			// here failed that write with EROFS exactly when the GPU had state to
+			// clear, so the remediation an operator reaches for first reported
+			// "GPU Reset couldn't run" on precisely the GPUs that needed it, while
+			// healthy ones "succeeded" through the no-write path.
 			{
 				HostPath:      overlayHostRoot + "/driver/config",
 				ContainerPath: "/etc/nvml-mock",
-				Options:       []string{"ro", "nosuid", "nodev", "bind"},
+				Options:       []string{"rw", "nosuid", "nodev", "bind"},
 			},
 		},
 		// update-ldcache rebuilds the dynamic linker cache inside the container

--- a/internal/agent/cdi/spec_test.go
+++ b/internal/agent/cdi/spec_test.go
@@ -58,6 +58,27 @@ func TestNvidiaSpecMounts(t *testing.T) {
 	}, containerPaths)
 }
 
+// The container does not only read the config directory: `nvidia-smi --gpu-reset`
+// clears the device's bucket from overrides.yaml, taking an flock and rewriting
+// the file. Mounted read-only, that write fails with EROFS exactly when the GPU
+// has state to clear, so the reset fails on the GPUs that need it and "succeeds"
+// on the healthy ones that skip the write. The driver library and nvidia-smi
+// stay read-only; only the config directory is writable.
+func TestNvidiaSpecConfigDirIsWritable(t *testing.T) {
+	spec := buildNvidiaSpec(twoGPUState())
+	require.NotNil(t, spec.ContainerEdits)
+
+	for _, m := range spec.ContainerEdits.Mounts {
+		switch m.ContainerPath {
+		case "/etc/nvml-mock":
+			require.Contains(t, m.Options, "rw", "the reset writes overrides.yaml through this mount")
+			require.NotContains(t, m.Options, "ro")
+		case "/usr/lib64/libnvidia-ml.so.1", "/usr/bin/nvidia-smi":
+			require.Contains(t, m.Options, "ro", "%s must stay immutable inside the container", m.ContainerPath)
+		}
+	}
+}
+
 func TestNvidiaSpecHookAndEnv(t *testing.T) {
 	spec := buildNvidiaSpec(twoGPUState())
 	require.NotNil(t, spec.ContainerEdits)

--- a/internal/nri/inject/adjust.go
+++ b/internal/nri/inject/adjust.go
@@ -10,6 +10,8 @@
 // the plugin's DaemonSet after the agent's.
 package inject
 
+import "path/filepath"
+
 // Adjust returns what to add to a container, or ok=false when the container
 // should be left exactly as authored.
 //
@@ -52,16 +54,35 @@ func skip(cfg Config, container Container) bool {
 	return false
 }
 
-// mountOverlay binds the staged mock driver tree into the container.
+// mountOverlay binds the staged mock driver tree into the container, read-only
+// except for the config directory.
 //
 // This is the one step with no opt-in gate: the shims, the mock NVML config and
 // the IB sysfs tree all live under this path, so every later step describes
 // something reachable only through it.
+//
+// The config directory is writable because the container writes back through
+// it: the mock serves `nvidia-smi --gpu-reset` by clearing the device's bucket
+// from overrides.yaml, under the same flock every other writer takes. With the
+// whole overlay read-only that write failed with EROFS, so a reset reported
+// "GPU Reset couldn't run" on exactly the GPUs that had state to clear, while
+// healthy ones reported success by skipping the write. Layering a narrower
+// writable bind over the read-only tree keeps the mock library and nvidia-smi
+// below it immutable; the order matters, since the overlay would cover this
+// mount if it came second.
 func mountOverlay(cfg Config, adjustment *Adjustment) {
-	adjustment.Mounts = append(adjustment.Mounts, Mount{
-		Source:      cfg.HostOverlayPath,
-		Destination: cfg.ContainerOverlayPath,
-		Type:        "bind",
-		Options:     []string{"rbind", "ro", "nosuid", "nodev"},
-	})
+	adjustment.Mounts = append(adjustment.Mounts,
+		Mount{
+			Source:      cfg.HostOverlayPath,
+			Destination: cfg.ContainerOverlayPath,
+			Type:        "bind",
+			Options:     []string{"rbind", "ro", "nosuid", "nodev"},
+		},
+		Mount{
+			Source:      filepath.Join(cfg.HostOverlayPath, configRelPath),
+			Destination: filepath.Join(cfg.ContainerOverlayPath, configRelPath),
+			Type:        "bind",
+			Options:     []string{"rbind", "rw", "nosuid", "nodev"},
+		},
+	)
 }

--- a/internal/nri/inject/adjust_test.go
+++ b/internal/nri/inject/adjust_test.go
@@ -20,12 +20,49 @@ func overlayMount() Mount {
 	}
 }
 
+// configMount is the writable window in the otherwise read-only overlay.
+func configMount() Mount {
+	return Mount{
+		Source:      "/var/lib/nvml-mock/driver/config",
+		Destination: "/opt/nvml-mock/driver/config",
+		Type:        "bind",
+		Options:     []string{"rbind", "rw", "nosuid", "nodev"},
+	}
+}
+
 func TestAdjustMountsTheOverlayForAPlainContainer(t *testing.T) {
 	t.Parallel()
 
 	adjustment, ok := Adjust(DefaultConfig(), Container{Namespace: "default"})
 	require.True(t, ok)
 	require.Contains(t, adjustment.Mounts, overlayMount())
+}
+
+// `nvidia-smi --gpu-reset` clears the device's bucket from overrides.yaml, which
+// sits beside the config.yaml MOCK_NVML_CONFIG points at. With the whole overlay
+// read-only that write failed with EROFS on exactly the GPUs that had state to
+// clear, so the config directory gets its own writable bind. It has to stay
+// layered over the overlay: ordered first, the read-only rbind would cover it.
+func TestAdjustMountsConfigDirWritableOverReadOnlyOverlay(t *testing.T) {
+	t.Parallel()
+
+	adjustment, ok := Adjust(DefaultConfig(), Container{Namespace: "default"})
+	require.True(t, ok)
+	require.Contains(t, adjustment.Mounts, configMount())
+
+	overlay, config := -1, -1
+	for i, m := range adjustment.Mounts {
+		switch m.Destination {
+		case "/opt/nvml-mock":
+			overlay = i
+			require.Contains(t, m.Options, "ro", "the mock library and nvidia-smi stay immutable")
+		case "/opt/nvml-mock/driver/config":
+			config = i
+		}
+	}
+	require.NotEqual(t, -1, overlay)
+	require.NotEqual(t, -1, config)
+	require.Less(t, overlay, config, "the writable config bind must be applied after the overlay it sits inside")
 }
 
 // An unannotated container gets the overlay and the environment but nothing

--- a/internal/nri/inject/config.go
+++ b/internal/nri/inject/config.go
@@ -22,6 +22,11 @@ const (
 	// resolves against the host overlay path for the existence check and against
 	// the container overlay path for the injected MOCK_TOPOLOGY_CONFIG.
 	topologyRelPath = "topology/topology.yaml"
+	// configRelPath holds the mock NVML config and, beside it, the overrides
+	// file runtime state is injected into. It is named once because the mount
+	// and the injected MOCK_NVML_CONFIG have to agree: the overrides the
+	// container resets are resolved relative to that config.
+	configRelPath = "driver/config"
 )
 
 // defaultShims are preloaded in the order listed, so a symbol defined by more

--- a/internal/nri/inject/env.go
+++ b/internal/nri/inject/env.go
@@ -17,7 +17,7 @@ func setEnvironment(cfg Config, container Container, adjustment *Adjustment) {
 	env.prepend("PATH", filepath.Join(cfg.ContainerOverlayPath, "driver/usr/bin"))
 	env.prepend("LD_LIBRARY_PATH", filepath.Join(cfg.ContainerOverlayPath, "driver/usr/lib64"))
 	env.appendList("LD_PRELOAD", shimPaths(cfg))
-	env.setDefault("MOCK_NVML_CONFIG", filepath.Join(cfg.ContainerOverlayPath, "driver/config/config.yaml"))
+	env.setDefault("MOCK_NVML_CONFIG", filepath.Join(cfg.ContainerOverlayPath, configRelPath, "config.yaml"))
 	env.setDefault("MOCK_IB", "full")
 	env.setDefault("MOCK_IB_ROOT", filepath.Join(cfg.ContainerOverlayPath, "ib"))
 	env.setDefault("MOCK_IB_PING_SOCKET", filepath.Join(cfg.ContainerOverlayPath, "run/mock-ib.sock"))

--- a/pkg/gpu/mockctl/reset.go
+++ b/pkg/gpu/mockctl/reset.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mockctl
+
+// Resetting one device's overrides as a single operation, for callers that have
+// no command dispatcher to hang it off. nvml-mock-ctl reaches Doc.Reset through
+// its generic load-mutate-validate-write flow; the mock NVML library serves
+// `nvidia-smi --gpu-reset` from a CGo callback with no such flow around it, and
+// needs the whole read-modify-write in one call.
+
+import (
+	"strconv"
+)
+
+// ResetDevice returns one device to its healthy baseline by removing its
+// override bucket, taking the same flock as every other writer of this file so a
+// concurrent injection cannot interleave with the reset.
+//
+// The index is deliberately not a Target: a Target can say "all", and the shared
+// `all:` bucket is not resettable per device. Doc.Reset leaves that bucket alone
+// for a device target (so state injected with `--gpu all` survives, and needs
+// `Doc.Reset(Target{All: true})` to clear), and a caller resetting a single GPU
+// must not be able to ask for something this cannot honour.
+//
+// A device with nothing injected is reset without touching the file at all — no
+// write and no lock. That is not just an optimisation: resetting a healthy device
+// is the common case, and skipping the write keeps it working where the overrides
+// are not writable. Only a reset that genuinely has state to clear can fail.
+func ResetDevice(path string, index int) error {
+	if path == "" {
+		// No config, so no injected state to clear: the device is already at its
+		// baseline and the reset has nothing to do.
+		return nil
+	}
+	if has, err := deviceHasOverrides(path, index); err != nil || !has {
+		return err
+	}
+
+	unlock, err := LockOverride(path)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	// Re-read under the lock: the peek above raced with any concurrent writer.
+	doc, err := Load(path)
+	if err != nil {
+		return err
+	}
+	doc.Reset(Target{Index: index})
+	return WriteAtomic(path, doc)
+}
+
+// deviceHasOverrides reports whether the document carries a bucket for the
+// device. A missing or empty file is not an error: it means nothing was injected.
+func deviceHasOverrides(path string, index int) (bool, error) {
+	doc, err := Load(path)
+	if err != nil {
+		return false, err
+	}
+	_, ok := doc.Devices[strconv.Itoa(index)]
+	return ok, nil
+}

--- a/pkg/gpu/mockctl/reset_test.go
+++ b/pkg/gpu/mockctl/reset_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package mockctl
 
 import (
 	"os"
@@ -21,33 +21,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// writeOverrides seeds an overrides file and returns its path.
-func writeOverrides(t *testing.T, body string) string {
+// writeOverridesFile seeds an overrides file and returns its path.
+func writeOverridesFile(t *testing.T, body string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "overrides.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
 	return path
 }
 
-func TestClearDeviceOverrides_RemovesTheDeviceBucket(t *testing.T) {
-	path := writeOverrides(t, `version: 1
+func TestResetDevice_RemovesTheDeviceBucket(t *testing.T) {
+	path := writeOverridesFile(t, `version: 1
 devices:
   "1":
     thermal:
       temperature_gpu_c: 99
 `)
 
-	require.NoError(t, clearDeviceOverrides(path, 1))
+	require.NoError(t, ResetDevice(path, 1))
 
-	has, err := hasDeviceOverrides(path, 1)
+	has, err := deviceHasOverrides(path, 1)
 	require.NoError(t, err)
 	require.False(t, has, "GPU 1's overrides should be gone after the reset")
 }
 
 // A reset is scoped to the GPU nvidia-smi targeted with -i, so a sibling's
 // injected state has to survive it.
-func TestClearDeviceOverrides_LeavesOtherDevicesAlone(t *testing.T) {
-	path := writeOverrides(t, `version: 1
+func TestResetDevice_LeavesOtherDevicesAlone(t *testing.T) {
+	path := writeOverridesFile(t, `version: 1
 devices:
   "0":
     thermal:
@@ -57,25 +57,25 @@ devices:
       temperature_gpu_c: 99
 `)
 
-	require.NoError(t, clearDeviceOverrides(path, 1))
+	require.NoError(t, ResetDevice(path, 1))
 
-	has, err := hasDeviceOverrides(path, 0)
+	has, err := deviceHasOverrides(path, 0)
 	require.NoError(t, err)
 	require.True(t, has, "GPU 0 must keep its overrides when only GPU 1 was reset")
 }
 
 // Resetting a healthy GPU must not rewrite the file. That is the common case,
 // and it is what keeps a reset working where the overrides are not writable.
-func TestClearDeviceOverrides_HealthyDeviceLeavesFileUntouched(t *testing.T) {
+func TestResetDevice_HealthyDeviceLeavesFileUntouched(t *testing.T) {
 	body := `version: 1
 devices:
   "0":
     thermal:
       temperature_gpu_c: 91
 `
-	path := writeOverrides(t, body)
+	path := writeOverridesFile(t, body)
 
-	require.NoError(t, clearDeviceOverrides(path, 3))
+	require.NoError(t, ResetDevice(path, 3))
 
 	after, err := os.ReadFile(path)
 	require.NoError(t, err)
@@ -85,32 +85,32 @@ devices:
 
 // No overrides file at all means nothing was ever injected: the device is
 // already at its baseline, so the reset succeeds without creating a file.
-func TestClearDeviceOverrides_MissingFileSucceeds(t *testing.T) {
+func TestResetDevice_MissingFileSucceeds(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "overrides.yaml")
 
-	require.NoError(t, clearDeviceOverrides(path, 0))
+	require.NoError(t, ResetDevice(path, 0))
 	require.NoFileExists(t, path)
 }
 
 // With no config there is no override file to resolve, and nothing to clear.
-func TestClearDeviceOverrides_EmptyPathSucceeds(t *testing.T) {
-	require.NoError(t, clearDeviceOverrides("", 0))
+func TestResetDevice_EmptyPathSucceeds(t *testing.T) {
+	require.NoError(t, ResetDevice("", 0))
 }
 
 // A per-device reset leaves the shared `all:` bucket in place, matching
 // `nvml-mock-ctl reset --gpu <n>` exactly — the override schema cannot express
 // "drop the shared block for one GPU only". An operator who injected with
-// `--gpu all` needs `nvml-mock-ctl reset --gpu all`; nvidia-smi will report a
+// `--gpu all` needs a Target{All: true} reset; nvidia-smi will report a
 // successful reset while the shared block still masks the device.
-func TestClearDeviceOverrides_LeavesSharedAllBucket(t *testing.T) {
+func TestResetDevice_LeavesSharedAllBucket(t *testing.T) {
 	body := `version: 1
 all:
   thermal:
     temperature_gpu_c: 88
 `
-	path := writeOverrides(t, body)
+	path := writeOverridesFile(t, body)
 
-	require.NoError(t, clearDeviceOverrides(path, 0))
+	require.NoError(t, ResetDevice(path, 0))
 
 	after, err := os.ReadFile(path)
 	require.NoError(t, err)
@@ -119,8 +119,8 @@ all:
 
 // A corrupt overrides file must fail the reset rather than be silently treated
 // as "nothing injected", which would report success over unknown device state.
-func TestClearDeviceOverrides_ReportsUnparseableFile(t *testing.T) {
-	path := writeOverrides(t, "devices: [this is not a mapping\n")
+func TestResetDevice_ReportsUnparseableFile(t *testing.T) {
+	path := writeOverridesFile(t, "devices: [this is not a mapping\n")
 
-	require.Error(t, clearDeviceOverrides(path, 0))
+	require.Error(t, ResetDevice(path, 0))
 }

--- a/pkg/gpu/mockctl/reset_test.go
+++ b/pkg/gpu/mockctl/reset_test.go
@@ -103,18 +103,26 @@ func TestResetDevice_EmptyPathSucceeds(t *testing.T) {
 // `--gpu all` needs a Target{All: true} reset; nvidia-smi will report a
 // successful reset while the shared block still masks the device.
 func TestResetDevice_LeavesSharedAllBucket(t *testing.T) {
-	body := `version: 1
+	// The device bucket is what makes this test load-bearing: without it the
+	// reset stops at the "nothing injected" early return, never reaches
+	// Doc.Reset, and passes on a file it never opened for writing.
+	path := writeOverridesFile(t, `version: 1
 all:
   thermal:
     temperature_gpu_c: 88
-`
-	path := writeOverridesFile(t, body)
+devices:
+  "0":
+    thermal:
+      temperature_gpu_c: 99
+`)
 
 	require.NoError(t, ResetDevice(path, 0))
 
-	after, err := os.ReadFile(path)
+	doc, err := Load(path)
 	require.NoError(t, err)
-	require.Equal(t, body, string(after))
+	require.NotContains(t, doc.Devices, "0", "the reset must clear the device's own bucket")
+	require.Equal(t, map[string]any{"thermal": map[string]any{"temperature_gpu_c": float64(88)}}, doc.All,
+		"the shared block survives a per-device reset, so the device stays masked by it")
 }
 
 // A corrupt overrides file must fail the reset rather than be silently treated

--- a/pkg/gpu/mocknvml/bridge/gpu_reset.go
+++ b/pkg/gpu/mocknvml/bridge/gpu_reset.go
@@ -23,7 +23,6 @@ package main
 import "C"
 
 import (
-	"strconv"
 	"unsafe"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
@@ -39,9 +38,9 @@ import (
 // Clearing the overrides is the reset a mock can honour. A real reset clears the
 // GPU's transient hardware and software error state — the double-bit ECC error
 // or hung channel that made an operator reach for it in the first place — and on
-// the mock that state is exactly what `nvml-mock-ctl` injected. So the same
-// mutation `nvml-mock-ctl reset --gpu <n>` performs is the faithful analogue,
-// and it is the same code path: mockctl.Doc.Reset under mockctl's lock.
+// the mock that state is exactly what `nvml-mock-ctl` injected. So this performs
+// the same mutation `nvml-mock-ctl reset --gpu <n>` performs, through the same
+// function, rather than a second implementation of it.
 //
 // Scope follows nvidia-smi rather than being decided here. It calls this once per
 // GPU being reset, so `-i 1` clears one device and a bare `--gpu-reset` walks
@@ -60,61 +59,12 @@ func mockInternalResetGPU(handle unsafe.Pointer) C.int {
 		debugLog("[RESET] device %p reports no index (ret=%d)\n", handle, ret)
 		return 0
 	}
-	if err := clearDeviceOverrides(engine.ConfigOverridePath(), index); err != nil {
+	// engine.ConfigOverridePath resolves the same file the engine reads, so the
+	// reader and this writer can never disagree on which one is authoritative.
+	if err := mockctl.ResetDevice(engine.ConfigOverridePath(), index); err != nil {
 		debugLog("[RESET] GPU %d: %v\n", index, err)
 		return 0
 	}
 	debugLog("[RESET] GPU %d returned to its healthy baseline\n", index)
 	return 1
-}
-
-// clearDeviceOverrides removes the device's override bucket, taking the same
-// flock nvml-mock-ctl takes so a concurrent injection cannot interleave with the
-// reset.
-//
-// The shared `all:` bucket is deliberately left alone, which matches
-// `nvml-mock-ctl reset --gpu <n>`: the schema cannot express "drop the shared
-// block for one GPU only". State injected with `--gpu all` therefore survives a
-// reset of any single GPU, and survives a bare `nvidia-smi --gpu-reset` too,
-// because nvidia-smi drives that as one per-device reset per GPU rather than as
-// one all-GPU operation. Clearing it needs `nvml-mock-ctl reset --gpu all`.
-//
-// A device with nothing injected is reset without touching the file at all — no
-// write and no lock. That is not just an optimisation: resetting a healthy GPU is
-// the common case, and skipping the write keeps it working where the overrides
-// are not writable. Only a reset that genuinely has state to clear can fail.
-func clearDeviceOverrides(path string, index int) error {
-	if path == "" {
-		// No config, so no injected state to clear; the device is already at its
-		// baseline and the reset has nothing to do.
-		return nil
-	}
-	if has, err := hasDeviceOverrides(path, index); err != nil || !has {
-		return err
-	}
-
-	unlock, err := mockctl.LockOverride(path)
-	if err != nil {
-		return err
-	}
-	defer unlock()
-
-	// Re-read under the lock: the peek above raced with any concurrent writer.
-	doc, err := mockctl.Load(path)
-	if err != nil {
-		return err
-	}
-	doc.Reset(mockctl.Target{Index: index})
-	return mockctl.WriteAtomic(path, doc)
-}
-
-// hasDeviceOverrides reports whether the document carries a bucket for the
-// device. A missing or empty file is not an error: it means nothing was injected.
-func hasDeviceOverrides(path string, index int) (bool, error) {
-	doc, err := mockctl.Load(path)
-	if err != nil {
-		return false, err
-	}
-	_, ok := doc.Devices[strconv.Itoa(index)]
-	return ok, nil
 }

--- a/pkg/gpu/mocknvml/bridge/gpu_reset.go
+++ b/pkg/gpu/mocknvml/bridge/gpu_reset.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The GPU reset behind `nvidia-smi --gpu-reset` / `-r`. nvidia-smi drives the
+// reset through the internal export table (see MOCK_SLOT_GPU_RESET in
+// internal.go), not through any public NVML entry point, so this is reachable
+// only from that dispatcher.
+package main
+
+/*
+#include "nvml_types.h"
+*/
+import "C"
+
+import (
+	"strconv"
+	"unsafe"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mockctl"
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
+)
+
+// mockInternalResetGPU returns the device nvidia-smi is resetting to its healthy
+// baseline by dropping the overrides injected onto it, and reports 1 when the
+// device is now clean.
+//
+// Clearing the overrides is the reset a mock can honour. A real reset clears the
+// GPU's transient hardware and software error state — the double-bit ECC error
+// or hung channel that made an operator reach for it in the first place — and on
+// the mock that state is exactly what `nvml-mock-ctl` injected. So the same
+// mutation `nvml-mock-ctl reset --gpu <n>` performs is the faithful analogue,
+// and it is the same code path: mockctl.Doc.Reset under mockctl's lock.
+//
+// Scope follows nvidia-smi rather than being decided here. It calls this once per
+// GPU being reset, so `-i 1` clears one device and a bare `--gpu-reset` walks
+// every device in turn, which is what nvidia-smi documents for a reset with no
+// -i switch.
+//
+//export mockInternalResetGPU
+func mockInternalResetGPU(handle unsafe.Pointer) C.int {
+	dev := engine.GetEngine().LookupConfigurableDevice(handle)
+	if dev == nil {
+		debugLog("[RESET] unknown device handle %p\n", handle)
+		return 0
+	}
+	index, ret := dev.GetIndex()
+	if ret != nvml.SUCCESS {
+		debugLog("[RESET] device %p reports no index (ret=%d)\n", handle, ret)
+		return 0
+	}
+	if err := clearDeviceOverrides(engine.ConfigOverridePath(), index); err != nil {
+		debugLog("[RESET] GPU %d: %v\n", index, err)
+		return 0
+	}
+	debugLog("[RESET] GPU %d returned to its healthy baseline\n", index)
+	return 1
+}
+
+// clearDeviceOverrides removes the device's override bucket, taking the same
+// flock nvml-mock-ctl takes so a concurrent injection cannot interleave with the
+// reset.
+//
+// The shared `all:` bucket is deliberately left alone, which matches
+// `nvml-mock-ctl reset --gpu <n>`: the schema cannot express "drop the shared
+// block for one GPU only". State injected with `--gpu all` therefore survives a
+// reset of any single GPU, and survives a bare `nvidia-smi --gpu-reset` too,
+// because nvidia-smi drives that as one per-device reset per GPU rather than as
+// one all-GPU operation. Clearing it needs `nvml-mock-ctl reset --gpu all`.
+//
+// A device with nothing injected is reset without touching the file at all — no
+// write and no lock. That is not just an optimisation: resetting a healthy GPU is
+// the common case, and skipping the write keeps it working where the overrides
+// are not writable. Only a reset that genuinely has state to clear can fail.
+func clearDeviceOverrides(path string, index int) error {
+	if path == "" {
+		// No config, so no injected state to clear; the device is already at its
+		// baseline and the reset has nothing to do.
+		return nil
+	}
+	if has, err := hasDeviceOverrides(path, index); err != nil || !has {
+		return err
+	}
+
+	unlock, err := mockctl.LockOverride(path)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	// Re-read under the lock: the peek above raced with any concurrent writer.
+	doc, err := mockctl.Load(path)
+	if err != nil {
+		return err
+	}
+	doc.Reset(mockctl.Target{Index: index})
+	return mockctl.WriteAtomic(path, doc)
+}
+
+// hasDeviceOverrides reports whether the document carries a bucket for the
+// device. A missing or empty file is not an error: it means nothing was injected.
+func hasDeviceOverrides(path string, index int) (bool, error) {
+	doc, err := mockctl.Load(path)
+	if err != nil {
+		return false, err
+	}
+	_, ok := doc.Devices[strconv.Itoa(index)]
+	return ok, nil
+}

--- a/pkg/gpu/mocknvml/bridge/gpu_reset_test.go
+++ b/pkg/gpu/mocknvml/bridge/gpu_reset_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeOverrides seeds an overrides file and returns its path.
+func writeOverrides(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "overrides.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	return path
+}
+
+func TestClearDeviceOverrides_RemovesTheDeviceBucket(t *testing.T) {
+	path := writeOverrides(t, `version: 1
+devices:
+  "1":
+    thermal:
+      temperature_gpu_c: 99
+`)
+
+	require.NoError(t, clearDeviceOverrides(path, 1))
+
+	has, err := hasDeviceOverrides(path, 1)
+	require.NoError(t, err)
+	require.False(t, has, "GPU 1's overrides should be gone after the reset")
+}
+
+// A reset is scoped to the GPU nvidia-smi targeted with -i, so a sibling's
+// injected state has to survive it.
+func TestClearDeviceOverrides_LeavesOtherDevicesAlone(t *testing.T) {
+	path := writeOverrides(t, `version: 1
+devices:
+  "0":
+    thermal:
+      temperature_gpu_c: 91
+  "1":
+    thermal:
+      temperature_gpu_c: 99
+`)
+
+	require.NoError(t, clearDeviceOverrides(path, 1))
+
+	has, err := hasDeviceOverrides(path, 0)
+	require.NoError(t, err)
+	require.True(t, has, "GPU 0 must keep its overrides when only GPU 1 was reset")
+}
+
+// Resetting a healthy GPU must not rewrite the file. That is the common case,
+// and it is what keeps a reset working where the overrides are not writable.
+func TestClearDeviceOverrides_HealthyDeviceLeavesFileUntouched(t *testing.T) {
+	body := `version: 1
+devices:
+  "0":
+    thermal:
+      temperature_gpu_c: 91
+`
+	path := writeOverrides(t, body)
+
+	require.NoError(t, clearDeviceOverrides(path, 3))
+
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, body, string(after), "a reset with nothing to clear must not rewrite the file")
+	require.NoFileExists(t, path+".lock", "a reset with nothing to clear must not even take the lock")
+}
+
+// No overrides file at all means nothing was ever injected: the device is
+// already at its baseline, so the reset succeeds without creating a file.
+func TestClearDeviceOverrides_MissingFileSucceeds(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "overrides.yaml")
+
+	require.NoError(t, clearDeviceOverrides(path, 0))
+	require.NoFileExists(t, path)
+}
+
+// With no config there is no override file to resolve, and nothing to clear.
+func TestClearDeviceOverrides_EmptyPathSucceeds(t *testing.T) {
+	require.NoError(t, clearDeviceOverrides("", 0))
+}
+
+// A per-device reset leaves the shared `all:` bucket in place, matching
+// `nvml-mock-ctl reset --gpu <n>` exactly — the override schema cannot express
+// "drop the shared block for one GPU only". An operator who injected with
+// `--gpu all` needs `nvml-mock-ctl reset --gpu all`; nvidia-smi will report a
+// successful reset while the shared block still masks the device.
+func TestClearDeviceOverrides_LeavesSharedAllBucket(t *testing.T) {
+	body := `version: 1
+all:
+  thermal:
+    temperature_gpu_c: 88
+`
+	path := writeOverrides(t, body)
+
+	require.NoError(t, clearDeviceOverrides(path, 0))
+
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, body, string(after))
+}
+
+// A corrupt overrides file must fail the reset rather than be silently treated
+// as "nothing injected", which would report success over unknown device state.
+func TestClearDeviceOverrides_ReportsUnparseableFile(t *testing.T) {
+	path := writeOverrides(t, "devices: [this is not a mapping\n")
+
+	require.Error(t, clearDeviceOverrides(path, 0))
+}

--- a/pkg/gpu/mocknvml/bridge/internal.go
+++ b/pkg/gpu/mocknvml/bridge/internal.go
@@ -41,6 +41,10 @@ extern unsigned int mockInternalFillProcessList(void* handle, void* buf, unsigne
 // below in Go). Returns 0 when the device is unknown or configures no PCIe block.
 extern unsigned int mockInternalHostMaxPcieLinkGen(void* handle);
 
+// Forward declaration of the GPU reset (defined in gpu_reset.go). Returns 1 when
+// the device returned to its healthy baseline, 0 when it could not.
+extern int mockInternalResetGPU(void* handle);
+
 // Debug mode - check MOCK_NVML_DEBUG env var once at startup
 static int debugChecked = 0;
 static int debugEnabled = 0;
@@ -59,7 +63,9 @@ static int isDebugEnabled() {
 // is what identifies the internal entry point being called. Recovered by giving
 // every slot its own trampoline and logging which slots each nvidia-smi view
 // hits (580.65.06).
+#define MOCK_SLOT_GPU_RESET 20
 #define MOCK_SLOT_DEVICE_HANDLE_BY_INDEX 81
+#define MOCK_SLOT_GPU_RESET_COMPLETE 197
 #define MOCK_SLOT_PROCESS_LIST_FIRST 213
 #define MOCK_SLOT_PROCESS_LIST_LAST 215
 #define MOCK_SLOT_HOST_MAX_PCIE_LINK_GEN 230
@@ -80,6 +86,36 @@ static nvmlReturn_t internalStubFunction(unsigned int slot, void* arg0, void* ar
                     slot, (unsigned int)rawArg0, ret, (void*)outputPtr->handle);
         }
         return ret;
+    }
+
+    // GPU reset. `nvidia-smi --gpu-reset` / `-r` performs the whole reset through
+    // these two slots and nothing else reaches either of them, so serving them
+    // costs no other view. nvidia-smi calls slot 20 once per GPU being reset and
+    // slot 197 twice, then prints "GPU <busid> was successfully reset."
+    //
+    // Both must return before the zero write at the bottom of this function. That
+    // write assumes arg1 is a caller-supplied count, and on slot 197 it is not:
+    // the write faulted there, which is what made every reset die with a SIGSEGV
+    // and no diagnostic (the fault landed ahead of the debug print, so the log
+    // stopped mid-sequence and pointed at nvidia-smi rather than at us).
+    if (slot == MOCK_SLOT_GPU_RESET) {
+        // The reset the mock can actually perform is clearing the device's
+        // injected overrides, the same mutation `nvml-mock-ctl reset --gpu <n>`
+        // makes. Real hardware clears its transient error state here, so a
+        // profile returning to its healthy baseline is the faithful analogue.
+        int ok = mockInternalResetGPU(arg0);
+        if (isDebugEnabled()) {
+            fprintf(stderr, "[C-STUB] slot %u GPU reset (handle=%p) -> ok=%d\n", slot, arg0, ok);
+        }
+        // An error here is what nvidia-smi renders as "GPU Reset couldn't run",
+        // which is the honest answer when the overrides could not be cleared.
+        return ok ? NVML_SUCCESS : NVML_ERROR_OPERATING_SYSTEM;
+    }
+    if (slot == MOCK_SLOT_GPU_RESET_COMPLETE) {
+        if (isDebugEnabled()) {
+            fprintf(stderr, "[C-STUB] slot %u GPU reset completion (handle=%p)\n", slot, arg0);
+        }
+        return NVML_SUCCESS;
     }
 
     if (arg1 == NULL || !mockInternalIsDeviceHandle(arg0)) {

--- a/pkg/gpu/mocknvml/bridge/internal.go
+++ b/pkg/gpu/mocknvml/bridge/internal.go
@@ -98,7 +98,15 @@ static nvmlReturn_t internalStubFunction(unsigned int slot, void* arg0, void* ar
     // the write faulted there, which is what made every reset die with a SIGSEGV
     // and no diagnostic (the fault landed ahead of the debug print, so the log
     // stopped mid-sequence and pointed at nvidia-smi rather than at us).
-    if (slot == MOCK_SLOT_GPU_RESET) {
+    //
+    // The device-handle gate matters for what an error here means. Without it a
+    // slot 20 call carrying anything other than a registered handle -- a probe,
+    // or an engine still at initCount 0 -- fails the lookup and reports
+    // NVML_ERROR_OPERATING_SYSTEM, the one answer the catch-all below documents
+    // as unsafe for a call that was never a device call. Falling through to that
+    // guard instead keeps NVML_ERROR_OPERATING_SYSTEM meaning "this device's
+    // reset was attempted and failed".
+    if (slot == MOCK_SLOT_GPU_RESET && mockInternalIsDeviceHandle(arg0)) {
         // The reset the mock can actually perform is clearing the device's
         // injected overrides, the same mutation `nvml-mock-ctl reset --gpu <n>`
         // makes. Real hardware clears its transient error state here, so a

--- a/pkg/gpu/mocknvml/engine/config_override_store.go
+++ b/pkg/gpu/mocknvml/engine/config_override_store.go
@@ -78,6 +78,14 @@ func newConfigOverrideStoreAt(pathFn func() string, now func() time.Time) *confi
 	return &configOverrideStore{now: now, pathFn: pathFn, ttl: configOverrideTTL()}
 }
 
+// ConfigOverridePath is the overrides file the engine reads, for callers that
+// need to mutate it rather than observe it — the GPU reset path writes through
+// the same resolution the reader uses so the two can never disagree on which
+// file is authoritative.
+func ConfigOverridePath() string {
+	return resolveConfigOverridePath()
+}
+
 // resolveConfigOverridePath derives the config override path from the same resolution the
 // engine uses for config. It is cheap and only called on cache misses.
 func resolveConfigOverridePath() string {

--- a/tests/e2e/go/assertions/nvidiasmi/checks.go
+++ b/tests/e2e/go/assertions/nvidiasmi/checks.go
@@ -217,6 +217,40 @@ func ProcessMonitorProblems(exitCode int, output string) []string {
 		exitCode, pmonAcceptableExitCodes, output)}
 }
 
+// resetSuccessLine is what nvidia-smi prints per GPU after a successful reset,
+// and resetTrailer closes the report. Both come from real hardware output.
+const (
+	resetSuccessLine = "was successfully reset."
+	resetTrailer     = "All done."
+)
+
+// GpuResetProblems checks that `nvidia-smi --gpu-reset` actually reset wantGPUs
+// devices: exit 0, one success line per GPU, and the trailer.
+//
+// Reset is driven entirely through the internal export table, and the mock used
+// to fault inside its own dispatcher while serving it — the catch-all wrote a
+// zero count through an argument that is not a count on the reset completion
+// slot, so every invocation died with a bare SIGSEGV (exit 139 through kubectl)
+// and no output at all. Asserting the report rather than just a non-crashing
+// exit is deliberate: a reset that silently does nothing would still exit 0.
+func GpuResetProblems(exitCode int, output string, wantGPUs int) []string {
+	if exitCode != 0 {
+		return []string{fmt.Sprintf(
+			"nvidia-smi --gpu-reset exited %d, want 0 (139 is a SIGSEGV through kubectl): %s",
+			exitCode, output)}
+	}
+
+	var problems []string
+	if got := strings.Count(output, resetSuccessLine); got != wantGPUs {
+		problems = append(problems, fmt.Sprintf("nvidia-smi --gpu-reset reported %d %q lines, want %d: %s",
+			got, resetSuccessLine, wantGPUs, output))
+	}
+	if !strings.Contains(output, resetTrailer) {
+		problems = append(problems, fmt.Sprintf("nvidia-smi --gpu-reset omitted %q: %s", resetTrailer, output))
+	}
+	return problems
+}
+
 // EncoderFBCStats are the non-default values issue #636 expects nvidia-smi to
 // surface.
 type EncoderFBCStats struct {

--- a/tests/e2e/go/assertions/nvidiasmi/checks_test.go
+++ b/tests/e2e/go/assertions/nvidiasmi/checks_test.go
@@ -585,6 +585,58 @@ func TestProcessMonitorProblems_RejectsOtherAbnormalExits(t *testing.T) {
 	}
 }
 
+// The real nvidia-smi reset report: one line per GPU naming its PCI bus id,
+// then a single trailer.
+const gpuResetReport = "GPU 00000000:0A:00.0 was successfully reset.\n" +
+	"GPU 00000000:0B:00.0 was successfully reset.\n" +
+	"All done.\n"
+
+func TestGpuResetProblems_AcceptsFullReport(t *testing.T) {
+	assert.Empty(t, GpuResetProblems(0, gpuResetReport, 2))
+	assert.Empty(t, GpuResetProblems(0,
+		"GPU 00000000:0B:00.0 was successfully reset.\nAll done.\n", 1))
+}
+
+// Exit 139 is the SIGSEGV the mock used to die with while serving the reset
+// slots, and the reason this check exists.
+func TestGpuResetProblems_RejectsSegfault(t *testing.T) {
+	problems := GpuResetProblems(139, "command terminated with exit code 139", 1)
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "139")
+}
+
+// A refusal is no longer acceptable: the reset is implemented, so nvidia-smi
+// giving up ("GPU Reset couldn't run...") is a regression rather than a baseline.
+func TestGpuResetProblems_RejectsRefusal(t *testing.T) {
+	for _, code := range []int{3, 255, 2} {
+		assert.NotEmpty(t, GpuResetProblems(code,
+			"GPU Reset couldn't run because it could not be determined if GPU 0 is the primary GPU.", 1),
+			"exit %d", code)
+	}
+}
+
+// Exit 0 with no report means the reset did nothing, which a bare exit-code
+// check would pass.
+func TestGpuResetProblems_RejectsSilentSuccess(t *testing.T) {
+	problems := GpuResetProblems(0, "", 1)
+	require.NotEmpty(t, problems)
+	assert.Contains(t, strings.Join(problems, "; "), "want 1")
+}
+
+// Resetting every GPU must report every GPU; a report covering only the first
+// would mean the walk stopped early.
+func TestGpuResetProblems_RejectsPartialReport(t *testing.T) {
+	problems := GpuResetProblems(0, gpuResetReport, 4)
+	require.NotEmpty(t, problems)
+	assert.Contains(t, problems[0], "want 4")
+}
+
+func TestGpuResetProblems_RejectsMissingTrailer(t *testing.T) {
+	problems := GpuResetProblems(0, "GPU 00000000:0A:00.0 was successfully reset.\n", 1)
+	require.Len(t, problems, 1)
+	assert.Contains(t, problems[0], "All done.")
+}
+
 // The captured document is the defect: every SRAM reading, the source breakdown
 // and the threshold flag are N/A, so a health checker cannot tell a GPU with no
 // SRAM errors from one whose SRAM state is unknown (#641).

--- a/tests/e2e/go/assertions/nvidiasmi/exec.go
+++ b/tests/e2e/go/assertions/nvidiasmi/exec.go
@@ -110,6 +110,32 @@ func ProcessMonitorAndTopology(ctx context.Context, k *kube.Client, pod kube.Pod
 		"nvidia-smi topo -m exited %d: %s", res.ExitCode, res.Combined())
 }
 
+// GpuReset asserts `nvidia-smi --gpu-reset` resets the GPUs it is pointed at and
+// reports it the way real hardware does. Reset runs entirely through the internal
+// export table, where the dispatcher's catch-all used to fault writing a zero
+// count through an argument that carries no count on the reset completion slot —
+// every invocation died with a bare exit 139 and no output.
+//
+// Both spellings are covered because `-r` is the one a runbook or a remediation
+// controller is likely to carry, and both scopes are covered because a bare
+// --gpu-reset walks every GPU while -i names one.
+func GpuReset(ctx context.Context, k *kube.Client, pod kube.PodRef, p profile.Profile) {
+	ginkgo.GinkgoHelper()
+
+	for _, tc := range []struct {
+		args     []string
+		wantGPUs int
+	}{
+		{[]string{"nvidia-smi", "--gpu-reset"}, p.ExpectedGPUs()},
+		{[]string{"nvidia-smi", "-r", "-i", "0"}, 1},
+	} {
+		ginkgo.By(fmt.Sprintf("%s resets %d GPU(s)", strings.Join(tc.args, " "), tc.wantGPUs))
+		res, _ := k.Exec(ctx, pod, tc.args...)
+		problems := GpuResetProblems(res.ExitCode, res.Combined(), tc.wantGPUs)
+		gomega.Expect(problems).To(gomega.BeEmpty(), strings.Join(problems, "\n"))
+	}
+}
+
 // TemperatureThresholds asserts nvidia-smi -q -x uses the
 // architecture-correct threshold presentation for the profile: absolute
 // elements on pre-Ada, *_tlimit_threshold elements on Ada and later. See issue

--- a/tests/e2e/go/scenario_nri_test.go
+++ b/tests/e2e/go/scenario_nri_test.go
@@ -134,6 +134,10 @@ var _ = Describe("nvml-mock node-wide NRI injection", Label("nri"), Ordered, fun
 				assertAgentSeesGPUs(ctx, h, p.ExpectedGPUs())
 			})
 
+			It("resets a GPU with nvidia-smi -r from inside an injected container", Label("nvidia-smi"), Label("nri-inject"), func(ctx SpecContext) {
+				assertGpuResetFromInjectedContainer(ctx, h)
+			})
+
 			// #438. The IB CLI tools are dynamically linked and setup.sh
 			// relocates them into the overlay, which until this change carried
 			// none of their libraries. Nothing in CI ran them from an injected
@@ -800,6 +804,55 @@ func assertAgentSeesGPUs(ctx context.Context, h *harness.Harness, expectedGPUs i
 	pod := firstNRIAgentPod(ctx, h)
 	Expect(visibleGPUCount(ctx, h, pod)).To(Equal(expectedGPUs),
 		"gpu-agent should see %d NRI-injected GPUs", expectedGPUs)
+}
+
+// assertGpuResetFromInjectedContainer runs the reset where a remediation
+// controller runs it: inside a container the mock was injected into, rather than
+// in the nvml-mock pod.
+//
+// The distinction is the whole point of the spec. Clearing a device's bucket
+// rewrites overrides.yaml under an flock, and an injected container reaches that
+// file through the overlay the NRI plugin mounts. While that overlay was
+// read-only end to end, the write failed with EROFS and nvidia-smi reported
+// "GPU Reset couldn't run" on exactly the GPUs that had something to clear, with
+// healthy ones still reporting success through the no-write path. Every other
+// reset spec execs into the nvml-mock pod, where the file is a writable
+// hostPath, so none of them could see it.
+//
+// The injection and the reset are pinned to one node: the overrides are
+// node-local, so a fault injected on another node would not be the state this
+// reset clears.
+func assertGpuResetFromInjectedContainer(ctx SpecContext, h *harness.Harness) {
+	GinkgoHelper()
+	consumer := firstNRIAgentPod(ctx, h)
+	node := podNode(ctx, h, consumer)
+
+	// Distinct from the dynamic baseline and below every profile's shutdown
+	// threshold, so nvidia-smi never clamps the reading.
+	const overrideC = 87
+
+	nvmlMockCtlOnNode(ctx, h, node, "temp", "--gpu", "0", strconv.Itoa(overrideC))
+	DeferCleanup(func(ctx SpecContext) {
+		nvmlMockCtlOnNode(ctx, h, node, "reset")
+	})
+
+	Eventually(func() int {
+		return smiGPUTempC(ctx, h, consumer, 0)
+	}).WithContext(ctx).WithTimeout(runtimeTTLTimeout).WithPolling(runtimeTTLPoll).
+		Should(Equal(overrideC), "the injected container must observe the pinned temperature before the reset")
+
+	By("reset GPU 0 with nvidia-smi -r from the injected container")
+	res, _ := h.Kube.Exec(ctx, consumer, "nvidia-smi", "-r", "-i", "0")
+	problems := nvidiasmi.GpuResetProblems(res.ExitCode, res.Combined(), 1)
+	Expect(problems).To(BeEmpty(), strings.Join(problems, "\n"))
+
+	Eventually(func() int {
+		return smiGPUTempC(ctx, h, consumer, 0)
+	}).WithContext(ctx).WithTimeout(runtimeTTLTimeout).WithPolling(runtimeTTLPoll).
+		Should(BeNumerically("<", overrideC), "GPU 0 should return to the simulator baseline after the reset")
+	Expect(nvmlMockCtlOnNode(ctx, h, node, "status", "--gpu", "0")).
+		To(ContainSubstring("no active overrides for gpu 0"),
+			"a reset from an injected container must clear the override, not just exit 0")
 }
 
 // assertNodeCliqueIdentities runs the staged `check-fabric` consumer inside the

--- a/tests/e2e/go/scenario_runtime_control.go
+++ b/tests/e2e/go/scenario_runtime_control.go
@@ -393,6 +393,78 @@ func assertRuntimeTempCommand(ctx SpecContext, h *harness.Harness, consumer kube
 			"GPU %d temperature should return to the simulator baseline after reset", target)
 }
 
+// assertGpuResetViaNvidiaSmi covers `nvidia-smi --gpu-reset` / `-r` as a
+// remediation an operator or controller actually reaches for: pin a GPU's
+// temperature, reset that GPU through nvidia-smi rather than nvml-mock-ctl, and
+// confirm the device returns to its baseline and the override is gone.
+//
+// The reset performs the same mutation as `nvml-mock-ctl reset --gpu <n>`,
+// reached from the other direction — nvidia-smi drives it through the internal
+// export table, so this is the only test that covers those slots doing real
+// work. Two bugs are guarded at once: the dispatcher's catch-all used to fault
+// writing a zero count through an argument that carries none on the reset
+// completion slot (every reset died with a bare exit 139 and no output), and a
+// reset that reported success while clearing nothing would leave the pinned
+// temperature in place here.
+//
+// Scope is asserted too: nvidia-smi calls the reset slot once per targeted GPU,
+// so `-i <target>` must leave a second pinned GPU alone.
+func assertGpuResetViaNvidiaSmi(ctx SpecContext, h *harness.Harness, consumer kube.PodRef) {
+	GinkgoHelper()
+	resetRuntimeOverrides(ctx, h)
+
+	count := gpuCount(ctx, h, consumer)
+	target := count - 1 // exercise a non-zero index where possible
+	// Distinct from the ~55-70 dynamic baseline and below every profile's
+	// shutdown threshold (min 92), so nvidia-smi never clamps the reading.
+	const overrideC = 87
+
+	baseline := smiGPUTempC(ctx, h, consumer, target)
+	Expect(baseline).NotTo(Equal(overrideC), "baseline temperature must differ from the override for a meaningful assertion")
+
+	By(fmt.Sprintf("pin temperature to %dC on GPU %d via nvml-mock-ctl temp", overrideC, target))
+	nvmlMockCtl(ctx, h, "temp", "--gpu", strconv.Itoa(target), strconv.Itoa(overrideC))
+	if count > 1 {
+		// A second pinned GPU makes the -i scoping assertion below meaningful.
+		nvmlMockCtl(ctx, h, "temp", "--gpu", "0", strconv.Itoa(overrideC))
+	}
+
+	Eventually(func() int {
+		return smiGPUTempC(ctx, h, consumer, target)
+	}).WithContext(ctx).WithTimeout(runtimeTTLTimeout).WithPolling(runtimeTTLPoll).
+		Should(Equal(overrideC), "GPU %d temperature should reflect the override before the reset", target)
+
+	By(fmt.Sprintf("reset GPU %d with nvidia-smi -r", target))
+	res, _ := h.Kube.Exec(ctx, consumer, "nvidia-smi", "-r", "-i", strconv.Itoa(target))
+	problems := nvidiasmi.GpuResetProblems(res.ExitCode, res.Combined(), 1)
+	Expect(problems).To(BeEmpty(), strings.Join(problems, "\n"))
+
+	Eventually(func() int {
+		return smiGPUTempC(ctx, h, consumer, target)
+	}).WithContext(ctx).WithTimeout(runtimeTTLTimeout).WithPolling(runtimeTTLPoll).
+		Should(And(BeNumerically(">", 0), BeNumerically("<", overrideC)),
+			"GPU %d temperature should return to the simulator baseline after nvidia-smi -r", target)
+	Expect(nvmlMockCtl(ctx, h, "status", "--gpu", strconv.Itoa(target))).
+		To(ContainSubstring(fmt.Sprintf("no active overrides for gpu %d", target)),
+			"nvidia-smi -r should clear the target's overrides, like nvml-mock-ctl reset")
+
+	if count > 1 {
+		By("verify the reset is scoped to the target GPU (GPU 0 still pinned)")
+		Expect(smiGPUTempC(ctx, h, consumer, 0)).To(Equal(overrideC),
+			"GPU 0 must keep its override when only GPU %d was reset", target)
+
+		By("a bare nvidia-smi --gpu-reset resets every GPU")
+		all, _ := h.Kube.Exec(ctx, consumer, "nvidia-smi", "--gpu-reset")
+		problems = nvidiasmi.GpuResetProblems(all.ExitCode, all.Combined(), count)
+		Expect(problems).To(BeEmpty(), strings.Join(problems, "\n"))
+		Eventually(func() int {
+			return smiGPUTempC(ctx, h, consumer, 0)
+		}).WithContext(ctx).WithTimeout(runtimeTTLTimeout).WithPolling(runtimeTTLPoll).
+			Should(BeNumerically("<", overrideC), "GPU 0 should return to baseline after a bare --gpu-reset")
+		Expect(nvmlMockCtl(ctx, h, "status")).To(ContainSubstring("no active overrides"))
+	}
+}
+
 // assertRuntimePowerCommand covers the `power` convenience command: pin a GPU's
 // power draw (in watts, the unit nvidia-smi displays) and read it back through
 // power.draw. The command writes both the static and zero-variation dynamic

--- a/tests/e2e/go/scenario_standalone_test.go
+++ b/tests/e2e/go/scenario_standalone_test.go
@@ -137,6 +137,15 @@ var _ = Describe("nvml-mock standalone", Ordered, func() {
 				nvidiasmi.ProcessMonitorAndTopology(ctx, h.Kube, pod)
 			})
 
+			It("resets GPUs through nvidia-smi --gpu-reset", Label("nvidia-smi"), func(ctx SpecContext) {
+				// Reset runs entirely through the internal export table, where
+				// the dispatcher's catch-all used to fault writing a zero count
+				// through an argument that carries none on the completion slot:
+				// an operator reaching for the most common GPU remediation got a
+				// bare exit 139 with no output at all.
+				nvidiasmi.GpuReset(ctx, h.Kube, pod, p)
+			})
+
 			It("reports the profile's platform identity via nvidia-smi", Label("nvidia-smi"), func(ctx SpecContext) {
 				// Issue #642: nvmlDeviceGetPlatformInfo was a generated stub, so
 				// the whole Platform Info block read N/A even on gb200/gb300,
@@ -265,6 +274,14 @@ var _ = Describe("nvml-mock standalone", Ordered, func() {
 
 				It("pins temperature via the nvml-mock-ctl temp command", Label("runtime-control"), func(ctx SpecContext) {
 					assertRuntimeTempCommand(ctx, h, pod)
+				})
+
+				It("resets a GPU via nvidia-smi -r, clearing its overrides", Label("runtime-control"), Label("nvidia-smi"), func(ctx SpecContext) {
+					// The remediation an operator reaches for first, and the
+					// only coverage of the reset export-table slots doing real
+					// work: nvidia-smi must clear the injected state, not just
+					// exit without crashing.
+					assertGpuResetViaNvidiaSmi(ctx, h, pod)
 				})
 
 				It("pins power draw via the nvml-mock-ctl power command", Label("runtime-control"), func(ctx SpecContext) {

--- a/tests/mocknvml/internal_table_tests.go
+++ b/tests/mocknvml/internal_table_tests.go
@@ -75,7 +75,9 @@ import (
 // library on purpose: these tests pin the slots nvidia-smi calls, so a change on
 // either side has to be deliberate.
 const (
+	slotGpuReset            = 20
 	slotDeviceHandleByIndex = 81
+	slotGpuResetComplete    = 197
 	slotProcessListFirst    = 213
 	slotProcessListLast     = 215
 	slotHostMaxPcieLinkGen  = 230
@@ -124,6 +126,7 @@ func testInternalExportTable() []testResult {
 
 	results = append(results, testInternalProcessList(table, handle)...)
 	results = append(results, testInternalHostMaxPcieLinkGen(table, handle)...)
+	results = append(results, testInternalGpuReset(table, handle)...)
 	results = append(results, testInternalOtherSlotsDoNotWrite(table, handle)...)
 	return results
 }
@@ -167,6 +170,62 @@ func testInternalHostMaxPcieLinkGen(table, handle unsafe.Pointer) []testResult {
 				"this as the Host Max PCIe generation", slotHostMaxPcieLinkGen, gen, wantMaxPcieLinkGen)})
 	}
 	return append(results, testResult{name, true, ""})
+}
+
+// testInternalGpuReset checks the two slots behind `nvidia-smi --gpu-reset`
+// (`-r`). They are the exception to the zero-count rule the sweep below
+// enforces: nvidia-smi passes no count to either, so the second argument holds a
+// leftover register value rather than a caller's capacity. Writing a zero
+// through it is what made every reset die with a SIGSEGV, and the fault landed
+// ahead of the slot's debug print, so it left no trace of its own and looked
+// like nvidia-smi crashing on driver state a mock cannot supply.
+//
+// The count is therefore asserted to come back untouched, not zeroed — that is
+// the whole point of excluding these two slots. The guard buffer still has to be
+// untouched, and both slots still have to report success, or nvidia-smi abandons
+// the reset and prints "GPU Reset couldn't run".
+//
+// Slot 20 performs a real reset, which against this fixture means clearing
+// device 0's runtime overrides. There is no overrides file here, so it resolves
+// to a no-op that still exercises the device lookup and the path resolution.
+func testInternalGpuReset(table, handle unsafe.Pointer) []testResult {
+	var results []testResult
+
+	const guardSize = 2 * procEntrySize
+	guard := C.malloc(guardSize)
+	if guard == nil {
+		return append(results, testResult{"internal/gpu_reset", false, "malloc failed"})
+	}
+	defer C.free(guard)
+	want := bytes.Repeat([]byte{guardFill}, guardSize)
+
+	for _, slot := range []int{slotGpuReset, slotGpuResetComplete} {
+		name := fmt.Sprintf("internal/gpu_reset_slot_%d", slot)
+		C.memset(guard, guardFill, guardSize)
+		// The same value nvidia-smi's uninitialized variable held on the call
+		// that faulted, so a stray write shows up as a change from it.
+		const notACount = 65535
+		count := C.uint(notACount)
+
+		ret := C.mockCallSlot(table, C.uint(slot), handle, unsafe.Pointer(&count), guard, nil)
+
+		switch {
+		case ret != 0:
+			results = append(results, testResult{name, false,
+				fmt.Sprintf("slot %d returned %d, want NVML_SUCCESS: nvidia-smi renders anything "+
+					"else as a reset that could not run", slot, ret)})
+		case !bytes.Equal(C.GoBytes(guard, C.int(guardSize)), want):
+			results = append(results, testResult{name, false,
+				fmt.Sprintf("slot %d wrote into a buffer it was never given", slot)})
+		case count != notACount:
+			results = append(results, testResult{name, false,
+				fmt.Sprintf("slot %d wrote %d through an argument that carries no count: "+
+					"this is the write that segfaulted every reset", slot, count)})
+		default:
+			results = append(results, testResult{name, true, ""})
+		}
+	}
+	return results
 }
 
 // testInternalProcessList checks that the process-list slots report the
@@ -219,9 +278,10 @@ func testInternalProcessList(table, handle unsafe.Pointer) []testResult {
 // zero entries.
 //
 // The slots with a known meaning are excluded: the process list writes entries,
-// and the host-max PCIe generation writes a scalar reading. Both are covered by
-// their own test above, so anything still in this loop is a slot we have not
-// identified and must therefore keep treating as a list count.
+// the host-max PCIe generation writes a scalar reading, and the two reset slots
+// take no count at all. Each is covered by its own test above, so anything still
+// in this loop is a slot we have not identified and must therefore keep treating
+// as a list count.
 func testInternalOtherSlotsDoNotWrite(table, handle unsafe.Pointer) []testResult {
 	const name = "internal/other_slots_no_write"
 	var results []testResult
@@ -239,6 +299,9 @@ func testInternalOtherSlotsDoNotWrite(table, handle unsafe.Pointer) []testResult
 			continue
 		}
 		if slot == slotHostMaxPcieLinkGen {
+			continue
+		}
+		if slot == slotGpuReset || slot == slotGpuResetComplete {
 			continue
 		}
 		C.memset(guard, guardFill, guardSize)

--- a/tests/mocknvml/internal_table_tests.go
+++ b/tests/mocknvml/internal_table_tests.go
@@ -225,6 +225,34 @@ func testInternalGpuReset(table, handle unsafe.Pointer) []testResult {
 			results = append(results, testResult{name, true, ""})
 		}
 	}
+
+	// A slot 20 call carrying anything other than a registered device handle is
+	// a probe, not a reset, and the dispatcher's catch-all requires those to see
+	// NVML_SUCCESS: nvidia-smi aborts `topo -m` on any error. Serving the reset
+	// ahead of that guard without checking the handle turned a failed device
+	// lookup into NVML_ERROR_OPERATING_SYSTEM, indistinguishable from a reset
+	// attempted on a real device that failed. The guard buffer is a live
+	// allocation never registered as a device, so it exercises that path.
+	{
+		const name = "internal/gpu_reset_non_device_handle"
+		const notACount = 65535
+		C.memset(guard, guardFill, guardSize)
+		count := C.uint(notACount)
+
+		ret := C.mockCallSlot(table, C.uint(slotGpuReset), guard, unsafe.Pointer(&count), guard, nil)
+
+		switch {
+		case ret != 0:
+			results = append(results, testResult{name, false,
+				fmt.Sprintf("slot %d returned %d for a handle that is not a device, want NVML_SUCCESS: "+
+					"a probe must not read as a reset that could not run", slotGpuReset, ret)})
+		case count != notACount:
+			results = append(results, testResult{name, false,
+				fmt.Sprintf("slot %d wrote %d through an argument that carries no count", slotGpuReset, count)})
+		default:
+			results = append(results, testResult{name, true, ""})
+		}
+	}
 	return results
 }
 
@@ -282,6 +310,22 @@ func testInternalProcessList(table, handle unsafe.Pointer) []testResult {
 // take no count at all. Each is covered by its own test above, so anything still
 // in this loop is a slot we have not identified and must therefore keep treating
 // as a list count.
+// hasDedicatedTest reports whether a slot's meaning is known, which is what
+// keeps it out of the unidentified-slot sweep: each of these is asserted
+// against its real contract by one of the tests above.
+func hasDedicatedTest(slot int) bool {
+	switch {
+	case slot >= slotProcessListFirst && slot <= slotProcessListLast:
+		return true
+	case slot == slotHostMaxPcieLinkGen:
+		return true
+	case slot == slotGpuReset, slot == slotGpuResetComplete:
+		return true
+	default:
+		return false
+	}
+}
+
 func testInternalOtherSlotsDoNotWrite(table, handle unsafe.Pointer) []testResult {
 	const name = "internal/other_slots_no_write"
 	var results []testResult
@@ -295,13 +339,7 @@ func testInternalOtherSlotsDoNotWrite(table, handle unsafe.Pointer) []testResult
 	want := bytes.Repeat([]byte{guardFill}, guardSize)
 
 	for slot := 1; slot < exportTableSlots; slot++ {
-		if slot >= slotProcessListFirst && slot <= slotProcessListLast {
-			continue
-		}
-		if slot == slotHostMaxPcieLinkGen {
-			continue
-		}
-		if slot == slotGpuReset || slot == slotGpuResetComplete {
+		if hasDedicatedTest(slot) {
 			continue
 		}
 		C.memset(guard, guardFill, guardSize)


### PR DESCRIPTION
## Summary

`nvidia-smi --gpu-reset` (`-r`) died with a SIGSEGV on every invocation, so an operator reaching for the most common GPU remediation got a bare exit 139 with no output.

**The fault was ours, not `nvidia-smi`'s.** The internal export-table catch-all for per-device calls ends by writing a zero count through `arg1`, and on slot 197 — reached only while resetting — `arg1` carries no count. That write sits *ahead* of the slot's debug print, so it produced no log line of its own: the trace stopped mid-sequence, which made the crash look like `nvidia-smi` walking into a post-reset re-attach sequence and dying on driver state a mock cannot supply. It isn't, and no driver ioctl is involved. Returning before that write is the whole fix — `nvidia-smi` then completes the reset entirely in-process.

That makes the reset worth *serving* rather than refusing. Slot 20 now calls into Go and clears the device's injected overrides under the same flock `nvml-mock-ctl` takes — the same mutation as `nvml-mock-ctl reset --gpu <n>`. A real reset clears the transient error state that made someone reach for it; on the mock, that state is exactly what was injected. So a remediation controller or runbook that already uses the standard GPU reset works unmodified, and the NVSentinel demo's heal-and-uncordon step can be driven either way.

Scope follows `nvidia-smi` rather than being decided in the mock: it calls the slot once per targeted GPU, so `-i <n>` clears one device and a bare `--gpu-reset` walks every device.

Two consequences of it being per-device are documented rather than worked around (`docs/nvml-mock-ctl.md`):

- State injected with `--gpu all` lives in a shared bucket no per-device reset clears. Verified to match `nvml-mock-ctl reset --gpu <n>` exactly, so this is inherited CLI semantics; `reset --gpu all` is still the way to clear it.
- A GPU with nothing injected is reset without writing the file or taking the lock, so a reset on a healthy GPU cannot fail on a read-only overrides mount.

## Test plan

- [x] `go test ./...` — 39 packages, 0 failures
- [x] `go vet -tags e2e ./tests/e2e/go/...` clean
- [x] `golangci-lint run` clean, including the cgo bridge linted on Linux
- [x] 7 new unit tests for the reset's file logic (scoping, healthy no-op, missing/corrupt file, shared `all:` bucket)
- [x] `GpuResetProblems` asserts the per-GPU report and trailer, not just a non-crashing exit — a reset that silently cleared nothing would still exit 0
- [x] New `assertGpuResetViaNvidiaSmi` runtime-control scenario injects a fault and heals it through `nvidia-smi`, the only coverage of these slots doing real work

Verified against a live kind cluster (gb300 profile, 4 GPUs):

```
$ nvml-mock-ctl fail --gpu 1 --mode lost
$ nvidia-smi -i 1 --query-gpu=temperature.gpu --format=csv,noheader
[GPU is lost]
$ nvidia-smi -r -i 1
GPU 00000000:0B:00.0 was successfully reset.
All done.                                        exit=0
$ nvidia-smi -i 1 --query-gpu=temperature.gpu --format=csv,noheader
63
```

Regression sweep: 19 other `nvidia-smi` views are byte-identical old-vs-new, while `--gpu-reset` goes from exit 139 to exit 0. A separate sweep confirms both reset slots are reset-exclusive — 18 other views reach neither.