### PR TITLE
refactor(mocknvml): describe the host CPU as cpu.type, not grace_superchip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   public NVML APIs.
 
 ### Changed
+- mocknvml: the `grace_superchip:` profile block is now `cpu:`, with `cpu_cores`
+  and `cpu_memory_gb` renamed to `cores` and `memory_gb` and the `enabled` flag
+  replaced by a free-form `type:` (`grace` on the gb200 and gb300 profiles). The
+  old key hardcoded one CPU family into the schema, so a profile for a part
+  behind any other host had no way to describe it. A profile that omits the
+  block makes no claim about its host, which is the honest reading for a PCIe or
+  SXM part. Profiles carrying `grace_superchip:` must be updated — the key is no
+  longer read.
 - The NRI plugin binary is renamed from `nvml-mock-nri` to `nri-plugin`, and its
   injection logic moves from `pkg/nri/nvmlmock` into `internal/`. The chart gains
   `nri.logging.level` and `nri.logging.format`, and `nri.*` values are now

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/gb200.yaml
@@ -383,12 +383,12 @@ device_defaults:
     fifth_gen_tensor_cores: true    # 5th generation tensor cores
 
   # ---------------------------------------------------------------------------
-  # Grace CPU pairing (GB200 specific)
+  # Host CPU pairing (GB200 superchip)
   # ---------------------------------------------------------------------------
-  grace_superchip:
-    enabled: true
-    cpu_cores: 72                   # Grace CPU cores
-    cpu_memory_gb: 480              # LPDDR5X per Grace CPU
+  cpu:
+    type: "grace"                   # NVLink-C2C attached Grace, not a PCIe host
+    cores: 72                       # Grace CPU cores
+    memory_gb: 480                  # LPDDR5X per Grace CPU
     coherent_memory: true           # NVLink-C2C coherent memory
 
   # ---------------------------------------------------------------------------

--- a/deployments/nvml-mock/helm/nvml-mock/profiles/gb300.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/profiles/gb300.yaml
@@ -386,12 +386,12 @@ device_defaults:
     fifth_gen_tensor_cores: true    # 5th generation tensor cores
 
   # ---------------------------------------------------------------------------
-  # Grace CPU pairing (GB300 superchip)
+  # Host CPU pairing (GB300 superchip)
   # ---------------------------------------------------------------------------
-  grace_superchip:
-    enabled: true
-    cpu_cores: 72                   # Grace CPU cores (same Grace as GB200)
-    cpu_memory_gb: 480              # LPDDR5X per Grace CPU
+  cpu:
+    type: "grace"                   # NVLink-C2C attached Grace, not a PCIe host
+    cores: 72                       # Grace CPU cores (same Grace as GB200)
+    memory_gb: 480                  # LPDDR5X per Grace CPU
     coherent_memory: true           # NVLink-C2C coherent memory
 
   # ---------------------------------------------------------------------------

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/configmap_test.yaml.snap
@@ -1353,12 +1353,12 @@ should match snapshot with default gb300 profile:
             fifth_gen_tensor_cores: true    # 5th generation tensor cores
 
           # ---------------------------------------------------------------------------
-          # Grace CPU pairing (GB300 superchip)
+          # Host CPU pairing (GB300 superchip)
           # ---------------------------------------------------------------------------
-          grace_superchip:
-            enabled: true
-            cpu_cores: 72                   # Grace CPU cores (same Grace as GB200)
-            cpu_memory_gb: 480              # LPDDR5X per Grace CPU
+          cpu:
+            type: "grace"                   # NVLink-C2C attached Grace, not a PCIe host
+            cores: 72                       # Grace CPU cores (same Grace as GB200)
+            memory_gb: 480                  # LPDDR5X per Grace CPU
             coherent_memory: true           # NVLink-C2C coherent memory
 
           # ---------------------------------------------------------------------------
@@ -1879,12 +1879,12 @@ should match snapshot with gb200 profile:
             fifth_gen_tensor_cores: true    # 5th generation tensor cores
 
           # ---------------------------------------------------------------------------
