### PR TITLE
chore(deps): consolidate the 2026-09-09 dependabot queue

### DIFF
--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -88,4 +88,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/.github/workflows/nvml-mock-publish.yaml
+++ b/.github/workflows/nvml-mock-publish.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4

--- a/deployments/devel/Dockerfile
+++ b/deployments/devel/Dockerfile
@@ -14,4 +14,4 @@
 
 # This Dockerfile is also used to define the golang version used in this project
 # This allows dependabot to manage this version in addition to other images.
-FROM golang:1.26.7
+FROM golang:1.26.8

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/containerd/nri v0.12.2
 	github.com/go-chi/chi/v5 v5.3.2
 	github.com/onsi/ginkgo/v2 v2.32.1
-	github.com/onsi/gomega v1.42.1
+	github.com/onsi/gomega v1.43.0
 	github.com/stretchr/testify v1.12.1
 	github.com/urfave/cli/v3 v3.11.0
 	go.uber.org/zap v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.32.1 h1:6tlvcDm/3sE8lGJbZ4+d4mO3RLy24/tQWOFzVSQNIfw=
 github.com/onsi/ginkgo/v2 v2.32.1/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
-github.com/onsi/gomega v1.42.1 h1:iN1rCUX+44NZ1Dc97MPoeFYbFR0vh8zxoxMFwKdyZ6I=
-github.com/onsi/gomega v1.42.1/go.mod h1:REff/hsDsodHoKlWsP2mAPhu1+5/6hVYNf9rIEBpeSg=
+github.com/onsi/gomega v1.43.0 h1:VlG/1FxqNxhSO+lq/OHBNaaqwiBK/mO8JbVkX9Y+FeU=
+github.com/onsi/gomega v1.43.0/go.mod h1:REff/hsDsodHoKlWsP2mAPhu1+5/6hVYNf9rIEBpeSg=
 github.com/opencontainers/runtime-spec v1.3.0 h1:YZupQUdctfhpZy3TM39nN9Ika5CBWT5diQ8ibYCRkxg=
 github.com/opencontainers/runtime-spec v1.3.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
## Problem

Four Dependabot PRs were queued against `main`, each costing its own full CI
matrix and each needing a rebase round whenever another landed first.

## Approach

Cherry-picked all four onto one branch, preserving `dependabot[bot]` authorship,
the original commit messages and the `updated-dependencies` trailers. History
stays linear. Ordered workflow-only first, then the Go module bump, then the
Dockerfile, so nothing collides.

- #809 actions/deploy-pages 5.0.0 -> 5.0.1 (`.github/workflows/deploy-pages.yaml`)
- #810 docker/setup-qemu-action 4.2.0 -> 4.3.0 (`.github/workflows/nvml-mock-publish.yaml`)
- #800 github.com/onsi/gomega 1.42.1 -> 1.43.0 (`go.mod`, `go.sum`)
- #782 golang 1.26.7 -> 1.26.8 (`deployments/devel/Dockerfile`)

The four touch disjoint files, so there were no conflicts to resolve. No
`go-nvml` bump is involved, so none of the bridge-stub or `dgxa100` hazards
apply here.

## Testing done

Run locally against the rebased branch:

- `go build ./...` clean
- `go vet ./...` clean
- `go mod tidy` leaves `go.mod` and `go.sum` unchanged
- `make deps-verify` passes
- `make test` passes, 43 packages, no failures
- `make gen-check` passes and leaves the tree clean

`make lint` could not be used as a local gate: it fails the same way on an
unmodified `main` checkout, because golangci-lint 2.13.2 cannot typecheck the
standard library of the Go toolchain installed here while the repo pins 1.26.8.
CI runs the pinned version, so the lint result there is the one that counts.

## Breaking changes

None.

Closes #809
Closes #810
Closes #800
Closes #782