### PR TITLE
docs: describe demos in terms of Kubernetes, and fix the Helm claims

### DIFF
--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -5,8 +5,11 @@ End-to-end demos for nvml-mock.
 Most run on any Kubernetes cluster: point your `KUBECONFIG` at one and go.
 Two of them (node-wide injection and ComputeDomain) need containerd NRI
 enabled on every node, so they provision a dedicated Kind cluster instead,
-and say so in their own README. All of them need Helm 3.8+
-(<https://helm.sh/docs/intro/install/>). No cluster? Start with the
+and say so in their own README. Every demo needs Helm
+(<https://helm.sh/docs/intro/install/>), but the floor is not the same for all
+of them: it ranges from 3.6 to 3.13 depending on whether the demo pulls a chart
+from an OCI registry and which flags it uses. Each entry below states its own,
+and each demo's README explains why. No cluster? Start with the
 [quick start](../quickstart.md).
 
 Run one nvml-mock demo per cluster at a time. The chart's hostPath mounts are
@@ -24,7 +27,7 @@ Dedicated cluster (`nvml-mock-node-wide-demo`) with containerd NRI enabled.
 Installs the `nvml-mock-nri` DaemonSet and proves a plain pod can run
 `nvidia-smi` without GPU requests, annotations, or pod-spec mutation.
 
-**Requirements:** Docker, Kind, Helm 3.8+, kubectl (creates its own cluster)
+**Requirements:** Docker, Kind, Helm 3.6+, kubectl (creates its own cluster)
 
 ```bash
 cd node-wide-injection && ./run.sh
@@ -39,7 +42,7 @@ Deploy nvml-mock with FGO-style GPU labels on the cluster your current
 context points at. No external GPU operator is required -- nvml-mock
 generates the labels and ConfigMaps itself.
 
-**Requirements:** KUBECONFIG, Helm 3.8+, kubectl
+**Requirements:** KUBECONFIG, Helm 3.6+, kubectl
 
 ```bash
 cd standalone && ./demo.sh
@@ -51,7 +54,7 @@ Full integration with Run:ai's fake-gpu-operator. nvml-mock handles the
 "integration" node pool (real NVML shim) while FGO handles the "scale" pool
 (lightweight fake shim).
 
-**Requirements:** KUBECONFIG, Helm 3.8+, kubectl, fake-gpu-operator Helm chart
+**Requirements:** KUBECONFIG, Helm 3.8+ (OCI chart), kubectl, fake-gpu-operator Helm chart
 
 See [with-fgo/README.md](with-fgo/README.md) for the step-by-step guide.
 
@@ -65,7 +68,7 @@ scenarios (`healthy`, `ecc_uncorrectable`, `lost`, `fallen_off_bus`),
 upgrading the running release into each one and asserting the result
 against `nvidia-smi` output.
 
-**Requirements:** KUBECONFIG, Helm 3.8+, kubectl
+**Requirements:** KUBECONFIG, Helm 3.6+, kubectl
 
 ```bash
 cd failure-injection && ./run.sh
@@ -86,7 +89,7 @@ the real protocol, not a simulation. Concludes with a `helm upgrade`
 that rebinds every node into a new clique without rebuilding the
 image.
 
-**Requirements:** Docker, Kind, Helm 3.8+, kubectl, jq (creates its own cluster)
+**Requirements:** Docker, Kind, Helm 3.13+, kubectl, jq (creates its own cluster)
 
 ```bash
 cd compute-domain && ./run.sh
@@ -106,7 +109,7 @@ margin crossing via DCGM + the metadata-collector's slowdown offset,
 reschedules to the healthy worker), and then **auto-recovers** — cooling the GPU
 uncordons the node automatically, with no DCGM restart.
 
-**Requirements:** Docker, Kind, Helm 3.8+, kubectl (jq optional; creates its own cluster)
+**Requirements:** Docker, Kind, Helm 3.8+ (OCI chart), kubectl (jq optional; creates its own cluster)
 
 ```bash
 cd nv-sentinel && ./run.sh

--- a/docs/demo/compute-domain/README.md
+++ b/docs/demo/compute-domain/README.md
@@ -44,7 +44,7 @@ The demo expects the following tools on `$PATH`:
 | `bash`    | 3.2+           | `run.sh` uses `set -euo pipefail` — no bash 4+ features. |
 | `jq`      | any recent     | Scenario 2 parses `nvidia-imex-ctl -N -j` JSON. |
 
-Install Helm at the version the table above pins, from the official docs:
+Install Helm at the version the table above lists, from the official docs:
 <https://helm.sh/docs/intro/install/>
 
 New to Mokka? The [quick start](../../quickstart.md) is the fastest way to see

--- a/docs/demo/failure-injection/README.md
+++ b/docs/demo/failure-injection/README.md
@@ -73,8 +73,11 @@ FGO-style labels) — failure injection doesn't need its own topology.
 - **A Kubernetes cluster and a valid `KUBECONFIG`.** This demo installs into
   whatever cluster your current context points at. Check yours with
   `kubectl config current-context`.
-- **Helm 3.8 or newer.** Install it from the official docs:
-  <https://helm.sh/docs/intro/install/>
+- **Helm 3.6 or newer.** The demo installs the chart from this checkout, not
+  from a registry, so 3.6 is the floor: the chart's `_helpers.tpl` uses a
+  multi-line `dict` that only the Go 1.16 template parser in Helm 3.6 accepts.
+  On 3.5 and older, rendering fails with `unclosed action`. Install it from the
+  official docs: <https://helm.sh/docs/intro/install/>
 - `kubectl`, matching your cluster version.
 
 > **No cluster yet?** The [quick start](../../quickstart.md) creates a
@@ -144,15 +147,16 @@ chart. Pin `NVML_MOCK_IMAGE` to a released tag if you need a fixed pairing.
      which only affects the host-side CDI spec.
    * the aggregate uncorrectable ECC counter starts at `0`.
 4. **Scenario 2 — `ecc_uncorrectable` + Xid 79**. Upgrades the
-   release with `mode=ecc_uncorrectable, after_calls=3, xid.code=79`,
+   release with `mode=ecc_uncorrectable, after_calls=1, xid.code=79`,
    recycles the DaemonSet, and asserts:
    * the ConfigMap now contains `mode: ecc_uncorrectable`,
    * `nvidia-smi -L` **still** lists every GPU (mode contract: device
      stays addressable),
-   * `nvidia-smi -q -d ECC` reports a strictly-positive aggregate
-     uncorrectable total — the third guarded NVML call within that
-     same process meets `after_calls: 3`, so the trip fires while the
-     same `nvidia-smi` invocation is still running.
+   * `nvidia-smi --query-gpu=ecc.errors.uncorrected.aggregate.total
+     --format=csv,noheader,nounits` prints a strictly-positive integer
+     for at least one GPU. Each device keeps its own call counter, so
+     that query (one guarded ECC read per GPU) trips every GPU on its
+     first read, inside the one `nvidia-smi` invocation.
 5. **Scenario 3 — `lost`**. Upgrades with `mode=lost, after_calls=1`,
    recycles the DaemonSet, and asserts that
    `nvidia-smi --query-gpu=temperature.gpu --format=csv` surfaces an
@@ -217,15 +221,23 @@ lifetime — matching real NVML semantics. Real consumers see it via:
   wait. Drop those calls and the wait blocks out its timeout forever, no
   matter what `failure.xid` is configured.
 
-### The injector counter is per-process
+### The injector counter is per-process, and per-device within it
 
 Each `kubectl exec ... -- nvidia-smi` is a fresh process with a fresh
-`failureInjector` whose call counter resets to 0. That's why
-Scenario 2 uses `after_calls: 3` (so a single
-`nvidia-smi -q -d ECC` reaches the threshold during its own
-invocation) and Scenarios 3-4 use `after_calls: 1` (the very first
-guarded call trips). For interactive exploration, use a long-running
-process — e.g.
+`failureInjector` whose call counter resets to 0, so a threshold has to
+be met inside a single invocation or it is never met at all. The counter
+is also per-device: each GPU counts its own guarded calls rather than
+sharing one process-wide tally.
+
+That is why all three injection scenarios (2, 3 and 4) use
+`after_calls: 1`. A query issuing exactly one guarded call per GPU, such
+as Scenario 2's `--query-gpu=ecc.errors.uncorrected.aggregate.total`,
+still trips every GPU, because each device reaches its own threshold on
+its own first read. A larger `after_calls` would need a single command
+to hit the same device that many times, which the demo's one-shot
+queries never do.
+
+For interactive exploration, use a long-running process, for example
 
 ```bash
 kubectl --context kind-nvml-mock-failure-demo exec -it "$POD" -- nvidia-smi \
@@ -233,7 +245,7 @@ kubectl --context kind-nvml-mock-failure-demo exec -it "$POD" -- nvidia-smi \
   --format=csv -l 1
 ```
 
-— and watch the counter increment on every poll.
+Watch the counter increment on every poll.
 
 For the full per-mode behaviour contract see
 [`pkg/gpu/mocknvml/README.md#failure-injection-optional`](https://github.com/NVIDIA/k8s-test-infra/blob/main/pkg/gpu/mocknvml/README.md#failure-injection-optional).

--- a/docs/demo/lib/portability_test.sh
+++ b/docs/demo/lib/portability_test.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# macOS ships bash 3.2 and every demo script starts with #!/usr/bin/env bash, so
+# a bash 4 builtin aborts the demo with "command not found" on a stock Mac.
+# nv-sentinel/run.sh shipped `mapfile` and died at run.sh:99, immediately after
+# creating the cluster and before the demo showed anything, while its README
+# advertised Apple Silicon. This scans every demo script for the constructs that
+# bite and names the file, the line and the reason.
+#
+# The fixture cases are not decoration. Three demo scripts deliberately mention
+# `mapfile` in a prose comment warning about this exact trap, so a scanner that
+# fired on comments would be permanently red and would be deleted; a scanner
+# that tolerates comments by matching nothing at all is equally worthless. Every
+# run therefore proves both halves against fixtures: each construct written as
+# code is flagged with its own reason, and the same constructs written as
+# comments are not flagged.
+#
+# Written for bash 3.2 itself: no mapfile, no associative arrays, no ${var,,}.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEMO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SELF="${SCRIPT_DIR}/$(basename "${BASH_SOURCE[0]}")"
+FAILURES=0
+
+# pattern%reason, one per line. The separator is '%' rather than '|' because
+# every useful pattern below needs ERE alternation; a pattern must therefore
+# never contain '%'. The "checks table is well formed" case at the bottom fails
+# if a future row breaks that rule, so this cannot rot into silently truncated
+# patterns that match everything.
+#
+# The version in brackets is the bash release that introduced the construct.
+CHECKS='(^|[^[:alnum:]_.-])mapfile[[:space:]]%mapfile is a bash 4.0 builtin
+(^|[^[:alnum:]_.-])readarray[[:space:]]%readarray is a bash 4.0 builtin
+(^|[^[:alnum:]_.-])(declare|local|typeset)[[:space:]]+-[A-Za-z]*A([[:space:]]|$)%associative arrays (declare -A) are bash 4.0
+(^|[^[:alnum:]_.-])(declare|local|typeset)[[:space:]]+-[A-Za-z]*n([[:space:]]|$)%namerefs (declare -n) are bash 4.3
+(^|[^[:alnum:]_.-])(declare|typeset)[[:space:]]+-[A-Za-z]*g([[:space:]]|$)%declare -g is bash 4.2
+\$\{[A-Za-z0-9_]+(\[[^]]*\])?(,,|,|\^\^|\^)%${var,,} and ${var^^} case modification is bash 4.0
+\$\{[A-Za-z0-9_]+(\[[^]]*\])?@[A-Za-z]\}%${var@Q} parameter transformation is bash 4.4
+(^|[^[:alnum:]_.-])wait[[:space:]]+-n([[:space:]]|$)%wait -n is bash 4.3
+&>>%&>> append redirection is bash 4.0
+\|&%|& as shorthand for 2>&1 | is bash 4.0
+(^|[^[:alnum:]_.-])coproc([[:space:]]|$)%coproc is bash 4.0
+(^|[^[:alnum:]_.-])shopt[[:space:]].*globstar%shopt -s globstar is bash 4.0
+(^|[^[:alnum:]_.-])shopt[[:space:]].*lastpipe%shopt -s lastpipe is bash 4.2
+(^|[^[:alnum:]_.-])read[[:space:]]+-[A-Za-z]*N([[:space:]]|$)%read -N is bash 4.1
+(^|[^[:alnum:]_.-])read[[:space:]]+-[A-Za-z]*i([[:space:]]|$)%read -i is bash 4.0
+;;&%the ;;& case fall-through is bash 4.0
+\[\[[[:space:]]+-v[[:space:]]%[[ -v name ]] is bash 4.2
+(^|[^[:alnum:]_.-])(EPOCHSECONDS|EPOCHREALTIME)([^[:alnum:]_]|$)%EPOCHSECONDS and EPOCHREALTIME are bash 5.0
+(^|[^[:alnum:]_.-])SRANDOM([^[:alnum:]_]|$)%SRANDOM is bash 5.1'
+
+# Strip comments before matching. A leading-whitespace-or-start-of-line '#'
+# begins a comment for our purposes, which is what the four intentional
+# "no mapfile" warnings in this tree look like. It over-strips a '#' that sits
+# inside a double-quoted string after a space, which can only lose a hit, never
+# invent one; the fixture cases below are what keep the code half honest.
+strip_comments() {
+    sed 's/[[:space:]]#.*$//; s/^#.*$//' "$1"
+}
+
+# Scans one directory of *.sh files. Prints "path:line  reason" per hit and
+# leaves the count in SCAN_HITS. Every loop is fed by a heredoc rather than a
+# pipe so it runs in this shell and SCAN_HITS survives.
+SCAN_HITS=0
+scan() {
+    local dir="$1" skip="${2:-}"
+    local file pattern reason hit stripped
+    SCAN_HITS=0
+    while IFS= read -r file; do
+        [ -z "${file}" ] && continue
+        if [ -n "${skip}" ] && [ "${file}" = "${skip}" ]; then
+            continue
+        fi
+        stripped="$(strip_comments "${file}")"
+        while IFS='%' read -r pattern reason; do
+            [ -z "${pattern}" ] && continue
+            while IFS= read -r hit; do
+                [ -z "${hit}" ] && continue
+                printf '%s:%s  %s\n' "${file}" "${hit%%:*}" "${reason}"
+                SCAN_HITS=$((SCAN_HITS + 1))
+            done <<INNER
+$(printf '%s\n' "${stripped}" | grep -nE "${pattern}")
+INNER
+        done <<TABLE
+${CHECKS}
+TABLE
+    done <<FILES
+$(find "${dir}" -type f -name '*.sh' | sort)
+FILES
+}
+
+fail() {
+    echo "FAIL $1"
+    FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+    echo "ok   $1"
+}
+
+###############################################################################
+# Case 0: the checks table is well formed. A row whose pattern swallowed the
+# separator would leave an empty reason and a pattern that matches far more than
+# it should, which is exactly the failure mode that makes a guard useless while
+# it still exits 0.
+###############################################################################
+ROWS=0
+while IFS='%' read -r pattern reason; do
+    ROWS=$((ROWS + 1))
+    if [ -z "${pattern}" ] || [ -z "${reason}" ]; then
+        fail "checks row ${ROWS} does not split into pattern and reason"
+    fi
+    case "${reason}" in
+        *%*) fail "checks row ${ROWS} has more than one '%' separator" ;;
+    esac
+done <<TABLE
+${CHECKS}
+TABLE
+if [ "${ROWS}" -lt 10 ]; then
+    fail "only ${ROWS} checks defined; the table has been gutted"
+else
+    pass "checks table is well formed (${ROWS} constructs)"
+fi
+
+###############################################################################
+# Case 1: the scan actually reaches the demo scripts. "No bash 4 constructs
+# found" means nothing if the file list was empty, which a moved directory or a
+# broken find would produce silently.
+###############################################################################
+SCANNED=0
+SAW_SENTINEL=0
+while IFS= read -r f; do
+    [ -z "${f}" ] && continue
+    [ "${f}" = "${SELF}" ] && continue
+    SCANNED=$((SCANNED + 1))
+    case "${f}" in
+        */nv-sentinel/run.sh) SAW_SENTINEL=1 ;;
+    esac
+done <<FILES
+$(find "${DEMO_DIR}" -type f -name '*.sh' | sort)
+FILES
+if [ "${SCANNED}" -lt 5 ]; then
+    fail "only ${SCANNED} demo scripts found under ${DEMO_DIR}; the scan is empty"
+else
+    pass "scan covers ${SCANNED} demo scripts"
+fi
+if [ "${SAW_SENTINEL}" -ne 1 ]; then
+    fail "nv-sentinel/run.sh was not in the scan list"
+else
+    pass "nv-sentinel/run.sh is in the scan list"
+fi
+
+###############################################################################
+# Case 2: every construct in the table is detected when written as code. This
+# is per-construct: a pattern that stops matching takes its own reason out of
+# the output and only that case goes red.
+###############################################################################
+FIXDIR="$(mktemp -d 2>/dev/null)" || FIXDIR=""
+if [ -z "${FIXDIR}" ] || [ ! -d "${FIXDIR}" ]; then
+    echo "FATAL: mktemp -d failed (TMPDIR=${TMPDIR:-unset}). Without fixtures the" >&2
+    echo "       scan below would be green whether or not it discriminates." >&2
+    exit 1
+fi
+trap 'rm -rf "${FIXDIR}"' EXIT
+
+mkdir -p "${FIXDIR}/code" "${FIXDIR}/comment"
+cat >"${FIXDIR}/code/bash4.sh" <<'FIXTURE'
+#!/usr/bin/env bash
+mapfile -t ARR < <(printf 'a\n')
+readarray -t ARR2 < <(printf 'a\n')
+declare -A MAP
+local -A LMAP
+typeset -A TMAP
+declare -n REF=ARR
+declare -g GLOBAL_THING=1
+LOWER="${NAME,,}"
+UPPER="${NAME^^}"
+QUOTED="${NAME@Q}"
+wait -n
+runthing &>>/var/log/thing
+runthing |& cat
+coproc CO { cat; }
+shopt -s globstar
+shopt -s lastpipe
+read -N 4 CHUNK
+read -i default -e ANSWER
+case x in a) echo a ;;& *) echo b ;; esac
+echo "${EPOCHSECONDS}"
+echo "${SRANDOM}"
+[[ -v NAME ]] && echo yes
+FIXTURE
+
+scan "${FIXDIR}/code" >"${FIXDIR}/code.out"
+MISSED=0
+while IFS='%' read -r pattern reason; do
+    [ -z "${reason}" ] && continue
+    if ! grep -qF -- "${reason}" "${FIXDIR}/code.out"; then
+        fail "code fixture was not flagged for: ${reason}"
+        MISSED=$((MISSED + 1))
+    fi
+done <<TABLE
+${CHECKS}
+TABLE
+if [ "${MISSED}" -eq 0 ]; then
+    pass "every construct in the table is flagged when written as code"
+fi
+
+###############################################################################
+# Case 3: the same constructs written as comments are NOT flagged. Without this
+# the cheapest way to make the guard green is to make it match nothing, and the
+# three intentional "no mapfile" warnings already in this tree would break it.
+###############################################################################
+cat >"${FIXDIR}/comment/warned.sh" <<'FIXTURE'
+#!/usr/bin/env bash
+# Written for bash 3.2: no mapfile -t, no readarray -t, no declare -A MAP,
+# no declare -n REF, no declare -g X, no ${NAME,,}, no ${NAME^^}, no ${NAME@Q},
+# no wait -n, no coproc CO, no shopt -s globstar, no shopt -s lastpipe,
+# no read -N 4 X, no read -i default X, no [[ -v NAME ]], no ${EPOCHSECONDS},
+# no ${SRANDOM}, no thing &>>/var/log/thing, no thing |& cat, no ;;& in case.
+echo "portable"   # not even mapfile -t ARR in a trailing comment
+FIXTURE
+
+scan "${FIXDIR}/comment" >/dev/null
+if [ "${SCAN_HITS}" -ne 0 ]; then
+    fail "comment fixture produced ${SCAN_HITS} hit(s); the guard fires on prose"
+    scan "${FIXDIR}/comment" | sed 's/^/      /'
+else
+    pass "constructs mentioned only in comments are not flagged"
+fi
+
+###############################################################################
+# Case 4: the real scan. This is the guard itself.
+###############################################################################
+# Redirected to a file rather than captured with $(...): command substitution
+# forks, and SCAN_HITS set inside a subshell would never reach this comparison.
+scan "${DEMO_DIR}" "${SELF}" >"${FIXDIR}/real.out"
+if [ "${SCAN_HITS}" -ne 0 ]; then
+    echo "FAIL ${SCAN_HITS} bash 4 construct(s) in the demo scripts:"
+    sed 's/^/      /' "${FIXDIR}/real.out"
+    FAILURES=$((FAILURES + SCAN_HITS))
+else
+    pass "all demo scripts are bash 3.2 compatible"
+fi
+
+if [ "${FAILURES}" -ne 0 ]; then
+    echo "${FAILURES} failure(s)"
+    exit 1
+fi
+echo "all portability tests passed"

