### PR TITLE
feat(nvml-mock-ctl): announce injected Xids on the node kernel log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- nvml-mock: the node agent announces an injected Xid on the node's kernel log,
+  the way a driver's printk does, so agents that watch kernel messages see the
+  fault instead of only NVML clients. It watches the runtime override document,
+  so an Xid raised through `nvml-mock-ctl fail --xid` or any other writer is
+  announced alike, naming each device by the address it serves through NVML.
+  Opt in with `nodeAgent.kernelLog.enabled=true`: it makes the node agent
+  PRIVILEGED and mounts `/dev/kmsg`, because the device cgroup rejects the write
+  from an unprivileged pod even with the device mounted, so it is off unless
+  asked for and no `helm upgrade` widens an install's privileges on its own. The
+  local Tilt values and the nv-sentinel demo turn it on. `MOCK_NVML_KMSG` picks
+  a different log or disables the announcement, which is always best-effort: a
+  node with no writable kernel log keeps the NVML injection.
+- nv-sentinel demo: `run.sh` now configures `journald` on each Kind node
+  (`Storage=persistent`, `ReadKMsg=yes`), giving the node a kernel-log "syslog"
+  NVSentinel's syslog monitor can read. Stock Kind nodes drop kernel messages
+  and keep a volatile journal, so the monitor sees nothing.
+
 ### Removed
 - nvml-mock: the DaemonSet no longer runs the `nvml-mock` container; the node
   agent is the only simulation container.

--- a/cmd/node-agent/main.go
+++ b/cmd/node-agent/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/internal/agent/gpudriver"
 	"github.com/NVIDIA/k8s-test-infra/internal/agent/host"
 	"github.com/NVIDIA/k8s-test-infra/internal/agent/ib"
+	"github.com/NVIDIA/k8s-test-infra/internal/agent/kernellog"
 	"github.com/NVIDIA/k8s-test-infra/internal/agent/source"
 	"github.com/NVIDIA/k8s-test-infra/internal/health"
 	"github.com/NVIDIA/k8s-test-infra/internal/logging"
@@ -101,6 +102,14 @@ func startCommand() *cli.Command {
 				Usage:   "enable the cross-pod fabric relay; required for multi-node ibping and iblinkinfo",
 				Sources: cli.EnvVars("MOCK_IB_PING_FABRIC"),
 			},
+			// Not rooted at --host-root: the deployment grants the kernel log
+			// as a device mount at its own path, rather than through /host.
+			&cli.StringFlag{
+				Name:    "kernel-log",
+				Value:   kernellog.DefaultPath,
+				Usage:   "kernel log to announce injected Xids on, as a driver's printk does ('' announces nowhere)",
+				Sources: cli.EnvVars("MOCK_NVML_KMSG"),
+			},
 			&cli.DurationFlag{
 				Name:    "fabricmanager-init-delay",
 				Usage:   "withhold fabric readiness for this long, simulating NVSwitch registration latency",
@@ -171,6 +180,7 @@ func runStart(ctx context.Context, cmd *cli.Command) error {
 			cdi.New(),
 			imex.New(),
 			nvlink.New(),
+			kernellog.New(kernellog.Options{Path: cmd.String("kernel-log")}),
 			fabricmanager.New(fabricmanager.Options{
 				InitDelay: cmd.Duration("fabricmanager-init-delay"),
 			}),

--- a/cmd/nvml-mock-ctl/faults.go
+++ b/cmd/nvml-mock-ctl/faults.go
@@ -57,6 +57,8 @@ func failCommand() *cli.Command {
 				Name:  "after-calls",
 				Usage: "trip only after N guarded calls have succeeded",
 			},
+			// The node agent watches the override this writes and announces
+			// the Xid on the node's kernel log, as a driver's printk does.
 			&cli.Uint64Flag{
 				Name:  "xid",
 				Usage: "Xid code to surface alongside the failure",

--- a/cmd/nvml-mock-ctl/main_test.go
+++ b/cmd/nvml-mock-ctl/main_test.go
@@ -46,6 +46,38 @@ func TestCLI_FailWritesConfigOverride(t *testing.T) {
 	require.Contains(t, readConfigOverride(t, configOverride), "ecc_uncorrectable")
 }
 
+// writeConfig lays down a two-GPU profile, so the command resolves its target
+// against a device list as it does on a node.
+func writeConfig(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`version: "1.0"
+system:
+  driver_version: "550.163.01"
+devices:
+  - index: 0
+    uuid: "GPU-12345678-1234-1234-1234-123456780000"
+    pci:
+      bus_id: "0000:1A:00.0"
+  - index: 1
+    uuid: "GPU-12345678-1234-1234-1234-123456780001"
+    pci:
+      bus_id: "0000:1B:00.0"
+`), 0o644))
+	return path
+}
+
+// The code the node agent reads back to announce the Xid on the kernel log.
+func TestCLI_FailRecordsTheXidCode(t *testing.T) {
+	dir := t.TempDir()
+	configOverride := filepath.Join(dir, "overrides.yaml")
+
+	_, e, c := runCLI(t, configOverride, "fail", "--gpu", "0", "--mode", "ecc_uncorrectable",
+		"--xid", "79", "--config", writeConfig(t, dir))
+	require.Equalf(t, 0, c, "fail exited %d: %s", c, e)
+	require.Contains(t, readConfigOverride(t, configOverride), "code: 79")
+}
+
 func TestCLI_SetRejectsUnknownField(t *testing.T) {
 	dir := t.TempDir()
 	configOverride := filepath.Join(dir, "overrides.yaml")

--- a/deployments/nvml-mock/helm/nvml-mock/README.md
+++ b/deployments/nvml-mock/helm/nvml-mock/README.md
@@ -47,6 +47,7 @@ helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock \
 | `gpu` | Profile, device count, per-device overrides |
 | `image` | Repository, tag, pull policy |
 | `nodeSelector`, `tolerations` | Standard scheduling; `nodeAgent.resources` sets limits |
+| `nodeAgent.kernelLog` | Announce injected Xids on the node's `/dev/kmsg` (off; makes the agent privileged) |
 | `nodeLabels` | Labels applied to nodes running the mock |
 | `allocationWatcher` | Tracks device-plugin allocations for utilization simulation |
 | `nri` | Node-wide NRI injection (see MEP-0002) |

--- a/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/templates/daemonset.yaml
@@ -112,6 +112,14 @@ spec:
             # the CLI can never write to.
             - name: MOCK_NVML_OVERRIDES
               value: /var/lib/nvml-mock/driver/config/overrides.yaml
+            # Where the agent announces an injected Xid, as a driver's printk
+            # would. Unlike the env above this one is the agent's own: it
+            # watches the override document and writes the kernel line, so an
+            # Xid raised by any writer reaches the node's log. Empty says this
+            # pod cannot reach the kernel log -- it is only mounted, and only
+            # writable, when nodeAgent.kernelLog is enabled.
+            - name: MOCK_NVML_KMSG
+              value: {{ ternary "/dev/kmsg" "" .Values.nodeAgent.kernelLog.enabled | quote }}
             {{- if .Values.topology.enabled }}
             - name: MOCK_TOPOLOGY_CONFIG
               value: /etc/nvml-mock/topology/topology.yaml
@@ -149,10 +157,19 @@ spec:
               protocol: TCP
             {{- end }}
           securityContext:
+            {{- if .Values.nodeAgent.kernelLog.enabled }}
+            # Writing /dev/kmsg needs no capability, but it does need past the
+            # device cgroup, which only privileged lifts -- mounting the device
+            # into an unprivileged container still fails with EPERM. Stated
+            # alone: a capability set is inert under privileged, so dropping ALL
+            # here would advertise a bound the container does not have.
+            privileged: true
+            {{- else }}
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ALL]
               add: [MKNOD]
+            {{- end }}
           volumeMounts:
             # Where the simulators write. Every path they stage is rooted here.
             - name: mokka-root
@@ -195,6 +212,12 @@ spec:
             - name: node-sysfs
               mountPath: /host/sys
               readOnly: true
+            {{- if .Values.nodeAgent.kernelLog.enabled }}
+            # The node's kernel ring buffer, for the Xid announcement. Write
+            # only in practice: nothing here reads it back.
+            - name: kernel-log
+              mountPath: /dev/kmsg
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -276,6 +299,14 @@ spec:
           hostPath:
             path: /sys
             type: Directory
+        {{- if .Values.nodeAgent.kernelLog.enabled }}
+        # CharDevice, so a node that exposes no kernel ring buffer fails the
+        # pod instead of silently swallowing announcements into a new file.
+        - name: kernel-log
+          hostPath:
+            path: /dev/kmsg
+            type: CharDevice
+        {{- end }}
         {{- if .Values.topology.enabled }}
         - name: cluster-topology
           configMap:

--- a/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/__snapshot__/daemonset_test.yaml.snap
@@ -63,6 +63,8 @@ should match snapshot with all overrides:
                   value: /etc/nvml-mock/config.yaml
                 - name: MOCK_NVML_OVERRIDES
                   value: /var/lib/nvml-mock/driver/config/overrides.yaml
+                - name: MOCK_NVML_KMSG
+                  value: ""
                 - name: MOCK_IB_PING_SOCKET
                   value: /var/lib/nvml-mock/run/mock-ib.sock
                 - name: LD_PRELOAD
@@ -222,6 +224,8 @@ should match snapshot with b200 profile:
                   value: /etc/nvml-mock/config.yaml
                 - name: MOCK_NVML_OVERRIDES
                   value: /var/lib/nvml-mock/driver/config/overrides.yaml
+                - name: MOCK_NVML_KMSG
+                  value: ""
                 - name: MOCK_IB_PING_SOCKET
                   value: /var/lib/nvml-mock/run/mock-ib.sock
                 - name: LD_PRELOAD
@@ -373,6 +377,8 @@ should match snapshot with default values:
                   value: /etc/nvml-mock/config.yaml
                 - name: MOCK_NVML_OVERRIDES
                   value: /var/lib/nvml-mock/driver/config/overrides.yaml
+                - name: MOCK_NVML_KMSG
+                  value: ""
                 - name: MOCK_IB_PING_SOCKET
                   value: /var/lib/nvml-mock/run/mock-ib.sock
                 - name: LD_PRELOAD

--- a/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/tests/daemonset_test.yaml
@@ -1021,3 +1021,79 @@ tests:
             hostPath:
               path: /var/lib/k0s/kubelet/pod-resources
               type: Directory
