### PR TITLE
refactor(nvml-mock-ctl): parse the command line with urfave/cli v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   public NVML APIs.
 
 ### Changed
+- `nvml-mock-ctl` parses its command line with `urfave/cli` v3, the library the
+  node agent and NRI plugin already use, instead of one hand-rolled
+  `flag.FlagSet` shared by every subcommand. Each command now declares only its
+  own flags and positional arguments, so `nvml-mock-ctl <command> --help`
+  documents that command rather than offering `--mode`, `--links` and `--type`
+  on all of them, and `--help` is generated from the commands themselves rather
+  than a usage string maintained by hand beside them. Command names, aliases,
+  positional arguments, the `--file`/`--config` global flags and their
+  environment fallbacks, the exit codes (2 for a bad invocation or an invalid
+  value, 1 for an override file that could not be locked, read or written) and
+  every stderr message are unchanged. One invocation that used to work no longer
+  does: `--gpu` was global, so it could precede the command
+  (`nvml-mock-ctl --gpu 0 temp 85`), and it now has to follow it
+  (`nvml-mock-ctl temp --gpu 0 85`) — the form every doc, script and e2e caller
+  already uses.
 - Dependencies no longer ship in `vendor/`. Go resolves them through a module
   proxy — NVIDIA's DGXC Artifactory in CI and for the published `nvml-mock`
   image, the public proxy locally — so builds and `make gen` need network access

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,11 +226,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   positional arguments, the `--file`/`--config` global flags and their
   environment fallbacks, the exit codes (2 for a bad invocation or an invalid
   value, 1 for an override file that could not be locked, read or written) and
-  every stderr message are unchanged. One invocation that used to work no longer
-  does: `--gpu` was global, so it could precede the command
+  every stderr message are unchanged. Two invocations that used to work no
+  longer do: `--gpu` was global, so it could precede the command
   (`nvml-mock-ctl --gpu 0 temp 85`), and it now has to follow it
   (`nvml-mock-ctl temp --gpu 0 85`) — the form every doc, script and e2e caller
-  already uses.
+  already uses; and `status --gpu ""` is now a usage error rather than a report
+  of every override, so a script whose index variable came out empty is told
+  instead of being handed the whole node's state as if it had asked for it.
 - Dependencies no longer ship in `vendor/`. Go resolves them through a module
   proxy — NVIDIA's DGXC Artifactory in CI and for the published `nvml-mock`
   image, the public proxy locally — so builds and `make gen` need network access

--- a/cmd/nvml-mock-ctl/args.go
+++ b/cmd/nvml-mock-ctl/args.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/urfave/cli/v3"
+)
+
+// The positional values of the convenience commands. urfave/cli parses and
+// types them; the arity and range checks that keep a typo from being published
+// as a plausible reading live here.
+//
+// A required single value is declared as a one-value slice rather than the
+// singular Arg types, which accept an absent value and leave the zero value
+// behind. With Min 1 the action only runs once the value has parsed, so the
+// readers below can index the result.
+
+func requiredIntArg(name string) cli.Argument {
+	return &cli.IntArgs{Name: name, UsageText: name, Min: 1, Max: 1}
+}
+
+func requiredFloatArg(name string) cli.Argument {
+	return &cli.FloatArgs{Name: name, UsageText: name, Min: 1, Max: 1}
+}
+
+// requiredStringArgs declares one or more mandatory values, as the commands
+// taking a list of throttle reasons, fabric conditions or assignments need.
+func requiredStringArgs(name string) cli.Argument {
+	return &cli.StringArgs{Name: name, UsageText: fmt.Sprintf("%s [%s ...]", name, name), Min: 1, Max: -1}
+}
+
+// intArg reads a single integer positional, bounded to [lo, hi].
+func intArg(cmd *cli.Command, name string, lo, hi int) (int, error) {
+	if err := rejectExtraArgs(cmd, name); err != nil {
+		return 0, err
+	}
+	v := cmd.IntArgs(name)[0]
+	if v < lo || v > hi {
+		return 0, fmt.Errorf("%s value %d out of range [%d,%d]", name, v, lo, hi)
+	}
+	return v, nil
+}
+
+// floatArg reads a single floating-point positional, bounded to [lo, hi]. NaN
+// and +/-Inf are rejected: they parse without error and would otherwise slip
+// past a bare comparison and overflow a downstream integer conversion.
+func floatArg(cmd *cli.Command, name string, lo, hi float64) (float64, error) {
+	if err := rejectExtraArgs(cmd, name); err != nil {
+		return 0, err
+	}
+	v := cmd.FloatArgs(name)[0]
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0, fmt.Errorf("%s value %v must be finite", name, v)
+	}
+	if v < lo || v > hi {
+		return 0, fmt.Errorf("%s value %v out of range [%v,%v]", name, v, lo, hi)
+	}
+	return v, nil
+}
+
+// rejectExtraArgs fails a single-value command that was given more than one.
+// Values a command's arguments did not consume are left in Args() rather than
+// being reported, so `temp --gpu 0 85 90` would otherwise silently apply 85.
+func rejectExtraArgs(cmd *cli.Command, name string) error {
+	if extra := cmd.Args().Slice(); len(extra) > 0 {
+		return fmt.Errorf("%s takes exactly one value; unexpected %q", name, strings.Join(extra, " "))
+	}
+	return nil
+}