--- a/docs/demo/node-wide-injection/README.md
+++ b/docs/demo/node-wide-injection/README.md
@@ -19,8 +19,11 @@ delivered ambiently through NRI instead of the nvml-mock DaemonSet pod.
 
 - **Docker**, with the daemon running.
 - **Kind**, to provision the demo's dedicated cluster.
-- **Helm 3.8 or newer.** Install it from the official docs:
-  <https://helm.sh/docs/intro/install/>
+- **Helm 3.6 or newer.** The demo installs the chart from this checkout, not
+  from a registry, so 3.6 is the floor: the chart's `_helpers.tpl` uses a
+  multi-line `dict` that only the Go 1.16 template parser in Helm 3.6 accepts.
+  On 3.5 and older, rendering fails with `unclosed action`. Install it from the
+  official docs: <https://helm.sh/docs/intro/install/>
 - `kubectl`.
 
 New to Mokka? The [quick start](../../quickstart.md) is the fastest way to see
@@ -180,6 +183,10 @@ the demo resources:
 
 ```bash
 kubectl --context kind-nvml-mock-node-wide-demo -n default delete daemonset gpu-agent --ignore-not-found
-helm uninstall nvml-mock --kube-context kind-nvml-mock-node-wide-demo --namespace mokka --ignore-not-found
+helm uninstall nvml-mock --kube-context kind-nvml-mock-node-wide-demo --namespace mokka
 kubectl --context kind-nvml-mock-node-wide-demo delete namespace mokka --ignore-not-found
 ```
