### PR TITLE
fix(mocknvml): keep device indices consistent after visibility filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the same minor number — including where one of them defaulted to it — or when
   a minor falls outside the range a GPU node can carry.
 - mocknvml: keep device indices consistent after visibility filtering, preserve
-  physical GPU targets for reset, and exclude hidden devices from topology results (#807).
+  physical GPU targets for reset, and exclude hidden devices from topology results
+  and event waits (#807).
 - mocknvml: `nvidia-smi --gpu-reset` (`-r`) now resets a GPU instead of
   segfaulting. The mock's export-table dispatcher ended every per-device call by
   writing a zero count through `arg1`, which the reset slots do not carry, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rejected, by the agent as well as the engine, when two devices would end up on
   the same minor number — including where one of them defaulted to it — or when
   a minor falls outside the range a GPU node can carry.
+- mocknvml: keep device indices consistent after visibility filtering, preserve
+  physical GPU targets for reset, and exclude hidden devices from topology results (#807).
 - mocknvml: `nvidia-smi --gpu-reset` (`-r`) now resets a GPU instead of
   segfaulting. The mock's export-table dispatcher ended every per-device call by
   writing a zero count through `arg1`, which the reset slots do not carry, so the

--- a/pkg/gpu/mocknvml/bridge/gpu_reset.go
+++ b/pkg/gpu/mocknvml/bridge/gpu_reset.go
@@ -54,11 +54,13 @@ func mockInternalResetGPU(handle unsafe.Pointer) C.int {
 		debugLog("[RESET] unknown device handle %p\n", handle)
 		return 0
 	}
-	index, ret := dev.GetIndex()
+	_, ret := dev.GetIndex()
 	if ret != nvml.SUCCESS {
 		debugLog("[RESET] device %p reports no index (ret=%d)\n", handle, ret)
 		return 0
 	}
+	// Overrides are keyed by physical index, not the container-visible ordinal.
+	index := dev.PhysicalIndex()
 	// engine.ConfigOverridePath resolves the same file the engine reads, so the
 	// reader and this writer can never disagree on which one is authoritative.
 	if err := mockctl.ResetDevice(engine.ConfigOverridePath(), index); err != nil {

--- a/pkg/gpu/mocknvml/bridge/gpu_reset.go
+++ b/pkg/gpu/mocknvml/bridge/gpu_reset.go
@@ -54,19 +54,20 @@ func mockInternalResetGPU(handle unsafe.Pointer) C.int {
 		debugLog("[RESET] unknown device handle %p\n", handle)
 		return 0
 	}
-	_, ret := dev.GetIndex()
+	// Reject hidden or unhealthy handles before mutating shared overrides.
+	visibleIndex, ret := dev.GetIndex()
 	if ret != nvml.SUCCESS {
 		debugLog("[RESET] device %p reports no index (ret=%d)\n", handle, ret)
 		return 0
 	}
 	// Overrides are keyed by physical index, not the container-visible ordinal.
-	index := dev.PhysicalIndex()
+	physicalIndex := dev.PhysicalIndex()
 	// engine.ConfigOverridePath resolves the same file the engine reads, so the
 	// reader and this writer can never disagree on which one is authoritative.
-	if err := mockctl.ResetDevice(engine.ConfigOverridePath(), index); err != nil {
-		debugLog("[RESET] GPU %d: %v\n", index, err)
+	if err := mockctl.ResetDevice(engine.ConfigOverridePath(), physicalIndex); err != nil {
+		debugLog("[RESET] GPU %d (physical %d): %v\n", visibleIndex, physicalIndex, err)
 		return 0
 	}
-	debugLog("[RESET] GPU %d returned to its healthy baseline\n", index)
+	debugLog("[RESET] GPU %d (physical %d) returned to its healthy baseline\n", visibleIndex, physicalIndex)
 	return 1
 }

--- a/pkg/gpu/mocknvml/bridge/gpu_reset_test.go
+++ b/pkg/gpu/mocknvml/bridge/gpu_reset_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mockctl"
+	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
+)
+
+func TestResetGPU_UsesPhysicalIndexAfterFiltering(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "overrides.yaml")
+	t.Setenv("MOCK_NVML_NUM_DEVICES", "2")
+	t.Setenv("MOCK_NVML_CONFIG", "")
+	t.Setenv("MOCK_NVML_OVERRIDES", path)
+	engine.ResetForTesting()
+	t.Cleanup(engine.ResetForTesting)
+	e := engine.GetEngine()
+	require.Equal(t, nvml.SUCCESS, e.Init())
+	t.Cleanup(func() { require.Equal(t, nvml.SUCCESS, e.Shutdown()) })
+	e.SetVisibleDevicesForTesting([]int{1})
+	require.NoError(t, os.WriteFile(path, []byte(`version: 1
+devices:
+  "0":
+    name: GPU-zero
+  "1":
+    name: GPU-one
+`), 0600))
+	h, ret := e.DeviceGetHandleByIndex(0)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Equal(t, 1, int(mockInternalResetGPU(h)))
+	doc, err := mockctl.Load(path)
+	require.NoError(t, err)
+	require.Contains(t, doc.Devices, "0")
+	require.NotContains(t, doc.Devices, "1")
+}

--- a/pkg/gpu/mocknvml/bridge/gpu_reset_test.go
+++ b/pkg/gpu/mocknvml/bridge/gpu_reset_test.go
@@ -36,6 +36,9 @@ func TestResetGPU_UsesPhysicalIndexAfterFiltering(t *testing.T) {
 	e := engine.GetEngine()
 	require.Equal(t, nvml.SUCCESS, e.Init())
 	t.Cleanup(func() { require.Equal(t, nvml.SUCCESS, e.Shutdown()) })
+	e.SetVisibleDevicesForTesting(nil)
+	hidden, ret := e.DeviceGetHandleByIndex(0)
+	require.Equal(t, nvml.SUCCESS, ret)
 	e.SetVisibleDevicesForTesting([]int{1})
 	require.NoError(t, os.WriteFile(path, []byte(`version: 1
 devices:
@@ -44,6 +47,13 @@ devices:
   "1":
     name: GPU-one
 `), 0600))
+	before, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Zero(t, int(mockInternalResetGPU(hidden)))
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, before, after, "resetting a hidden GPU must preserve overrides")
+
 	h, ret := e.DeviceGetHandleByIndex(0)
 	require.Equal(t, nvml.SUCCESS, ret)
 	require.Equal(t, 1, int(mockInternalResetGPU(h)))

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -428,14 +428,15 @@ func (d *ConfigurableDevice) GetConfig() *DeviceConfig {
 	return d.cfg()
 }
 
-// GetIndex returns the device index
+// GetIndex returns the zero-based ordinal among visible devices.
+// A handle for a hidden device returns ERROR_INVALID_ARGUMENT.
 func (d *ConfigurableDevice) GetIndex() (int, nvml.Return) {
 	if ret := d.handleLookupReturn(); ret != nvml.SUCCESS {
 		return 0, ret
 	}
 	index := int(d.nvmlIndex.Load())
 	if index < 0 {
-		return 0, nvml.ERROR_NO_PERMISSION
+		return 0, nvml.ERROR_INVALID_ARGUMENT
 	}
 	debugLog("[NVML] nvmlDeviceGetIndex -> %d\n", index)
 	return index, nvml.SUCCESS

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -46,6 +46,7 @@ type ConfigurableDevice struct {
 	*dgxa100.Device
 	fabric      *NodeFabric
 	index       int
+	nvmlIndex   atomic.Int64
 	minorNumber int
 
 	// baseConfig is the pristine, merged (defaults+per-device) YAML config.
@@ -99,6 +100,8 @@ func NewConfigurableDevice(index int, baseDevice *mockserver.Device, config *Dev
 		minorNumber: minorNumber,
 		baseConfig:  config,
 	}
+
+	dev.nvmlIndex.Store(int64(index))
 
 	// Override base device properties from config
 	applyDeviceBaseOverrides(dev, config)
@@ -430,8 +433,18 @@ func (d *ConfigurableDevice) GetIndex() (int, nvml.Return) {
 	if ret := d.handleLookupReturn(); ret != nvml.SUCCESS {
 		return 0, ret
 	}
-	debugLog("[NVML] nvmlDeviceGetIndex -> %d\n", d.index)
-	return d.index, nvml.SUCCESS
+	index := int(d.nvmlIndex.Load())
+	if index < 0 {
+		return 0, nvml.ERROR_NO_PERMISSION
+	}
+	debugLog("[NVML] nvmlDeviceGetIndex -> %d\n", index)
+	return index, nvml.SUCCESS
+}
+
+// PhysicalIndex identifies the device in the shared override configuration.
+// It must not change when a consumer sees only a subset of the devices.
+func (d *ConfigurableDevice) PhysicalIndex() int {
+	return d.index
 }
 
 // GetUUID returns the device UUID. Overrides the embedded dgxa100.Device
@@ -2500,4 +2513,20 @@ func (s *MockServer) isDeviceVisible(deviceIndex int) bool {
 		return true
 	}
 	return slices.Contains(s.visibleDevices, deviceIndex)
+}
+
+// setVisibleDevices keeps enumeration indices consistent without changing physical
+// device identity (minor number, PCI address, or topology index).
+func (s *MockServer) setVisibleDevices(visible []int) {
+	s.visibleDevices = visible
+	for physical, d := range s.configurableDevices {
+		if d == nil {
+			continue
+		}
+		index := physical
+		if visible != nil {
+			index = slices.Index(visible, physical)
+		}
+		d.nvmlIndex.Store(int64(index))
+	}
 }

--- a/pkg/gpu/mocknvml/engine/device.go
+++ b/pkg/gpu/mocknvml/engine/device.go
@@ -2398,6 +2398,7 @@ type MockServer struct {
 	// /dev/nvidia* nodes (via CDI injection), this slice contains only the
 	// devices whose device nodes exist, mimicking real NVML's cgroup-based
 	// device filtering. If nil, all devices are visible (no filtering).
+	// Assign only through setVisibleDevices to keep cached NVML indices in sync.
 	visibleDevices []int
 }
 
@@ -2519,14 +2520,14 @@ func (s *MockServer) isDeviceVisible(deviceIndex int) bool {
 // setVisibleDevices keeps enumeration indices consistent without changing physical
 // device identity (minor number, PCI address, or topology index).
 func (s *MockServer) setVisibleDevices(visible []int) {
-	s.visibleDevices = visible
+	s.visibleDevices = slices.Clone(visible)
 	for physical, d := range s.configurableDevices {
 		if d == nil {
 			continue
 		}
 		index := physical
-		if visible != nil {
-			index = slices.Index(visible, physical)
+		if s.visibleDevices != nil {
+			index = slices.Index(s.visibleDevices, physical)
 		}
 		d.nvmlIndex.Store(int64(index))
 	}

--- a/pkg/gpu/mocknvml/engine/engine.go
+++ b/pkg/gpu/mocknvml/engine/engine.go
@@ -542,7 +542,7 @@ func (e *Engine) GetConfig() *Config {
 }
 
 // PendingXidEvent claims the next undelivered Xid critical-error event
-// from any device that has tripped failure injection with a `xid:` block
+// from any visible device that has tripped failure injection with a `xid:` block
 // configured. It returns the device handle (auto-registering one if the
 // caller hasn't resolved a handle for that device yet), the Xid code,
 // and true on success. When no event is pending it returns (nil, 0,
@@ -560,8 +560,8 @@ func (e *Engine) PendingXidEvent() (unsafe.Pointer, uint64, bool) {
 		return nil, 0, false
 	}
 
-	for _, dev := range e.server.configurableDevices {
-		if dev == nil {
+	for index, dev := range e.server.configurableDevices {
+		if dev == nil || !e.server.isDeviceVisible(index) {
 			continue
 		}
 		fi := dev.failureInjector()
@@ -585,7 +585,7 @@ func (e *Engine) PendingXidEvent() (unsafe.Pointer, uint64, bool) {
 	return nil, 0, false
 }
 
-// AnyDeviceLost reports whether any configured device is lost / fallen_off_bus.
+// AnyDeviceLost reports whether any visible device is lost / fallen_off_bus.
 // nvmlEventSetWait consults it so a wait on a set that (in real NVML) contains
 // a lost GPU fails with ERROR_GPU_IS_LOST like every other call against that
 // device. Does not advance any failure injector (no Tick).
@@ -599,7 +599,7 @@ func (e *Engine) PendingXidEvent() (unsafe.Pointer, uint64, bool) {
 // those semantics are unchanged.
 //
 // The mock does not record event-set membership (nvmlDeviceRegisterEvents
-// is a success stub), so any lost device fails every wait.
+// is a success stub), so any visible lost device fails every wait.
 func (e *Engine) AnyDeviceLost() bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -608,8 +608,8 @@ func (e *Engine) AnyDeviceLost() bool {
 		return false
 	}
 
-	for _, dev := range e.server.configurableDevices {
-		if dev == nil {
+	for index, dev := range e.server.configurableDevices {
+		if dev == nil || !e.server.isDeviceVisible(index) {
 			continue
 		}
 		if dev.failureLostByConfig() {

--- a/pkg/gpu/mocknvml/engine/engine.go
+++ b/pkg/gpu/mocknvml/engine/engine.go
@@ -16,6 +16,7 @@ package engine
 import (
 	"fmt"
 	"os"
+	"slices"
 	"sync"
 	"unsafe"
 
@@ -98,7 +99,7 @@ func (e *Engine) Init() nvml.Return {
 	// only the allocated GPUs (e.g. /dev/nvidia0 but not /dev/nvidia1-7),
 	// filter the visible device set to match. This mimics real NVML behavior
 	// where cgroup device permissions limit GPU visibility per container.
-	server.visibleDevices = detectVisibleDevices(e.config)
+	server.setVisibleDevices(detectVisibleDevices(e.config))
 
 	e.server = server
 	e.initCount = 1
@@ -433,7 +434,7 @@ func (e *Engine) TopologyNearestGpus(handle unsafe.Pointer, level nvml.GpuTopolo
 
 	var out []unsafe.Pointer
 	for j := 0; j < cd.fabric.NumDevices(); j++ {
-		if j == cd.index {
+		if j == cd.index || !e.server.isDeviceVisible(j) {
 			continue
 		}
 		if cd.fabric.TopoLevel(cd.index, j) > level {
@@ -469,17 +470,10 @@ func (e *Engine) TopologyGpuSet(cpuNumber int) ([]unsafe.Pointer, nvml.Return) {
 	var out []unsafe.Pointer
 	for j := 0; j < len(e.server.configurableDevices); j++ {
 		dev := e.server.configurableDevices[j]
-		if dev == nil || dev.fabric == nil {
+		if dev == nil || dev.fabric == nil || !e.server.isDeviceVisible(j) {
 			continue
 		}
-		matched := false
-		for _, c := range dev.fabric.CPUs(dev.index) {
-			if c == cpuNumber {
-				matched = true
-				break
-			}
-		}
-		if !matched {
+		if !slices.Contains(dev.fabric.CPUs(dev.index), cpuNumber) {
 			continue
 		}
 		h := e.handles.HandleFor(dev)
@@ -629,7 +623,7 @@ func (e *Engine) AnyDeviceLost() bool {
 // engine's server. Pass nil to disable filtering. Only use in tests.
 func (e *Engine) SetVisibleDevicesForTesting(visible []int) {
 	if e.server != nil {
-		e.server.visibleDevices = visible
+		e.server.setVisibleDevices(visible)
 	}
 }
 

--- a/pkg/gpu/mocknvml/engine/engine.go
+++ b/pkg/gpu/mocknvml/engine/engine.go
@@ -389,7 +389,8 @@ func (e *Engine) LookupConfigurableDevice(handle unsafe.Pointer) *ConfigurableDe
 // ProcessByPID returns the first configured process with that pid, searching
 // every device's process list, and whether one was found. This backs
 // nvmlSystemGetProcessName, whose signature carries a bare pid with no device,
-// so the search cannot be narrowed. Callers that already know the device should
+// so GPU visibility intentionally does not restrict this system-wide lookup.
+// Callers that already know the device should
 // use ConfigurableDevice.ProcessByPID instead.
 func (e *Engine) ProcessByPID(pid uint32) (ProcessConfig, bool) {
 	e.mu.RLock()
@@ -425,7 +426,7 @@ func (e *Engine) TopologyNearestGpus(handle unsafe.Pointer, level nvml.GpuTopolo
 	}
 	dev := e.handles.Lookup(handle)
 	cd, ok := dev.(*ConfigurableDevice)
-	if !ok || cd == nil {
+	if !ok || cd == nil || !e.server.isDeviceVisible(cd.index) {
 		return nil, nvml.ERROR_INVALID_ARGUMENT
 	}
 	if cd.fabric == nil {

--- a/pkg/gpu/mocknvml/engine/engine_test.go
+++ b/pkg/gpu/mocknvml/engine/engine_test.go
@@ -746,6 +746,8 @@ func TestVisibility_IndexRoundTrip(t *testing.T) {
 
 func TestVisibility_TopologyHandles(t *testing.T) {
 	e := newFabricEngine(t)
+	// Ignore device files on the host before capturing the physical GPU handle.
+	e.SetVisibleDevicesForTesting(nil)
 	hidden, ret := e.DeviceGetHandleByIndex(0)
 	require.Equal(t, nvml.SUCCESS, ret)
 	e.SetVisibleDevicesForTesting([]int{1})
@@ -758,5 +760,5 @@ func TestVisibility_TopologyHandles(t *testing.T) {
 	require.Equal(t, nvml.SUCCESS, ret)
 	require.Equal(t, []unsafe.Pointer{h}, devices)
 	_, ret = e.LookupDevice(hidden).GetIndex()
-	require.Equal(t, nvml.ERROR_NO_PERMISSION, ret)
+	require.Equal(t, nvml.ERROR_INVALID_ARGUMENT, ret)
 }

--- a/pkg/gpu/mocknvml/engine/engine_test.go
+++ b/pkg/gpu/mocknvml/engine/engine_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/stretchr/testify/require"
@@ -676,4 +677,86 @@ func pciInfoBusIdString(pci nvml.PciInfo) string {
 	}
 	s += sSb553.String()
 	return s
+}
+
+// TestVisibility_IndexRoundTrip checks enumeration independently of physical identity.
+func TestVisibility_IndexRoundTrip(t *testing.T) {
+	e := NewEngine(&Config{NumDevices: 4, DriverVersion: "550.54.15"})
+	require.Equal(t, nvml.SUCCESS, e.Init())
+	t.Cleanup(func() { require.Equal(t, nvml.SUCCESS, e.Shutdown()) })
+	e.SetVisibleDevicesForTesting(nil)
+
+	var uuids [4]string
+	var pci [4]nvml.PciInfo
+	for i := range uuids {
+		h, ret := e.DeviceGetHandleByIndex(i)
+		require.Equal(t, nvml.SUCCESS, ret)
+		d := e.LookupDevice(h)
+		uuids[i], ret = d.GetUUID()
+		require.Equal(t, nvml.SUCCESS, ret)
+		pci[i], ret = d.GetPciInfo()
+		require.Equal(t, nvml.SUCCESS, ret)
+	}
+
+	// Reuse the engine so changing and clearing the filter must update indices too.
+	for _, visible := range [][]int{nil, {0}, {1}, {1, 3}, {2, 3}, {3, 1}, {}, nil} {
+		t.Run(fmt.Sprintf("visible=%v", visible), func(t *testing.T) {
+			e.SetVisibleDevicesForTesting(visible)
+			count, ret := e.DeviceGetCount()
+			require.Equal(t, nvml.SUCCESS, ret)
+			expected := len(visible)
+			if visible == nil {
+				expected = len(uuids)
+			}
+			require.Equal(t, expected, count)
+			for i := 0; i < count; i++ {
+				h, ret := e.DeviceGetHandleByIndex(i)
+				require.Equal(t, nvml.SUCCESS, ret)
+				d := e.LookupDevice(h)
+				index, ret := d.GetIndex()
+				require.Equal(t, nvml.SUCCESS, ret)
+				require.Equal(t, i, index)
+				roundTrip, ret := e.DeviceGetHandleByIndex(index)
+				require.Equal(t, nvml.SUCCESS, ret)
+				require.Equal(t, h, roundTrip)
+
+				physical := i
+				if visible != nil {
+					physical = visible[i]
+				}
+				minor, ret := d.GetMinorNumber()
+				require.Equal(t, nvml.SUCCESS, ret)
+				require.Equal(t, physical, minor)
+				uuid, ret := d.GetUUID()
+				require.Equal(t, nvml.SUCCESS, ret)
+				require.Equal(t, uuids[physical], uuid)
+				info, ret := d.GetPciInfo()
+				require.Equal(t, nvml.SUCCESS, ret)
+				require.Equal(t, pci[physical], info)
+				byUUID, ret := e.DeviceGetHandleByUUID(uuid)
+				require.Equal(t, nvml.SUCCESS, ret)
+				require.Equal(t, h, byUUID)
+				byPCI, ret := e.DeviceGetHandleByPciBusId(pciInfoBusIdString(info))
+				require.Equal(t, nvml.SUCCESS, ret)
+				require.Equal(t, h, byPCI)
+			}
+		})
+	}
+}
+
+func TestVisibility_TopologyHandles(t *testing.T) {
+	e := newFabricEngine(t)
+	hidden, ret := e.DeviceGetHandleByIndex(0)
+	require.Equal(t, nvml.SUCCESS, ret)
+	e.SetVisibleDevicesForTesting([]int{1})
+	h, ret := e.DeviceGetHandleByIndex(0)
+	require.Equal(t, nvml.SUCCESS, ret)
+	peers, ret := e.TopologyNearestGpus(h, nvml.TOPOLOGY_SYSTEM)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Empty(t, peers)
+	devices, ret := e.TopologyGpuSet(0)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Equal(t, []unsafe.Pointer{h}, devices)
+	_, ret = e.LookupDevice(hidden).GetIndex()
+	require.Equal(t, nvml.ERROR_NO_PERMISSION, ret)
 }

--- a/pkg/gpu/mocknvml/engine/engine_test.go
+++ b/pkg/gpu/mocknvml/engine/engine_test.go
@@ -759,6 +759,29 @@ func TestVisibility_TopologyHandles(t *testing.T) {
 	devices, ret := e.TopologyGpuSet(0)
 	require.Equal(t, nvml.SUCCESS, ret)
 	require.Equal(t, []unsafe.Pointer{h}, devices)
+	peers, ret = e.TopologyNearestGpus(hidden, nvml.TOPOLOGY_SYSTEM)
+	require.Equal(t, nvml.ERROR_INVALID_ARGUMENT, ret)
+	require.Empty(t, peers)
 	_, ret = e.LookupDevice(hidden).GetIndex()
 	require.Equal(t, nvml.ERROR_INVALID_ARGUMENT, ret)
+}
+
+func TestVisibility_CopiesMapping(t *testing.T) {
+	e := newFabricEngine(t)
+	visible := []int{1}
+	e.SetVisibleDevicesForTesting(visible)
+	h, ret := e.DeviceGetHandleByIndex(0)
+	require.Equal(t, nvml.SUCCESS, ret)
+
+	// Reusing the caller's slice must not change enumeration or cached indices.
+	visible[0] = 0
+	got, ret := e.DeviceGetHandleByIndex(0)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Equal(t, h, got)
+	index, ret := e.LookupDevice(got).GetIndex()
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Zero(t, index)
+	devices, ret := e.TopologyGpuSet(0)
+	require.Equal(t, nvml.SUCCESS, ret)
+	require.Equal(t, []unsafe.Pointer{h}, devices)
 }

--- a/pkg/gpu/mocknvml/engine/failure_injector_test.go
+++ b/pkg/gpu/mocknvml/engine/failure_injector_test.go
@@ -837,3 +837,55 @@ func TestFailureInjector_SameConfig(t *testing.T) {
 	var nilInjector *failureInjector
 	require.False(t, nilInjector.sameConfig(&FailureInjectionConfig{Mode: FailureModeLost}))
 }
+
+func TestVisibility_FailureEvents(t *testing.T) {
+	for _, mode := range []string{FailureModeECCUncorrectable, FailureModeLost, FailureModeFallenOffBus} {
+		t.Run(mode, func(t *testing.T) {
+			cfg := &Config{
+				NumDevices:    2,
+				DriverVersion: "550.163",
+				YAMLConfig: &YAMLConfig{
+					Version: "1.0",
+					System:  SystemConfig{DriverVersion: "550.163", NVMLVersion: "12.550.163", NumDevices: 2},
+					DeviceDefaults: *withFailure(&FailureInjectionConfig{
+						Mode: mode, AfterCalls: 1, Xid: &XidErrorConfig{Code: 79},
+					}),
+				},
+			}
+			e := NewEngine(cfg)
+			require.Equal(t, nvml.SUCCESS, e.Init())
+			t.Cleanup(func() { require.Equal(t, nvml.SUCCESS, e.Shutdown()) })
+			e.SetVisibleDevicesForTesting(nil)
+			hidden, ret := e.DeviceGetHandleByIndex(0)
+			require.Equal(t, nvml.SUCCESS, ret)
+			_, ret = e.LookupDevice(hidden).GetTemperature(nvml.TEMPERATURE_GPU)
+			lost := mode != FailureModeECCUncorrectable
+			if lost {
+				require.Equal(t, nvml.ERROR_GPU_IS_LOST, ret)
+			} else {
+				require.Equal(t, nvml.SUCCESS, ret)
+			}
+
+			for _, visible := range [][]int{{1}, {}} {
+				e.SetVisibleDevicesForTesting(visible)
+				require.False(t, e.AnyDeviceLost(), "hidden GPU must not fail event waits")
+				h, xid, ok := e.PendingXidEvent()
+				require.False(t, ok)
+				require.Nil(t, h)
+				require.Zero(t, xid)
+			}
+
+			// Filtering must leave the hidden event pending for when the GPU is visible.
+			e.SetVisibleDevicesForTesting([]int{0})
+			require.Equal(t, lost, e.AnyDeviceLost())
+			h, xid, ok := e.PendingXidEvent()
+			require.True(t, ok)
+			require.Equal(t, hidden, h)
+			require.Equal(t, uint64(79), xid)
+			_, _, ok = e.PendingXidEvent()
+			require.False(t, ok)
+			e.SetVisibleDevicesForTesting(nil)
+			require.Equal(t, lost, e.AnyDeviceLost())
+		})
+	}
+}


### PR DESCRIPTION
## What This PR Does

<!-- Brief description of the changes -->

When only physical GPU 1 is visible, `GetHandleByIndex(0)` returns its handle but `GetIndex` returns 1, which cannot be resolved back. Keep a separate visible NVML index so these calls round-trip, while preserving physical device identity.

- Keep GPU reset keyed by physical index, so resetting visible GPU 0 does not clear another GPU's overrides.
- Filter hidden devices from topology results and return `ERROR_INVALID_ARGUMENT` when querying a hidden handle's index or topology.
- Exclude hidden GPUs from Xid delivery and device-loss checks without consuming their pending events.
- Copy visibility mappings so later caller mutations cannot desynchronize enumeration and cached indices.
- Add regressions for filter changes, mapping ownership, UUID/PCI identity, topology visibility, event isolation, and per-device reset, including rejection of hidden reset handles. Make the topology test independent of host device files.
- Explain the reset visibility/health guard and distinguish visible and physical indices in reset logs.

## Why

<!-- Link to issue or explain motivation -->

Fixes #807.

This follows the mock's existing filtered enumeration model. It does not claim to reproduce every real-driver container visibility behaviour.

Validation on Linux/amd64: `make test` (race detection and coverage), `make lint-fix`, and targeted engine/bridge race tests passed. The standalone shared-library probe also verified the index round trip. Local macOS engine race tests passed.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`go test -v -race ./...`)
- [x] Linter passes (`make lint-fix`)
- [x] New code has SPDX license headers
- [x] Documentation updated (if applicable) — changelog updated; no setup changes
- [x] CHANGELOG.md updated (if user-facing change)