--- a/cmd/nvml-mock-ctl/faults.go
+++ b/cmd/nvml-mock-ctl/faults.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mockctl"
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
+)
+
+// The commands that inject a fault. Each is authoritative for the block it
+// writes, so re-running one replaces the previous injection instead of
+// accumulating on top of it, and the healing value ('healthy', 'none', 0)
+// clears just that block.
+
+const (
+	// maxNvlinkErrorRate bounds the `nvlink-error` command (errors/second). A
+	// degrading NVLink tops out well below this; the generous cap keeps the
+	// accrual math (rate * elapsed seconds) far from overflowing uint64.
+	maxNvlinkErrorRate = 1e9
+
+	// maxSramEccCount bounds the `sram-ecc` command. A GPU is retired long
+	// before its SRAM error count approaches this, so the cap only exists to
+	// keep an obvious typo from being written as a plausible counter.
+	maxSramEccCount = 1e9
+)
+
+func failCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "fail",
+		Usage: "inject a device failure, or clear one with --mode healthy",
+		Flags: []cli.Flag{
+			gpuFlag(),
+			&cli.StringFlag{
+				Name:     "mode",
+				Usage:    "failure mode: healthy | lost | fallen_off_bus | ecc_uncorrectable",
+				Required: true,
+			},
+			&cli.IntFlag{
+				Name:  "after-calls",
+				Usage: "trip only after N guarded calls have succeeded",
+			},
+			&cli.Uint64Flag{
+				Name:  "xid",
+				Usage: "Xid code to surface alongside the failure",
+			},
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			return mutate(cmd, func(doc *mockctl.Doc, target mockctl.Target, _ *engine.DeviceConfig) error {
+				return doc.Fail(target, cmd.String("mode"), cmd.Int("after-calls"), cmd.Uint64("xid"))
+			})
+		},
+	}
+}
+
+func nvlinkErrorCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "nvlink-error",
+		Usage: "inject NVLink DL errors at a rate in errors/second (0 heals)",
+		Flags: []cli.Flag{
+			gpuFlag(),
+			&cli.StringFlag{
+				Name:  "links",
+				Usage: "comma-separated NVLink ids to inject on (default: every active link)",
+			},
+		},
+		Arguments: []cli.Argument{requiredFloatArg("errors_per_sec")},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			rate, err := floatArg(cmd, "errors_per_sec", 0, maxNvlinkErrorRate)
+			if err != nil {
+				return err
+			}
+			links, err := parseLinkIDs(cmd.String("links"))
+			if err != nil {
+				return err
+			}
+			return setPatch(cmd, mockctl.NVLinkErrorPatch(rate, links))
+		},
+	}
+}
+
+func sramECCCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "sram-ecc",
+		Usage: "inject SRAM ECC errors (0 heals)",
+		Flags: []cli.Flag{
+			gpuFlag(),
+			&cli.StringFlag{
+				Name:  "type",
+				Value: "secded",
+				Usage: "SRAM error type: correctable | parity | secded",
+			},
+			&cli.StringFlag{
+				Name:  "source",
+				Usage: "unit the errors are attributed to: l2 | sm | microcontroller | pcie | other",
+			},
+			&cli.BoolFlag{
+				Name:  "threshold-exceeded",
+				Usage: "raise the SRAM error threshold flag",
+			},
+		},
+		Arguments: []cli.Argument{requiredIntArg("count")},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			count, err := intArg(cmd, "count", 0, maxSramEccCount)
+			if err != nil {
+				return err
+			}
+			patch, err := mockctl.SramECCPatch(
+				uint64(count), cmd.String("type"), cmd.String("source"), cmd.Bool("threshold-exceeded"))
+			if err != nil {
+				return err
+			}
+			return setPatch(cmd, patch)
+		},
+	}
+}
+
+func fabricHealthCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "fabric-health",
+		Usage: "degrade NVLink fabric health ('healthy' clears it)",
+		Description: "conditions: degraded_bandwidth, route_recovery, route_unhealthy,\n" +
+			"access_timeout_recovery, or a misconfiguration (no_partition,\n" +
+			"insufficient_nvlinks, incompatible_gpu_fw, invalid_location,\n" +
+			"incorrect_sysguid, incorrect_chassis_sn, gpu_state_invalid)",
+		Flags:     []cli.Flag{gpuFlag()},
+		Arguments: []cli.Argument{requiredStringArgs("condition")},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			patch, err := mockctl.FabricHealthPatch(cmd.StringArgs("condition"))
+			if err != nil {
+				return err
+			}
+			return setPatch(cmd, patch)
+		},
+	}
+}
+
+// parseLinkIDs parses the --links CSV (e.g. "0,3,7") into a sorted-as-given
+// slice of non-negative link ids. An empty string yields nil (inject on all
+// active links). Whitespace around entries is tolerated.
+func parseLinkIDs(csv string) ([]int, error) {
+	csv = strings.TrimSpace(csv)
+	if csv == "" {
+		return nil, nil
+	}
+	var out []int
+	for _, tok := range strings.Split(csv, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		v, err := strconv.Atoi(tok)
+		if err != nil {
+			return nil, fmt.Errorf("--links entry %q must be an integer", tok)
+		}
+		if v < 0 {
+			return nil, fmt.Errorf("--links entry %d must be non-negative", v)
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}

--- a/cmd/nvml-mock-ctl/main.go
+++ b/cmd/nvml-mock-ctl/main.go
@@ -17,43 +17,141 @@ package main
 
 import (
 	"context"
-	"flag"
+	"errors"
 	"fmt"
 	"io"
-	"math"
 	"os"
-	"os/signal"
-	"strconv"
-	"strings"
-	"syscall"
-	"time"
 
-	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/allocwatch"
-	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mockctl"
-	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
+	"github.com/urfave/cli/v3"
 )
 
 const (
 	defaultConfigOverride = "/var/lib/nvml-mock/driver/config/overrides.yaml"
 	defaultConfig         = "/var/lib/nvml-mock/driver/config/config.yaml"
+)
 
-	// maxPowerWatts bounds the `power` command. Real GPUs top out around ~1.5kW;
-	// this generous cap keeps watts*1000 far under the uint32 milliwatt ceiling
-	// (~4.29e6 W) so the schema-field conversion can never overflow.
-	maxPowerWatts = 100000
-
-	// maxNvlinkErrorRate bounds the `nvlink-error` command (errors/second). A
-	// degrading NVLink tops out well below this; the generous cap keeps the
-	// accrual math (rate * elapsed seconds) far from overflowing uint64.
-	maxNvlinkErrorRate = 1e9
-
-	// maxSramEccCount bounds the `sram-ecc` command. A GPU is retired long
-	// before its SRAM error count approaches this, so the cap only exists to
-	// keep an obvious typo from being written as a plausible counter.
-	maxSramEccCount = 1e9
+// Exit codes the CLI's callers branch on: a bad invocation or an invalid value
+// is reported separately from a node whose override file could not be written.
+const (
+	exitFailure = 1
+	exitUsage   = 2
 )
 
 func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
+
+// run executes one invocation and returns its exit code. Keeping the process
+// exit in main() alone lets a test drive the CLI end to end.
+func run(args []string, stdout, stderr io.Writer) int {
+	root := newCLI(stdout, stderr)
+
+	err := root.Run(context.Background(), append([]string{root.Name}, args...))
+	if err == nil {
+		return 0
+	}
+
+	// A usage error has already written the offending command's help, and
+	// carries no message of its own so nothing is reported twice.
+	if err.Error() != "" {
+		fprintf(stderr, "%v\n", err)
+	}
+
+	var coder cli.ExitCoder
+	if errors.As(err, &coder) {
+		return coder.ExitCode()
+	}
+	return exitUsage
+}
+
+func newCLI(stdout, stderr io.Writer) *cli.Command {
+	root := &cli.Command{
+		Name:  "nvml-mock-ctl",
+		Usage: "mutate the simulated GPU state of a running nvml-mock node",
+		// Root flags are persistent, so --file and --config keep working on
+		// either side of the subcommand as they did under the hand-rolled
+		// parser this replaces.
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "file",
+				Usage:   "config override path",
+				Value:   defaultConfigOverride,
+				Sources: cli.EnvVars("MOCK_NVML_OVERRIDES"),
+			},
+			&cli.StringFlag{
+				Name:    "config",
+				Usage:   "config path for UUID resolution and validation",
+				Value:   defaultConfig,
+				Sources: cli.EnvVars("MOCK_NVML_CONFIG"),
+			},
+		},
+		Commands: []*cli.Command{
+			failCommand(),
+			temperatureCommand(),
+			powerCommand(),
+			fanCommand(),
+			utilizationCommand(),
+			clocksCommand(),
+			throttleCommand(),
+			pstateCommand(),
+			nvlinkErrorCommand(),
+			sramECCCommand(),
+			fabricHealthCommand(),
+			setCommand(),
+			statusCommand(),
+			resetCommand(),
+			watchAllocationsCommand(),
+		},
+		Action:    rootAction,
+		Writer:    stdout,
+		ErrWriter: stderr,
+		// The default handler prints the error and exits the process itself;
+		// run() owns both so the CLI stays an ordinary function.
+		ExitErrHandler: func(context.Context, *cli.Command, error) {},
+	}
+	reportUsageErrors(root)
+	return root
+}
+
+// rootAction runs when no subcommand matched. The binary does nothing on its
+// own, so a bare invocation and an unknown command are both usage errors.
+func rootAction(_ context.Context, cmd *cli.Command) error {
+	if name := cmd.Args().First(); name != "" {
+		fprintf(cmd.Root().ErrWriter, "unknown command %q\n\n", name)
+	}
+	return reportUsage(cmd)
+}
+
+// reportUsageErrors routes every command's flag and positional-argument errors
+// through reportUsage. The library's own reporting splits a failure across both
+// streams — message on stderr, help on stdout — and leaves the error for run()
+// to print a second time.
+func reportUsageErrors(cmd *cli.Command) {
+	cmd.OnUsageError = func(_ context.Context, errCmd *cli.Command, err error, _ bool) error {
+		fprintf(errCmd.Root().ErrWriter, "%v\n\n", err)
+		return reportUsage(errCmd)
+	}
+	for _, sub := range cmd.Commands {
+		reportUsageErrors(sub)
+	}
+}
+
+// reportUsage writes cmd's help to stderr and returns the usage exit code
+// carrying an empty message, marking the failure as already reported.
+func reportUsage(cmd *cli.Command) error {
+	template := cli.CommandHelpTemplate
+	if cmd == cmd.Root() {
+		template = cli.RootCommandHelpTemplate
+	}
+	// The library's ShowHelp helpers always write to the root's stdout writer;
+	// help printed because an invocation was wrong belongs on stderr.
+	cli.HelpPrinter(cmd.Root().ErrWriter, template, cmd)
+	return cli.Exit("", exitUsage)
+}
+
+// failf reports an infrastructure failure — the override file could not be
+// locked, read or written — which exits 1 rather than the usage code.
+func failf(format string, a ...any) error {
+	return cli.Exit(fmt.Sprintf(format, a...), exitFailure)
+}
 
 // Writes to the CLI's stdout/stderr can't meaningfully fail-recover, so these
 // helpers swallow the error (and satisfy errcheck, which only whitelists the
@@ -61,561 +159,3 @@ func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
 func fprint(w io.Writer, a ...any)                 { _, _ = fmt.Fprint(w, a...) }
 func fprintln(w io.Writer, a ...any)               { _, _ = fmt.Fprintln(w, a...) }
 func fprintf(w io.Writer, format string, a ...any) { _, _ = fmt.Fprintf(w, format, a...) }