+
+`helm uninstall` gained `--ignore-not-found` only in 3.13, so on the 3.6 floor
+above it exits non-zero when the release is already gone. That message is safe
+to ignore; the two `kubectl` lines around it are quiet either way.

--- a/docs/demo/nv-sentinel/README.md
+++ b/docs/demo/nv-sentinel/README.md
@@ -60,7 +60,10 @@ workload reschedules onto the second, healthy worker.
 
 - **Docker**, with the daemon running.
 - **Kind**, to provision the demo's dedicated cluster.
-- **Helm 3.8 or newer.** Install it from the official docs:
+- **Helm 3.8 or newer.** This demo installs NVSentinel from
+  `oci://ghcr.io/nvidia/nvsentinel`, and OCI registry support is what needs
+  3.8; the nvml-mock chart itself comes from this checkout and would render on
+  3.6. Install it from the official docs:
   <https://helm.sh/docs/intro/install/>
 - `kubectl`.
 - `jq` (optional, only used to pretty-print node conditions).

--- a/docs/demo/nv-sentinel/run.sh
+++ b/docs/demo/nv-sentinel/run.sh
@@ -94,7 +94,13 @@ if ! kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
 fi
 
 # Worker node names == docker container names (default kind naming).
-mapfile -t WORKERS < <(kind get nodes --name "${CLUSTER_NAME}" | grep -v control-plane | sort)
+# Populated with a while-read loop rather than mapfile: mapfile is a bash 4.0
+# builtin and macOS ships bash 3.2, where it aborts the demo outright with
+# "mapfile: command not found" before anything has been demonstrated.
+WORKERS=()
+while IFS= read -r worker_node; do
+  [ -n "${worker_node}" ] && WORKERS+=("${worker_node}")
+done < <(kind get nodes --name "${CLUSTER_NAME}" | grep -v control-plane | sort)
 [[ "${#WORKERS[@]}" -ge 1 ]] || fail "no worker nodes found"
 info "GPU workers: ${WORKERS[*]}"
 

