### PR TITLE
docs: document security practices and link the OpenSSF Best Practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
     <a href="https://scorecard.dev/viewer/?uri=github.com/NVIDIA/k8s-test-infra">
         <img src="https://api.scorecard.dev/projects/github.com/NVIDIA/k8s-test-infra/badge" alt="OpenSSF Scorecard" />
     </a>
+    <a href="https://www.bestpractices.dev/projects/14445">
+        <img src="https://www.bestpractices.dev/projects/14445/badge" alt="OpenSSF Best Practices" />
+    </a>
     <a href="LICENSE">
         <img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License" />
     </a>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,3 +42,90 @@ Areas of particular interest:
 - GitHub Actions workflow security
 - Supply chain integrity (dependencies, build process)
 - Helm chart security (RBAC, privileges)
+
+## Security Expectations
+
+Mokka is a test double. It implements the NVIDIA driver interfaces that GPU
+software talks to, so that the device plugin, the DRA driver, the GPU Operator
+and `nvidia-smi` behave as though hardware were present. That purpose shapes
+what you should and should not expect from it:
+
+- **Mokka is for test and CI clusters, not production.** The `nvml-mock`
+  DaemonSet container runs privileged and stages driver-shaped files onto host
+  paths. Do not install it on a cluster carrying production workloads.
+- **Mokka makes no security claims about the software it simulates hardware
+  for.** It provides no isolation, admission control, or policy enforcement for
+  the GPU software that consumes its mock driver files.
+- **Mokka processes no sensitive data.** It has no user accounts, stores no
+  credentials, and keeps no persistent state beyond the driver files it stages
+  and the node labels it patches.
+
+What you can expect is the least-privilege posture and the supply-chain
+practices described below.
+
+## Secure Development Practices
+
+### Design principles
+
+Least privilege is applied per component rather than claimed globally:
+
+- The ClusterRole grants `get` and `patch` on `nodes`, and nothing else.
+- The control plane Deployment runs `runAsNonRoot` as UID 65532 with
+  `readOnlyRootFilesystem`, `capabilities.drop: [ALL]`, and
+  `seccompProfile: RuntimeDefault`.
+- The allocation watcher drops all capabilities and runs with
+  `readOnlyRootFilesystem`; it only reads the kubelet pod-resources socket.
+- The container that creates device nodes drops all capabilities and adds back
+  only `MKNOD`.
+- The `nvml-mock` container runs `privileged: true`. Staging driver files and
+  device nodes onto the host requires it. We disclose this rather than work
+  around it, and we reduce what it exposes: the InfiniBand ping relay in that
+  pod listens without authentication, so an opt-out NetworkPolicy restricts its
+  ingress to peer nvml-mock daemon pods.
+
+### Common implementation errors
+
+Review attention goes to the error classes this codebase can actually hit:
+
+- **Memory handling across the CGo boundary** in `shims/` and
+  `pkg/gpu/mocknvml`, where Go code fills C structs consumed by real NVIDIA
+  client software.
+- **Path handling** in the code that writes to hostPath mounts and performs NRI
+  injection, since that code runs privileged against host directories.
+
+### Input validation
+
+Mokka's inputs come from the cluster operator installing the chart, not from
+untrusted third parties, so validation is scoped accordingly:
+
+- **Chart values** are validated against a JSON Schema
+  (`deployments/nvml-mock/helm/nvml-mock/values.schema.json`), which Helm
+  enforces at install and upgrade time.
+- **The YAML device profile** is validated by `validateYAMLConfig` in
+  `pkg/gpu/mocknvml/engine/config.go`: it requires a config version and a
+  driver version, and rejects duplicate device indices.
+
+## Cryptography
+
+Mokka implements no cryptographic functionality. It stores no passwords,
+generates no keys, and defines no cryptographic protocols. Where TLS is needed
+to reach the Kubernetes API server, it calls `client-go` and the Go standard
+library, which perform certificate verification by default.
+
+## Security Analysis
+
+Static and dynamic analysis run in CI on every pull request and on every push to
+`main`:
+
+| Tool | Scope | Where |
+|------|-------|-------|
+| CodeQL | Semantic static analysis of the Go tree | `.github/workflows/code_scanning.yaml` |
+| golangci-lint | Go linting, including tag-guarded e2e and integration sources | `.golangci.yml` |
+| Race detector | `go test -race` across all packages | `make test` |
+| Go fuzzing | `pkg/gpu/mocknvml/engine/fuzz_test.go` | `go test -fuzz` |
+| `-Wall -Wextra` | The C shims | `shims/libibmock/Makefile`, `shims/libpcisysfs/Makefile` |
+| Dependabot | Weekly Go module and GitHub Actions updates | `.github/dependabot.yml` |
+| OpenSSF Scorecard | Supply-chain posture, reported publicly | `.github/workflows/scorecard.yaml` |
+
+Findings from these tools are fixed rather than suppressed wholesale; the
+per-path exclusions in `.golangci.yml` each carry a written justification.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,89 +43,34 @@ Areas of particular interest:
 - Supply chain integrity (dependencies, build process)
 - Helm chart security (RBAC, privileges)
 