-
-func usage(w io.Writer) {
-	fprint(w, `usage: nvml-mock-ctl <command> [flags]
-
-commands:
-  fail   --gpu <idx|all|uuid> --mode <healthy|lost|fallen_off_bus|ecc_uncorrectable> [--after-calls N] [--xid CODE]
-  temp   --gpu <idx|all|uuid> <celsius>    pin reported GPU temperature
-  power  --gpu <idx|all|uuid> <watts>      pin reported power draw
-  fan    --gpu <idx|all|uuid> <percent>    pin reported fan speed (forces fan count >= 1)
-  util   --gpu <idx|all|uuid> <percent>    pin reported GPU + memory utilization
-  clocks --gpu <idx|all|uuid> <mhz>        pin reported SM + graphics clocks
-  throttle --gpu <idx|all|uuid> <reason>[ reason ...]  set active throttle reasons ('none' clears)
-  pstate --gpu <idx|all|uuid> <0-15>       pin reported performance state (P-state)
-  nvlink-error --gpu <idx|all|uuid> <errors_per_sec> [--links a,b,c]  inject NVLink DL errors (0 heals)
-  sram-ecc --gpu <idx|all|uuid> <count> [--type correctable|parity|secded]
-           [--source l2|sm|microcontroller|pcie|other] [--threshold-exceeded]
-                                           inject SRAM ECC errors (0 heals)
-  fabric-health --gpu <idx|all|uuid> <condition>[ condition ...]  degrade NVLink fabric health ('healthy' clears)
-         conditions: degraded_bandwidth, route_recovery, route_unhealthy,
-         access_timeout_recovery, or a misconfiguration (no_partition,
-         insufficient_nvlinks, incompatible_gpu_fw, invalid_location,
-         incorrect_sysguid, incorrect_chassis_sn, gpu_state_invalid)
-  set    --gpu <idx|all|uuid> key.path=value [key.path=value ...]
-  status [--gpu <idx>]
-  reset  [--gpu <idx|all|uuid>]
-  watch-allocations [--socket PATH] [--interval D] [--used-fraction F]
-         run in the foreground, mirroring each pod's nvidia.com/gpu claim into
-         memory.used_bytes/free_bytes until signalled (#506)
-
-global flags:
-  --file    config override path (default $MOCK_NVML_OVERRIDES or `+defaultConfigOverride+`)
-  --config  config path for UUID resolution/validation (default $MOCK_NVML_CONFIG or `+defaultConfig+`)
-`)
-}
-
-//nolint:cyclop // existing complexity; refactor deferred
-func run(args []string, stdout, stderr io.Writer) int {
-	var configOverridePath, configPath, gpu, mode, links, socket string
-	var sramErrorType, sramSource string
-	var sramThresholdExceeded bool
-	var afterCalls int
-	var xid uint64
-	var interval time.Duration
-	var usedFraction float64
-	fs := flag.NewFlagSet("nvml-mock-ctl", flag.ContinueOnError)
-	fs.SetOutput(stderr)
-	fs.Usage = func() {} // usage printed explicitly below so it isn't duplicated
-	fs.StringVar(&configOverridePath, "file", envOr("MOCK_NVML_OVERRIDES", defaultConfigOverride), "config override path")
-	fs.StringVar(&configPath, "config", envOr("MOCK_NVML_CONFIG", defaultConfig), "config path")
-	fs.StringVar(&gpu, "gpu", "", "target: index, 'all', or UUID")
-	fs.StringVar(&mode, "mode", "", "failure mode (fail command)")
-	fs.IntVar(&afterCalls, "after-calls", 0, "trip after N guarded calls (fail)")
-	fs.Uint64Var(&xid, "xid", 0, "Xid code to surface (fail)")
-	fs.StringVar(&links, "links", "", "comma-separated NVLink ids for nvlink-error (default: all active links)")
-	fs.StringVar(&sramErrorType, "type", "secded", "SRAM error type: correctable|parity|secded (sram-ecc)")
-	fs.StringVar(&sramSource, "source", "", "unit the SRAM errors are attributed to (sram-ecc, default: other)")
-	fs.BoolVar(&sramThresholdExceeded, "threshold-exceeded", false, "raise the SRAM error threshold flag (sram-ecc)")
-	fs.StringVar(&socket, "socket", envOr("MOCK_NVML_PODRESOURCES_SOCKET", allocwatch.DefaultSocketPath),
-		"kubelet pod-resources socket (watch-allocations)")
-	fs.DurationVar(&interval, "interval", allocwatch.DefaultInterval,
-		"allocation poll interval (watch-allocations)")
-	fs.Float64Var(&usedFraction, "used-fraction", allocwatch.DefaultPolicy().UsedFractionPerClaim,
-		"share of the usable aperture attributed per GPU claim (watch-allocations)")
-
-	// Global flags may appear before or after the subcommand, interspersed
-	// with the command's positional key.path=value args. The stdlib flag
-	// package stops at the first non-flag token, so we parse in a loop:
-	// the first bare token is the command, the rest are positionals.
-	var cmd string
-	var positional []string
-	rest := args
-	for len(rest) > 0 {
-		if err := fs.Parse(rest); err != nil {
-			if err == flag.ErrHelp {
-				usage(stdout)
-				return 0
-			}
-			usage(stderr)
-			return 2
-		}
-		remaining := fs.Args()
-		if len(remaining) == 0 {
-			break
-		}
-		if cmd == "" {
-			cmd = remaining[0]
-		} else {
-			positional = append(positional, remaining[0])
-		}
-		rest = remaining[1:]
-	}
-
-	if cmd == "" {
-		usage(stderr)
-		return 2
-	}
-
-	cfg := loadConfig(configPath, stderr) // best-effort; nil-safe downstream
-	base := deviceDefaults(cfg)
-
-	switch cmd {
-	case "help":
-		usage(stdout)
-		return 0
-	case "status":
-		return doStatus(configOverridePath, gpu, stdout, stderr)
-	case "fail", "temp", "temperature", "power", "fan", "util", "utilization",
-		"clocks", "throttle", "pstate", "nvlink-error", "sram-ecc", "fabric-health", "set", "reset":
-		sram := sramECCOptions{errorType: sramErrorType, source: sramSource, thresholdExceeded: sramThresholdExceeded}
-		return mutate(cmd, configOverridePath, gpu, mode, links, afterCalls, xid, positional, sram, cfg, base, stdout, stderr)
-	case "watch-allocations":
-		return doWatchAllocations(configOverridePath, socket, interval, usedFraction, cfg, stdout, stderr)
-	default:
-		fprintf(stderr, "unknown command %q\n", cmd)
-		usage(stderr)
-		return 2
-	}
-}
-
-// sramECCOptions carries the sram-ecc command's flags: which SRAM error type to
-// inject, the unit it is attributed to, and whether the error threshold flag is
-// raised.
-type sramECCOptions struct {
-	errorType         string
-	source            string
-	thresholdExceeded bool
-}
-
-//nolint:cyclop // existing complexity; refactor deferred
-func mutate(cmd, configOverridePath, gpu, mode, links string, afterCalls int, xid uint64,
-	positional []string, sram sramECCOptions, cfg *engine.Config, base *engine.DeviceConfig, stdout, stderr io.Writer,
-) int {
-	if gpu == "" && cmd != "reset" {
-		fprintln(stderr, "--gpu is required")
-		return 2
-	}
-
-	unlock, err := mockctl.LockOverride(configOverridePath)
-	if err != nil {
-		fprintf(stderr, "lock: %v\n", err)
-		return 1
-	}
-	defer unlock()
-
-	doc, err := mockctl.Load(configOverridePath)
-	if err != nil {
-		fprintf(stderr, "load: %v\n", err)
-		return 1
-	}
-
-	var target mockctl.Target
-	if gpu != "" {
-		target, err = mockctl.ResolveTarget(gpu, cfg)
-		if err != nil {
-			fprintf(stderr, "%v\n", err)
-			return 2
-		}
-	} else {
-		target = mockctl.Target{All: true} // reset with no --gpu means everything
-	}
-
-	switch cmd {
-	case "fail":
-		if mode == "" {
-			fprintln(stderr, "--mode is required for fail")
-			return 2
-		}
-		if err := doc.Fail(target, mode, afterCalls, xid); err != nil {
-			fprintf(stderr, "%v\n", err)
-			return 2
-		}
-	case "temp", "temperature":
-		celsius, perr := singleIntArg(positional, cmd, 0, 200)
-		if perr != nil {
-			fprintf(stderr, "%v\n", perr)
-			return 2
-		}
-		if code := applyPatch(doc, target, base, mockctl.TemperaturePatch(celsius), stderr); code != 0 {
-			return code
-		}
-	case "power":
-		// Bound watts to a finite, non-negative range well under the uint32
-		// milliwatt ceiling so watts*1000 can't overflow the schema field.
-		watts, perr := singleFloatArg(positional, cmd, 0, maxPowerWatts)
-		if perr != nil {
-			fprintf(stderr, "%v\n", perr)
-			return 2
-		}
-		// NVML power fields are milliwatts; the CLI takes the watts value
-		// nvidia-smi displays and converts.
-		mw := uint32(watts*1000 + 0.5)
-		if code := applyPatch(doc, target, base, mockctl.PowerPatch(mw), stderr); code != 0 {
-			return code
-		}
-	case "fan":
-		pct, perr := singleIntArg(positional, cmd, 0, 100)
-		if perr != nil {
-			fprintf(stderr, "%v\n", perr)
-			return 2
-		}
-		if code := applyPatch(doc, target, base, mockctl.FanPatch(pct, baseFanCount(base)), stderr); code != 0 {
-			return code
-		}
-	case "util", "utilization":
-		pct, perr := singleIntArg(positional, cmd, 0, 100)
-		if perr != nil {
-			fprintf(stderr, "%v\n", perr)
-			return 2
-		}
-		if code := applyPatch(doc, target, base, mockctl.UtilizationPatch(pct), stderr); code != 0 {
-			return code
-		}
-	case "clocks":
-		mhz, perr := singleIntArg(positional, cmd, 0, 100000)
-		if perr != nil {
-			fprintf(stderr, "%v\n", perr)
-			return 2
-		}
-		if code := applyPatch(doc, target, base, mockctl.ClocksPatch(mhz), stderr); code != 0 {
-			return code
-		}
-	case "throttle":
-		if len(positional) == 0 {
-			fprintln(stderr, "throttle requires at least one reason (or 'none')")
-			return 2
-		}
-		patch, perr := mockctl.ThrottlePatch(positional)
-		if perr != nil {
-			fprintf(stderr, "%v\n", perr)
-			return 2
-		}
-		if code := applyPatch(doc, target, base, patch, stderr); code != 0 {
-			return code
-		}
-	case "pstate":
-		n, perr := singleIntArg(positional, cmd, 0, 15)
-		if perr != nil {
-			fprintf(stderr, "%v\n", perr)
-			return 2
-		}
-		if code := applyPatch(doc, target, base, mockctl.PStatePatch(n), stderr); code != 0 {
-			return code
-		}
-	case "nvlink-error":
-		rate, perr := singleFloatArg(positional, cmd, 0, maxNvlinkErrorRate)
-		if perr != nil {
-			fprintf(stderr, "%v\n", perr)
-			return 2
-		}
-		linkIDs, perr := parseLinkIDs(links)
-		if perr != nil {
-			fprintf(stderr, "%v\n", perr)
-			return 2
-		}
-		if code := applyPatch(doc, target, base, mockctl.NVLinkErrorPatch(rate, linkIDs), stderr); code != 0 {
-			return code
-		}
-	case "sram-ecc":
-		count, perr := singleIntArg(positional, cmd, 0, maxSramEccCount)
-		if perr != nil {
-			fprintf(stderr, "%v\n", perr)
-			return 2
-		}
-		patch, perr := mockctl.SramECCPatch(uint64(count), sram.errorType, sram.source, sram.thresholdExceeded)
-		if perr != nil {
-			fprintf(stderr, "%v\n", perr)
-			return 2
-		}
-		if code := applyPatch(doc, target, base, patch, stderr); code != 0 {
-			return code
-		}
-	case "fabric-health":
-		if len(positional) == 0 {
-			fprintln(stderr, "fabric-health requires at least one condition (or 'healthy')")
-			return 2
-		}
-		patch, perr := mockctl.FabricHealthPatch(positional)
-		if perr != nil {
-			fprintf(stderr, "%v\n", perr)
-			return 2
-		}
-		if code := applyPatch(doc, target, base, patch, stderr); code != 0 {
-			return code
-		}
-	case "set":
-		if len(positional) == 0 {
-			fprintln(stderr, "set requires at least one key.path=value")
-			return 2
-		}
-		kv, err := mockctl.ParseSet(positional)
-		if err != nil {
-			fprintf(stderr, "%v\n", err)
-			return 2
-		}
-		if err := mockctl.Validate(base, kv); err != nil {
-			fprintf(stderr, "invalid: %v\n", err)
-			return 2
-		}
-		doc.SetFields(target, kv)
-	case "reset":
-		doc.Reset(target)
-	}
-
-	// Validate the resulting merged config for the affected bucket(s).
-	if err := validateDoc(doc, base); err != nil {
-		fprintf(stderr, "invalid config override: %v\n", err)
-		return 2
-	}
-
-	if err := mockctl.WriteAtomic(configOverridePath, doc); err != nil {
-		fprintf(stderr, "write: %v\n", err)
-		return 1
-	}
-	fprintf(stdout, "ok: %s applied to %s\n", cmd, gpuLabel(gpu))
-	return 0
-}
-
-// applyPatch validates a convenience-command patch against the device schema
-// and merges it into the target bucket, returning a non-zero exit code (already
-// reported to stderr) on failure so callers can propagate it.
-func applyPatch(doc *mockctl.Doc, target mockctl.Target, base *engine.DeviceConfig, patch map[string]any, stderr io.Writer) int {
-	if err := mockctl.Validate(base, patch); err != nil {
-		fprintf(stderr, "invalid: %v\n", err)
-		return 2
-	}
-	doc.SetFields(target, patch)
-	return 0
-}
-
-// singleIntArg parses the lone positional value of a convenience command as an
-// integer within [lo, hi].
-func singleIntArg(positional []string, name string, lo, hi int) (int, error) {
-	if len(positional) != 1 {
-		return 0, fmt.Errorf("%s requires exactly one value (got %d)", name, len(positional))
-	}
-	v, err := strconv.Atoi(positional[0])
-	if err != nil {
-		return 0, fmt.Errorf("%s value %q must be an integer", name, positional[0])
-	}
-	if v < lo || v > hi {
-		return 0, fmt.Errorf("%s value %d out of range [%d,%d]", name, v, lo, hi)
-	}
-	return v, nil
-}
-
-// singleFloatArg parses the lone positional value of a convenience command as a
-// finite floating-point number within [lo, hi]. NaN and +/-Inf are rejected:
-// strconv.ParseFloat accepts them with a nil error, and they would otherwise
-// slip past a bare comparison and overflow a downstream integer conversion.
-func singleFloatArg(positional []string, name string, lo, hi float64) (float64, error) {
-	if len(positional) != 1 {
-		return 0, fmt.Errorf("%s requires exactly one value (got %d)", name, len(positional))
-	}
-	v, err := strconv.ParseFloat(positional[0], 64)
-	if err != nil {
-		return 0, fmt.Errorf("%s value %q must be a number", name, positional[0])
-	}
-	if math.IsNaN(v) || math.IsInf(v, 0) {
-		return 0, fmt.Errorf("%s value %q must be finite", name, positional[0])
-	}
-	if v < lo || v > hi {
-		return 0, fmt.Errorf("%s value %v out of range [%v,%v]", name, v, lo, hi)
-	}
-	return v, nil
-}
-
-// parseLinkIDs parses the --links CSV (e.g. "0,3,7") into a sorted-as-given
-// slice of non-negative link ids. An empty string yields nil (inject on all
-// active links). Whitespace around entries is tolerated.
-func parseLinkIDs(csv string) ([]int, error) {
-	csv = strings.TrimSpace(csv)
-	if csv == "" {
-		return nil, nil
-	}
-	var out []int
-	for _, tok := range strings.Split(csv, ",") {
-		tok = strings.TrimSpace(tok)
-		if tok == "" {
-			continue
-		}
-		v, err := strconv.Atoi(tok)
-		if err != nil {
-			return nil, fmt.Errorf("--links entry %q must be an integer", tok)
-		}
-		if v < 0 {
-			return nil, fmt.Errorf("--links entry %d must be non-negative", v)
-		}
-		out = append(out, v)
-	}
-	return out, nil
-}
-
-// baseFanCount reports the fan count declared by the base config so the fan
-// command can preserve a multi-fan count instead of collapsing it to 1.
-func baseFanCount(base *engine.DeviceConfig) int {
-	if base != nil && base.Fan != nil {
-		return base.Fan.Count
-	}
-	return 0
-}
-
-func envOr(k, def string) string {
-	if v := os.Getenv(k); v != "" {
-		return v
-	}
-	return def
-}
-
-// loadConfig loads the pristine profile so `--gpu` can resolve UUIDs and the
-// index bounds check knows the real device count. NumDevices is resolved the
-// same way the engine's LoadConfig does: the device-list length, unless
-// system.num_devices (which the node agent stamps from GPU_COUNT) overrides it — so
-// the bounds check matches the count the running engine actually serves even
-// when gpu.count differs from the profile's device list. A load failure is
-// non-fatal (UUID resolution and the bounds check degrade to best-effort) but
-// is surfaced as a warning instead of being swallowed silently.
-func loadConfig(path string, stderr io.Writer) *engine.Config {
-	yc, err := engine.LoadYAMLConfig(path)
-	if err != nil {
-		fprintf(stderr, "warning: could not load config %q: %v; UUID resolution and --gpu bounds checks are disabled\n", path, err)
-		return nil
-	}
-	numDevices := len(yc.Devices)
-	if numDevices == 0 {
-		numDevices = 8 // engine default when no device list is present
-	}
-	if yc.System.NumDevices > 0 {
-		numDevices = yc.System.NumDevices // system.num_devices wins, matching the engine
-	}
-	return &engine.Config{YAMLConfig: yc, NumDevices: numDevices, DriverVersion: yc.System.DriverVersion}
-}
-
-func deviceDefaults(cfg *engine.Config) *engine.DeviceConfig {
-	if cfg == nil || cfg.YAMLConfig == nil {
-		return &engine.DeviceConfig{}
-	}
-	dd := cfg.YAMLConfig.DeviceDefaults
-	return &dd
-}
-
-func gpuLabel(g string) string {
-	if g == "" {
-		return "all"
-	}
-	return g
-}
-
-//nolint:cyclop // existing complexity; refactor deferred
-func doStatus(configOverridePath, gpu string, stdout, stderr io.Writer) int {
-	doc, err := mockctl.Load(configOverridePath)
-	if err != nil {
-		fprintf(stderr, "load: %v\n", err)
-		return 1
-	}
-
-	// A targeted status only reports a single device's bucket (plus the
-	// shared "all" bucket). Only an integer index is supported here.
-	if gpu != "" {
-		idx, err := strconv.Atoi(gpu)
-		if err != nil {
-			fprintf(stderr, "status --gpu expects an integer index, got %q\n", gpu)
-			return 2
-		}
-		dev := doc.Devices[strconv.Itoa(idx)]
-		if dev == nil && doc.All == nil {
-			fprintf(stdout, "no active overrides for gpu %d\n", idx)
-			return 0
-		}
-		filtered := &mockctl.Doc{Version: doc.Version, All: doc.All}
-		if dev != nil {
-			filtered.Devices = map[string]map[string]any{strconv.Itoa(idx): dev}
-		}
-		b, err := filtered.Bytes()
-		if err != nil {
-			fprintf(stderr, "%v\n", err)
-			return 1
-		}
-		fprint(stdout, string(b))
-		return 0
-	}
-
-	if doc.All == nil && len(doc.Devices) == 0 {
-		fprintln(stdout, "no active overrides")
-		return 0
-	}
-	b, err := doc.Bytes()
-	if err != nil {
-		fprintf(stderr, "%v\n", err)
-		return 1
-	}
-	fprint(stdout, string(b))
-	return 0
-}
-
-// validateDoc runs MergeDeviceConfig for All and each per-device bucket so a
-// bad value anywhere fails the command.
-func validateDoc(doc *mockctl.Doc, base *engine.DeviceConfig) error {
-	if doc.All != nil {
-		if err := mockctl.Validate(base, doc.All); err != nil {
-			return fmt.Errorf("all: %w", err)
-		}
-	}
-	for idx, patch := range doc.Devices {
-		if err := mockctl.Validate(base, patch); err != nil {
-			return fmt.Errorf("device %s: %w", idx, err)
-		}
-	}
-	return nil
-}
-
-// doWatchAllocations runs the allocation watcher until the process is signalled.
-//
-// This is #506 item 1: it is the producer that makes memory.used_bytes respond
-// to a pod holding an nvidia.com/gpu claim. The consumer side already existed —
-// the engine re-reads the override file this writes within one TTL — so the
-// watcher only has to keep that file honest.
-//
-// It runs as a sidecar in the nvml-mock DaemonSet rather than as its own
-// workload so it shares the driver-root mount the override file lives in.
-func doWatchAllocations(configOverridePath, socket string, interval time.Duration,
-	usedFraction float64, cfg *engine.Config, stdout, stderr io.Writer,
-) int {
-	if cfg == nil || cfg.NumDevices == 0 {
-		fprintf(stderr, "watch-allocations: no GPU config resolved; nothing to reconcile\n")
-		return 1
-	}
-	if usedFraction <= 0 || usedFraction > 1 {
-		fprintf(stderr, "watch-allocations: --used-fraction must be in (0, 1], got %v\n", usedFraction)
-		return 2
-	}
-
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
-
-	lister, err := allocwatch.NewPodResourcesLister(ctx, socket)
-	if err != nil {
-		fprintf(stderr, "watch-allocations: %v\n", err)
-		return 1
-	}
-	defer func() { _ = lister.Close() }()
-
-	devices := allocwatch.DevicesFromConfig(cfg)
-	fprintf(stdout, "watch-allocations: %d GPUs, polling %s every %s -> %s\n",
-		len(devices), socket, interval, configOverridePath)
-
-	w := &allocwatch.Watcher{
-		Lister:       lister,
-		Devices:      devices,
-		Policy:       allocwatch.Policy{UsedFractionPerClaim: usedFraction},
-		OverridePath: configOverridePath,
-		Interval:     interval,
-	}
-	if err := w.Run(ctx); err != nil {
-		fprintf(stderr, "watch-allocations: %v\n", err)
-		return 1
-	}
-	return 0
-}

