### PR TITLE
fix(ci): scope the CodeQL SARIF write to the jobs that need it

### DIFF
--- a/.github/workflows/basic-checks.yaml
+++ b/.github/workflows/basic-checks.yaml
@@ -13,9 +13,10 @@
 # limitations under the License.
 name: "basic checks"
 
+# Read-only default for all jobs. Only the code-scanning job elevates, so a
+# newly added job cannot silently inherit a write token.
 permissions:
   contents: read
-  security-events: write
   actions: read
   packages: read
 
@@ -50,6 +51,13 @@ jobs:
   code-scanning:
     needs:
     - variables
+    # CodeQL uploads SARIF results. A job-level block replaces the workflow
+    # defaults rather than merging with them, so the read grants are repeated.
+    permissions:
+      contents: read
+      actions: read
+      packages: read
+      security-events: write
     uses: ./.github/workflows/code_scanning.yaml
     with:
       golang_version: ${{ needs.variables.outputs.golang_version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,9 +13,10 @@
 # limitations under the License.
 name: CI Pipeline
 
+# Read-only default for all jobs. Only the basic job elevates, so a newly
+# added job cannot silently inherit a write token.
 permissions:
   contents: read
-  security-events: write
   actions: read
   packages: read
 
@@ -28,6 +29,14 @@ on:
   
 jobs:
   basic:
+    # Fans out to CodeQL, which uploads SARIF. A called workflow can never
+    # hold more than its caller grants, so the write is threaded through
+    # every level of the call chain.
+    permissions:
+      contents: read
+      actions: read
+      packages: read
+      security-events: write
     uses: ./.github/workflows/basic-checks.yaml
 
   nvml-mock-e2e:


### PR DESCRIPTION
## Summary

`ci.yaml` and `basic-checks.yaml` both granted `security-events: write` at the
workflow level, so every job in both call trees — lint, e2e, variables — ran
with a token that could write vulnerability data. Only the CodeQL `analyze` job
uploads SARIF.

A reusable workflow can never hold more than its calling job grants, so the
write is threaded through each level of the call chain (`basic` in `ci.yaml`,
`code-scanning` in `basic-checks.yaml`) instead of being handed to everything.
Workflow-level defaults are now read-only, which also means a newly added job
cannot silently inherit the write. `code_scanning.yaml` already scoped the
permission to its `analyze` job and is unchanged.

The job-level blocks repeat `contents/actions/packages: read` on purpose: a
job's `permissions` block replaces the workflow defaults rather than merging
with them, so omitting them would strip those reads from the CodeQL chain.

This clears the two Scorecard `Token-Permissions` findings ([#16](https://github.com/NVIDIA/k8s-test-infra/security/code-scanning/16), [#17](https://github.com/NVIDIA/k8s-test-infra/security/code-scanning/17)) that were holding
the check at 8/10 — each top-level `security-events: write` costs a full point.

Related: [#47](https://github.com/NVIDIA/k8s-test-infra/security/code-scanning/47) flagged `packages: write` on the `helm.yaml` publish job. That one
is dismissed as won't-fix rather than patched: the permission is required for
`helm push` to GHCR, is already job-scoped under a `contents: read` default,
and is gated to `push` on `main`. Scorecard only deducts for a job-level write
when the top-level permissions are undeclared or write, so it costs no score.

## Test plan

- [x] `actionlint` clean on `ci.yaml`, `basic-checks.yaml`, `code_scanning.yaml`
- [ ] CI run on this PR shows the `code-scanning` job still uploading CodeQL
      SARIF successfully (the one thing static linting cannot prove)
- [ ] Next scheduled Scorecard run on `main` closes alerts #16 and #17