-## Security Expectations
+## Secure Development
 
-Mokka is a test double. It implements the NVIDIA driver interfaces that GPU
-software talks to, so that the device plugin, the DRA driver, the GPU Operator
-and `nvidia-smi` behave as though hardware were present. That purpose shapes
-what you should and should not expect from it:
+Mokka is a test double for CI and test clusters, not production. The `nvml-mock`
+DaemonSet container runs `privileged: true` because staging driver-shaped files
+and device nodes onto the host requires it; we disclose that rather than work
+around it. Every other component is least-privileged: the ClusterRole grants
+`get` and `patch` on `nodes` and nothing else, the control plane and allocation
+watcher drop all capabilities and run with `readOnlyRootFilesystem`, and the
+container that creates device nodes adds back only `MKNOD`.
 
-- **Mokka is for test and CI clusters, not production.** The `nvml-mock`
-  DaemonSet container runs privileged and stages driver-shaped files onto host
-  paths. Do not install it on a cluster carrying production workloads.
-- **Mokka makes no security claims about the software it simulates hardware
-  for.** It provides no isolation, admission control, or policy enforcement for
-  the GPU software that consumes its mock driver files.
-- **Mokka processes no sensitive data.** It has no user accounts, stores no
-  credentials, and keeps no persistent state beyond the driver files it stages
-  and the node labels it patches.
+Inputs come from the operator installing the chart rather than from untrusted
+third parties, so validation is scoped accordingly: chart values are checked
+against `deployments/nvml-mock/helm/nvml-mock/values.schema.json`, and the YAML
+device profile is checked by `validateYAMLConfig` in
+`pkg/gpu/mocknvml/engine/config.go`. Review attention goes to the error classes
+this codebase can actually hit — memory handling across the CGo boundary in
+`shims/` and `pkg/gpu/mocknvml`, and path handling in the privileged code that
+writes to hostPath mounts and performs NRI injection.
 
-What you can expect is the least-privilege posture and the supply-chain
-practices described below.
-
-## Secure Development Practices
-
-### Design principles
-
-Least privilege is applied per component rather than claimed globally:
-
-- The ClusterRole grants `get` and `patch` on `nodes`, and nothing else.
-- The control plane Deployment runs `runAsNonRoot` as UID 65532 with
-  `readOnlyRootFilesystem`, `capabilities.drop: [ALL]`, and
-  `seccompProfile: RuntimeDefault`.
-- The allocation watcher drops all capabilities and runs with
-  `readOnlyRootFilesystem`; it only reads the kubelet pod-resources socket.
-- The container that creates device nodes drops all capabilities and adds back
-  only `MKNOD`.
-- The `nvml-mock` container runs `privileged: true`. Staging driver files and
-  device nodes onto the host requires it. We disclose this rather than work
-  around it, and we reduce what it exposes: the InfiniBand ping relay in that
-  pod listens without authentication, so an opt-out NetworkPolicy restricts its
-  ingress to peer nvml-mock daemon pods.
-
-### Common implementation errors
-
-Review attention goes to the error classes this codebase can actually hit:
-
-- **Memory handling across the CGo boundary** in `shims/` and
-  `pkg/gpu/mocknvml`, where Go code fills C structs consumed by real NVIDIA
-  client software.
-- **Path handling** in the code that writes to hostPath mounts and performs NRI
-  injection, since that code runs privileged against host directories.
-
-### Input validation
-
-Mokka's inputs come from the cluster operator installing the chart, not from
-untrusted third parties, so validation is scoped accordingly:
-
-- **Chart values** are validated against a JSON Schema
-  (`deployments/nvml-mock/helm/nvml-mock/values.schema.json`), which Helm
-  enforces at install and upgrade time.
-- **The YAML device profile** is validated by `validateYAMLConfig` in
-  `pkg/gpu/mocknvml/engine/config.go`: it requires a config version and a
-  driver version, and rejects duplicate device indices.
-
-## Cryptography
-
-Mokka implements no cryptographic functionality. It stores no passwords,
-generates no keys, and defines no cryptographic protocols. Where TLS is needed
-to reach the Kubernetes API server, it calls `client-go` and the Go standard
-library, which perform certificate verification by default.
+Mokka implements no cryptography. It stores no passwords and generates no keys,
+and where TLS is needed to reach the Kubernetes API server it calls `client-go`
+and the Go standard library, which verify certificates by default.
 
 ## Security Analysis
 