--- a/cmd/nvml-mock-ctl/main_test.go
+++ b/cmd/nvml-mock-ctl/main_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -267,6 +268,52 @@ func TestCLI_StatusFilterByGPU(t *testing.T) {
 	// Non-integer index is a usage error.
 	_, _, code = runCLI(t, configOverride, "status", "--gpu", "all")
 	require.Equalf(t, 2, code, "status --gpu all exit = %d, want 2", code)
+}
+
+// The global flags are declared on the root command and inherited, so they
+// still work on either side of the subcommand the way callers write them.
+func TestCLI_GlobalFlagsWorkOnEitherSideOfTheCommand(t *testing.T) {
+	t.Parallel()
+	for _, args := range [][]string{
+		{"--file", "%s", "temp", "--gpu", "0", "85"},
+		{"temp", "--gpu", "0", "--file", "%s", "85"},
+		{"temp", "--gpu", "0", "85", "--file", "%s"},
+	} {
+		configOverride := filepath.Join(t.TempDir(), "overrides.yaml")
+		full := make([]string, len(args))
+		for i, a := range args {
+			full[i] = strings.Replace(a, "%s", configOverride, 1)
+		}
+		var out, errb bytes.Buffer
+		code := run(full, &out, &errb)
+		require.Equalf(t, 0, code, "args %v exited %d: %s", args, code, errb.String())
+		require.Contains(t, readConfigOverride(t, configOverride), "temperature_gpu_c: 85")
+	}
+}
+
+func TestCLI_MissingTargetIsUsageError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, _, code := runCLI(t, filepath.Join(dir, "overrides.yaml"), "temp", "85")
+	require.Equal(t, 2, code, "a mutation without --gpu must not be applied")
+}
+
+func TestCLI_UnknownCommandIsUsageError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, errStr, code := runCLI(t, filepath.Join(dir, "overrides.yaml"), "bogus")
+	require.Equal(t, 2, code)
+	require.Contains(t, errStr, `unknown command "bogus"`)
+}
+
+func TestCLI_HelpListsEveryCommand(t *testing.T) {
+	t.Parallel()
+	var out, errb bytes.Buffer
+	code := run([]string{"--help"}, &out, &errb)
+	require.Equalf(t, 0, code, "--help exited %d: %s", code, errb.String())
+	for _, want := range []string{"fail", "temp", "sram-ecc", "fabric-health", "status", "reset", "watch-allocations"} {
+		require.Containsf(t, out.String(), want, "help output missing %q", want)
+	}
 }
 
 func TestCLI_ResetGPU(t *testing.T) {

--- a/cmd/nvml-mock-ctl/main_test.go
+++ b/cmd/nvml-mock-ctl/main_test.go
@@ -291,6 +291,17 @@ func TestCLI_GlobalFlagsWorkOnEitherSideOfTheCommand(t *testing.T) {
 	}
 }
 