+
+  # ── Kernel log (Xid announcement) ───────────────────────────────────
+  - it: should grant the kernel log and the privilege it needs when enabled
+    set:
+      nodeAgent:
+        kernelLog:
+          enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MOCK_NVML_KMSG
+            value: /dev/kmsg
+      # The device cgroup rejects the write from an unprivileged container even
+      # with /dev/kmsg mounted, so the mount alone would render a no-op.
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.privileged
+          value: true
+      # A capability set is inert under privileged, so the chart must not claim
+      # one: `drop: [ALL]` here would read as a bound on a container that has
+      # every capability.
+      - isNull:
+          path: spec.template.spec.containers[0].securityContext.capabilities
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: kernel-log
+            mountPath: /dev/kmsg
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: kernel-log
+            hostPath:
+              path: /dev/kmsg
+              type: CharDevice
+
+  # The default, and it must stay the default: `helm upgrade` of an existing
+  # install cannot be what turns the node agent privileged.
+  - it: should leave the node agent unprivileged by default
+    asserts:
+      # Empty, not absent: it tells the agent the pod cannot reach /dev/kmsg,
+      # so it skips the announcement instead of warning on every injection.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MOCK_NVML_KMSG
+            value: ""
+      - isNull:
+          path: spec.template.spec.containers[0].securityContext.privileged
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: kernel-log
+            mountPath: /dev/kmsg
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: kernel-log
+            hostPath:
+              path: /dev/kmsg
+              type: CharDevice
+
+  # A misspelled key here is the dangerous kind of typo: the operator believes
+  # they turned the privilege off, and the chart renders it on. The schema
+  # rejects the install instead of quietly granting more than was asked for.
+  - it: should reject a misspelled kernel log key
+    set:
+      nodeAgent:
+        kernelLog:
+          enable: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "values don't meet the specifications of the schema(s) in the following chart(s):\nnvml-mock:\n- at '/nodeAgent/kernelLog': additional properties 'enable' not allowed\n"

--- a/deployments/nvml-mock/helm/nvml-mock/values.schema.json
+++ b/deployments/nvml-mock/helm/nvml-mock/values.schema.json
@@ -165,6 +165,14 @@
           "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
           "description": "Go duration string passed to --shutdown-timeout."
         },
+        "kernelLog": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Announce injected Xids on the node's kernel log. Closed to unknown keys because a typo here would leave the privileged container it grants in place while reading as if it had been turned off.",
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
         "resources": { "type": "object" }
       }
     },

--- a/deployments/nvml-mock/helm/nvml-mock/values.yaml
+++ b/deployments/nvml-mock/helm/nvml-mock/values.yaml
@@ -83,6 +83,24 @@ nodeAgent:
   logging:
     level: info    # debug | info | warn | error
     format: json   # json | plain
+  # Let the agent announce an injected Xid on the node's kernel log, the way a
+  # real driver's printk does, so agents that read kernel logs (and journald
+  # consumers such as NVSentinel's syslog monitor) see it instead of only NVML
+  # clients. It watches the runtime override document, so an Xid raised through
+  # `nvml-mock-ctl fail --xid` or any other writer is announced alike.
+  #
+  # Off by default because turning it on makes the node-agent container
+  # PRIVILEGED: /dev/kmsg sits behind the device cgroup, which rejects the write
+  # from an unprivileged pod even with the device mounted, so there is no lesser
+  # grant that works. A default of true would widen an existing install's
+  # privileges on `helm upgrade` alone, which no value here should do.
+  #
+  # Turn it on to evaluate an agent that reads kernel logs; a cluster whose
+  # PodSecurity admits no privileged pod, or a node with no /dev/kmsg, cannot
+  # (the CharDevice hostPath fails the pod rather than inventing one). Left off,
+  # the announcement is skipped and the NVML injection is unaffected.
+  kernelLog:
+    enabled: false
   # Go duration string: 5s, 1m30s, etc. Teardown is a handful of parallel file
   # removals, and it has to finish inside terminationGracePeriodSeconds.
   shutdownTimeout: 5s

--- a/docs/demo/nv-sentinel/run.sh
+++ b/docs/demo/nv-sentinel/run.sh
@@ -104,6 +104,32 @@ done < <(kind get nodes --name "${CLUSTER_NAME}" | grep -v control-plane | sort)
 [[ "${#WORKERS[@]}" -ge 1 ]] || fail "no worker nodes found"
 info "GPU workers: ${WORKERS[*]}"
 
+# --- Node "syslog" for the syslog health monitor ------------------------------
+# The monitor opens the journal DIRECTORY under a /var/log hostPath and admits
+# only kernel-transport entries, neither of which a stock Kind node offers: it
+# keeps a volatile journal in /run/log/journal and ships ReadKMsg=no, so the
+# Xid the node agent puts on /dev/kmsg is dropped. Both restarts
+# are needed — journald cannot reload, and it does not create /var/log/journal
+# itself; journal-flush is what creates it and moves the journal there.
+#
+# Exactly one node, because the kernel ring buffer is not namespaced: every Kind
+# node on this host shares the machine's, so an Xid injected on any node reaches
+# all of them. Enabling ingestion everywhere would have each node's monitor
+# report the same fault and NVSentinel quarantine the whole cluster.
+SYSLOG_NODE="${WORKERS[0]}"
+info "Enabling persistent kernel-log journaling on ${SYSLOG_NODE}"
+docker exec "${SYSLOG_NODE}" bash -c '
+set -e
+mkdir -p /etc/systemd/journald.conf.d
+cat > /etc/systemd/journald.conf.d/99-node-syslog.conf <<EOF
+[Journal]
+Storage=persistent
+ReadKMsg=yes
+EOF
+systemctl restart systemd-journald
+systemctl restart systemd-journal-flush
+'
+
 # --- Label GPU workers + install nvidia-container-toolkit / CDI ---------------
 for node in "${WORKERS[@]}"; do
   info "Labeling ${node} with ${GPU_NODE_LABEL}"
@@ -149,6 +175,10 @@ info "Loading image into Kind"
 kind load docker-image "${IMAGE_NAME}" --name "${CLUSTER_NAME}"
 
 # --- Install nvml-mock (pinned to the GPU workers) ----------------------------
+# nodeAgent.kernelLog is what this demo turns on: the chart ships it off, since
+# it makes the node-agent container privileged, and without it an injected Xid
+# reaches NVML alone -- invisible to NVSentinel's syslog monitor, which is the
+# half of NVSentinel this demo exists to show.
 info "Installing nvml-mock (profile=${GPU_PROFILE}) on the GPU workers"
 helm upgrade --install nvml-mock "${REPO_ROOT}/${CHART_PATH}" \
   --kube-context "${KUBE_CONTEXT}" \
@@ -158,6 +188,7 @@ helm upgrade --install nvml-mock "${REPO_ROOT}/${CHART_PATH}" \
   --set "gpu.profile=${GPU_PROFILE}" \
   --set gpu.dynamicMetrics.enabled=true \
   --set-string "nodeSelector.nvml-mock-gpu=true" \
+  --set nodeAgent.kernelLog.enabled=true \
   --wait --timeout 180s
 
 # --- Install the NVIDIA GPU Operator with standalone DCGM ---------------------

