### PR TITLE
fix(ci): restore the id-token grant the CodeQL and golang call trees need

### DIFF
--- a/.github/workflows/basic-checks.yaml
+++ b/.github/workflows/basic-checks.yaml
@@ -55,12 +55,16 @@ jobs:
     needs:
     - variables
     # CodeQL uploads SARIF results. A job-level block replaces the workflow
-    # defaults rather than merging with them, so the read grants are repeated.
+    # defaults rather than merging with them, so every grant the call tree
+    # needs is repeated here — including the id-token the analyze job mints
+    # its Artifactory token with. A call tree asking for more than its caller
+    # holds fails the whole run before any job starts.
     permissions:
       contents: read
       actions: read
       packages: read
       security-events: write
+      id-token: write
     uses: ./.github/workflows/code_scanning.yaml
     with:
       golang_version: ${{ needs.variables.outputs.golang_version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,14 +32,16 @@ on:
   
 jobs:
   basic:
-    # Fans out to CodeQL, which uploads SARIF. A called workflow can never
-    # hold more than its caller grants, so the write is threaded through
-    # every level of the call chain.
+    # Fans out to CodeQL, which uploads SARIF, and to golang.yaml, which mints
+    # an Artifactory token. A called workflow can never hold more than its
+    # caller grants, and a call tree that asks for more fails the whole run
+    # before any job starts, so both writes are threaded through every level.
     permissions:
       contents: read
       actions: read
       packages: read
       security-events: write
+      id-token: write
     uses: ./.github/workflows/basic-checks.yaml
 
   nvml-mock-e2e:


### PR DESCRIPTION
## What This PR Does

Adds `id-token: write` back to the two jobs that call into the CodeQL and golang workflows, restoring every CI run in the repository.

`main` is currently red. Every `CI Pipeline` run since #785 landed, and `basic checks` on every open pull request, ends in a zero-second `startup_failure` with no logs:

| run | workflow | branch | result |
| --- | --- | --- | --- |
| [33851284514](https://github.com/NVIDIA/k8s-test-infra/actions/runs/33851284514) | CI Pipeline | `main` (#785 merge) | `startup_failure` |
| [33854036759](https://github.com/NVIDIA/k8s-test-infra/actions/runs/33854036759) | CI Pipeline | `main` (next commit) | `startup_failure` |
| [33853649606](https://github.com/NVIDIA/k8s-test-infra/actions/runs/33853649606) | basic checks | PR #742 | `startup_failure` |

## Why

#785 moved `security-events: write` off the workflow defaults and onto the jobs that fan out to CodeQL, which was the right call. But a job-level `permissions` block *replaces* the workflow defaults rather than merging with them, so `id-token: write` was dropped along the way — the grant the workflow-level comment flags as *"Passed down to golang.yaml, which mints a short-lived Artifactory token"*, and which `code_scanning.yaml`'s `analyze` job asks for as well.

A called workflow can never hold more permission than its caller, and GitHub validates the entire call tree *before* starting any job. That is why the symptom is a startup failure with no logs rather than a job that runs and fails:

- `ci.yaml` job `basic` → `basic-checks.yaml`, which declares `id-token: write` at workflow level.
- `basic-checks.yaml` job `code-scanning` → `code_scanning.yaml`, whose `analyze` job requests `id-token: write`.

The point of #785 is preserved: the workflow defaults stay read-only, so a newly added job still cannot inherit a write token by accident. Only the two jobs that already need to thread the CodeQL write now thread the id-token with it.

I checked every local reusable-workflow call for the same subset violation, not just the two that failed. On `main` exactly two call edges are broken, both missing `id-token: write`; with this change all five edges satisfy the rule:

```
BROKEN basic-checks.yaml job 'code-scanning' -> code_scanning.yaml  MISSING: {'id-token': 'write'}
BROKEN ci.yaml         job 'basic'          -> basic-checks.yaml    MISSING: {'id-token': 'write'}
2 violation(s) on upstream/main

ok basic-checks.yaml job 'variables'     -> variables.yaml
ok basic-checks.yaml job 'golang'        -> golang.yaml
ok basic-checks.yaml job 'code-scanning' -> code_scanning.yaml
ok ci.yaml           job 'basic'         -> basic-checks.yaml
ok ci.yaml           job 'nvml-mock-e2e' -> nvml-mock-e2e-go.yaml
0 violation(s)
```

The real proof is this PR's own checks: if `basic checks` starts and runs, the call tree validates.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`make test` — 43 packages, unaffected by a workflows-only change)
- [x] Linter passes (`make lint-fix` — no findings in this tree; the change is YAML only)
- [x] New code has SPDX license headers (no new files; both workflows keep their Apache headers)
- [x] Documentation updated (the job-level comments now say why the id-token is repeated, so the next person moving permissions does not drop it again)
- [x] CHANGELOG.md updated (not user-facing; CI-only, as with #785)