+// An explicitly empty target must not be read as "every device". Only reset
+// applies to everything, and only when --gpu is absent altogether, so a
+// mistyped `--gpu ""` has to fail rather than quietly hit the whole node.
+func TestCLI_EmptyTargetIsRejectedNotBroadcast(t *testing.T) {
+	t.Parallel()
+	configOverride := filepath.Join(t.TempDir(), "overrides.yaml")
+	_, _, code := runCLI(t, configOverride, "temp", "--gpu", "", "85")
+	require.Equal(t, 2, code)
+	require.NoFileExists(t, configOverride, "an empty target must not be applied to any device")
+}
+
 func TestCLI_MissingTargetIsUsageError(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/cmd/nvml-mock-ctl/metrics.go
+++ b/cmd/nvml-mock-ctl/metrics.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mockctl"
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
+)
+
+// The commands that pin one reported reading. Each parses its own positional
+// value and leaves the schema patch to pkg/gpu/mockctl.
+
+// maxPowerWatts bounds the `power` command. Real GPUs top out around ~1.5kW;
+// this generous cap keeps watts*1000 far under the uint32 milliwatt ceiling
+// (~4.29e6 W) so the schema-field conversion can never overflow.
+const maxPowerWatts = 100000
+
+func temperatureCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "temp",
+		Aliases:   []string{"temperature"},
+		Usage:     "pin reported GPU temperature",
+		Flags:     []cli.Flag{gpuFlag()},
+		Arguments: []cli.Argument{requiredIntArg("celsius")},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			celsius, err := intArg(cmd, "celsius", 0, 200)
+			if err != nil {
+				return err
+			}
+			return setPatch(cmd, mockctl.TemperaturePatch(celsius))
+		},
+	}
+}
+
+func powerCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "power",
+		Usage:     "pin reported power draw",
+		Flags:     []cli.Flag{gpuFlag()},
+		Arguments: []cli.Argument{requiredFloatArg("watts")},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			watts, err := floatArg(cmd, "watts", 0, maxPowerWatts)
+			if err != nil {
+				return err
+			}
+			// NVML power fields are milliwatts; the CLI takes the watts value
+			// nvidia-smi displays and converts.
+			return setPatch(cmd, mockctl.PowerPatch(uint32(watts*1000+0.5)))
+		},
+	}
+}
+
+func fanCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "fan",
+		Usage:     "pin reported fan speed (forces fan count >= 1)",
+		Flags:     []cli.Flag{gpuFlag()},
+		Arguments: []cli.Argument{requiredIntArg("percent")},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			percent, err := intArg(cmd, "percent", 0, 100)
+			if err != nil {
+				return err
+			}
+			return applyPatch(cmd, func(base *engine.DeviceConfig) map[string]any {
+				return mockctl.FanPatch(percent, baseFanCount(base))
+			})
+		},
+	}
+}
+
+func utilizationCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "util",
+		Aliases:   []string{"utilization"},
+		Usage:     "pin reported GPU + memory utilization",
+		Flags:     []cli.Flag{gpuFlag()},
+		Arguments: []cli.Argument{requiredIntArg("percent")},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			percent, err := intArg(cmd, "percent", 0, 100)
+			if err != nil {
+				return err
+			}
+			return setPatch(cmd, mockctl.UtilizationPatch(percent))
+		},
+	}
+}
+
+func clocksCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "clocks",
+		Usage:     "pin reported SM + graphics clocks",
+		Flags:     []cli.Flag{gpuFlag()},
+		Arguments: []cli.Argument{requiredIntArg("mhz")},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			mhz, err := intArg(cmd, "mhz", 0, 100000)
+			if err != nil {
+				return err
+			}
+			return setPatch(cmd, mockctl.ClocksPatch(mhz))
+		},
+	}
+}
+
+func throttleCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "throttle",
+		Usage:     "set the active throttle reasons ('none' clears them)",
+		Flags:     []cli.Flag{gpuFlag()},
+		Arguments: []cli.Argument{requiredStringArgs("reason")},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			patch, err := mockctl.ThrottlePatch(cmd.StringArgs("reason"))
+			if err != nil {
+				return err
+			}
+			return setPatch(cmd, patch)
+		},
+	}
+}
+
+func pstateCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "pstate",
+		Usage:     "pin the reported performance state (P-state)",
+		Flags:     []cli.Flag{gpuFlag()},
+		Arguments: []cli.Argument{requiredIntArg("pstate")},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			n, err := intArg(cmd, "pstate", 0, 15)
+			if err != nil {
+				return err
+			}
+			return setPatch(cmd, mockctl.PStatePatch(n))
+		},
+	}
+}