--- a/docs/demo/standalone/README.md
+++ b/docs/demo/standalone/README.md
@@ -11,8 +11,11 @@ the node labels that downstream consumers expect.
 - **A Kubernetes cluster and a valid `KUBECONFIG`.** This demo installs into
   whatever cluster your current context points at. Check yours with
   `kubectl config current-context`.
-- **Helm 3.8 or newer.** Install it from the official docs:
-  <https://helm.sh/docs/intro/install/>
+- **Helm 3.6 or newer.** The demo installs the chart from this checkout, not
+  from a registry, so 3.6 is the floor: the chart's `_helpers.tpl` uses a
+  multi-line `dict` that only the Go 1.16 template parser in Helm 3.6 accepts.
+  On 3.5 and older, rendering fails with `unclosed action`. Install it from the
+  official docs: <https://helm.sh/docs/intro/install/>
 - `kubectl`, matching your cluster version.
 
 > **No cluster yet?** The [quick start](../../quickstart.md) creates a

--- a/docs/demo/with-fgo/README.md
+++ b/docs/demo/with-fgo/README.md
@@ -44,6 +44,11 @@ cluster you already have: Step 1, which creates a throwaway Kind cluster, and
 Step 2, which builds the image from source. Skip both and Step 3 installs the
 published image.
 
