### PR TITLE
fix(agent): address GPU device nodes by minor number, not NVML index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shipped profile describes, but where a profile sets them apart a container was
   handed the `/dev/nvidia<N>` belonging to a different GPU. NVML indices are
   unchanged, so `nvidia-smi` and CDI device names still enumerate from 0. A
-  device that omits `minor_number` keeps taking its index, and a config that
-  gives two devices the same minor number is now rejected rather than pointing
-  both at one node.
+  device that omits `minor_number` keeps taking its index. A profile is now
+  rejected, by the agent as well as the engine, when two devices would end up on
+  the same minor number — including where one of them defaulted to it — or when
+  a minor falls outside the range a GPU node can carry.
 - mocknvml: `nvidia-smi --gpu-reset` (`-r`) now resets a GPU instead of
   segfaulting. The mock's export-table dispatcher ended every per-device call by
   writing a zero count through `arg1`, which the reset slots do not carry, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   SIGKILL instead of being cut short.
 
 ### Fixed
+- agent: GPU character devices, both CDI specs and the NVML visibility filter
+  now address a device by its `minor_number` rather than by its NVML index. The
+  two match on a node whose driver probed in PCI enumeration order, which every
+  shipped profile describes, but where a profile sets them apart a container was
+  handed the `/dev/nvidia<N>` belonging to a different GPU. NVML indices are
+  unchanged, so `nvidia-smi` and CDI device names still enumerate from 0. A
+  device that omits `minor_number` keeps taking its index, and a config that
+  gives two devices the same minor number is now rejected rather than pointing
+  both at one node.
 - mocknvml: `nvidia-smi --gpu-reset` (`-r`) now resets a GPU instead of
   segfaulting. The mock's export-table dispatcher ended every per-device call by
   writing a zero count through `arg1`, which the reset slots do not carry, so the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -528,7 +528,12 @@ devices:
 `minor_number` is the `N` in `/dev/nvidia<N>`, which the agent stages and both
 CDI specs point at. It defaults to the index — the numbering a driver produces
 when it probes in PCI enumeration order — so set it only to describe a node
-where the two differ, and give each device a distinct value.
+where the two differ.
+
+Minor numbers are a permutation of the device indices: remapping one device
+means remapping whichever device held the minor it took. A profile that leaves
+two devices on the same minor is rejected, defaults included, as is a minor
+outside 0-254 (255 is `nvidiactl`).
 
 ## NVLink Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -524,6 +524,12 @@ devices:
       temperature_gpu_c: 37
 ```
 
+`index` is the NVML enumeration position and the key the override matches on.
+`minor_number` is the `N` in `/dev/nvidia<N>`, which the agent stages and both
+CDI specs point at. It defaults to the index — the numbering a driver produces
+when it probes in PCI enumeration order — so set it only to describe a node
+where the two differ, and give each device a distinct value.
+
 ## NVLink Configuration
 
 ```yaml