--- a/cmd/nvml-mock-ctl/state.go
+++ b/cmd/nvml-mock-ctl/state.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"io"
+	"strconv"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mockctl"
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
+)
+
+// The commands that operate on the override document as a whole: write
+// arbitrary fields, report what is active, or clear it.
+
+func setCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "set",
+		Usage:     "write arbitrary schema fields, as key.path=value",
+		Flags:     []cli.Flag{gpuFlag()},
+		Arguments: []cli.Argument{requiredStringArgs("key.path=value")},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			kv, err := mockctl.ParseSet(cmd.StringArgs("key.path=value"))
+			if err != nil {
+				return err
+			}
+			return applyPatch(cmd, func(*engine.DeviceConfig) map[string]any { return kv })
+		},
+	}
+}
+
+func resetCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "reset",
+		Usage: "clear the targeted overrides, returning the device(s) to the pristine profile",
+		Flags: []cli.Flag{optionalGPUFlag()},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			return mutate(cmd, func(doc *mockctl.Doc, target mockctl.Target, _ *engine.DeviceConfig) error {
+				doc.Reset(target)
+				return nil
+			})
+		},
+	}
+}
+
+func statusCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "status",
+		Usage: "print the overrides currently in effect",
+		Flags: []cli.Flag{
+			&cli.IntFlag{
+				Name:  "gpu",
+				Usage: "report one device index (default: every override)",
+			},
+		},
+		Action: runStatus,
+	}
+}
+
+func runStatus(_ context.Context, cmd *cli.Command) error {
+	doc, err := mockctl.Load(configOverridePath(cmd))
+	if err != nil {
+		return failf("load: %v", err)
+	}
+	out := cmd.Root().Writer
+
+	if cmd.IsSet("gpu") {
+		return printDeviceStatus(out, doc, cmd.Int("gpu"))
+	}
+	if doc.All == nil && len(doc.Devices) == 0 {
+		fprintln(out, "no active overrides")
+		return nil
+	}
+	return printDoc(out, doc)
+}
+
+// printDeviceStatus reports one device's bucket alongside the shared "all"
+// bucket, which applies to that device too.
+func printDeviceStatus(out io.Writer, doc *mockctl.Doc, index int) error {
+	key := strconv.Itoa(index)
+	device := doc.Devices[key]
+	if device == nil && doc.All == nil {
+		fprintf(out, "no active overrides for gpu %d\n", index)
+		return nil
+	}
+	filtered := &mockctl.Doc{Version: doc.Version, All: doc.All}
+	if device != nil {
+		filtered.Devices = map[string]map[string]any{key: device}
+	}
+	return printDoc(out, filtered)
+}
+
+func printDoc(out io.Writer, doc *mockctl.Doc) error {
+	b, err := doc.Bytes()
+	if err != nil {
+		return failf("%v", err)
+	}
+	fprint(out, string(b))
+	return nil
+}