+Steps 1 and 2 name paths inside this repository (`docs/demo/kind.yaml`,
+`deployments/nvml-mock/Dockerfile`), so run the commands in this guide from the
+root of a checkout. Steps 3 to 5 only need `kubectl` and `helm` and work from
+any directory.
+
 ## Step 1 (Optional) -- Create a Kind cluster
 
 Skip this if your `KUBECONFIG` already points at a cluster whose nodes carry
@@ -136,10 +141,21 @@ kubectl --context kind-nvml-mock-fgo-demo exec "${POD}" -- ibstatus
 
 ### Scale pool (fake-gpu-operator)
 
+FGO names each pod after the component it runs and labels it to match
+(`app=device-plugin`, `app=status-updater`, `app=topology-server` and so on).
+No FGO object carries `app=fake-gpu-operator`, so that selector, which this
+guide used to show, matched nothing in any namespace and still exited 0, which
+reads as "no pods yet" rather than "wrong query". List the release namespace
+Step 4 installed into and read the NODE column instead:
+
 ```bash
-# FGO pods should be running on the scale workers.
-kubectl --context kind-nvml-mock-fgo-demo get pods -l app=fake-gpu-operator -o wide
+kubectl --context kind-nvml-mock-fgo-demo get pods -n gpu-operator -o wide
 ```