--- a/docs/nvml-mock-ctl.md
+++ b/docs/nvml-mock-ctl.md
@@ -176,7 +176,79 @@ Sets the `failure` block for the target. Modes:
   (omit for "trip on first guarded call").
 - `--xid CODE` — surface this Xid code through the NVML event set once the
   device trips (delivered for any tripped failure mode with a Xid configured,
-  e.g. `--mode ecc_uncorrectable --xid 79`).
+  e.g. `--mode ecc_uncorrectable --xid 79`), **and** have the node agent
+  announce it on the node's kernel log — see below.
+
+#### Xid on the kernel log
+
+A real driver raises an Xid with a kernel printk, and the agents that watch for
+Xids read that line rather than NVML: some scan `/dev/kmsg` directly, while
+NVSentinel's syslog monitor reads the journal, admitting only kernel-transport
+entries. So an injection that carries an `--xid` also reaches the kernel log,
+once per targeted GPU:
+
+```text
+kernel: NVRM: Xid (PCI:0000:1a:00): 79
+```
+
+The node agent writes it, not this CLI. The agent watches the same override
+document `fail` writes and announces each Xid that appears on it, so the kernel
+log follows the simulated GPU state itself rather than one way of changing it —
+an injection from the allocation watcher, a hand-edited override or a future
+control plane raises the line just the same. It also means the announcement is
+the node's to make: the agent names each device by the address it serves through
+NVML, and only the devices this node actually runs (`gpu.count`), which the CLI
+could only infer from the profile.
+
+That address — the profile's `pci.bus_id`, or the mock's own for a profile that
+sets none — is spelled the way the driver spells it, lower case and without the
+function, so the kernel line, the NVML event and the simulated `/sys/bus/pci`
+tree all name the same device. Recovery announces nothing: `--mode healthy`
+clears the injection, but kernel logs never retract an Xid. Re-injecting after a
+recovery announces again, even with the same code, because it is a new fault.
+
+The line appears within about a second of the injection, alongside the NVML
+event: both sides poll the override document. With `--after-calls N` the kernel
+line leads the NVML failure, because a deferred failure trips inside whichever
+consumer makes the Nth guarded call — a counter that lives in that process and
+never reaches disk, so nothing outside it can wait for the trip. Omit
+`--after-calls` when a consumer must not see the Xid before NVML reports the
+device failed.
+
+Announcing is best-effort and never fails the injection: a node whose kernel log
+is missing or unwritable keeps the NVML side, and the agent logs the skip.
+
+Two node-level requirements, neither of which the mock can arrange for itself:
+
+- the agent must be able to write `/dev/kmsg`, which takes
+  `nodeAgent.kernelLog.enabled=true`. It is off by default because it mounts the
+  device and runs `node-agent` **privileged**: mounting alone is not enough, as
+  the container device cgroup rejects the write (`operation not permitted`) even
+  for root with the node's world-writable `/dev/kmsg` bind-mounted, and no
+  lesser capability lifts that. A cluster that will not take a privileged pod,
+  or a node with no `/dev/kmsg`, has to leave it off; the DaemonSet then sets
+  `MOCK_NVML_KMSG=""` and the agent stays quiet instead of warning about a
+  device it was not given. `local/nvml-mock.values.yaml` and the nv-sentinel
+  demo enable it, so an Xid injected there lands on the kernel log. Where
+  PodSecurity is enforced, the namespace has to admit the pod:
+  `kubectl label namespace mokka pod-security.kubernetes.io/enforce=privileged`
+  — under `baseline` or `restricted` the DaemonSet is rejected outright rather
+  than degraded;
+- for journal-based consumers, journald must ingest the kernel ring buffer
+  (`ReadKMsg=yes`) and keep the journal where the consumer looks. Kind's node
+  image sets `ReadKMsg=no` and keeps a volatile journal, so a Kind cluster needs
+  a `journald` drop-in with `Storage=persistent` and `ReadKMsg=yes`. Applied
+  after boot it takes two restarts — `systemd-journald` cannot reload, and it
+  does not create `/var/log/journal` itself; `systemd-journal-flush` is what
+  creates the directory and moves the journal there.
+
+On a Kind cluster the kernel line is not node-local. The kernel ring buffer is
+not namespaced, so every node container on a host shares the machine's: an Xid
+written on one node is in `dmesg` on all of them, and on the host. Ingest it on
+one node only (the NVSentinel demo's `run.sh` configures a single worker), or
+every node's monitor reports the same fault and a remediator quarantines nodes
+whose GPUs are fine. Real nodes each have their own kernel, so this is an
+artifact of sharing a host, not something a consumer needs to handle.
 
 `fail --mode healthy` is how you *recover* a single device (it deletes the
 `failure` block from that bucket). See the failure-injection section of the
@@ -455,6 +527,8 @@ All examples assume `$POD` is set as shown in [Where it runs](#where-it-runs).
 kubectl -n mokka exec "$POD" -- nvml-mock-ctl fail --gpu 0 --mode ecc_uncorrectable --after-calls 1 --xid 79
 # verify from any consumer pod:
 kubectl exec <consumer> -- nvidia-smi --query-gpu=ecc.errors.uncorrected.aggregate.total --format=csv,noheader
+# the same Xid on the node's kernel log (on Kind, read it on the node itself):
+docker exec <node> sh -c 'dmesg | grep "NVRM: Xid"'
 ```
 
 ```bash
@@ -548,6 +622,14 @@ kubectl -n mokka delete pod "$POD"
   (no `uuid:` in the profile). Target it by index instead.
 - **Nothing changed on other nodes.** Scope is per-node. Repeat the command
   against each node's DaemonSet pod.
+- **The Xid isn't in the kernel log.** Silence usually means the announcement
+  was never turned on: it needs `nodeAgent.kernelLog.enabled=true`, and without
+  it the DaemonSet sets `MOCK_NVML_KMSG=""`. Otherwise the node agent's log says
+  why — it writes the line, so that is where the failure is reported: `kubectl
+  -n mokka logs "$POD" -c node-agent | grep kernellog`. A failed write means the
+  container cannot reach `/dev/kmsg`. If `dmesg` shows the line but a journal
+  consumer does not see it, the node's journald is dropping kernel messages — see
+  [Xid on the kernel log](#xid-on-the-kernel-log).
 - **An identity field didn't change.** Device `name`, `architecture`, `brand`,
   `compute_capability`, `uuid`, and PCI `bus_id` are baked at construction and
   are not hot-reloadable in v1. Change the profile/Helm values and restart the

--- a/docs/tools/node-agent.md
+++ b/docs/tools/node-agent.md
@@ -5,10 +5,11 @@ process the nvml-mock DaemonSet runs: a single `start` command that watches the
 profile, fans every change out to the simulators, and serves the two probes the
 kubelet reads.
 
-Seven simulators run under it, each owning one slice of the mock driver tree:
-`gpudriver`, `pcibus`, `cdi`, `imex`, `nvlink`, `fabricmanager` and `ib`. They
-all write below `--host-root`, so the tree a workload later sees is entirely a
-function of that flag plus the profile.
+Eight simulators run under it, each owning one slice of the mock driver tree:
+`gpudriver`, `pcibus`, `cdi`, `imex`, `nvlink`, `fabricmanager`, `ib` and
+`kernellog`. All but the last write below `--host-root`, so the tree a workload
+later sees is entirely a function of that flag plus the profile; `kernellog`
+writes no tree at all, announcing injected Xids on the node's kernel log.
 
 ## Reconcile contract
 
@@ -19,12 +20,12 @@ startup and then only when the bytes of either document change.
 
 Each state change runs one reconcile:
 
-1. `Stage` on all seven simulators concurrently. A failing simulator does not
+1. `Stage` on all eight simulators concurrently. A failing simulator does not
    cancel its siblings; every error is collected and the rest of the reconcile
    is skipped, because the later steps read what `Stage` wrote.
-2. The daemons (`fabricmanager` and `ib`) start on that barrier, once per
-   process lifetime. Later states reach an already running daemon through
-   `Reload`, so a profile edit does not need a pod restart.
+2. The daemons (`fabricmanager`, `ib` and `kernellog`) start on that barrier,
+   once per process lifetime. Later states reach an already running daemon
+   through `Reload`, so a profile edit does not need a pod restart.
 3. `Apply` on the three simulators that publish artifacts off-node
    (`gpudriver`, `pcibus`, `cdi`). This wave fails fast: the CDI spec refers to
    device nodes `gpudriver` must have staged first.
@@ -45,6 +46,20 @@ are cleared, at both locations the mock NVML engine resolves:
 `<host-root>/var/lib/nvml-mock/config/overrides.yaml` and
 `<host-root>/var/lib/nvml-mock/driver/config/overrides.yaml`. A pod restart is
 therefore the documented way back to the pristine profile.
+
+Afterwards the second of those two documents is polled every second, by
+`kernellog` alone: an Xid that appears on it is announced on `--kernel-log`, the
+way a driver's printk announces a fault. Every other simulator takes its input
+from the profile, and none of them reads the overrides — they are the runtime
+surface, hot-reloaded by the engine inside each NVML consumer.
+
+Each fault is announced once, not for as long as it stands. Clearing a fault
+prints nothing, as it does for a real driver, and re-injecting it prints again —
+unless the clear and the re-injection both land between two reads, in which case
+the document that comes back is the one already announced and the repeat is
+silent. The kernel log then holds one line where a driver would have printed
+two; the fault it reports, and the absence of any retraction, are the same
+either way.
 
 ## Probes
 
@@ -73,6 +88,7 @@ variable; the flag wins when both are set.
 | `--ib-fabric` | `MOCK_IB_PING_FABRIC` | `false` | enable the cross-pod fabric relay; required for multi-node `ibping` and `iblinkinfo` |
 | `--ib-fabric-port` | `MOCK_IB_PING_PORT` | `18515` | TCP port for the cross-pod mock-ib fabric relay |
 | `--fabricmanager-init-delay` | `MOCK_FABRICMANAGER_INIT_DELAY` | `0` | withhold fabric readiness for this long, simulating NVSwitch registration latency |
+| `--kernel-log` | `MOCK_NVML_KMSG` | `/dev/kmsg` | kernel log to announce injected Xids on, as a driver's printk does. Empty announces nowhere, which is how the chart states that the container was not given a writable one — it sets this empty unless `nodeAgent.kernelLog.enabled` asks for the device and the privilege writing it takes. Not rooted at `--host-root`: the deployment grants the device at its own path |
 
 An unrecognized `--log-level`, `--log-format` or `--ib-mode` is a startup error
 rather than a silent fallback, so a typo in a Helm value fails the pod instead

--- a/internal/agent/kernellog/kernellog.go
+++ b/internal/agent/kernellog/kernellog.go
@@ -1,0 +1,289 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// Package kernellog simulates the kernel side of an Xid: the printk a real
+// driver emits when a GPU faults.
+//
+// It belongs to the agent rather than to nvml-mock-ctl because the kernel log
+// is host state, like the character devices and the PCI sysfs tree the other
+// simulators write, and because the fault is not the CLI's to announce — an
+// injection reaches the mock through the runtime override document, whoever
+// writes it. Watching that document instead of the CLI's own invocation is what
+// lets the allocation watcher, a hand-edited file or a future control plane
+// raise an Xid that the agents watching this node can see.
+package kernellog
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/NVIDIA/k8s-test-infra/internal/agent"
+	"github.com/NVIDIA/k8s-test-infra/internal/agent/host"
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mockctl"
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
+)
+
+const name = "kernellog"
+
+// defaultInterval matches the TTL of the engine's own override cache, so the
+// kernel line and the NVML event follow an injection within the same second.
+const defaultInterval = time.Second
+
+var (
+	_ agent.Simulator = (*Simulator)(nil)
+	_ agent.Daemon    = (*Simulator)(nil)
+)
+
+// Simulator announces newly injected Xids on the node's kernel log.
+type Simulator struct {
+	path     string // kernel log to write; empty announces nowhere
+	interval time.Duration
+	staged   atomic.Bool
+
+	mu        sync.Mutex
+	overrides string         // runtime override document to watch
+	devices   []device       // in device order, so a fault on several prints in it
+	announced map[int]uint64 // device index -> Xid already on the kernel log
+	warned    map[int]uint64 // device index -> Xid we already failed to write
+	lastErr   string         // deduplicates a persistent read failure
+}
+
+// device is what this simulator needs of a GPU: which bucket of the override
+// document speaks for it, and what to call it in a kernel line.
+type device struct {
+	index int
+	busID string
+}
+
+// Options configures the simulator.
+type Options struct {
+	// Path is the kernel log to write, /dev/kmsg on a node that grants one.
+	// Empty disables the announcement, which is how a deployment that cannot
+	// reach the kernel log says so: the NVML side of an injection stands on its
+	// own, so this is a quiet degradation rather than an error.
+	Path string
+	// Interval is how often the override document is re-read. Zero picks a
+	// default aligned with the engine's own polling.
+	Interval time.Duration
+}
+
+// New returns a kernel log Simulator.
+func New(opts Options) *Simulator {
+	interval := opts.Interval
+	if interval == 0 {
+		interval = defaultInterval
+	}
+
+	return &Simulator{
+		path:      opts.Path,
+		interval:  interval,
+		announced: map[int]uint64{},
+		warned:    map[int]uint64{},
+	}
+}
+
+// Name returns the simulator's stable identifier.
+func (s *Simulator) Name() string { return name }
+
+// Ready reports whether the simulator knows which devices this node serves.
+func (s *Simulator) Ready() bool { return s.staged.Load() }
+
+// Stage records where the injections arrive and which address each device
+// answers to, so a kernel line names the device the way NVML does. It writes
+// nothing: the artifact this simulator produces is an event, not a file.
+func (s *Simulator) Stage(_ context.Context, h *host.Host, state *agent.State) error {
+	zap.L().Info("staging simulator", zap.String("simulator", name))
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// The document nvml-mock-ctl writes and the engine reads. Derived rather
+	// than configured because both ends already agree on it: the DaemonSet
+	// points MOCK_NVML_OVERRIDES here, and it is the CLI's default besides.
+	s.overrides = h.RootPath("driver/config/overrides.yaml")
+
+	previous := s.devices
+	s.devices = make([]device, 0, len(state.Devices))
+	for _, d := range state.Devices {
+		// A profile is free to leave addressing to the mock, and such a device
+		// still serves the address it inherits from the base mock. Naming it
+		// any other way would leave the kernel line pointing at no GPU.
+		busID := strings.ToLower(d.PCIBusID)
+		if busID == "" {
+			busID = engine.BaseDevicePCIBusID(d.Index)
+		}
+
+		// The boundary the rendered PCI tree already applies to bus_id, for a
+		// sharper reason: the address goes into the node's kernel ring buffer,
+		// which is unnamespaced and read by health agents, so an address
+		// carrying a newline would let whoever can edit the profile put lines
+		// of their own where a remediator reads them. Logged verbatim, which is
+		// safe — zap escapes it — and is what names the offending value.
+		if !agent.ValidBDF(busID) {
+			zap.L().Warn("device has no usable PCI address; its Xids cannot be announced",
+				zap.String("simulator", name), zap.Int("device", d.Index),
+				zap.String("pci", d.PCIBusID))
+			continue
+		}
+		s.devices = append(s.devices, device{index: d.Index, busID: busID})
+	}
+
+	// A profile edit can renumber devices, and an index that now names another
+	// GPU must not inherit what the old one announced, or the new device's
+	// first Xid is read as a fault already reported.
+	s.forgetRenumbered(previous)
+
+	s.staged.Store(true)
+	// Says how many devices can be named, which is what a silent kernel log
+	// comes down to when a profile's addresses do not survive the check above.
+	zap.L().Info("simulator staged", zap.String("simulator", name),
+		zap.Int("devices", len(s.devices)), zap.String("kernelLog", s.path))
+
+	return nil
+}
+
+// forgetRenumbered drops what was announced for any device whose address is not
+// the one it had at the previous staging, including a device that is gone.
+func (s *Simulator) forgetRenumbered(previous []device) {
+	current := make(map[int]string, len(s.devices))
+	for _, d := range s.devices {
+		current[d.index] = d.busID
+	}
+
+	for _, was := range previous {
+		if current[was.index] != was.busID {
+			delete(s.announced, was.index)
+			delete(s.warned, was.index)
+		}
+	}
+}
+
+// Run announces injections until the agent shuts down.
+func (s *Simulator) Run(ctx context.Context) error {
+	if s.path == "" {
+		<-ctx.Done()
+		return nil
+	}
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			s.Poll(ctx)
+		}
+	}
+}
+
+// Reload is a no-op: Stage already delivers every revision.
+func (s *Simulator) Reload(_ context.Context, _ *agent.State) error { return nil }
+
+// Discard stops the announcements. It retracts nothing — a kernel log never
+// takes an Xid back — and forgets what it announced, so the next agent may
+// report a fault that outlives this one.
+func (s *Simulator) Discard(_ context.Context, _ *host.Host) error {
+	zap.L().Info("discarding simulator", zap.String("simulator", name))
+	s.staged.Store(false)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.announced = map[int]uint64{}
+	s.warned = map[int]uint64{}
+
+	return nil
+}
+
+// Poll announces every Xid that has appeared since the last call. It is the
+// unit of work Run repeats, exported so a caller can drive it directly.
+//
+// Nothing here fails the agent: the fault has already been injected into NVML,
+// and a node whose kernel log cannot be written is worse off but not broken.
+func (s *Simulator) Poll(_ context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Not yet staged, or a deployment that told us it has no kernel log: in
+	// neither case is there anything to say.
+	if s.overrides == "" || s.path == "" {
+		return
+	}
+
+	doc, err := mockctl.Load(s.overrides)
+	if err != nil {
+		// Once per distinct failure: a malformed document stays malformed
+		// until someone rewrites it, and this runs every second.
+		if msg := err.Error(); msg != s.lastErr {
+			s.lastErr = msg
+			zap.L().Warn("cannot read runtime overrides; Xids will not be announced",
+				zap.String("simulator", name), zap.String("path", s.overrides), zap.Error(err))
+		}
+		return
+	}
+	s.lastErr = ""
+
+	for _, d := range s.devices {
+		code := doc.FailureXid(d.index)
+		if code == 0 {
+			// Recovered, or never faulted. Forgetting it here is what makes a
+			// repeat of the same Xid a new event rather than a duplicate.
+			delete(s.announced, d.index)
+			delete(s.warned, d.index)
+			continue
+		}
+		// A code this device is already known to raise is the same fault, not a
+		// new one. This does swallow a clear and a re-arm of the same code that
+		// both land between two reads: what comes back is byte-for-byte the
+		// document already announced, so no reader of state can tell the two
+		// apart, at any poll rate. Harmless for a reader of the log, since
+		// recovery prints nothing either — one line and two both say the device
+		// raised this Xid and never took it back.
+		if s.announced[d.index] == code {
+			continue
+		}
+
+		s.emit(d, code)
+	}
+}
+
+func (s *Simulator) emit(d device, code uint64) {
+	wrote, err := emitXid(s.path, d.busID, code)
+	if wrote {
+		s.announced[d.index] = code
+		delete(s.warned, d.index)
+		zap.L().Info("announced Xid on the kernel log",
+			zap.String("simulator", name), zap.Int("device", d.index),
+			zap.String("pci", d.busID), zap.Uint64("xid", code))
+
+		return
+	}
+
+	// A write that did not happen is not an announcement, so it is left out of
+	// announced and the next tick tries again: a transient failure costs a
+	// second rather than the Xid, which would otherwise go unannounced until
+	// the fault was cleared and injected afresh. The dedupe moves onto the
+	// warning, which is what must not repeat every second.
+	if s.warned[d.index] == code {
+		return
+	}
+	s.warned[d.index] = code
+
+	if err != nil {
+		zap.L().Warn("could not announce Xid on the kernel log",
+			zap.String("simulator", name), zap.String("path", s.path),
+			zap.Int("device", d.index), zap.Uint64("xid", code), zap.Error(err))
+
+		return
+	}
+
+	zap.L().Warn("no kernel log on this node; Xid announced nowhere",
+		zap.String("simulator", name), zap.String("path", s.path),
+		zap.Int("device", d.index), zap.Uint64("xid", code))
+}

