### PR TITLE
ci(helm): publish the mokka-crds chart alongside nvml-mock

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -29,13 +29,16 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  CHART_NAME: nvml-mock
-  CHART_DIR: deployments/nvml-mock/helm
-
 jobs:
   lint:
     runs-on: ubuntu-latest
+
+    # `ct lint` covers the nvml-mock chart tree only. mokka-crds is linted and
+    # template-rendered by the `crds` job via `make helm-crds-tests`, because
+    # chart-testing wants a values/CI layout that a CRDs-only chart does not
+    # have.
+    env:
+      CHART_DIR: deployments/nvml-mock/helm
 
     steps:
       - name: Checkout repository
@@ -93,6 +96,11 @@ jobs:
     needs:
       - lint
       - unittest
+      # A matrix cannot express a per-leg `needs`, so the crds gate applies to
+      # both legs: a broken mokka-crds chart now also holds back the nvml-mock
+      # publish. That is the price of one job definition instead of two
+      # copy-pasted ones, and both charts are cut from the same commit anyway.
+      - crds
 
     # This job is privileged.
     # We protect it from malicious forks by only triggering when it's a push event on main.
@@ -101,6 +109,19 @@ jobs:
       github.ref == 'refs/heads/main'
 
     runs-on: ubuntu-latest
+
+    strategy:
+      # Never cancel a sibling leg. Each leg pushes and then cosign-signs in
+      # two non-atomic steps, and fail-fast cancellation of a leg sitting
+      # between those two steps would leave an unsigned chart in GHCR, which is
+      # the same hazard the workflow-level `cancel-in-progress` guards against.
+      fail-fast: false
+      matrix:
+        include:
+          - chart: nvml-mock
+            dir: deployments/nvml-mock/helm
+          - chart: mokka-crds
+            dir: deployments/mokka-crds/helm
 
     permissions:
       contents: read
@@ -117,7 +138,7 @@ jobs:
       - name: Read chart version
         id: chart
         run: |
-          version=$(helm show chart ${{ env.CHART_DIR }}/${{ env.CHART_NAME }} | grep '^version:' | awk '{print $2}')
+          version=$(helm show chart ${{ matrix.dir }}/${{ matrix.chart }} | grep '^version:' | awk '{print $2}')
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
@@ -130,7 +151,7 @@ jobs:
       - name: Package chart
         run: |
           helm package \
-            ${{ env.CHART_DIR }}/${{ env.CHART_NAME }} \
+            ${{ matrix.dir }}/${{ matrix.chart }} \
             --destination .cr-release-packages
 
       # GHCR intermittently 404s the tag operation right after a fresh
@@ -144,7 +165,7 @@ jobs:
 
           for attempt in 1 2 3; do
             if helm push \
-              .cr-release-packages/${{ env.CHART_NAME }}-${{ steps.chart.outputs.version }}.tgz \
+              .cr-release-packages/${{ matrix.chart }}-${{ steps.chart.outputs.version }}.tgz \
               oci://ghcr.io/nvidia/k8s-test-infra/chart \
               2>&1 | tee push.log; then
               break
@@ -184,4 +205,4 @@ jobs:
       - name: Sign OCI artifact
         run: |
           cosign sign --yes \
-            ghcr.io/nvidia/k8s-test-infra/chart/${{ env.CHART_NAME }}@${{ steps.push.outputs.digest }}
+            ghcr.io/nvidia/k8s-test-infra/chart/${{ matrix.chart }}@${{ steps.push.outputs.digest }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a follow-up. (#712)
 
 ### Added
+- The `mokka-crds` chart is published to
+  `oci://ghcr.io/nvidia/k8s-test-infra/chart` and cosign-signed, alongside the
+  `nvml-mock` chart. It was previously linted and template-rendered in CI but
+  never pushed, so the CRDs could only be applied from a source checkout. The
+  chart moves from 0.1.0 to 0.4.0 to line up with the release.
 - The node agent gains `pcibus`, `cdi` and `imex` simulators, each an
   `agent.Simulator` with the same stage/apply/discard lifecycle as the existing
   `gpudriver`. Together they subsume the device-surface construction that

--- a/deployments/mokka-crds/helm/mokka-crds/Chart.yaml
+++ b/deployments/mokka-crds/helm/mokka-crds/Chart.yaml
@@ -4,8 +4,12 @@ apiVersion: v2
 name: mokka-crds
 description: CustomResourceDefinitions for the Mokka Control Plane (mokka.nvidia.com/v1alpha1)
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.4.0
+# This chart ships nothing but the mokka.nvidia.com/v1alpha1 CRD schemas,
+# so there is no separately versioned image behind it: the CRD bundle is
+# the application. appVersion therefore tracks the chart version instead
+# of freezing at the value it was first cut with.
+appVersion: "0.4.0"
 # Match the kubeVersion floor set by the sibling nvml-mock chart. CRDs
 # themselves work on older clusters, but pinning to the same floor keeps the
 # Mokka install story coherent across charts.


### PR DESCRIPTION
## What This PR Does

Publishes the `mokka-crds` chart to `oci://ghcr.io/nvidia/k8s-test-infra/chart`
alongside `nvml-mock`, and moves it from 0.1.0 to 0.4.0.

The publish job becomes a `strategy.matrix` over the two charts rather than a
second copy-pasted job.

## Why

`mokka-crds` was linted and template-rendered in CI but never packaged or
pushed, so the CRDs could only be applied from a source checkout. With v0.4.0
shipping the control plane, the CRDs it depends on should be installable from
the registry like any other chart.

## appVersion

Bumped to 0.4.0 as well. The chart ships only the four
`mokka.nvidia.com/v1alpha1` CRD schemas, so the CRD bundle is the application
and there is no separately-versioned artifact for `appVersion` to track. This
differs from `nvml-mock`, where `appVersion` names the driver version being
mocked rather than the chart's own contents.

## Notes for review

The nvml-mock leg's effective behaviour is unchanged. Every `run:` body, `uses:`
pin, `if:` gate and `permissions:` block is identical after matrix substitution.
All four of the job's documented behaviours are preserved verbatim: the
three-attempt `helm push` retry that works around GHCR 404ing a tag right after
a fresh manifest upload, the `awk` digest extraction with an explicit failure on
an empty digest, the separate docker login that cosign needs because
`helm registry login` does not write the Docker config, and the concurrency
block that must not cancel between push and sign.

`fail-fast: false` is set for the same reason: cancelling a leg sitting between
its push and its cosign step would leave an unsigned chart in GHCR.

Three changes that are not silent and are worth a look:

1. `needs` gains `crds`. A matrix cannot express a per-leg `needs`, so a red
   `crds` job now also holds back the nvml-mock publish. Both charts are cut
   from the same commit, so this seems acceptable, but it is a one-line revert
   if you would rather run `make helm-crds-tests` as a conditional step instead.
2. The check name becomes `publish (nvml-mock)`. Safe here: `main` has no
   required status checks.
3. Workflow-level `env:` is gone; `CHART_DIR` moved into the `lint` job at the
   same value, so the rendered `ct lint` command is unchanged.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [ ] Tests pass (`go test -v -race ./...`) — no Go changes
- [x] Linter passes (`make lint-fix`)
- [x] New code has SPDX license headers
- [ ] Documentation updated (if applicable)
- [x] CHANGELOG.md updated (if user-facing change)

Verified locally: `make helm-crds-tests` clean, `make helm-tests` 170 tests
across 9 suites and 13 snapshots passing, `helm package` produces
`mokka-crds-0.4.0.tgz`, `actionlint` clean, and both matrix legs simulated end
to end through the real `helm show chart` version pipeline.