--- a/cmd/nvml-mock-ctl/target.go
+++ b/cmd/nvml-mock-ctl/target.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mockctl"
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
+)
+
+// gpuFlag declares the device selector every mutating command needs.
+func gpuFlag() cli.Flag {
+	return &cli.StringFlag{
+		Name:     "gpu",
+		Usage:    "target device: an index, 'all', or a GPU UUID",
+		Required: true,
+	}
+}
+
+// optionalGPUFlag is gpuFlag for reset, where omitting the target clears every
+// bucket rather than being a usage error.
+func optionalGPUFlag() cli.Flag {
+	return &cli.StringFlag{
+		Name:  "gpu",
+		Usage: "target device: an index, 'all', or a GPU UUID (default: every device)",
+	}
+}
+
+// configOverridePath and configPath keep the CLI's "set but empty means unset"
+// rule: an exported-and-empty MOCK_NVML_OVERRIDES or MOCK_NVML_CONFIG must fall
+// back to the default rather than resolve to the empty path.
+func configOverridePath(cmd *cli.Command) string {
+	return pathOr(cmd.String("file"), defaultConfigOverride)
+}
+
+func configPath(cmd *cli.Command) string {
+	return pathOr(cmd.String("config"), defaultConfig)
+}
+
+func pathOr(path, def string) string {
+	if path == "" {
+		return def
+	}
+	return path
+}
+
+// mutation applies one command's change to the override document. It runs with
+// the file lock held, between the load and the atomic write.
+type mutation func(doc *mockctl.Doc, target mockctl.Target, base *engine.DeviceConfig) error
+
+// mutate is the read-modify-write every mutating command shares. The whole
+// resulting document is validated, not just the patch, so a bad value in any
+// bucket fails the command instead of reaching a consumer process.
+func mutate(cmd *cli.Command, apply mutation) error {
+	path := configOverridePath(cmd)
+	cfg := loadConfig(cmd)
+	base := deviceDefaults(cfg)
+
+	spec := cmd.String("gpu")
+	target := mockctl.Target{All: true} // no --gpu (reset only) means everything
+	if spec != "" {
+		var err error
+		if target, err = mockctl.ResolveTarget(spec, cfg); err != nil {
+			return err
+		}
+	}
+
+	unlock, err := mockctl.LockOverride(path)
+	if err != nil {
+		return failf("lock: %v", err)
+	}
+	defer unlock()
+
+	doc, err := mockctl.Load(path)
+	if err != nil {
+		return failf("load: %v", err)
+	}
+
+	if err := apply(doc, target, base); err != nil {
+		return err
+	}
+	if err := validateDoc(doc, base); err != nil {
+		return fmt.Errorf("invalid config override: %w", err)
+	}
+	if err := mockctl.WriteAtomic(path, doc); err != nil {
+		return failf("write: %v", err)
+	}
+
+	fprintf(cmd.Root().Writer, "ok: %s applied to %s\n", cmd.Name, gpuLabel(spec))
+	return nil
+}
+
+// applyPatch is mutate for a command whose patch depends on the pristine
+// profile: it validates the patch against the device schema before merging it
+// into the target bucket.
+func applyPatch(cmd *cli.Command, build func(base *engine.DeviceConfig) map[string]any) error {
+	return mutate(cmd, func(doc *mockctl.Doc, target mockctl.Target, base *engine.DeviceConfig) error {
+		patch := build(base)
+		if err := mockctl.Validate(base, patch); err != nil {
+			return fmt.Errorf("invalid: %w", err)
+		}
+		doc.SetFields(target, patch)
+		return nil
+	})
+}
+
+// setPatch is applyPatch for a patch the command already holds.
+func setPatch(cmd *cli.Command, patch map[string]any) error {
+	return applyPatch(cmd, func(*engine.DeviceConfig) map[string]any { return patch })
+}
+
+// validateDoc runs the schema merge for the shared bucket and every per-device
+// bucket, so a bad value anywhere fails the command.
+func validateDoc(doc *mockctl.Doc, base *engine.DeviceConfig) error {
+	if doc.All != nil {
+		if err := mockctl.Validate(base, doc.All); err != nil {
+			return fmt.Errorf("all: %w", err)
+		}
+	}
+	for idx, patch := range doc.Devices {
+		if err := mockctl.Validate(base, patch); err != nil {
+			return fmt.Errorf("device %s: %w", idx, err)
+		}
+	}
+	return nil
+}
+
+// loadConfig loads the pristine profile so `--gpu` can resolve UUIDs and the
+// index bounds check knows the real device count. NumDevices is resolved the
+// same way the engine's LoadConfig does: the device-list length, unless
+// system.num_devices (which the node agent stamps from GPU_COUNT) overrides it — so
+// the bounds check matches the count the running engine actually serves even
+// when gpu.count differs from the profile's device list. A load failure is
+// non-fatal (UUID resolution and the bounds check degrade to best-effort) but
+// is surfaced as a warning instead of being swallowed silently.
+func loadConfig(cmd *cli.Command) *engine.Config {
+	path := configPath(cmd)
+	yc, err := engine.LoadYAMLConfig(path)
+	if err != nil {
+		fprintf(cmd.Root().ErrWriter,
+			"warning: could not load config %q: %v; UUID resolution and --gpu bounds checks are disabled\n", path, err)
+		return nil
+	}
+	numDevices := len(yc.Devices)
+	if numDevices == 0 {
+		numDevices = 8 // engine default when no device list is present
+	}
+	if yc.System.NumDevices > 0 {
+		numDevices = yc.System.NumDevices // system.num_devices wins, matching the engine
+	}
+	return &engine.Config{YAMLConfig: yc, NumDevices: numDevices, DriverVersion: yc.System.DriverVersion}
+}
+
+func deviceDefaults(cfg *engine.Config) *engine.DeviceConfig {
+	if cfg == nil || cfg.YAMLConfig == nil {
+		return &engine.DeviceConfig{}
+	}
+	dd := cfg.YAMLConfig.DeviceDefaults
+	return &dd
+}
+
+// baseFanCount reports the fan count declared by the base config so the fan
+// command can preserve a multi-fan count instead of collapsing it to 1.
+func baseFanCount(base *engine.DeviceConfig) int {
+	if base != nil && base.Fan != nil {
+		return base.Fan.Count
+	}
+	return 0
+}
+
+func gpuLabel(spec string) string {
+	if spec == "" {
+		return "all"
+	}
+	return spec
+}

--- a/cmd/nvml-mock-ctl/target.go
+++ b/cmd/nvml-mock-ctl/target.go
@@ -14,7 +14,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/urfave/cli/v3"
 
@@ -23,11 +25,21 @@ import (
 )
 
 // gpuFlag declares the device selector every mutating command needs.
+//
+// Required only rejects an absent flag, not an empty one, and mutate reads an
+// empty target as the shared "all" bucket — so without the validator a
+// mistyped `--gpu ""` would quietly mutate every device on the node.
 func gpuFlag() cli.Flag {
 	return &cli.StringFlag{
 		Name:     "gpu",
 		Usage:    "target device: an index, 'all', or a GPU UUID",
 		Required: true,
+		Validator: func(spec string) error {
+			if strings.TrimSpace(spec) == "" {
+				return errors.New("--gpu needs a target: an index, 'all', or a GPU UUID")
+			}
+			return nil
+		},
 	}
 }
 

--- a/cmd/nvml-mock-ctl/watch.go
+++ b/cmd/nvml-mock-ctl/watch.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/signal"
+	"syscall"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/allocwatch"
+)
+
+// watchAllocationsCommand runs the allocation watcher until the process is
+// signalled.
+//
+// This is #506 item 1: it is the producer that makes memory.used_bytes respond
+// to a pod holding an nvidia.com/gpu claim. The consumer side already existed —
+// the engine re-reads the override file this writes within one TTL — so the
+// watcher only has to keep that file honest.
+//
+// It runs as a sidecar in the nvml-mock DaemonSet rather than as its own
+// workload so it shares the driver-root mount the override file lives in.
+func watchAllocationsCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "watch-allocations",
+		Usage: "mirror each pod's nvidia.com/gpu claim into memory.used_bytes/free_bytes",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "socket",
+				Value:   allocwatch.DefaultSocketPath,
+				Usage:   "kubelet pod-resources socket",
+				Sources: cli.EnvVars("MOCK_NVML_PODRESOURCES_SOCKET"),
+			},
+			&cli.DurationFlag{
+				Name:  "interval",
+				Value: allocwatch.DefaultInterval,
+				Usage: "allocation poll interval",
+			},
+			&cli.FloatFlag{
+				Name:  "used-fraction",
+				Value: allocwatch.DefaultPolicy().UsedFractionPerClaim,
+				Usage: "share of the usable aperture attributed per GPU claim",
+			},
+		},
+		Action: runWatchAllocations,
+	}
+}
+
+func runWatchAllocations(ctx context.Context, cmd *cli.Command) error {
+	cfg := loadConfig(cmd)
+	if cfg == nil || cfg.NumDevices == 0 {
+		return failf("watch-allocations: no GPU config resolved; nothing to reconcile")
+	}
+
+	usedFraction := cmd.Float("used-fraction")
+	if usedFraction <= 0 || usedFraction > 1 {
+		return fmt.Errorf("watch-allocations: --used-fraction must be in (0, 1], got %v", usedFraction)
+	}
+
+	signalCtx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	socket := cmd.String("socket")
+	lister, err := allocwatch.NewPodResourcesLister(signalCtx, socket)
+	if err != nil {
+		return failf("watch-allocations: %v", err)
+	}
+	defer func() { _ = lister.Close() }()
+
+	overridePath := configOverridePath(cmd)
+	interval := cmd.Duration("interval")
+	devices := allocwatch.DevicesFromConfig(cfg)
+	fprintf(cmd.Root().Writer, "watch-allocations: %d GPUs, polling %s every %s -> %s\n",
+		len(devices), socket, interval, overridePath)
+
+	w := &allocwatch.Watcher{
+		Lister:       lister,
+		Devices:      devices,
+		Policy:       allocwatch.Policy{UsedFractionPerClaim: usedFraction},
+		OverridePath: overridePath,
+		Interval:     interval,
+	}
+	if err := w.Run(signalCtx); err != nil {
+		return failf("watch-allocations: %v", err)
+	}
+	return nil
+}