--- a/internal/agent/kernellog/kernellog_test.go
+++ b/internal/agent/kernellog/kernellog_test.go
@@ -1,0 +1,333 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package kernellog
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/k8s-test-infra/internal/agent"
+	"github.com/NVIDIA/k8s-test-infra/internal/agent/host"
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mockctl"
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
+)
+
+// node builds a host whose kernel log is a regular file, so a test can read
+// back what a driver would have printed.
+func node(t *testing.T, devices ...agent.DeviceSpec) (*host.Host, *agent.State, string) {
+	t.Helper()
+
+	h := host.New(t.TempDir())
+	require.NoError(t, os.MkdirAll(h.RootPath("driver/config"), 0o755))
+
+	kmsg := filepath.Join(t.TempDir(), "kmsg")
+	require.NoError(t, os.WriteFile(kmsg, nil, 0o600))
+
+	return h, &agent.State{Devices: devices}, kmsg
+}
+
+func gpus(busIDs ...string) []agent.DeviceSpec {
+	specs := make([]agent.DeviceSpec, 0, len(busIDs))
+	for i, busID := range busIDs {
+		specs = append(specs, agent.DeviceSpec{Index: i, PCIBusID: busID})
+	}
+
+	return specs
+}
+
+// inject writes what `nvml-mock-ctl fail` writes, since the override file is
+// the only thing that passes between the two.
+func inject(t *testing.T, h *host.Host, target mockctl.Target, mode string, xid uint64) {
+	t.Helper()
+
+	path := h.RootPath("driver/config/overrides.yaml")
+	doc, err := mockctl.Load(path)
+	require.NoError(t, err)
+	require.NoError(t, doc.Fail(target, mode, 0, xid))
+	require.NoError(t, mockctl.WriteAtomic(path, doc))
+}
+
+func kernelLog(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	return string(data)
+}
+
+func staged(t *testing.T, h *host.Host, state *agent.State, kmsg string) *Simulator {
+	t.Helper()
+
+	s := New(Options{Path: kmsg})
+	require.NoError(t, s.Stage(t.Context(), h, state))
+	require.True(t, s.Ready())
+
+	return s
+}
+
+// The announcement follows the injection the CLI wrote, and follows it once:
+// the watcher re-reads the file on every tick, but a driver prints an Xid when
+// the fault happens, not for as long as the GPU stays broken.
+func TestSimulator_AnnouncesEachInjectionOnce(t *testing.T) {
+	t.Parallel()
+
+	h, state, kmsg := node(t, gpus("0000:1A:00.0", "0000:2B:00.0")...)
+	s := staged(t, h, state, kmsg)
+
+	s.Poll(t.Context())
+	require.Empty(t, kernelLog(t, kmsg), "a healthy node prints nothing")
+
+	inject(t, h, mockctl.Target{Index: 1}, engine.FailureModeLost, 79)
+	s.Poll(t.Context())
+	require.Equal(t, "kernel: NVRM: Xid (PCI:0000:2b:00): 79\n", kernelLog(t, kmsg))
+
+	s.Poll(t.Context())
+	s.Poll(t.Context())
+	require.Equal(t, "kernel: NVRM: Xid (PCI:0000:2b:00): 79\n", kernelLog(t, kmsg),
+		"a standing failure is not a new Xid")
+}
+
+// Recovery retracts nothing — kernel logs never do — but it does end the fault,
+// so the next injection is a new Xid even when the code repeats.
+func TestSimulator_AnnouncesAgainAfterRecovery(t *testing.T) {
+	t.Parallel()
+
+	h, state, kmsg := node(t, gpus("0000:1A:00.0")...)
+	s := staged(t, h, state, kmsg)
+
+	inject(t, h, mockctl.Target{Index: 0}, engine.FailureModeLost, 79)
+	s.Poll(t.Context())
+
+	inject(t, h, mockctl.Target{Index: 0}, engine.FailureModeHealthy, 0)
+	s.Poll(t.Context())
+	require.Equal(t, "kernel: NVRM: Xid (PCI:0000:1a:00): 79\n", kernelLog(t, kmsg),
+		"recovery prints nothing of its own")
+
+	inject(t, h, mockctl.Target{Index: 0}, engine.FailureModeLost, 79)
+	s.Poll(t.Context())
+	require.Equal(t, "kernel: NVRM: Xid (PCI:0000:1a:00): 79\nkernel: NVRM: Xid (PCI:0000:1a:00): 79\n",
+		kernelLog(t, kmsg))
+}
+
+// The counterpart to the test above, and the limit of watching state instead
+// of events: a clear and a re-arm of the same code between two reads leave a
+// document identical to the one already announced, so the second injection
+// prints nothing. Pinned because it is inherent rather than an oversight — the
+// document that comes back is byte-for-byte the one before it, at any poll
+// rate — and because it costs a reader of the log nothing: recovery prints no
+// line either, so one line and two both say "Xid 79 here, never retracted".
+func TestSimulator_CollapsesAClearAndRearmBetweenPolls(t *testing.T) {
+	t.Parallel()
+
+	h, state, kmsg := node(t, gpus("0000:1A:00.0")...)
+	s := staged(t, h, state, kmsg)
+
+	inject(t, h, mockctl.Target{Index: 0}, engine.FailureModeLost, 79)
+	s.Poll(t.Context())
+
+	inject(t, h, mockctl.Target{Index: 0}, engine.FailureModeHealthy, 0)
+	inject(t, h, mockctl.Target{Index: 0}, engine.FailureModeLost, 79)
+	s.Poll(t.Context())
+
+	require.Equal(t, "kernel: NVRM: Xid (PCI:0000:1a:00): 79\n", kernelLog(t, kmsg))
+}
+
+// `--gpu all` faults every device, so every device raises the Xid — and only
+// the devices this node serves, since the agent announces from the state it
+// staged rather than from whatever the profile lists.
+func TestSimulator_AnnouncesEveryTargetedDevice(t *testing.T) {
+	t.Parallel()
+
+	h, state, kmsg := node(t, gpus("0000:1A:00.0", "0000:2B:00.0")...)
+	s := staged(t, h, state, kmsg)
+
+	inject(t, h, mockctl.Target{All: true}, engine.FailureModeECCUncorrectable, 48)
+	s.Poll(t.Context())
+
+	require.Equal(t, "kernel: NVRM: Xid (PCI:0000:1a:00): 48\nkernel: NVRM: Xid (PCI:0000:2b:00): 48\n",
+		kernelLog(t, kmsg))
+}
+
+// The allocation watcher rewrites the same file every few seconds. Only a
+// change in what a device raises is an event; anything else in the document is
+// not this simulator's business.
+func TestSimulator_IgnoresUnrelatedOverrides(t *testing.T) {
+	t.Parallel()
+
+	h, state, kmsg := node(t, gpus("0000:1A:00.0")...)
+	s := staged(t, h, state, kmsg)
+
+	inject(t, h, mockctl.Target{Index: 0}, engine.FailureModeLost, 79)
+	s.Poll(t.Context())
+
+	path := h.RootPath("driver/config/overrides.yaml")
+	doc, err := mockctl.Load(path)
+	require.NoError(t, err)
+	doc.SetFields(mockctl.Target{Index: 0}, map[string]any{"memory": map[string]any{"used_bytes": 42}})
+	require.NoError(t, mockctl.WriteAtomic(path, doc))
+
+	s.Poll(t.Context())
+	require.Equal(t, "kernel: NVRM: Xid (PCI:0000:1a:00): 79\n", kernelLog(t, kmsg))
+}
+
+// The engine deep-merges the shared bucket into the per-device one, so `fail
+// --gpu all --xid 79` followed by `fail --gpu 0 --mode lost` leaves device 0
+// raising 79 like the rest. Read as shadowing, the device an operator had just
+// singled out was the one device on the node that got no kernel line.
+func TestSimulator_AnnouncesADeviceSingledOutAfterAll(t *testing.T) {
+	t.Parallel()
+
+	h, state, kmsg := node(t, gpus("0000:1A:00.0", "0000:2B:00.0")...)
+	s := staged(t, h, state, kmsg)
+
+	inject(t, h, mockctl.Target{All: true}, engine.FailureModeLost, 79)
+	inject(t, h, mockctl.Target{Index: 0}, engine.FailureModeLost, 0)
+	s.Poll(t.Context())
+
+	require.Equal(t, "kernel: NVRM: Xid (PCI:0000:1a:00): 79\nkernel: NVRM: Xid (PCI:0000:2b:00): 79\n",
+		kernelLog(t, kmsg))
+}
+
+// bus_id is hand-authored, and this sink is node-wide and unnamespaced: an
+// address is only ever written after passing the same check the rendered PCI
+// tree applies, so nobody holding edit on the profile can put lines of their
+// own where a health agent reads them.
+func TestSimulator_RefusesAnAddressThatIsNotOne(t *testing.T) {
+	t.Parallel()
+
+	forged := "0000:1a:00\nkernel: NVRM: Xid (PCI:0000:ff:00): 48"
+	h, state, kmsg := node(t, gpus(forged, "0000:2B:00.0")...)
+	s := staged(t, h, state, kmsg)
+
+	inject(t, h, mockctl.Target{All: true}, engine.FailureModeLost, 79)
+	s.Poll(t.Context())
+
+	require.Equal(t, "kernel: NVRM: Xid (PCI:0000:2b:00): 79\n", kernelLog(t, kmsg),
+		"the forged device announces nothing; its neighbour is unaffected")
+}
+
+// A write that failed announced nothing, so the Xid is still owed: the next
+// tick has to carry it rather than treat it as already reported, which would
+// lose it until the fault was cleared and injected again.
+func TestSimulator_RetriesAFailedWrite(t *testing.T) {
+	t.Parallel()
+
+	h, state, kmsg := node(t, gpus("0000:1A:00.0")...)
+	s := staged(t, h, state, kmsg)
+
+	// Stands in for a transient failure: the write cannot land while the path
+	// is a directory, and can once it is the kernel log again.
+	unwritable := filepath.Join(t.TempDir(), "kmsg-dir")
+	require.NoError(t, os.Mkdir(unwritable, 0o755))
+	s.path = unwritable
+
+	inject(t, h, mockctl.Target{Index: 0}, engine.FailureModeLost, 79)
+	s.Poll(t.Context())
+
+	s.path = kmsg
+	s.Poll(t.Context())
+	require.Equal(t, "kernel: NVRM: Xid (PCI:0000:1a:00): 79\n", kernelLog(t, kmsg))
+
+	s.Poll(t.Context())
+	require.Equal(t, "kernel: NVRM: Xid (PCI:0000:1a:00): 79\n", kernelLog(t, kmsg),
+		"once written it is announced, and stays announced")
+}
+
+// Restaging rebuilds the device list, and an index that now names a different
+// GPU must not inherit what the old one announced — its first Xid would read as
+// a fault already reported.
+func TestSimulator_ForgetsRenumberedDevices(t *testing.T) {
+	t.Parallel()
+
+	h, state, kmsg := node(t, gpus("0000:1A:00.0")...)
+	s := staged(t, h, state, kmsg)
+
+	inject(t, h, mockctl.Target{Index: 0}, engine.FailureModeLost, 79)
+	s.Poll(t.Context())
+
+	// A profile edit puts another GPU at index 0, with the fault still standing.
+	require.NoError(t, s.Stage(t.Context(), h, &agent.State{Devices: gpus("0000:3C:00.0")}))
+	s.Poll(t.Context())
+
+	require.Equal(t, "kernel: NVRM: Xid (PCI:0000:1a:00): 79\nkernel: NVRM: Xid (PCI:0000:3c:00): 79\n",
+		kernelLog(t, kmsg), "the new device announces its own fault")
+}
+
+// A profile that declares no pci.bus_id still serves an address through NVML,
+// and the kernel line has to name the device the mock names.
+func TestSimulator_NamesDevicesTheProfileLeavesAddressless(t *testing.T) {
+	t.Parallel()
+
+	h, state, kmsg := node(t, gpus("")...)
+	s := staged(t, h, state, kmsg)
+
+	inject(t, h, mockctl.Target{Index: 0}, engine.FailureModeLost, 79)
+	s.Poll(t.Context())
+
+	require.Equal(t, xidRecord(engine.BaseDevicePCIBusID(0), 79)+"\n", kernelLog(t, kmsg))
+}
+
+// A cluster that will not grant the node agent a writable /dev/kmsg says so
+// with an empty path. The NVML injection stands on its own, so that has to be
+// quiet rather than an error on every tick.
+func TestSimulator_WithoutAKernelLogIsInert(t *testing.T) {
+	t.Parallel()
+
+	h, state, _ := node(t, gpus("0000:1A:00.0")...)
+	s := New(Options{Path: ""})
+	require.NoError(t, s.Stage(t.Context(), h, state))
+	require.True(t, s.Ready())
+
+	inject(t, h, mockctl.Target{Index: 0}, engine.FailureModeLost, 79)
+	s.Poll(t.Context())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	require.NoError(t, s.Run(ctx))
+}
+
+// The daemon has to reach Poll on its own: everything above drives it by hand.
+func TestSimulator_RunPolls(t *testing.T) {
+	t.Parallel()
+
+	h, state, kmsg := node(t, gpus("0000:1A:00.0")...)
+	s := New(Options{Path: kmsg, Interval: time.Millisecond})
+	require.NoError(t, s.Stage(t.Context(), h, state))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+
+	inject(t, h, mockctl.Target{Index: 0}, engine.FailureModeLost, 79)
+	require.Eventually(t, func() bool {
+		return kernelLog(t, kmsg) != ""
+	}, 5*time.Second, 5*time.Millisecond)
+
+	cancel()
+	require.NoError(t, <-done)
+}
+
+// Shutdown withdraws nothing: an Xid already in the kernel log is history, and
+// the next agent must be free to announce the same fault again.
+func TestSimulator_DiscardIsQuiet(t *testing.T) {
+	t.Parallel()
+
+	h, state, kmsg := node(t, gpus("0000:1A:00.0")...)
+	s := staged(t, h, state, kmsg)
+
+	inject(t, h, mockctl.Target{Index: 0}, engine.FailureModeLost, 79)
+	s.Poll(t.Context())
+
+	require.NoError(t, s.Discard(t.Context(), h))
+	require.False(t, s.Ready())
+	require.Equal(t, "kernel: NVRM: Xid (PCI:0000:1a:00): 79\n", kernelLog(t, kmsg))
+}