-          # Grace CPU pairing (GB200 specific)
+          # Host CPU pairing (GB200 superchip)
           # ---------------------------------------------------------------------------
-          grace_superchip:
-            enabled: true
-            cpu_cores: 72                   # Grace CPU cores
-            cpu_memory_gb: 480              # LPDDR5X per Grace CPU
+          cpu:
+            type: "grace"                   # NVLink-C2C attached Grace, not a PCIe host
+            cores: 72                       # Grace CPU cores
+            memory_gb: 480                  # LPDDR5X per Grace CPU
             coherent_memory: true           # NVLink-C2C coherent memory
 
           # ---------------------------------------------------------------------------

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -378,7 +378,7 @@ should match snapshot with default values:
       template:
         metadata:
           annotations:
-            checksum/config: fe6f2984729290d4ca69845836d40df01d3e5c857db8c170dbbbf185a7228bc4
+            checksum/config: c6dfd465923cdd4faa1c33e2324dec08654aa238f27ea884499079f4680f5578
           labels:
             app.kubernetes.io/component: daemon
             app.kubernetes.io/instance: RELEASE-NAME

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-gb200.yaml
@@ -320,12 +320,12 @@ device_defaults:
     fifth_gen_tensor_cores: true    # 5th generation tensor cores
 
   # ---------------------------------------------------------------------------
-  # Grace CPU pairing (GB200 specific)
+  # Host CPU pairing (GB200 superchip)
   # ---------------------------------------------------------------------------
-  grace_superchip:
-    enabled: true
-    cpu_cores: 72                   # Grace CPU cores
-    cpu_memory_gb: 480              # LPDDR5X per Grace CPU
+  cpu:
+    type: "grace"                   # NVLink-C2C attached Grace, not a PCIe host
+    cores: 72                       # Grace CPU cores
+    memory_gb: 480                  # LPDDR5X per Grace CPU
     coherent_memory: true           # NVLink-C2C coherent memory
 
   # ---------------------------------------------------------------------------

--- a/pkg/gpu/mocknvml/configs/mock-nvml-config-gb300.yaml
+++ b/pkg/gpu/mocknvml/configs/mock-nvml-config-gb300.yaml
@@ -323,12 +323,12 @@ device_defaults:
     fifth_gen_tensor_cores: true    # 5th generation tensor cores
 
   # ---------------------------------------------------------------------------
-  # Grace CPU pairing (GB300 superchip)
+  # Host CPU pairing (GB300 superchip)
   # ---------------------------------------------------------------------------
-  grace_superchip:
-    enabled: true
-    cpu_cores: 72                   # Grace CPU cores (same Grace as GB200)
-    cpu_memory_gb: 480              # LPDDR5X per Grace CPU
+  cpu:
+    type: "grace"                   # NVLink-C2C attached Grace, not a PCIe host
+    cores: 72                       # Grace CPU cores (same Grace as GB200)
+    memory_gb: 480                  # LPDDR5X per Grace CPU
     coherent_memory: true           # NVLink-C2C coherent memory
 
   # ---------------------------------------------------------------------------

