### PR TITLE
fix(lint): tolerate the unused staticcheck nolints in podresources.go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -123,6 +123,24 @@ linters:
         linters:
           - nolintlint
         text: 'directive .* is unused'
+      # pkg/gpu/allocwatch/podresources.go dials the kubelet pod-resources socket
+      # with grpc.DialContext + grpc.WithBlock, both marked "Deprecated: ... Will
+      # be supported throughout 1.x" by grpc-go. The blocking-with-timeout dial
+      # they provide has no NewClient equivalent, and the //nolint:staticcheck
+      # directives on those two lines are what keeps SA1019 quiet.
+      #
+      # Whether staticcheck actually raises SA1019 there is not stable across
+      # analysis environments: the same commit, toolchain and linter version
+      # reports it locally (directives used, tree clean) and does not report it
+      # on the pull_request runner (directives unused, two nolintlint errors, a
+      # red gate on every PR touching nothing near this file). Dropping the
+      # directives just inverts which environment is red. Scoping the "unused
+      # directive" tolerance to this one file keeps stale nolints flagged
+      # everywhere else, exactly as the nvml-mock-nri carve-out above does.
+      - path: ^pkg/gpu/allocwatch/podresources\.go$
+        linters:
+          - nolintlint
+        text: 'directive .* is unused'
 
 issues:
   # Report every occurrence, not the first three. The default of 3 groups by


### PR DESCRIPTION
## Summary

Every `pull_request` run of `golang / check` currently fails on two `nolintlint`
errors in `pkg/gpu/allocwatch/podresources.go` — a file the affected PRs do not
touch (see [#773](https://github.com/NVIDIA/k8s-test-infra/pull/773), where the
whole e2e matrix and the push-event `basic / golang / check` are green and only
this gate is red):

```
pkg/gpu/allocwatch/podresources.go:67:63: directive `//nolint:staticcheck // DialContext/WithBlock give blocking-with-timeout semantics NewClient cannot express; supported through grpc-go 1.x` is unused for linter "staticcheck" (nolintlint)
pkg/gpu/allocwatch/podresources.go:69:21: directive `//nolint:staticcheck // blocking dial semantics; see the DialContext nolint above` is unused for linter "staticcheck" (nolintlint)
```

The directives sit on `grpc.DialContext` and `grpc.WithBlock`, both marked
`Deprecated: ... Will be supported throughout 1.x` in grpc-go (still true in the
vendored 1.83.2). They are load-bearing wherever staticcheck raises SA1019, and
dead weight wherever it does not — and which of those happens is not stable
across analysis environments.

## Why not one of the other fixes

- **Removing the directives** only inverts which environment goes red: SA1019
  surfaces wherever staticcheck does report it.
- **Migrating to `grpc.NewClient`** would change the dial semantics the comments
  there deliberately rely on — the blocking dial is what makes a missing or
  unmountable socket fail at startup rather than leaving the watcher reporting a
  permanently idle node, which is indistinguishable from a genuinely idle one.

So this scopes the "unused directive" tolerance to this one file, mirroring the
carve-out `cmd/nvml-mock-nri/main.go` already carries for the Darwin/Linux
version of the same problem. Stale nolints everywhere else stay flagged
(`allow-unused` stays at its default `false`).

## Test plan

- [x] `golangci-lint config verify` passes
- [x] `golangci-lint run ./pkg/gpu/allocwatch/...` → `0 issues`
- [x] Reproduction attempts against the exact CI environment (Go 1.26.7,
      golangci-lint v2.13.2, linux/amd64, cold cache, `./...`, on the merge
      commit CI builds) — clean locally, which is the asymmetry this works around
- [ ] `golang / check` green on this PR