--- a/internal/agent/cdi/spec.go
+++ b/internal/agent/cdi/spec.go
@@ -134,11 +134,12 @@ func buildNvidiaSpec(state *agent.State) cdiSpec {
 	devices := make([]cdiDevice, 0, len(state.Devices)*2+1)
 	for _, d := range state.Devices {
 		node := cdiDeviceNode{
-			Path:     fmt.Sprintf("/dev/nvidia%d", d.Index),
-			HostPath: fmt.Sprintf("%s/nvidia%d", devRoot, d.Index),
+			Path:     fmt.Sprintf("/dev/nvidia%d", d.MinorNumber),
+			HostPath: fmt.Sprintf("%s/nvidia%d", devRoot, d.MinorNumber),
 		}
 		allNodes = append(allNodes, node)
 		// Index shorthand ("0".."N-1"): addressed by nvidia-container-runtime CLI.
+		// The name stays the NVML index even though the node carries the minor.
 		devices = append(devices, cdiDevice{
 			Name:           strconv.Itoa(d.Index),
 			ContainerEdits: cdiEdits{DeviceNodes: []cdiDeviceNode{node}},
@@ -208,8 +209,8 @@ func buildNRISpec(state *agent.State) cdiSpec {
 
 	for _, d := range state.Devices {
 		node := cdiDeviceNode{
-			Path:     fmt.Sprintf("/dev/nvidia%d", d.Index),
-			HostPath: fmt.Sprintf("%s/nvidia%d", devRoot, d.Index),
+			Path:     fmt.Sprintf("/dev/nvidia%d", d.MinorNumber),
+			HostPath: fmt.Sprintf("%s/nvidia%d", devRoot, d.MinorNumber),
 		}
 		devices = append(devices, cdiDevice{
 			Name:           strconv.Itoa(d.Index),

--- a/internal/agent/cdi/spec_test.go
+++ b/internal/agent/cdi/spec_test.go
@@ -16,8 +16,8 @@ import (
 func twoGPUState() *agent.State {
 	return &agent.State{
 		Devices: []agent.DeviceSpec{
-			{Index: 0, UUID: "GPU-aaa"},
-			{Index: 1, UUID: "GPU-bbb"},
+			{Index: 0, UUID: "GPU-aaa", MinorNumber: 0},
+			{Index: 1, UUID: "GPU-bbb", MinorNumber: 1},
 		},
 	}
 }
@@ -290,4 +290,24 @@ func TestNRISpecHostPathsUseOverlayRoot(t *testing.T) {
 				"hostPath %q must be rooted at overlayHostRoot", dn.HostPath)
 		}
 	}
+}
+
+// The device node a container gets has to be the one the driver would have
+// created for that GPU, which is named after the minor number. Naming it after
+// the NVML index hands the container a different GPU's node wherever the two
+// differ.
+func TestNvidiaSpecPerGPUDevicesFollowMinorNumbers(t *testing.T) {
+	state := &agent.State{Devices: []agent.DeviceSpec{{Index: 1, UUID: "GPU-bbb", MinorNumber: 3}}}
+	spec := buildNvidiaSpec(state)
+
+	require.Equal(t, "/dev/nvidia3", spec.Devices[0].ContainerEdits.DeviceNodes[0].Path)
+	// The index and UUID entries address the same GPU, so they share the node.
+	require.Equal(t, spec.Devices[0].ContainerEdits.DeviceNodes, spec.Devices[1].ContainerEdits.DeviceNodes)
+}
+
+func TestNRISpecPerGPUDevicesFollowMinorNumbers(t *testing.T) {
+	state := &agent.State{Devices: []agent.DeviceSpec{{Index: 1, MinorNumber: 3}}}
+	spec := buildNRISpec(state)
+
+	require.Equal(t, "/dev/nvidia3", spec.Devices[0].ContainerEdits.DeviceNodes[0].Path)
 }

--- a/internal/agent/gpudriver/gpudriver_test.go
+++ b/internal/agent/gpudriver/gpudriver_test.go
@@ -205,6 +205,23 @@ func TestStageCharDevs_CreatesDeviceNodes(t *testing.T) {
 	}
 }
 
+// The node name and the minor it is created with both come from the driver's
+// numbering, not from the NVML index, so a device whose two differ gets one
+// node under its minor rather than a stray node under its index.
+func TestStageCharDevs_UsesConfiguredMinorNumber(t *testing.T) {
+	skipUnlessRootLinux(t)
+
+	h := testHost(t)
+	state := testState(t)
+	state.Devices = []agent.DeviceSpec{{Index: 1, MinorNumber: 3}}
+
+	require.NoError(t, stageCharDevs(context.Background(), h, state))
+
+	devRoot := filepath.Join(h.Root, "driver/dev")
+	require.FileExists(t, filepath.Join(devRoot, "nvidia3"))
+	require.NoFileExists(t, filepath.Join(devRoot, "nvidia1"))
+}
+
 // ─── Apply / Revoke ──────────────────────────────────────────────────────────
 
 func TestApply_CreatesSymlink(t *testing.T) {
@@ -346,7 +363,10 @@ func TestStageCharDevs_PrunesShrunkDeviceSet(t *testing.T) {
 		require.NoError(t, fsutil.Mknod(filepath.Join(devRoot, n), 195, uint32(i)))
 	}
 
-	state := &agent.State{Devices: []agent.DeviceSpec{{Index: 0}, {Index: 1}}}
+	state := &agent.State{Devices: []agent.DeviceSpec{
+		{Index: 0, MinorNumber: 0},
+		{Index: 1, MinorNumber: 1},
+	}}
 	require.NoError(t, stageCharDevs(context.Background(), h, state))
 
 	require.FileExists(t, filepath.Join(devRoot, "nvidia0"))

--- a/internal/agent/gpudriver/stage.go
+++ b/internal/agent/gpudriver/stage.go
@@ -37,7 +37,7 @@ func stageCharDevs(ctx context.Context, h *host.Host, state *agent.State) error 
 	}
 	devs := make([]charDev, 0, len(state.Devices)+3)
 	for _, d := range state.Devices {
-		devs = append(devs, charDev{fmt.Sprintf("nvidia%d", d.Index), 195, uint32(d.Index)})
+		devs = append(devs, charDev{fmt.Sprintf("nvidia%d", d.MinorNumber), 195, uint32(d.MinorNumber)})
 	}
 	devs = append(devs,
 		charDev{"nvidiactl", 195, 255},

--- a/internal/agent/source/file.go
+++ b/internal/agent/source/file.go
@@ -265,7 +265,10 @@ func resolveDeviceCount(cfg engine.YAMLConfig) int {
 
 func buildDeviceSpec(i int, defaults engine.DeviceConfig, devices []engine.DeviceOverride) agent.DeviceSpec {
 	spec := agent.DeviceSpec{
-		Index:        i,
+		Index: i,
+		// Absent an explicit minor_number, the driver is taken to have probed
+		// in index order.
+		MinorNumber:  i,
 		Name:         defaults.Name,
 		Architecture: defaults.Architecture,
 		Serial:       defaults.Serial,
@@ -298,8 +301,8 @@ func applyDeviceOverride(spec *agent.DeviceSpec, ov engine.DeviceOverride) {
 	if ov.Serial != "" {
 		spec.Serial = ov.Serial
 	}
-	if ov.MinorNumber != 0 {
-		spec.MinorNumber = ov.MinorNumber
+	if ov.MinorNumber != nil {
+		spec.MinorNumber = *ov.MinorNumber
 	}
 	// Each PCI field overrides independently, matching how the mock NVML engine
 	// merges the same block (engine/config.go): a device that sets only bus_id

--- a/internal/agent/source/file.go
+++ b/internal/agent/source/file.go
@@ -149,13 +149,26 @@ func inputsHash(config, topology []byte) [32]byte {
 	return sha256.Sum256(append(c[:], t[:]...))
 }
 
+// parseProfile decodes a profile and checks what the agent acts on before the
+// engine ever sees the file. The agent stages the character devices and writes
+// both CDI specs, so it cannot wait for the engine to reject minors that
+// collide. Only that check runs here: the rest of the engine's validation
+// demands fields the agent deliberately tolerates, driver_version among them.
+func parseProfile(data []byte) (engine.YAMLConfig, error) {
+	var cfg engine.YAMLConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return cfg, fmt.Errorf("parse yaml: %w", err)
+	}
+	return cfg, engine.ValidateMinorNumbers(&cfg)
+}
+
 // compileState parses raw YAML config bytes and builds the agent State.
 // Runtime telemetry fields (utilization, power, temperature, clocks) are
 // discarded — they belong to the runtime override file owned by nvml-mock-ctl.
 func compileState(data []byte) (*agent.State, error) {
-	var cfg engine.YAMLConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("parse yaml: %w", err)
+	cfg, err := parseProfile(data)
+	if err != nil {
+		return nil, err
 	}
 
 	dv := cfg.System.DriverVersion

--- a/internal/agent/source/file_test.go
+++ b/internal/agent/source/file_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"sigs.k8s.io/yaml"
 
 	"github.com/NVIDIA/k8s-test-infra/internal/agent"
 	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
@@ -474,4 +475,49 @@ devices:
 	require.NoError(t, err)
 	require.Equal(t, 1, state.Devices[0].MinorNumber)
 	require.Equal(t, 0, state.Devices[1].MinorNumber, "minor 0 on a device that is not index 0")
+}
+
+// The agent stages the character devices and writes both CDI specs, so a
+// profile whose minor numbers collide has to be rejected here too — the engine
+// refusing it later does not stop the nodes from being created.
+func TestCompileState_RejectsCollidingMinorNumbers(t *testing.T) {
+	cfg := `
+version: "1.0"
+system:
+  driver_version: "550.163.01"
+  num_devices: 2
+devices:
+  - index: 0
+    minor_number: 1
+  - index: 1
+`
+	_, err := compileState([]byte(cfg))
+	require.ErrorContains(t, err, "duplicate device minor number: 1")
+}
+
+// The agent's device nodes and the engine's visibility filter have to agree on
+// which minor belongs to which index, or a container is filtered against nodes
+// that were never staged.
+func TestCompileState_MinorNumbersAgreeWithTheEngine(t *testing.T) {
+	cfg := `
+version: "1.0"
+system:
+  driver_version: "550.163.01"
+  num_devices: 4
+devices:
+  - index: 1
+    minor_number: 3
+  - index: 3
+    minor_number: 1
+`
+	state, err := compileState([]byte(cfg))
+	require.NoError(t, err)
+
+	var yc engine.YAMLConfig
+	require.NoError(t, yaml.Unmarshal([]byte(cfg), &yc))
+	ec := &engine.Config{YAMLConfig: &yc}
+
+	for _, d := range state.Devices {
+		require.Equal(t, ec.GetDeviceMinorNumber(d.Index), d.MinorNumber, "device %d", d.Index)
+	}
 }

--- a/internal/agent/source/file_test.go
+++ b/internal/agent/source/file_test.go
@@ -434,3 +434,44 @@ func TestFileSource_ReportsAnUnreadableTopology(t *testing.T) {
 	require.Error(t, u.Err)
 	require.Nil(t, u.State)
 }
+
+// A profile that leaves minor_number out is saying the driver numbered the
+// devices in index order. Compiling that to minor 0 would stage a single
+// /dev/nvidia0 for the whole node.
+func TestCompileState_MinorNumberDefaultsToIndex(t *testing.T) {
+	cfg := `
+version: "1.0"
+system:
+  driver_version: "550.163.01"
+  num_devices: 4
+devices:
+  - index: 0
+    uuid: "GPU-aaa"
+  - index: 1
+    uuid: "GPU-bbb"
+`
+	state, err := compileState([]byte(cfg))
+	require.NoError(t, err)
+	require.Len(t, state.Devices, 4)
+	for i, d := range state.Devices {
+		require.Equal(t, i, d.MinorNumber, "device %d", i)
+	}
+}
+
+func TestCompileState_HonorsExplicitMinorNumbers(t *testing.T) {
+	cfg := `
+version: "1.0"
+system:
+  driver_version: "550.163.01"
+  num_devices: 2
+devices:
+  - index: 0
+    minor_number: 1
+  - index: 1
+    minor_number: 0
+`
+	state, err := compileState([]byte(cfg))
+	require.NoError(t, err)
+	require.Equal(t, 1, state.Devices[0].MinorNumber)
+	require.Equal(t, 0, state.Devices[1].MinorNumber, "minor 0 on a device that is not index 0")
+}

--- a/pkg/gpu/mocknvml/engine/config.go
+++ b/pkg/gpu/mocknvml/engine/config.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -258,16 +259,8 @@ func validateYAMLConfig(config *YAMLConfig) error {
 		seen[dev.Index] = true
 	}
 
-	// Two devices sharing a minor number would share one /dev/nvidia<N>.
-	seenMinor := make(map[int]bool)
-	for _, dev := range config.Devices {
-		if dev.MinorNumber == nil {
-			continue
-		}
-		if seenMinor[*dev.MinorNumber] {
-			return fmt.Errorf("duplicate device minor number: %d", *dev.MinorNumber)
-		}
-		seenMinor[*dev.MinorNumber] = true
+	if err := ValidateMinorNumbers(config); err != nil {
+		return err
 	}
 
 	return nil
@@ -308,20 +301,92 @@ func (c *Config) GetDeviceUUID(index int) string {
 	return ""
 }
 
-// GetDeviceMinorNumber returns the minor number for a specific device index,
+// GetDeviceMinorNumber returns the minor number for a specific device index.
+func (c *Config) GetDeviceMinorNumber(index int) int {
+	return DeviceMinorNumber(c.YAMLConfig, index)
+}
+
+// maxDeviceMinor is the highest minor major 195 leaves for a GPU: the driver
+// keeps 255 for nvidiactl.
+const maxDeviceMinor = 254
+
+// DeviceMinorNumber returns the /dev/nvidia<N> a device is staged under,
 // defaulting to the index for devices that do not declare one — the numbering
 // a driver produces when it probes in PCI enumeration order.
-func (c *Config) GetDeviceMinorNumber(index int) int {
-	if c.YAMLConfig == nil {
+//
+// The agent and the engine both resolve minors through here so the nodes that
+// get staged and the nodes the visibility filter looks for cannot drift apart.
+func DeviceMinorNumber(config *YAMLConfig, index int) int {
+	if config == nil {
 		return index
 	}
 
-	for _, dev := range c.YAMLConfig.Devices {
+	for _, dev := range config.Devices {
 		if dev.Index == index && dev.MinorNumber != nil {
 			return *dev.MinorNumber
 		}
 	}
 	return index
+}
+
+// ValidateMinorNumbers rejects minors that no device node can carry and minors
+// two devices would end up sharing. Defaulted devices take part: one that never
+// declares a minor still occupies its index, so an explicit value elsewhere can
+// collide with it.
+func ValidateMinorNumbers(config *YAMLConfig) error {
+	if config == nil {
+		return nil
+	}
+
+	for _, dev := range config.Devices {
+		if dev.MinorNumber == nil {
+			continue
+		}
+		if *dev.MinorNumber < 0 || *dev.MinorNumber > maxDeviceMinor {
+			return fmt.Errorf("device %d: device minor number out of range (0-%d): %d",
+				dev.Index, maxDeviceMinor, *dev.MinorNumber)
+		}
+	}
+
+	seen := make(map[int]int, deviceSpace(config))
+	for _, index := range deviceIndices(config) {
+		minor := DeviceMinorNumber(config, index)
+		if other, dup := seen[minor]; dup {
+			return fmt.Errorf("duplicate device minor number: %d (devices %d and %d)", minor, other, index)
+		}
+		seen[minor] = index
+	}
+
+	return nil
+}
+
+// deviceIndices lists every device the config brings into being: those the
+// count covers, plus any the overrides declare beyond it.
+func deviceIndices(config *YAMLConfig) []int {
+	n := deviceSpace(config)
+	indices := make([]int, 0, n)
+	seen := make(map[int]bool, n)
+	for i := 0; i < n; i++ {
+		indices = append(indices, i)
+		seen[i] = true
+	}
+	for _, dev := range config.Devices {
+		if !seen[dev.Index] {
+			indices = append(indices, dev.Index)
+			seen[dev.Index] = true
+		}
+	}
+	sort.Ints(indices)
+	return indices
+}
+
+// deviceSpace is how many devices the config describes before any runtime cap.
+func deviceSpace(config *YAMLConfig) int {
+	n := len(config.Devices)
+	if config.System.NumDevices > n {
+		n = config.System.NumDevices
+	}
+	return n
 }
 
 // GetDevicePCIBusID returns the PCI bus ID for a specific device index

--- a/pkg/gpu/mocknvml/engine/config.go
+++ b/pkg/gpu/mocknvml/engine/config.go
@@ -258,6 +258,18 @@ func validateYAMLConfig(config *YAMLConfig) error {
 		seen[dev.Index] = true
 	}
 
+	// Two devices sharing a minor number would share one /dev/nvidia<N>.
+	seenMinor := make(map[int]bool)
+	for _, dev := range config.Devices {
+		if dev.MinorNumber == nil {
+			continue
+		}
+		if seenMinor[*dev.MinorNumber] {
+			return fmt.Errorf("duplicate device minor number: %d", *dev.MinorNumber)
+		}
+		seenMinor[*dev.MinorNumber] = true
+	}
+
 	return nil
 }
 
@@ -296,15 +308,17 @@ func (c *Config) GetDeviceUUID(index int) string {
 	return ""
 }
 
-// GetDeviceMinorNumber returns the minor number for a specific device index
+// GetDeviceMinorNumber returns the minor number for a specific device index,
+// defaulting to the index for devices that do not declare one — the numbering
+// a driver produces when it probes in PCI enumeration order.
 func (c *Config) GetDeviceMinorNumber(index int) int {
 	if c.YAMLConfig == nil {
 		return index
 	}
 
 	for _, dev := range c.YAMLConfig.Devices {
-		if dev.Index == index {
-			return dev.MinorNumber
+		if dev.Index == index && dev.MinorNumber != nil {
+			return *dev.MinorNumber
 		}
 	}
 	return index

--- a/pkg/gpu/mocknvml/engine/config_test.go
+++ b/pkg/gpu/mocknvml/engine/config_test.go
@@ -14,6 +14,7 @@
 package engine
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -286,4 +287,71 @@ devices:
 	require.NoError(t, yaml.Unmarshal([]byte(y), &yc), "yaml decode")
 
 	require.ErrorContains(t, validateYAMLConfig(&yc), "duplicate device minor number: 3")
+}
+
+// A device that omits minor_number still occupies its index as a minor, so an
+// explicit value elsewhere can collide with it. Checking only the values that
+// were spelled out would let both devices reach the same /dev/nvidia<N>.
+func TestValidateYAMLConfig_RejectsCollisionWithADefaultedMinorNumber(t *testing.T) {
+	t.Parallel()
+
+	y := `
+version: "1.0"
+system:
+  driver_version: "550.163.01"
+devices:
+  - index: 0
+    minor_number: 1
+  - index: 1
+`
+	var yc YAMLConfig
+	require.NoError(t, yaml.Unmarshal([]byte(y), &yc), "yaml decode")
+
+	require.ErrorContains(t, validateYAMLConfig(&yc), "duplicate device minor number: 1")
+}
+
+// An implicit device — one the count covers but no entry describes — takes its
+// index as a minor and can be collided with just the same.
+func TestValidateYAMLConfig_RejectsCollisionWithAnUndeclaredDevice(t *testing.T) {
+	t.Parallel()
+
+	y := `
+version: "1.0"
+system:
+  driver_version: "550.163.01"
+  num_devices: 4
+devices:
+  - index: 0
+    minor_number: 3
+`
+	var yc YAMLConfig
+	require.NoError(t, yaml.Unmarshal([]byte(y), &yc), "yaml decode")
+
+	require.ErrorContains(t, validateYAMLConfig(&yc), "duplicate device minor number: 3")
+}
+
+// stageCharDevs formats the node name from the minor and casts it to uint32.
+// A negative value names a node the GPU-node pattern cannot match, so it
+// survives pruning, and 255 is nvidiactl's.
+func TestValidateYAMLConfig_RejectsMinorNumbersOutsideTheDeviceRange(t *testing.T) {
+	t.Parallel()
+
+	for name, minor := range map[string]int{"negative": -1, "nvidiactl": 255} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			y := fmt.Sprintf(`
+version: "1.0"
+system:
+  driver_version: "550.163.01"
+devices:
+  - index: 0
+    minor_number: %d
+`, minor)
+			var yc YAMLConfig
+			require.NoError(t, yaml.Unmarshal([]byte(y), &yc), "yaml decode")
+
+			require.ErrorContains(t, validateYAMLConfig(&yc), "device minor number out of range")
+		})
+	}
 }

--- a/pkg/gpu/mocknvml/engine/config_test.go
+++ b/pkg/gpu/mocknvml/engine/config_test.go
@@ -217,3 +217,73 @@ devices:
 	require.Len(t, d2.Processes, 1, "device 2 (inherit) len")
 	require.Equal(t, uint32(1), d2.Processes[0].PID, "device 2 (inherit) PID")
 }
+
+// A device that does not declare minor_number takes the index, which is what
+// the driver assigns when probe order follows PCI enumeration order. Treating
+// an omitted key as minor 0 would point every such device at /dev/nvidia0.
+func TestGetDeviceMinorNumber_DefaultsToIndex(t *testing.T) {
+	t.Parallel()
+
+	y := `
+version: "1.0"
+system:
+  driver_version: "550.163.01"
+devices:
+  - index: 0
+    uuid: "GPU-aaa"
+  - index: 1
+    uuid: "GPU-bbb"
+`
+	var yc YAMLConfig
+	require.NoError(t, yaml.Unmarshal([]byte(y), &yc), "yaml decode")
+	c := &Config{YAMLConfig: &yc}
+
+	require.Equal(t, 0, c.GetDeviceMinorNumber(0))
+	require.Equal(t, 1, c.GetDeviceMinorNumber(1))
+	require.Equal(t, 2, c.GetDeviceMinorNumber(2), "device without an override entry")
+}
+
+// Nodes whose driver probe order does not follow PCI enumeration order report
+// minor numbers that do not match the NVML index, so the profile must be able
+// to say so — including minor 0 on a device that is not index 0.
+func TestGetDeviceMinorNumber_HonorsExplicitValue(t *testing.T) {
+	t.Parallel()
+
+	y := `
+version: "1.0"
+system:
+  driver_version: "550.163.01"
+devices:
+  - index: 0
+    minor_number: 2
+  - index: 1
+    minor_number: 0
+`
+	var yc YAMLConfig
+	require.NoError(t, yaml.Unmarshal([]byte(y), &yc), "yaml decode")
+	c := &Config{YAMLConfig: &yc}
+
+	require.Equal(t, 2, c.GetDeviceMinorNumber(0))
+	require.Equal(t, 0, c.GetDeviceMinorNumber(1))
+}
+
+// Two devices claiming one minor number would collapse onto a single
+// /dev/nvidia<N>, silently handing both GPUs the same character device.
+func TestValidateYAMLConfig_RejectsDuplicateMinorNumbers(t *testing.T) {
+	t.Parallel()
+
+	y := `
+version: "1.0"
+system:
+  driver_version: "550.163.01"
+devices:
+  - index: 0
+    minor_number: 3
+  - index: 1
+    minor_number: 3
+`
+	var yc YAMLConfig
+	require.NoError(t, yaml.Unmarshal([]byte(y), &yc), "yaml decode")
+
+	require.ErrorContains(t, validateYAMLConfig(&yc), "duplicate device minor number: 3")
+}

--- a/pkg/gpu/mocknvml/engine/config_types.go
+++ b/pkg/gpu/mocknvml/engine/config_types.go
@@ -227,9 +227,12 @@ type NVLinkErrorInjectionConfig struct {
 
 // DeviceOverride contains per-device settings that override defaults
 type DeviceOverride struct {
-	Index        int              `json:"index"`
-	UUID         string           `json:"uuid,omitempty"`
-	MinorNumber  int              `json:"minor_number,omitempty"`
+	Index int    `json:"index"`
+	UUID  string `json:"uuid,omitempty"`
+	// MinorNumber is the /dev/nvidia<N> the driver would have created. A
+	// pointer because minor 0 is a legal value on a device that is not index
+	// 0, so an omitted key has to stay distinguishable from an explicit zero.
+	MinorNumber  *int             `json:"minor_number,omitempty"`
 	GraceCPUPair int              `json:"grace_cpu_pair,omitempty"`
 	DeviceConfig `json:",inline"` // Embed all device config fields
 }

--- a/pkg/gpu/mocknvml/engine/engine.go
+++ b/pkg/gpu/mocknvml/engine/engine.go
@@ -98,7 +98,7 @@ func (e *Engine) Init() nvml.Return {
 	// only the allocated GPUs (e.g. /dev/nvidia0 but not /dev/nvidia1-7),
 	// filter the visible device set to match. This mimics real NVML behavior
 	// where cgroup device permissions limit GPU visibility per container.
-	server.visibleDevices = detectVisibleDevices(e.config.NumDevices)
+	server.visibleDevices = detectVisibleDevices(e.config)
 
 	e.server = server
 	e.initCount = 1
@@ -658,20 +658,26 @@ func ResetForTesting() {
 // Returns nil if ALL device nodes exist (no filtering needed) or if none
 // exist (host context where /dev/nvidia* may not be present but NVML should
 // still work).
-func detectVisibleDevices(numDevices int) []int {
-	return detectVisibleDevicesAt("/dev/nvidia%d", numDevices)
+func detectVisibleDevices(config *Config) []int {
+	minorNumbers := make([]int, 0, config.NumDevices)
+	for i := 0; i < config.NumDevices && i < MaxDevices; i++ {
+		minorNumbers = append(minorNumbers, config.GetDeviceMinorNumber(i))
+	}
+	return detectVisibleDevicesAt("/dev/nvidia%d", minorNumbers)
 }
 
 // detectVisibleDevicesAt is the testable core of detectVisibleDevices.
-// pathFmt is a printf format that takes the device index (e.g. "/dev/nvidia%d").
-func detectVisibleDevicesAt(pathFmt string, numDevices int) []int {
+// pathFmt is a printf format that takes the minor number of a device
+// (e.g. "/dev/nvidia%d"); minorNumbers is indexed by device index, so the
+// returned positions are NVML indices rather than minor numbers.
+func detectVisibleDevicesAt(pathFmt string, minorNumbers []int) []int {
 	var present []int
 	var absent int
 
-	for i := 0; i < numDevices && i < MaxDevices; i++ {
-		path := fmt.Sprintf(pathFmt, i)
+	for index, minor := range minorNumbers {
+		path := fmt.Sprintf(pathFmt, minor)
 		if _, err := os.Stat(path); err == nil {
-			present = append(present, i)
+			present = append(present, index)
 		} else {
 			absent++
 		}
@@ -685,6 +691,6 @@ func detectVisibleDevicesAt(pathFmt string, numDevices int) []int {
 	}
 
 	debugLog("[ENGINE] Device visibility filtering: %d of %d GPUs visible (by /dev/nvidia* presence)\n",
-		len(present), numDevices)
+		len(present), len(minorNumbers))
 	return present
 }

--- a/pkg/gpu/mocknvml/engine/engine_test.go
+++ b/pkg/gpu/mocknvml/engine/engine_test.go
@@ -513,7 +513,7 @@ func TestEngine_DeviceGetHandleByPciBusIdInvalid(t *testing.T) {
 func TestDetectVisibleDevices_NonePresent(t *testing.T) {
 	dir := t.TempDir()
 	// No files created – simulates no /dev/nvidia* nodes
-	result := detectVisibleDevicesAt(dir+"/nvidia%d", 4)
+	result := detectVisibleDevicesAt(dir+"/nvidia%d", []int{0, 1, 2, 3})
 	require.Nil(t, result, "Expected nil (no filtering) when no nodes exist")
 }
 
@@ -527,7 +527,7 @@ func TestDetectVisibleDevices_AllPresent(t *testing.T) {
 		require.NoError(t, f.Close())
 	}
 
-	result := detectVisibleDevicesAt(dir+"/nvidia%d", 4)
+	result := detectVisibleDevicesAt(dir+"/nvidia%d", []int{0, 1, 2, 3})
 	require.Nil(t, result, "Expected nil (no filtering) when all nodes exist")
 }
 
@@ -542,9 +542,24 @@ func TestDetectVisibleDevices_Subset(t *testing.T) {
 		require.NoError(t, f.Close())
 	}
 
-	result := detectVisibleDevicesAt(dir+"/nvidia%d", 4)
+	result := detectVisibleDevicesAt(dir+"/nvidia%d", []int{0, 1, 2, 3})
 	require.Len(t, result, 2, "Expected 2 visible devices")
 	require.Equal(t, []int{0, 2}, result, "Expected visible devices [0 2]")
+}
+
+// The scan looks for the node the driver would have created, which carries the
+// minor number, but NVML reports positions in its own index space. A node
+// staged for a device whose minor differs from its index must therefore be
+// reported under the index, not under the minor.
+func TestDetectVisibleDevices_ReportsIndicesNotMinorNumbers(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.Create(fmt.Sprintf("%s/nvidia%d", dir, 3))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Device index 2 owns minor 3, so the lone node makes index 2 visible.
+	result := detectVisibleDevicesAt(dir+"/nvidia%d", []int{1, 0, 3, 2})
+	require.Equal(t, []int{2}, result)
 }
 
 // TestVisibility_DeviceGetCount verifies that DeviceGetCount returns the


### PR DESCRIPTION
## What This PR Does

Makes the agent and the mock NVML engine address a GPU's character device by its `minor_number` instead of by its NVML index, at the three places that conflated the two:

- `stageCharDevs` mknod'd `nvidia<Index>` with minor `Index`.
- Both CDI builders (`nvidia.com/gpu` and the NRI spec) emitted `/dev/nvidia<Index>`.
- The engine's visibility filter looked for `/dev/nvidia<Index>` to decide which GPUs a container can see.

NVML indices stay the identity everything else addresses: CDI device names still count from `0`, and the visibility filter still returns indices even though it now looks for nodes by minor.

`minor_number` becomes a `*int` so an omitted key stays distinguishable from an explicit zero — minor 0 is legal on a device that is not index 0. A device that omits it still takes its index. Two devices claiming the same minor number are now rejected at config load instead of silently sharing one node.

## Why

The `N` in `/dev/nvidia<N>` is the minor number the driver assigned, and it only equals the NVML index when the driver probed in PCI enumeration order. Every shipped profile describes such a node, so nothing in-tree changes behaviour — but the mock already lets a profile describe a node where they differ, and `nvmlDeviceGetMinorNumber` already reports it. Before this change that combination was incoherent: NVML would report minor 3 for a GPU whose node was staged as `/dev/nvidia1`, so a consumer that resolves device nodes from the minor number (libnvidia-container does exactly this) reaches a different GPU than the one it asked for, and a container can end up with more device nodes than it was allocated.

The pointer change is load-bearing rather than cosmetic. Once these three boundaries read `minor_number`, its zero value stops being inert: a profile that lists devices without the key would compile every device to minor 0 and collapse the whole node onto `/dev/nvidia0`. The engine and the agent also disagreed on the default before this — the engine fell back to the index only when a device had no override entry at all, while the agent always left the field at zero.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`go test -v -race ./...`)
- [x] Linter passes (`make lint-fix`)
- [x] New code has SPDX license headers
- [x] Documentation updated (if applicable)
- [x] CHANGELOG.md updated (if user-facing change)

Regression coverage: non-identity mappings through the CDI builders, the visibility filter and `stageCharDevs`; index defaulting and explicit minors through `compileState` and `GetDeviceMinorNumber`; and the new duplicate-minor validation. `make helm-tests` passes unchanged.