--- a/pkg/gpu/mocknvml/engine/config_profiles_test.go
+++ b/pkg/gpu/mocknvml/engine/config_profiles_test.go
@@ -156,9 +156,9 @@ func TestLoadConfig_GB300Profile(t *testing.T) {
 	require.Equal(t, uint32(1400000), power.DefaultLimitMW, "GB300 power default_limit_mw")
 
 	// Grace pairing must be wired up — GB300 is a superchip part.
-	grace := yamlCfg.DeviceDefaults.GraceSuperchip
-	require.NotNil(t, grace, "GB300 grace_superchip config is nil")
-	require.True(t, grace.Enabled, "GB300 grace_superchip.enabled: got false, want true")
+	cpu := yamlCfg.DeviceDefaults.CPU
+	require.NotNil(t, cpu, "GB300 cpu config is nil")
+	require.Equal(t, "grace", cpu.Type, "GB300 cpu.type")
 
 	// NVLink v5, 18 links @ 100 GB/s (same fabric as GB200).
 	require.NotNil(t, yamlCfg.NVLink, "GB300 NVLink config is nil")

--- a/pkg/gpu/mocknvml/engine/config_types.go
+++ b/pkg/gpu/mocknvml/engine/config_types.go
@@ -125,8 +125,8 @@ type DeviceConfig struct {
 	// Blackwell-specific features (GB200)
 	Features *FeaturesConfig `json:"features,omitempty"`
 
-	// Grace Superchip (GB200)
-	GraceSuperchip *GraceSuperchipConfig `json:"grace_superchip,omitempty"`
+	// Host CPU the board is paired with
+	CPU *CPUConfig `json:"cpu,omitempty"`
 
 	// Topology
 	Topology *TopologyConfig `json:"topology,omitempty"`
@@ -557,12 +557,17 @@ type FeaturesConfig struct {
 	FifthGenTensorCores bool `json:"fifth_gen_tensor_cores,omitempty"`
 }
 
-// GraceSuperchipConfig defines Grace CPU pairing for GB200
-type GraceSuperchipConfig struct {
-	Enabled        bool `json:"enabled,omitempty"`
-	CPUCores       int  `json:"cpu_cores,omitempty"`
-	CPUMemoryGB    int  `json:"cpu_memory_gb,omitempty"`
-	CoherentMemory bool `json:"coherent_memory,omitempty"`
+// CPUConfig describes the host CPU the board is attached to. Type is free-form
+// and names the CPU family — "grace" on the superchip profiles. An absent block
+// means the profile makes no claim about its host, which is the honest reading
+// for a PCIe or SXM part that can ship behind any CPU.
+//
+// Descriptive metadata that no getter reads, on the same terms as FeaturesConfig.
+type CPUConfig struct {
+	Type           string `json:"type,omitempty"`
+	Cores          int    `json:"cores,omitempty"`
+	MemoryGB       int    `json:"memory_gb,omitempty"`
+	CoherentMemory bool   `json:"coherent_memory,omitempty"`
 }
 
 // ProcessConfig defines a running process


### PR DESCRIPTION
## Summary

The profile schema named one CPU family in a key. `grace_superchip:` was
reachable only by claiming to be a Grace superchip, so a part sitting behind any
other host had no way to describe its pairing.

- `grace_superchip:` becomes a generic `cpu:` block whose `type` names the CPU
  family — `grace` on `gb200` and `gb300`.
- `enabled` is dropped; it said nothing that the presence of the block did not.
- `cpu_cores` and `cpu_memory_gb` become `cores` and `memory_gb`, losing a prefix
  they no longer need.
- A profile that omits the block now makes no claim about its host, which is the
  honest reading for a PCIe or SXM part that ships behind any CPU.

`type` is deliberately free-form, matching how the other profile enums
(`persistence_mode`, `compute_mode`) are handled.

Nothing in the engine ever read these values — they are descriptive metadata on
the same terms as `features:`, and `CPUConfig` carries the same doctrine note.

**Breaking:** a custom profile carrying `grace_superchip:` must be updated; the
key is no longer read.

## Changes

- `pkg/gpu/mocknvml/engine/config_types.go`: `GraceSuperchipConfig` → `CPUConfig`,
  reached through `DeviceConfig.CPU`.
- The four shipped Grace-Blackwell profiles: `gb200`/`gb300` under both
  `deployments/nvml-mock/helm/nvml-mock/profiles/` and `pkg/gpu/mocknvml/configs/`.
- `config_profiles_test.go` asserts `cpu.Type == "grace"` in place of the old
  `enabled` flag.
- Helm snapshots regenerated. The daemonset snapshot moves too, because its
  config checksum annotation hashes the profile.
- Changelog entry under `Unreleased` → `Changed`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/gpu/mocknvml/...`
- [x] `helm unittest deployments/nvml-mock/helm/nvml-mock` (179 tests, 15 snapshots)
- [x] `make lint-fix` — golangci-lint and `go vet` clean
- [ ] CI