+
+The `device-plugin` DaemonSet is the part that lands on the scale workers:
+FGO's status-updater labels those nodes `nvidia.com/gpu.deploy.device-plugin=true`
+from the topology you passed in Step 4. The remaining components are
+single-replica Deployments with no node selector and can land anywhere.
 
 ## Expected outcome
 

--- a/docs/helm-chart.md
+++ b/docs/helm-chart.md
@@ -254,7 +254,11 @@ Expected: `4` (default gpu.count, derived from the `gb300` profile's four device
 kind delete cluster --name nvml-mock-dra
 ```
 
-## Quick Start: GPU Operator on KIND
+## Quick Start: GPU Operator on Kind
+
+These steps bootstrap a Kind node with nvidia-container-toolkit. On a cluster
+that already has a container runtime configured for CDI, skip to
+[the GPU Operator demo](demo/with-gpu-operator/README.md).
 
 This path validates the NVIDIA GPU Operator stack (device plugin, GFD, validator)
 using CDI mode with mock GPUs. `tests/e2e/kind-gpu-operator-config.yaml` and

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ though real hardware were present. No physical NVIDIA GPU is required.
 
 -   **Quick Start**
 
-    Install into a KIND cluster and see simulated GPUs in five minutes.
+    Install into any Kubernetes cluster and see simulated GPUs in five minutes.
 
     [Get started](quickstart.md)
 


### PR DESCRIPTION
## Problem

Earlier PRs in this stack changed what the demos do. This one makes the prose match, and
corrects version claims that are demonstrably wrong.

Three of them were not wording issues at all:

- `docs/demo/node-wide-injection/README.md` told readers to run
  `helm uninstall ... --ignore-not-found` under a stated floor of Helm 3.8. That flag
  arrives in 3.13, so a reader on the documented floor gets `unknown flag`.
- The Helm floor itself was asserted as 3.8 across pages that install from the local
  chart path, where nothing needs 3.8. Rendering this chart under 3.2.4, 3.5.4, 3.6.3,
  3.7.2 and 3.8.2 shows the real floor is **3.6**: everything below it dies with
  `parse error at (nvml-mock/templates/_helpers.tpl:156): unclosed action`, because the
  multi-line `dict` there needs the Go 1.16 template parser first shipped in Helm 3.6.
  3.6.3 and 3.8.2 render byte-identical output.
- `docs/demo/failure-injection/README.md` documented `after_calls=3` for Scenario 2 and
  built a whole passage explaining why that scenario differs from 3 and 4. The script
  uses `after_calls=1` for all three, and the real reason is that each device has its
  own call counter.

## Approach

Version claims are now stated per page and per what that page's commands actually do:

| Page | Floor | Why |
|---|---|---|
| standalone, failure-injection, node-wide-injection | 3.6 | installs the chart from this checkout |
| with-fgo, quickstart | 3.8 | installs from an OCI registry |
| nv-sentinel | 3.8 | installs NVSentinel from an OCI registry |
| compute-domain | its own tool table (v3.13+) | unchanged, it already pinned a version |

`docs/demo/README.md` no longer asserts one floor for all demos, because there isn't one.

The `--ignore-not-found` flag is dropped from the `helm uninstall`, with a note saying
why, rather than raising that page's floor to 3.13 for a flag the demo does not need.

The `after_calls` passage is rewritten from the source rather than patched: the value is
1, and the explanation now matches `failure_injector.go`, which tracks guarded calls per
device.

Prose describing the portable demos now says they install into the cluster your current
context points at. Genuine Kind references are left alone: the `kind.yaml` topologies,
the `BUILD_LOCAL` path, and the three demos that really do create their own cluster.

## Testing

- `make helm-tests` rc=0 (170 tests, 13 snapshots).
- `preflight_test.sh` 133 checks rc=0 and `portability_test.sh` 6 checks rc=0, both
  unaffected: this PR's own commit changes no script.
- `hack/check-docs-tools-sync.sh` rc=0.
- `make docs` rc=0: the strict build and the `exclude_docs` canary both pass.
- All seven demo READMEs still carry the KUBECONFIG prerequisite, the official Helm
  install link and the quick-start pointer.
- Every remaining `Helm 3.x` claim and every `after_calls` mention re-derived from the
  tree rather than edited in place.

`make docs` now runs on this branch, so the link-resolution and fence-balance check
that stood in for it is dropped. Running it needed a Python 3.12 interpreter, which
confirms the diagnosis below rather than working around it.

The earlier claim here, that `pymdown-extensions==11.0.1` is absent from the package
index, was wrong, and the correction matters because it points at the actual fix.
The release exists and declares `requires_python: >=3.10`. This branch's `docs-deps`
runs `$(PYTHON) -m pip` with `PYTHON ?= python3`, which on macOS resolves to Xcode's
Python 3.9.6, so pip filters the release out and reports the index as topping out at
10.21.3. The pin is fine; the interpreter is too old. Building the docs venv with
`uv venv --python 3.12` and pointing `MKDOCS` and `PYTHON` at it builds clean, which
is what #704 fixes properly.

## Breaking changes

None. Documentation only; no script is touched.

## Stack

PR 7 of 7, stacked on #772. GitHub shows the cumulative diff because a cross-fork PR
cannot use a fork branch as its base; the change belonging to this PR is its last
commit. #761, #762, #763 and #770 are merged. Only #772 still needs to land first.

#769 needs no merge. It sat under #770, and since a cross-fork PR is based on `main`,
the #770 squash (3b7f630a) carried #769's changes in with it: `preflight.sh` is
byte-identical in main, and the sibling-release checks #769 added were replaced by
#770's cluster-wide co-location guard. #769 should be closed rather than merged.

Rebased onto main on 2026-09-08 with `git rebase --onto upstream/main 2e53dcb2`,
dropping this branch's copies of the two commits that the #770 squash absorbed. The
two remaining commits replay unchanged: the #772 patch is byte-identical, and this
PR's patch differs only in one blob index line, because main's `nvml-mock-nri` to
`nri-plugin` rename changed the parent blob of `docs/helm-chart.md`. Both edits to
that file coexist.

Greptile findings from earlier in the stack are in main already: the co-location
guard is cluster-wide, refuses when it cannot list, and names the namespace the
sibling is actually in; PRIOR_CONTEXT is captured before the cluster is created;
image values use `--set-string`; and the GPU Operator demo sets
`GFD_MACHINE_TYPE_FILE` to match the CI overlay.