--- a/internal/agent/kernellog/kmsg.go
+++ b/internal/agent/kernellog/kmsg.go
@@ -1,0 +1,77 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package kernellog
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// DefaultPath is the kernel log an injected Xid is announced on.
+//
+// A real driver raises an Xid with a printk, and that kernel line — not NVML —
+// is what the health agents Mokka simulates for consume: some read /dev/kmsg
+// directly, and journald ingests it as a _TRANSPORT=kernel entry, which is the
+// only transport NVSentinel's syslog monitor admits. An Xid that lands only in
+// the NVML event path is invisible to both.
+const DefaultPath = "/dev/kmsg"
+
+// xidRecord renders the kernel log record announcing Xid code on the GPU at
+// busID (an NVML bus ID such as 0000:1A:00.0).
+//
+// None of the three deviations from the NVML spelling is cosmetic. The driver
+// names the PCI device without its function and prints hex in lower case, so a
+// real Xid reads "(PCI:0000:1a:00)" — the form agents normalize against, and
+// the one that matches the addresses in the simulated /sys/bus/pci tree. The
+// "kernel: " prefix is what keeps "NVRM: " inside the journal's MESSAGE field:
+// journald parses a leading "ident: " out of every /dev/kmsg line, so without
+// it the record arrives as SYSLOG_IDENTIFIER=NVRM with the prefix stripped and
+// patterns anchored on "NVRM: Xid" no longer match.
+func xidRecord(busID string, code uint64) string {
+	return fmt.Sprintf("kernel: NVRM: Xid (PCI:%s): %d", driverPCI(busID), code)
+}
+
+// emitXid announces Xid code on the kernel log at path for the GPU at busID,
+// and reports whether it wrote. One record per call, because /dev/kmsg turns
+// each write into exactly one kernel message.
+//
+// A missing kernel log is not an error. /dev/kmsg is absent from an
+// unprivileged container and from any host that does not expose it, and the
+// NVML side of the injection stands on its own — so a node that cannot be
+// written to degrades to the NVML-only behaviour rather than failing the
+// injection.
+func emitXid(path, busID string, code uint64) (bool, error) {
+	if path == "" || busID == "" {
+		return false, nil
+	}
+
+	// Never O_CREATE: on a node without a kernel log a created regular file
+	// would swallow the record and report success.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := f.WriteString(xidRecord(busID, code) + "\n"); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// driverPCI reduces an NVML bus ID to the lower-case domain:bus:device form the
+// driver prints, dropping the function suffix.
+func driverPCI(busID string) string {
+	if before, _, ok := strings.Cut(busID, "."); ok {
+		busID = before
+	}
+
+	return strings.ToLower(busID)
+}

--- a/internal/agent/kernellog/kmsg_test.go
+++ b/internal/agent/kernellog/kmsg_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package kernellog
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The shape health agents key off — NVSentinel's syslog-health-monitor matches
+// this exact pattern, and kmsg readers scan for the same "NVRM: Xid" text.
+// Pinned here so a change to the emitted record cannot silently stop matching.
+var agentXidPattern = regexp.MustCompile(`NVRM: Xid \(PCI:([0-9a-fA-F:.]+)\): (\d+)`)
+
+func TestXidRecord_SpellsTheAddressAsTheDriverDoes(t *testing.T) {
+	// The driver names the device, not the function, and prints hex in lower
+	// case: a real Xid reads "(PCI:0000:1a:00)" where NVML reports the BDF as
+	// 0000:1A:00.0. The case matters because an agent correlating the Xid with
+	// the simulated /sys/bus/pci tree finds lower case there.
+	require.Equal(t, "kernel: NVRM: Xid (PCI:0000:1a:00): 79", xidRecord("0000:1A:00.0", 79))
+}
+
+func TestXidRecord_IsMatchedByTheAgentPattern(t *testing.T) {
+	m := agentXidPattern.FindStringSubmatch(xidRecord("0000:1A:00.0", 48))
+	require.Len(t, m, 3, "emitted record must match the pattern health agents use")
+	require.Equal(t, "0000:1a:00", m[1], "captured PCI address")
+	require.Equal(t, "48", m[2], "captured Xid code")
+}
+
+// Each Xid is its own kernel message, and a later one never displaces what the
+// log already holds — a driver's printks accumulate.
+func TestEmitXid_AppendsOneRecordPerCall(t *testing.T) {
+	kmsg := fakeKernelLog(t)
+
+	for _, code := range []uint64{79, 48} {
+		wrote, err := emitXid(kmsg, "0000:1A:00.0", code)
+		require.NoError(t, err)
+		require.True(t, wrote)
+	}
+
+	require.Equal(t,
+		"kernel: NVRM: Xid (PCI:0000:1a:00): 79\nkernel: NVRM: Xid (PCI:0000:1a:00): 48\n",
+		readFile(t, kmsg))
+}
+
+func TestEmitXid_AbsentKernelLogIsNotAnError(t *testing.T) {
+	// The common case off a node: no /dev/kmsg to write to. The NVML side of
+	// the injection stands on its own, so this reports "not written", not an
+	// error.
+	kmsg := filepath.Join(t.TempDir(), "kmsg")
+
+	wrote, err := emitXid(kmsg, "0000:1A:00.0", 79)
+	require.NoError(t, err)
+	require.False(t, wrote)
+	require.NoFileExists(t, kmsg, "a missing kernel log must not be created")
+}
+
+func TestEmitXid_NothingToEmit(t *testing.T) {
+	kmsg := fakeKernelLog(t)
+
+	wrote, err := emitXid(kmsg, "", 79)
+	require.NoError(t, err)
+	require.False(t, wrote, "a device with no address is named nowhere")
+	require.Empty(t, readFile(t, kmsg))
+
+	wrote, err = emitXid("", "0000:1A:00.0", 79)
+	require.NoError(t, err)
+	require.False(t, wrote, "an empty path disables emission")
+}
+
+// fakeKernelLog stands in for /dev/kmsg: a writable file that already exists,
+// which is what the availability check looks for.
+func fakeKernelLog(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "kmsg")
+	require.NoError(t, os.WriteFile(path, nil, 0o644))
+	return path
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(data)
+}