-Static and dynamic analysis run in CI on every pull request and on every push to
-`main`:
-
-| Tool | Scope | Where |
-|------|-------|-------|
-| CodeQL | Semantic static analysis of the Go tree | `.github/workflows/code_scanning.yaml` |
-| golangci-lint | Go linting, including tag-guarded e2e and integration sources | `.golangci.yml` |
-| Race detector | `go test -race` across all packages | `make test` |
-| Go fuzzing | `pkg/gpu/mocknvml/engine/fuzz_test.go` | `go test -fuzz` |
-| `-Wall -Wextra` | The C shims | `shims/libibmock/Makefile`, `shims/libpcisysfs/Makefile` |
-| Dependabot | Weekly Go module and GitHub Actions updates | `.github/dependabot.yml` |
-| OpenSSF Scorecard | Supply-chain posture, reported publicly | `.github/workflows/scorecard.yaml` |
-
-Findings from these tools are fixed rather than suppressed wholesale; the
-per-path exclusions in `.golangci.yml` each carry a written justification.
+CodeQL, `golangci-lint`, and `go test -race` run on every pull request and every
+push to `main`. `-Wall -Wextra` gates the C shims, and
+`pkg/gpu/mocknvml/engine/fuzz_test.go` provides a Go fuzz target. Dependabot
+proposes weekly Go module and GitHub Actions updates, and
+[OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/NVIDIA/k8s-test-infra)
+reports supply-chain posture publicly.


### PR DESCRIPTION
## What

The project earned the [OpenSSF Best Practices **passing** badge](https://www.bestpractices.dev/projects/14445). This links it from the README and records in `SECURITY.md` the practices that several passing criteria attest to.

## Why

Two passing criteria, `know_secure_design` and `know_common_errors`, are both MUST and were answered on a maintainer's word alone — nothing in the tree stated which secure design principles the project applies or which classes of implementation error review targets. The nine `crypto_*` criteria were answered without a written rationale for why they do not apply.

Separately, silver criterion `documentation_achievements` requires the front page hyperlink any achievement within 48 hours of attainment.

Scorecard's `CII-Best-Practices` check resolves via the badge API keyed on the repo URL rather than by reading the README, so it will move from 0 to 5 on its own at the next scan. This PR does not affect that.

## Changes

`SECURITY.md` keeps its four existing sections byte-identical and first, since a reporter needs the reporting instructions before anything else and they earn Scorecard `Security-Policy: 10`. Two short sections are appended:

- **Secure Development** — why the `nvml-mock` DaemonSet is privileged and what the other components are restricted to, where the two input surfaces are validated (`values.schema.json` and `validateYAMLConfig`), the error classes review targets (CGo memory handling, path handling in the privileged writers), and that no cryptography is implemented.
- **Security Analysis** — the static and dynamic analysis that gates every change.

The content is deliberately prose rather than an enumeration of `securityContext` blocks and workflow files: that detail is already in the tree and goes stale the moment either changes. Only the facts a reader cannot recover by reading the chart are stated here.

README gains the badge next to the existing Scorecard badge.

## Testing

Documentation only. No Go, Helm, or workflow changes, and `SECURITY.md` is not part of the mkdocs site, so no build gate is affected.