### PR TITLE
fix(engine): clone DeviceDefaults.PCI before merging per-device overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - mocknvml: keep device indices consistent after visibility filtering, preserve
   physical GPU targets for reset, and exclude hidden devices from topology results
   and event waits (#807).
+- mocknvml: a per-device `pci` override no longer leaks into every device
+  merged after it. `GetDeviceConfig` copied `device_defaults` by value, but the
+  copy still aliased the shared `pci` block and the per-device merge wrote
+  through that pointer. A profile setting `devices[0].pci.device_id` left every
+  later device reporting device 0's ID, so `nvidia-smi -q` showed the wrong
+  Device Id and anything keying product identity off the PCI ID mislabelled
+  them. Heterogeneous profiles were the affected case.
 - mocknvml: `nvidia-smi --gpu-reset` (`-r`) now resets a GPU instead of
   segfaulting. The mock's export-table dispatcher ended every per-device call by
   writing a zero count through `arg1`, which the reset slots do not carry, so the

--- a/pkg/gpu/mocknvml/engine/config.go
+++ b/pkg/gpu/mocknvml/engine/config.go
@@ -273,8 +273,17 @@ func (c *Config) GetDeviceConfig(index int) *DeviceConfig {
 		return nil
 	}
 
-	// Start with a copy of defaults
+	// Start with a copy of defaults. The copy is shallow, so every pointer
+	// field still aliases the shared defaults. mergeDeviceOverride writes
+	// THROUGH the PCI pointer instead of replacing it, so clone PCIConfig here
+	// or a per-device PCI override lands on the defaults and leaks into every
+	// device merged afterwards (issue #589). mergePlatformOverride clones
+	// Platform itself; the remaining branches replace the pointer wholesale.
 	merged := c.YAMLConfig.DeviceDefaults
+	if merged.PCI != nil {
+		pci := *merged.PCI
+		merged.PCI = &pci
+	}
 
 	// Find and apply per-device overrides
 	for _, override := range c.YAMLConfig.Devices {

--- a/pkg/gpu/mocknvml/engine/config_pci_alias_test.go
+++ b/pkg/gpu/mocknvml/engine/config_pci_alias_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetDeviceConfigPCIOverrideDoesNotLeakIntoDefaults covers issue #589:
+// GetDeviceConfig shallow-copies DeviceDefaults, so the copy shares the
+// *PCIConfig with the defaults. mergeDeviceOverride is the only merge branch
+// that writes THROUGH that pointer, so a per-device PCI override used to be
+// stamped onto the shared defaults and inherited by every device merged after
+// it.
+func TestGetDeviceConfigPCIOverrideDoesNotLeakIntoDefaults(t *testing.T) {
+	t.Parallel()
+
+	const (
+		defaultDeviceID    uint32 = 0x20B010DE // A100-SXM4-80GB
+		overrideDeviceID   uint32 = 0x233010DE // H100-SXM5-80GB
+		defaultSubsystemID uint32 = 0x144E10DE
+		defaultBusID              = "00000000:07:00.0"
+	)
+
+	cfg := &Config{
+		NumDevices: 3,
+		YAMLConfig: &YAMLConfig{
+			DeviceDefaults: DeviceConfig{
+				PCI: &PCIConfig{
+					DeviceID:    defaultDeviceID,
+					SubsystemID: defaultSubsystemID,
+					BusID:       defaultBusID,
+				},
+			},
+			Devices: []DeviceOverride{
+				{
+					Index:        0,
+					DeviceConfig: DeviceConfig{PCI: &PCIConfig{DeviceID: overrideDeviceID}},
+				},
+			},
+		},
+	}
+
+	// Device 0 carries the override, and merging it is what corrupts the
+	// shared defaults, so it must be resolved before the other devices.
+	t.Run("overridden device gets the override plus untouched defaults", func(t *testing.T) {
+		dev0 := cfg.GetDeviceConfig(0)
+		require.NotNil(t, dev0)
+		require.NotNil(t, dev0.PCI)
+
+		assert.Equal(t, overrideDeviceID, dev0.PCI.DeviceID, "device 0 must report its own device ID")
+		// Fields the override leaves zero still come from the defaults.
+		assert.Equal(t, defaultSubsystemID, dev0.PCI.SubsystemID, "device 0 subsystem ID must fall back to the default")
+		assert.Equal(t, defaultBusID, dev0.PCI.BusID, "device 0 bus ID must fall back to the default")
+	})
+
+	for _, index := range []int{1, 2} {
+		t.Run(fmt.Sprintf("device %d keeps the default device ID", index), func(t *testing.T) {
+			dev := cfg.GetDeviceConfig(index)
+			require.NotNil(t, dev)
+			require.NotNil(t, dev.PCI)
+
+			assert.Equal(t, defaultDeviceID, dev.PCI.DeviceID,
+				"device 0's PCI override leaked into device %d through the shared defaults", index)
+		})
+	}
+
+	t.Run("shared defaults are not mutated", func(t *testing.T) {
+		assert.Equal(t, defaultDeviceID, cfg.YAMLConfig.DeviceDefaults.PCI.DeviceID,
+			"GetDeviceConfig wrote device 0's override onto YAMLConfig.DeviceDefaults")
+	})
+
+	t.Run("resolving a default-only device is repeatable", func(t *testing.T) {
+		// If the defaults were mutated, every later resolve keeps returning the
+		// corrupted value rather than re-deriving from a clean base.
+		again := cfg.GetDeviceConfig(1)
+		require.NotNil(t, again)
+		require.NotNil(t, again.PCI)
+
+		assert.Equal(t, defaultDeviceID, again.PCI.DeviceID, "second resolve of device 1 must still see the default")
+	})
+}


### PR DESCRIPTION
## What This PR Does

`GetDeviceConfig` copies `device_defaults` by value, but the copy still aliases
the shared `*PCIConfig`. `mergeDeviceOverride` is the one merge branch that
writes *through* that pointer rather than replacing it, so a per-device `pci`
override lands on the shared defaults and every device merged afterwards
inherits it.

The fix clones `PCIConfig` before the merge loop runs.

## Why

With a profile that sets `device_defaults.pci.device_id` and a per-device
`devices[0].pci.device_id`, `GetDeviceConfig(0)` mutates the shared defaults;
devices 1..N then start from a defaults block already carrying device 0's ID and
never overwrite it. `initPciInfo` reads that into `pciInfo.PciDeviceId`, so
`nvmlDeviceGetPciInfo` reports one GPU's ID for all of them: `nvidia-smi -q`
shows the wrong Device Id, and anything keying product identity off the PCI ID
mislabels every device after the first.

The same aliasing already happens with `bus_id` on every shipped profile. It is
simply not read yet, so it is latent rather than live.

Shipped profiles do not set a per-device `device_id`, so this needs a
user-written heterogeneous profile to bite. That is a supported config surface.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass (`go test -v -race ./...`)
- [x] Linter passes (`make lint-fix`)
- [x] New code has SPDX license headers
- [ ] Documentation updated (if applicable)
- [x] CHANGELOG.md updated (if user-facing change)

The regression test was written first and confirmed red against the current
behaviour, then mutation-checked: deleting only the clone block turns four of
its five subtests red again, and restoring it returns the file byte-identical.

Closes #589