--- a/cmd/nvml-mock-ctl/watch.go
+++ b/cmd/nvml-mock-ctl/watch.go
@@ -74,7 +74,11 @@ func runWatchAllocations(ctx context.Context, cmd *cli.Command) error {
 	signalCtx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	socket := cmd.String("socket")
+	// Same "set but empty means unset" rule as --file/--config, since the
+	// DaemonSet templates this var. The lister defaults an empty path too, so
+	// resolving it here is what keeps the startup line naming the real socket.
+	socket := pathOr(cmd.String("socket"), allocwatch.DefaultSocketPath)
+
 	lister, err := allocwatch.NewPodResourcesLister(signalCtx, socket)
 	if err != nil {
 		return failf("watch-allocations: %v", err)

--- a/docs/nvml-mock-ctl.md
+++ b/docs/nvml-mock-ctl.md
@@ -92,34 +92,62 @@ POD=$(kubectl -n mokka get pod -l app.kubernetes.io/name=nvml-mock \
 
 ## Command reference
 
+`nvml-mock-ctl --help` lists the commands, and `nvml-mock-ctl <command> --help`
+documents that command's own flags, defaults and positional arguments.
+
 ```text
-usage: nvml-mock-ctl <command> [flags]
+NAME:
+   nvml-mock-ctl - mutate the simulated GPU state of a running nvml-mock node
 
-commands:
-  fail   --gpu <idx|all|uuid> --mode <healthy|lost|fallen_off_bus|ecc_uncorrectable> [--after-calls N] [--xid CODE]
-  temp   --gpu <idx|all|uuid> <celsius>    pin reported GPU temperature
-  power  --gpu <idx|all|uuid> <watts>      pin reported power draw
-  fan    --gpu <idx|all|uuid> <percent>    pin reported fan speed (forces fan count >= 1)
-  util   --gpu <idx|all|uuid> <percent>    pin reported GPU + memory utilization
-  clocks --gpu <idx|all|uuid> <mhz>        pin reported SM + graphics clocks
-  throttle --gpu <idx|all|uuid> <reason>[ reason ...]  set active throttle reasons ('none' clears)
-  pstate --gpu <idx|all|uuid> <0-15>       pin reported performance state (P-state)
-  nvlink-error --gpu <idx|all|uuid> <errors_per_sec> [--links a,b,c]  inject NVLink DL errors (0 heals)
-  sram-ecc --gpu <idx|all|uuid> <count> [--type correctable|parity|secded]
-           [--source l2|sm|microcontroller|pcie|other] [--threshold-exceeded]
-                                           inject SRAM ECC errors (0 heals)
-  fabric-health --gpu <idx|all|uuid> <condition>[ condition ...]  degrade NVLink fabric health ('healthy' clears)
-         conditions: degraded_bandwidth, route_recovery, route_unhealthy,
-         access_timeout_recovery, or a misconfiguration (no_partition,
-         insufficient_nvlinks, incompatible_gpu_fw, invalid_location,
-         incorrect_sysguid, incorrect_chassis_sn, gpu_state_invalid)
-  set    --gpu <idx|all|uuid> key.path=value [key.path=value ...]
-  status [--gpu <idx>]
-  reset  [--gpu <idx|all|uuid>]
+USAGE:
+   nvml-mock-ctl [global options] [command [command options]]
 
-global flags:
-  --file    config override path (default $MOCK_NVML_OVERRIDES or /var/lib/nvml-mock/driver/config/overrides.yaml)
-  --config  config path for UUID resolution/validation (default $MOCK_NVML_CONFIG or /var/lib/nvml-mock/driver/config/config.yaml)
+COMMANDS:
+   fail               inject a device failure, or clear one with --mode healthy
+   temp, temperature  pin reported GPU temperature
+   power              pin reported power draw
+   fan                pin reported fan speed (forces fan count >= 1)
+   util, utilization  pin reported GPU + memory utilization
+   clocks             pin reported SM + graphics clocks
+   throttle           set the active throttle reasons ('none' clears them)
+   pstate             pin the reported performance state (P-state)
+   nvlink-error       inject NVLink DL errors at a rate in errors/second (0 heals)
+   sram-ecc           inject SRAM ECC errors (0 heals)
+   fabric-health      degrade NVLink fabric health ('healthy' clears it)
+   set                write arbitrary schema fields, as key.path=value
+   status             print the overrides currently in effect
+   reset              clear the targeted overrides, returning the device(s) to the pristine profile
+   watch-allocations  mirror each pod's nvidia.com/gpu claim into memory.used_bytes/free_bytes
+   help, h            Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --file string    config override path (default: "/var/lib/nvml-mock/driver/config/overrides.yaml") [$MOCK_NVML_OVERRIDES]
+   --config string  config path for UUID resolution and validation (default: "/var/lib/nvml-mock/driver/config/config.yaml") [$MOCK_NVML_CONFIG]
+   --help, -h       show help
+```
+
+Every mutating command takes `--gpu <idx|all|uuid>`; `reset` applies to every
+device without it, and `status` reports every override. The global flags are
+accepted on either side of the command, but `--gpu` and the command's own flags
+must follow it.
+
+```text
+nvml-mock-ctl fail --gpu <t> --mode <healthy|lost|fallen_off_bus|ecc_uncorrectable> [--after-calls N] [--xid CODE]
+nvml-mock-ctl temp --gpu <t> celsius
+nvml-mock-ctl power --gpu <t> watts
+nvml-mock-ctl fan --gpu <t> percent
+nvml-mock-ctl util --gpu <t> percent
+nvml-mock-ctl clocks --gpu <t> mhz
+nvml-mock-ctl throttle --gpu <t> reason [reason ...]
+nvml-mock-ctl pstate --gpu <t> pstate
+nvml-mock-ctl nvlink-error --gpu <t> [--links a,b,c] errors_per_sec
+nvml-mock-ctl sram-ecc --gpu <t> [--type correctable|parity|secded]
+              [--source l2|sm|microcontroller|pcie|other] [--threshold-exceeded] count
+nvml-mock-ctl fabric-health --gpu <t> condition [condition ...]
+nvml-mock-ctl set --gpu <t> key.path=value [key.path=value ...]
+nvml-mock-ctl status [--gpu <idx>]
+nvml-mock-ctl reset [--gpu <t>]
+nvml-mock-ctl watch-allocations [--socket PATH] [--interval D] [--used-fraction F]
 ```
 
 ### Targeting: `--gpu <idx|all|uuid>`


### PR DESCRIPTION
## What This PR Does

Replaces `nvml-mock-ctl`'s hand-rolled argument parsing with `urfave/cli` v3 — the library `cmd/node-agent` and `cmd/nri-plugin` already use — and splits the 621-line `main.go` into six focused files.

Before, one `flag.FlagSet` held every flag of every subcommand, so `--mode`, `--links`, `--type` and `--socket` were offered on all of them; a loop re-parsed the argument list to interleave global flags with positionals; the usage text was a string maintained by hand beside the code it described; and two switch statements carried `//nolint:cyclop` waivers.

Now each command declares only its own flags and positional arguments, help is generated from the commands themselves, and the read-modify-write of the override document (resolve target, take the flock, apply, validate the whole document, write atomically) lives in one place:

| file | holds |
| --- | --- |
| `main.go` | root command, exit-code mapping, usage-error reporting |
| `target.go` | `--gpu` resolution, config paths, the shared mutate/patch plumbing |
| `args.go` | positional argument declaration and range checks |
| `metrics.go` | `temp`, `power`, `fan`, `util`, `clocks`, `throttle`, `pstate` |
| `faults.go` | `fail`, `nvlink-error`, `sram-ecc`, `fabric-health` |
| `state.go` | `set`, `status`, `reset` |
| `watch.go` | `watch-allocations` |

Both `cyclop` waivers are gone. `--gpu` is now a `Required` flag on the mutating commands rather than a runtime check, and `nvml-mock-ctl sram-ecc --help` finally describes `sram-ecc` instead of every command advertising every flag.

## Why

`nvml-mock-ctl` was the only binary in the tree still parsing its own command line, and the shared `FlagSet` made its help actively misleading: every command listed every other command's flags. The hand-written usage string had to be kept in step with the code and with `docs/nvml-mock-ctl.md` by hand.

### Compatibility

Deliberately unchanged: command names and the `temperature`/`utilization` aliases, positional arguments, the `--file`/`--config` globals **and** their acceptance on either side of the subcommand (root flags are persistent in v3), the `MOCK_NVML_*` environment fallbacks including the "set but empty means unset" rule, the exit codes (2 for a bad invocation or invalid value, 1 for an override file that could not be locked, read or written), and every stderr message prefix (`invalid:`, `lock:`, `load:`, `write:`).

Verified with a differential harness that runs the same invocation through the old and new binaries and compares exit code, stdout and the resulting `overrides.yaml`: **65 of 68 invocations byte-identical**. The three differences are intentional:

- **`--gpu` must now follow the command.** It used to be global, so `nvml-mock-ctl --gpu 0 temp 85` worked; it is now `nvml-mock-ctl temp --gpu 0 85`. Every doc, script and e2e caller in the tree already uses the command-first form, so nothing in-tree changes. Called out in the CHANGELOG.
- Invoking an alias echoes the canonical name: `ok: temp applied to 2` rather than `ok: temperature applied to 2` (twice, for the two aliases).

The existing `main_test.go` passes unmodified and remains the regression harness. Four tests were added for the surface this refactor newly owns: global flags on either side of the command, a missing `--gpu` being a usage error, an unknown command exiting 2, and `--help` listing every command.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`go test ./cmd/... ./pkg/gpu/mockctl/`; `pkg/gpu/allocwatch` fails identically on `main` in my sandbox, where its unix-socket dial is blocked)
- [x] Linter passes (`golangci-lint run ./cmd/...` — 0 issues; full `make lint-fix` can't run in my sandbox, where its `gen` prerequisite cannot reach the module sumdb)
- [x] New code has SPDX license headers
- [x] Documentation updated (`docs/nvml-mock-ctl.md` command reference regenerated from the new `--help`, and it now documents `watch-allocations`, which the old block omitted)
- [x] CHANGELOG.md updated (if user-facing change)