--- a/internal/agent/state.go
+++ b/internal/agent/state.go
@@ -131,7 +131,7 @@ func rootIDForBDF(bdf string) string {
 	return "pci" + domain + ":" + bus
 }
 
-// validBDF reports whether s is a PCI address in the form the kernel names
+// ValidBDF reports whether s is a PCI address in the form the kernel names
 // sysfs entries with, DDDD:BB:DD.F, lowercase hex.
 //
 // The check is a boundary, not a nicety: gpu.customConfig authors bus_id by
@@ -141,7 +141,13 @@ func rootIDForBDF(bdf string) string {
 // consumer can look up either. The 8-digit domain NVML reports through
 // nvmlPciInfo_t.busId is not this form; the profile field carries the 4-digit
 // one, as busIdLegacy does.
-func validBDF(s string) bool {
+//
+// Exported for the simulators that put a device's address somewhere a
+// hand-authored string must not reach on trust. The kernel log is the sharpest
+// of those: it is node-wide, unnamespaced, and read by health agents, so an
+// address carrying a newline would let whoever can edit the profile write
+// kernel lines of their own.
+func ValidBDF(s string) bool {
 	const form = "dddd:bb:dd.f"
 	if len(s) != len(form) {
 		return false
@@ -177,7 +183,7 @@ func (s *State) activeBDFs() []string {
 
 	for _, d := range s.Devices {
 		bdf := strings.ToLower(d.PCIBusID)
-		if !validBDF(bdf) {
+		if !ValidBDF(bdf) {
 			continue
 		}
 		if seen[bdf] {

--- a/local/README.md
+++ b/local/README.md
@@ -38,6 +38,17 @@ make cluster-create PROFILE=compute-domain  # 1 CP + 4 workers (NVLink cliques)
 make cluster-delete                         # tear down (PROFILE= must match creation)
 ```
 
+The `default` profile also mounts `local/kind/journald-node-syslog.conf` on every
+node, which makes the Xid the node agent puts on `/dev/kmsg` for an
+`nvml-mock-ctl fail --xid` injection readable from the node journal —
+`docker exec worker-0 dmesg | grep 'NVRM: Xid'`. The announcement itself is off
+in the chart, since it makes the node agent privileged;
+`local/nvml-mock.values.yaml` turns it on for these clusters.
+Kind nodes share the host's kernel ring buffer, so an Xid injected on one node
+shows up on all of them.
+Since Kind resolves a config's paths against the working directory, create the
+cluster from the repo root (`make cluster-create` does).
+
 ## Step 2 — Start Tilt
 
 ### Homogeneous fleet (single Helm release)

--- a/local/kind/default.kind.yaml
+++ b/local/kind/default.kind.yaml
@@ -42,6 +42,18 @@
 #      overlay at container-creation time. Inert until a workload registers
 #      as an NRI plugin, so the node-wide-NRI scenario is the only consumer.
 #
+# Every node also mounts journald-node-syslog.conf, which is what makes the Xid
+# the node agent writes to /dev/kmsg for an injection readable from the node
+# journal (see that file), whichever node hosts the GPU under test. Its
+# hostPath is repo-relative, like every path in a Kind config, so create the
+# cluster from the repo root — `make cluster-create` does.
+#
+# Note that the journals will agree rather than partition the fleet: the kernel
+# ring buffer is not namespaced, so the node containers share this host's and an
+# Xid injected on one lands in all of their journals. Fine for reading the line
+# back by hand; a per-node log consumer running here would report one GPU's
+# fault against every node it watches.
+#
 # Worker names are pinned via JoinConfiguration instead of being derived from
 # the cluster name, so they stay stable across recreations and can be selected
 # directly: install_fleet() in local/nvml_mock.tiltfile pins each per-profile
@@ -71,6 +83,10 @@ containerdConfigPatches:
       socket_path = "/var/run/nri/nri.sock"
 nodes:
   - role: control-plane
+    extraMounts: &node-syslog
+      - hostPath: local/kind/journald-node-syslog.conf
+        containerPath: /etc/systemd/journald.conf.d/99-node-syslog.conf
+        readOnly: true
     kubeadmConfigPatches:
       - |
         kind: ClusterConfiguration
@@ -81,6 +97,7 @@ nodes:
     labels:
       run.ai/simulated-gpu-node-pool: integration
       mokka.nvidia.com/type: sgpu
+    extraMounts: *node-syslog
     kubeadmConfigPatches:
       - |
         kind: JoinConfiguration
@@ -90,6 +107,7 @@ nodes:
     labels:
       run.ai/simulated-gpu-node-pool: scale
       mokka.nvidia.com/type: sgpu
+    extraMounts: *node-syslog
     kubeadmConfigPatches:
       - |
         kind: JoinConfiguration

--- a/local/kind/journald-node-syslog.conf
+++ b/local/kind/journald-node-syslog.conf
@@ -1,0 +1,30 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+#
+# journald drop-in mounted onto every node by the Kind configs here, so a local
+# node keeps a "syslog" that agents reading host kernel logs can consume — the
+# Xid the node agent puts on /dev/kmsg for an injection, and NVSentinel's
+# syslog-health-monitor, which opens the journal DIRECTORY under a /var/log
+# hostPath and admits only kernel-transport entries. The stock Kind node image
+# satisfies neither requirement:
+#
+#   Storage=persistent  journald otherwise keeps the journal in /run/log/journal,
+#                       where a /var/log hostPath mount cannot see it. The
+#                       boot-time journal-flush unit creates the directory and
+#                       moves the journal there.
+#   ReadKMsg=yes        journald.conf ships ReadKMsg=no, dropping kernel
+#                       messages. With this, a line written to /dev/kmsg is
+#                       ingested as _TRANSPORT=kernel.
+#
+# Mounted at cluster creation rather than written into a running node because
+# journald cannot reload (CanReload=no), so a later drop-in would take a
+# restart of both systemd-journald and systemd-journal-flush to take effect.
+#
+# The nodes see one another's Xids: the kernel ring buffer is not namespaced, so
+# every node container on a host shares the machine's. Harmless when the journal
+# is read by hand, but a per-node log consumer deployed here would report one
+# GPU's fault against every node it watches — the NVSentinel demo's cluster
+# ingests kernel messages on a single node for that reason.
+[Journal]
+Storage=persistent
+ReadKMsg=yes

--- a/local/nvml-mock.values.yaml
+++ b/local/nvml-mock.values.yaml
@@ -15,3 +15,12 @@
 # deep-merges maps), so pinning stays additive.
 nodeSelector:
   mokka.nvidia.com/type: sgpu
+
+# Announce injected Xids on the node's kernel log, which the chart leaves off
+# because it makes the node-agent container privileged. On here because a local
+# cluster is exactly where that trade is worth making: `nvml-mock-ctl fail
+# --xid` is meant to be visible to an agent reading the node's kernel messages,
+# and local/kind/*.kind.yaml already configures journald to ingest them.
+nodeAgent:
+  kernelLog:
+    enabled: true

--- a/pkg/gpu/mockctl/config_override.go
+++ b/pkg/gpu/mockctl/config_override.go
@@ -124,6 +124,41 @@ func (d *Doc) Fail(t Target, mode string, afterCalls int, xidCode uint64) error 
 	return nil
 }
 
+// FailureXid reports the Xid code device index would raise under the current
+// overrides, or zero for a device that raises none.
+//
+// The shared and per-device buckets are resolved by the engine's own merge
+// rather than by a rule restated here, because the answer has to be what the
+// running mock raises. That merge is a deep one: a per-device failure block
+// does not replace the shared block, so a device singled out by a `fail` that
+// carries no Xid keeps the one the shared bucket holds.
+func (d *Doc) FailureXid(index int) uint64 {
+	overrides := &engine.ConfigOverrideDoc{All: d.All, Devices: d.Devices}
+
+	failure, ok := overrides.DeviceConfigOverride(index)["failure"].(map[string]any)
+	if !ok {
+		return 0
+	}
+
+	xid, ok := failure["xid"].(map[string]any)
+	if !ok {
+		return 0
+	}
+
+	// A document that has been through YAML carries the code as float64, one
+	// built in memory as an int or uint64.
+	switch code := xid["code"].(type) {
+	case float64:
+		return uint64(code)
+	case int:
+		return uint64(code) //nolint:gosec // a negative code cannot reach here: Fail takes a uint64
+	case uint64:
+		return code
+	default:
+		return 0
+	}
+}
+
 // TemperaturePatch builds an config override patch that pins the reported GPU
 // temperature to celsius. It writes both the static thermal block and a
 // zero-variation dynamic block: profiles that enable dynamic metrics (the

--- a/pkg/gpu/mockctl/config_override.go
+++ b/pkg/gpu/mockctl/config_override.go
@@ -127,36 +127,24 @@ func (d *Doc) Fail(t Target, mode string, afterCalls int, xidCode uint64) error 
 // FailureXid reports the Xid code device index would raise under the current
 // overrides, or zero for a device that raises none.
 //
-// The shared and per-device buckets are resolved by the engine's own merge
-// rather than by a rule restated here, because the answer has to be what the
-// running mock raises. That merge is a deep one: a per-device failure block
-// does not replace the shared block, so a device singled out by a `fail` that
-// carries no Xid keeps the one the shared bucket holds.
+// The engine resolves it, rather than a rule restated here reading the raw
+// document, because the answer has to be what the running mock raises — and
+// that includes the mock refusing the document. The merge is a deep one, so a
+// per-device failure block does not replace the shared block: a device singled
+// out by a `fail` that carries no Xid keeps the one the shared bucket holds.
+// It is also typed, so a code that is not a uint64 takes the whole override
+// down and leaves the device as it was, raising nothing; read raw, a
+// hand-written `code: -5` announced 2^64-5 and `79.5` announced 79, neither of
+// which any NVML client would have seen.
 func (d *Doc) FailureXid(index int) uint64 {
 	overrides := &engine.ConfigOverrideDoc{All: d.All, Devices: d.Devices}
 
-	failure, ok := overrides.DeviceConfigOverride(index)["failure"].(map[string]any)
-	if !ok {
+	merged, err := engine.MergeDeviceConfig(&engine.DeviceConfig{}, overrides.DeviceConfigOverride(index))
+	if err != nil || merged.Failure == nil || merged.Failure.Xid == nil {
 		return 0
 	}
 
-	xid, ok := failure["xid"].(map[string]any)
-	if !ok {
-		return 0
-	}
-
-	// A document that has been through YAML carries the code as float64, one
-	// built in memory as an int or uint64.
-	switch code := xid["code"].(type) {
-	case float64:
-		return uint64(code)
-	case int:
-		return uint64(code) //nolint:gosec // a negative code cannot reach here: Fail takes a uint64
-	case uint64:
-		return code
-	default:
-		return 0
-	}
+	return merged.Failure.Xid.Code
 }
 
 // TemperaturePatch builds an config override patch that pins the reported GPU

--- a/pkg/gpu/mockctl/config_override_test.go
+++ b/pkg/gpu/mockctl/config_override_test.go
@@ -14,6 +14,8 @@
 package mockctl
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -397,4 +399,83 @@ func TestResolveTarget_IndexBounds(t *testing.T) {
 	tg, err = ResolveTarget("99", nil)
 	require.NoError(t, err)
 	require.Equal(t, 99, tg.Index)
+}
+
+// What the node agent reads back to decide whether a device has a new Xid to
+// announce on the kernel log.
+func TestDoc_FailureXid(t *testing.T) {
+	t.Parallel()
+
+	doc := &Doc{}
+	require.Zero(t, doc.FailureXid(0), "an empty document injects nothing")
+
+	require.NoError(t, doc.Fail(Target{Index: 0}, engine.FailureModeLost, 0, 79))
+	require.Equal(t, uint64(79), doc.FailureXid(0))
+	require.Zero(t, doc.FailureXid(1), "one device's failure is not another's")
+
+	// The shared bucket stands in for every device that has no failure of its
+	// own, the way the engine merges the two.
+	require.NoError(t, doc.Fail(Target{All: true}, engine.FailureModeECCUncorrectable, 0, 48))
+	require.Equal(t, uint64(79), doc.FailureXid(0), "the device's own failure wins")
+	require.Equal(t, uint64(48), doc.FailureXid(1))
+
+	require.NoError(t, doc.Fail(Target{Index: 0}, engine.FailureModeHealthy, 0, 0))
+	require.Equal(t, uint64(48), doc.FailureXid(0), "recovered, so the shared bucket applies again")
+
+	// A failure without an Xid raises none: the device fails, silently.
+	require.NoError(t, doc.Fail(Target{All: true}, engine.FailureModeLost, 0, 0))
+	require.Zero(t, doc.FailureXid(1))
+}
+
+// The engine deep-merges the shared bucket into the per-device one, so a
+// per-device failure does not replace the shared one field by field: a device
+// singled out by a `fail` that carries no Xid keeps the shared bucket's. Read
+// as shadowing instead, this reported no Xid for exactly the device an operator
+// had just targeted, while the mock went on raising one through NVML.
+func TestDoc_FailureXidFollowsTheEnginesMerge(t *testing.T) {
+	t.Parallel()
+
+	doc := &Doc{}
+	require.NoError(t, doc.Fail(Target{All: true}, engine.FailureModeLost, 0, 79))
+	require.NoError(t, doc.Fail(Target{Index: 0}, engine.FailureModeLost, 0, 0))
+
+	require.Equal(t, uint64(79), doc.FailureXid(0))
+	require.Equal(t, engineXid(t, doc, 0), doc.FailureXid(0),
+		"the document must answer with what the running mock raises")
+	require.Equal(t, engineXid(t, doc, 1), doc.FailureXid(1))
+}
+
+// engineXid resolves the Xid a device raises the way the mock does, so a test
+// can hold FailureXid against the merge it stands in for rather than against a
+// second copy of the same assumptions.
+func engineXid(t *testing.T, doc *Doc, index int) uint64 {
+	t.Helper()
+
+	overrides := &engine.ConfigOverrideDoc{All: doc.All, Devices: doc.Devices}
+	merged, err := engine.MergeDeviceConfig(&engine.DeviceConfig{}, overrides.DeviceConfigOverride(index))
+	require.NoError(t, err)
+
+	if merged.Failure == nil || merged.Failure.Xid == nil {
+		return 0
+	}
+
+	return merged.Failure.Xid.Code
+}
+
+// A document that has been through YAML carries numbers as float64, so reading
+// the code back has to survive the round trip rather than only work in memory.
+func TestDoc_FailureXidSurvivesTheFile(t *testing.T) {
+	t.Parallel()
+
+	doc := &Doc{}
+	require.NoError(t, doc.Fail(Target{Index: 3}, engine.FailureModeLost, 0, 79))
+	data, err := doc.Bytes()
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "overrides.yaml")
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+
+	reloaded, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, uint64(79), reloaded.FailureXid(3))
 }

--- a/pkg/gpu/mockctl/config_override_test.go
+++ b/pkg/gpu/mockctl/config_override_test.go
@@ -439,27 +439,36 @@ func TestDoc_FailureXidFollowsTheEnginesMerge(t *testing.T) {
 	require.NoError(t, doc.Fail(Target{All: true}, engine.FailureModeLost, 0, 79))
 	require.NoError(t, doc.Fail(Target{Index: 0}, engine.FailureModeLost, 0, 0))
 
-	require.Equal(t, uint64(79), doc.FailureXid(0))
-	require.Equal(t, engineXid(t, doc, 0), doc.FailureXid(0),
-		"the document must answer with what the running mock raises")
-	require.Equal(t, engineXid(t, doc, 1), doc.FailureXid(1))
+	require.Equal(t, uint64(79), doc.FailureXid(0),
+		"the device singled out keeps the shared bucket's Xid, as it does in the mock")
+	require.Equal(t, uint64(79), doc.FailureXid(1))
 }
 
-// engineXid resolves the Xid a device raises the way the mock does, so a test
-// can hold FailureXid against the merge it stands in for rather than against a
-// second copy of the same assumptions.
-func engineXid(t *testing.T, doc *Doc, index int) uint64 {
-	t.Helper()
+// A document nobody wrote through Fail is not bound by what Fail accepts, and a
+// code the engine cannot decode into its uint64 takes the whole override down
+// with it: the device keeps the state it had, raising nothing. Announcing such
+// a code would put an Xid on the node's kernel log that no NVML client ever
+// saw — the one thing this document is read to avoid.
+func TestDoc_FailureXidRefusesWhatTheEngineRefuses(t *testing.T) {
+	t.Parallel()
 
-	overrides := &engine.ConfigOverrideDoc{All: doc.All, Devices: doc.Devices}
-	merged, err := engine.MergeDeviceConfig(&engine.DeviceConfig{}, overrides.DeviceConfigOverride(index))
-	require.NoError(t, err)
+	for name, code := range map[string]any{
+		"negative":     -5,
+		"fractional":   79.5,
+		"not a number": "79",
+		"past uint64":  1e20,
+	} {
+		doc := &Doc{Devices: map[string]map[string]any{"0": {"failure": map[string]any{
+			"mode": engine.FailureModeLost,
+			"xid":  map[string]any{"code": code},
+		}}}}
 
-	if merged.Failure == nil || merged.Failure.Xid == nil {
-		return 0
+		overrides := &engine.ConfigOverrideDoc{All: doc.All, Devices: doc.Devices}
+		_, err := engine.MergeDeviceConfig(&engine.DeviceConfig{}, overrides.DeviceConfigOverride(0))
+		require.Errorf(t, err, "%s: the engine must refuse it, or this test asserts nothing", name)
+
+		require.Zerof(t, doc.FailureXid(0), "%s", name)
 	}
-
-	return merged.Failure.Xid.Code
 }
 
 // A document that has been through YAML carries numbers as float64, so reading

--- a/pkg/gpu/mocknvml/engine/config_test.go
+++ b/pkg/gpu/mocknvml/engine/config_test.go
@@ -20,6 +20,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/NVIDIA/go-nvml/pkg/nvml/mock/dgxa100"
+	mockserver "github.com/NVIDIA/go-nvml/pkg/nvml/mock/server"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 )
@@ -354,4 +356,23 @@ devices:
 			require.ErrorContains(t, validateYAMLConfig(&yc), "device minor number out of range")
 		})
 	}
+}
+
+// The address the node agent announces in a kernel log has to be the one the
+// running device serves, so the fallback here must track the base mock the
+// engine builds devices from rather than a formula that happens to match today.
+func TestBaseDevicePCIBusID_TracksTheBaseMock(t *testing.T) {
+	t.Parallel()
+
+	base := dgxa100.New()
+
+	for i := range base.Devices {
+		dev, ok := base.Devices[i].(*mockserver.Device)
+		require.Truef(t, ok, "base device %d is not a mockserver.Device", i)
+		require.Equalf(t, dev.PciBusID, BaseDevicePCIBusID(i),
+			"device %d must report the address the base mock carries", i)
+	}
+
+	require.Empty(t, BaseDevicePCIBusID(MaxDevices), "no device exists past the base mock")
+	require.Empty(t, BaseDevicePCIBusID(-1))
 }

--- a/pkg/gpu/mocknvml/engine/engine.go
+++ b/pkg/gpu/mocknvml/engine/engine.go
@@ -180,6 +180,41 @@ func (e *Engine) createDevicesFromYAML(server *MockServer, base *mockserver.Serv
 	}
 }
 
+// baseDevicePCIBusIDs lists the PCI addresses of the mock every device is built
+// from, resolved once because building the base allocates a whole mock server.
+// createDevicesFromYAML passes an empty pci.bus_id straight through, so a device
+// whose profile is silent serves the base address — see BaseDevicePCIBusID.
+var baseDevicePCIBusIDs = sync.OnceValue(func() []string {
+	base := dgxa100.New()
+
+	busIDs := make([]string, 0, len(base.Devices))
+	for i := range base.Devices {
+		device, ok := base.Devices[i].(*mockserver.Device)
+		if !ok {
+			break
+		}
+		busIDs = append(busIDs, device.PciBusID)
+	}
+
+	return busIDs
+})
+
+// BaseDevicePCIBusID returns the address a device index serves when its profile
+// declares no pci.bus_id: the one it inherits from the base mock. It is ""
+// for an index the base does not cover — the engine creates no device there.
+//
+// Exported for callers outside the engine that must name a device the way the
+// running mock names it, such as the node agent announcing an Xid on the kernel
+// log for a profile that leaves addresses to the mock.
+func BaseDevicePCIBusID(index int) string {
+	busIDs := baseDevicePCIBusIDs()
+	if index < 0 || index >= len(busIDs) {
+		return ""
+	}
+
+	return busIDs[index]
+}
+
 // createDefaultDevices creates devices with default/env configuration (legacy mode).
 // Uses deterministic UUIDs and PCI bus IDs so that multiple processes loading the
 // library for the same device index see identical identifiers -- critical for shared


### PR DESCRIPTION
## What This PR Does

An injected Xid now reaches the node's kernel log the way a driver's printk does, in addition to being delivered through the NVML event set:

```text
kernel: NVRM: Xid (PCI:0000:1a:00): 79
```

- **`internal/agent/kernellog`** is the new simulator that writes it. It watches the runtime override document and announces each Xid that appears on it, once per fault: a standing failure is not re-announced, a recovery retracts nothing (kernel logs never do), and re-injecting after a recovery announces again even with the same code.
- **`pkg/gpu/mockctl`** gains the emitter. One write per targeted GPU, since `/dev/kmsg` turns each write into exactly one kernel message. Never `O_CREATE`: on a node without a kernel log, a created regular file would swallow the records and report success.
- **`nvml-mock-ctl`** is unchanged: it writes the override document, as before. `--xid` still records the code; what it no longer does is write the kernel line.
- **Chart**: `nodeAgent.kernelLog.enabled` (default `true`) mounts `/dev/kmsg` and runs `node-agent` privileged. Set to `false` and the DaemonSet sets `MOCK_NVML_KMSG=""`, so the agent stays quiet.
- **nv-sentinel demo**: `run.sh` configures `journald` on one Kind worker (`Storage=persistent`, `ReadKMsg=yes`).
- **Local dev**: the `default` Tilt cluster mounts the same drop-in (`local/kind/journald-node-syslog.conf`) at creation, so a hand-run `fail --xid` is readable with `docker exec <node> dmesg`.

## Why

Addresses #758 (simulate the journal/syslog GPU errors surface in).

The agents this project exists to exercise learn about Xids from the kernel log, not from NVML: NVSentinel's syslog monitor reads the journal and admits only `_TRANSPORT=kernel` entries. An NVML-only injection is invisible to them, so the one fault most worth simulating could not be simulated end to end.

Two details are load-bearing and pinned by tests. The driver names the PCI device without its function and prints hex in lower case, so a real Xid reads `(PCI:0000:1a:00)` for BDF `0000:1A:00.0` — the same spelling the simulated `/sys/bus/pci` tree uses. And the `kernel: ` prefix keeps `NVRM: ` inside the journal's `MESSAGE` field: journald parses a leading `ident: ` out of every kmsg line, so without it the entry arrives as `SYSLOG_IDENTIFIER=NVRM` with the prefix stripped, and patterns anchored on `NVRM: Xid` stop matching.

### Why the agent owns it

The kernel log is host state, like the character devices and the PCI sysfs tree the other simulators write, so it belongs to the agent rather than to a client whose job is to mutate a config file. Owning it there also decouples the announcement from one way of injecting a fault — the allocation watcher, a hand-edited override or a future control plane raise the same line — and it lets the announcement come from the device state the agent staged: already capped by `gpu.count`, and carrying the address each device serves through NVML, neither of which the CLI could do without re-deriving the node's device list from the profile ConfigMap.

The mock NVML engine was the other candidate, and the only one with real timing fidelity, but it runs unprivileged inside every NVML consumer: N processes would each emit, a node with no consumer would emit nothing, and no engine-to-agent channel exists. What no owner can do is announce at the moment of the trip: a deferred failure (`--after-calls N`) trips inside whichever consumer makes the Nth guarded call, an in-memory counter that never reaches disk. The kernel line therefore follows the injection, not the fault, and leads NVML when the failure is deferred.

### Why privileged, and why on by default

Mounting `/dev/kmsg` is not enough. Verified on a live cluster: a pod running as root, with the node's `crw-rw-rw-` device bind-mounted, gets `Operation not permitted`; the same pod with `privileged: true` writes fine. The device cgroup is what blocks it, and no capability lifts that — the capability set is identical in both cases (`drop: [ALL]`, `add: [MKNOD]`). That is a real escalation for a pod that otherwise drops everything, but an Xid that reaches only NVML is invisible to the agents this project exists to exercise, so it is on by default rather than hidden behind a flag nobody would find. `nodeAgent.kernelLog.enabled=false` restores the unprivileged pod for clusters that will not take one (a restricted PodSecurity namespace rejects it) and for nodes with no `/dev/kmsg`, where the `CharDevice` hostPath fails the pod rather than inventing a device. Announcing is always best-effort either way: a node that cannot be written to keeps the NVML injection and logs the skip.

### Why the demo needs a journald drop-in

Stock Kind nodes satisfy neither half of what the syslog monitor needs: journald ships `ReadKMsg=no`, dropping kernel messages, and keeps a volatile journal in `/run/log/journal` where a `/var/log` hostPath cannot see it. Applying the drop-in after node creation takes two restarts, verified on a throwaway cluster: journald declares `CanReload=no`, and it does not create `/var/log/journal` itself — `systemd-journal-flush` is what creates the directory and moves the journal there. The demo enables ingestion on a single worker because Kind nodes share the host's kernel ring buffer, so every node would otherwise report the same fault.

## Verification

- Unit tests for the emitter, the agent simulator (announce once, re-announce after recovery, every targeted device, ignore unrelated override edits, no kernel log) and the CLI; 172 Helm unit tests including the toggle cases; `golangci-lint` clean; `go test -race ./...` green.
- End to end on a fresh Kind cluster with an image built from this branch, `gpu.count=2`: the boot-time drop-in gave the node a persistent journal with `ReadKMsg=yes`; `nvml-mock-ctl fail --gpu 0 --xid 79` produced `MESSAGE: 'NVRM: Xid (PCI:0000:0a:00): 79'`, `_TRANSPORT: kernel`, `SYSLOG_IDENTIFIER: kernel` — the shape NVSentinel matches.
- The behaviours that only exist once the agent owns it, checked on that cluster: a standing failure is not re-announced (line count unchanged over repeated polls), a recovery announces nothing, re-injecting the same code announces again, and `--gpu all` reached only the two GPUs `gpu.count` serves — one line for the device the shared bucket applies to, none for the device whose own failure block already shadows it, exactly as the engine merges them.
- With `nodeAgent.kernelLog.enabled=false`, the upgraded DaemonSet came back unprivileged, an injection wrote nothing to the kernel log, and the agent logged no warning.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`go test -v -race ./...`)
- [x] Linter passes (`golangci-lint`: 0 issues). Note: `make lint-fix`'s `govulncheck` step fails on pre-existing Go 1.26.5 standard-library advisories (fixed in 1.26.6), unrelated to this diff.
- [x] New code has SPDX license headers
- [x] Documentation updated (if applicable)
- [x] CHANGELOG.md updated (if user-facing change)


