### PR TITLE
test(gpu): cover minor-number mappings without root

### DIFF
--- a/internal/agent/gpudriver/gpudriver_test.go
+++ b/internal/agent/gpudriver/gpudriver_test.go
@@ -190,6 +190,22 @@ func TestStageNVMLShim_CopiesLibAndCreatesLinks(t *testing.T) {
 	}
 }
 
+func TestCharDevsForDevices_UsesConfiguredMinorNumbers(t *testing.T) {
+	t.Parallel()
+
+	devices := []agent.DeviceSpec{
+		{Index: 0, MinorNumber: 3},
+		{Index: 1, MinorNumber: 0},
+	}
+	require.Equal(t, []charDev{
+		{"nvidia3", 195, 3},
+		{"nvidia0", 195, 0},
+		{"nvidiactl", 195, 255},
+		{"nvidia-uvm", 510, 0},
+		{"nvidia-uvm-tools", 510, 1},
+	}, charDevsForDevices(devices))
+}
+
 func TestStageCharDevs_CreatesDeviceNodes(t *testing.T) {
 	skipUnlessRootLinux(t)
 

--- a/internal/agent/gpudriver/stage.go
+++ b/internal/agent/gpudriver/stage.go
@@ -22,6 +22,25 @@ import (
 	"github.com/NVIDIA/k8s-test-infra/pkg/gpu/mocknvml/engine"
 )
 
+type charDev struct {
+	name         string
+	major, minor uint32
+}
+
+func charDevsForDevices(devices []agent.DeviceSpec) []charDev {
+	devs := make([]charDev, 0, len(devices)+3)
+	for _, d := range devices {
+		devs = append(devs, charDev{fmt.Sprintf("nvidia%d", d.MinorNumber), 195, uint32(d.MinorNumber)})
+	}
+	devs = append(devs,
+		charDev{"nvidiactl", 195, 255},
+		charDev{"nvidia-uvm", 510, 0},
+		charDev{"nvidia-uvm-tools", 510, 1},
+	)
+
+	return devs
+}
+
 // stageCharDevs creates the GPU character devices that ioctl-based callers
 // (CUDA, nvidia-smi) open to reach the driver. Without them open() fails.
 // Major 195 = nvidia (per-GPU + nvidiactl); major 510 = nvidia-uvm.
@@ -31,19 +50,7 @@ func stageCharDevs(ctx context.Context, h *host.Host, state *agent.State) error 
 		return err
 	}
 
-	type charDev struct {
-		name         string
-		major, minor uint32
-	}
-	devs := make([]charDev, 0, len(state.Devices)+3)
-	for _, d := range state.Devices {
-		devs = append(devs, charDev{fmt.Sprintf("nvidia%d", d.MinorNumber), 195, uint32(d.MinorNumber)})
-	}
-	devs = append(devs,
-		charDev{"nvidiactl", 195, 255},
-		charDev{"nvidia-uvm", 510, 0},
-		charDev{"nvidia-uvm-tools", 510, 1},
-	)
+	devs := charDevsForDevices(state.Devices)
 
 	wanted := make(map[string]bool, len(devs))
 	for _, d := range devs {

--- a/pkg/gpu/mocknvml/engine/engine.go
+++ b/pkg/gpu/mocknvml/engine/engine.go
@@ -659,18 +659,18 @@ func ResetForTesting() {
 // exist (host context where /dev/nvidia* may not be present but NVML should
 // still work).
 func detectVisibleDevices(config *Config) []int {
+	return detectVisibleDevicesAt("/dev/nvidia%d", config)
+}
+
+// detectVisibleDevicesAt uses the configured driver minor numbers to find
+// device nodes, but returns NVML indices. A separate path format lets tests
+// exercise the same configuration-to-visibility mapping without writing /dev.
+func detectVisibleDevicesAt(pathFmt string, config *Config) []int {
 	minorNumbers := make([]int, 0, config.NumDevices)
 	for i := 0; i < config.NumDevices && i < MaxDevices; i++ {
 		minorNumbers = append(minorNumbers, config.GetDeviceMinorNumber(i))
 	}
-	return detectVisibleDevicesAt("/dev/nvidia%d", minorNumbers)
-}
 
-// detectVisibleDevicesAt is the testable core of detectVisibleDevices.
-// pathFmt is a printf format that takes the minor number of a device
-// (e.g. "/dev/nvidia%d"); minorNumbers is indexed by device index, so the
-// returned positions are NVML indices rather than minor numbers.
-func detectVisibleDevicesAt(pathFmt string, minorNumbers []int) []int {
 	var present []int
 	var absent int
 

--- a/pkg/gpu/mocknvml/engine/engine_test.go
+++ b/pkg/gpu/mocknvml/engine/engine_test.go
@@ -513,7 +513,7 @@ func TestEngine_DeviceGetHandleByPciBusIdInvalid(t *testing.T) {
 func TestDetectVisibleDevices_NonePresent(t *testing.T) {
 	dir := t.TempDir()
 	// No files created – simulates no /dev/nvidia* nodes
-	result := detectVisibleDevicesAt(dir+"/nvidia%d", []int{0, 1, 2, 3})
+	result := detectVisibleDevicesAt(dir+"/nvidia%d", &Config{NumDevices: 4})
 	require.Nil(t, result, "Expected nil (no filtering) when no nodes exist")
 }
 
@@ -527,7 +527,7 @@ func TestDetectVisibleDevices_AllPresent(t *testing.T) {
 		require.NoError(t, f.Close())
 	}
 
-	result := detectVisibleDevicesAt(dir+"/nvidia%d", []int{0, 1, 2, 3})
+	result := detectVisibleDevicesAt(dir+"/nvidia%d", &Config{NumDevices: 4})
 	require.Nil(t, result, "Expected nil (no filtering) when all nodes exist")
 }
 
@@ -542,7 +542,7 @@ func TestDetectVisibleDevices_Subset(t *testing.T) {
 		require.NoError(t, f.Close())
 	}
 
-	result := detectVisibleDevicesAt(dir+"/nvidia%d", []int{0, 1, 2, 3})
+	result := detectVisibleDevicesAt(dir+"/nvidia%d", &Config{NumDevices: 4})
 	require.Len(t, result, 2, "Expected 2 visible devices")
 	require.Equal(t, []int{0, 2}, result, "Expected visible devices [0 2]")
 }
@@ -552,14 +552,24 @@ func TestDetectVisibleDevices_Subset(t *testing.T) {
 // staged for a device whose minor differs from its index must therefore be
 // reported under the index, not under the minor.
 func TestDetectVisibleDevices_ReportsIndicesNotMinorNumbers(t *testing.T) {
-	dir := t.TempDir()
-	f, err := os.Create(fmt.Sprintf("%s/nvidia%d", dir, 3))
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
+	t.Parallel()
 
-	// Device index 2 owns minor 3, so the lone node makes index 2 visible.
-	result := detectVisibleDevicesAt(dir+"/nvidia%d", []int{1, 0, 3, 2})
-	require.Equal(t, []int{2}, result)
+	dir := t.TempDir()
+	for _, minor := range []int{0, 3} {
+		require.NoError(t, os.WriteFile(fmt.Sprintf("%s/nvidia%d", dir, minor), nil, 0o600))
+	}
+	zero, one, two, three := 0, 1, 2, 3
+	config := &Config{
+		NumDevices: 4,
+		YAMLConfig: &YAMLConfig{Devices: []DeviceOverride{
+			{Index: 0, MinorNumber: &one},
+			{Index: 1, MinorNumber: &zero},
+			{Index: 2, MinorNumber: &three},
+			{Index: 3, MinorNumber: &two},
+		}},
+	}
+
+	require.Equal(t, []int{1, 2}, detectVisibleDevicesAt(dir+"/nvidia%d", config))
 }
 
 // TestVisibility_DeviceGetCount verifies that DeviceGetCount returns the


### PR DESCRIPTION
## What This PR Does

Extract the character-device names and major/minor pairs into a pure function used by staging. Move configuration-to-minor resolution inside the visibility helper so ordinary tests exercise the same path as production.

## Why

Closes #827.

The existing staging checks require root, and the visibility tests supplied the minor-number list themselves. Both index/minor regressions could therefore pass CI. The new coverage includes reordered minors and explicit minor zero; the privileged device-creation tests remain unchanged.

## Validation

- `make test`: 1,032 tests passed across 43 packages; 16 existing environment-dependent tests skipped on macOS arm64.
- `make lint-fix`: passed, including vet and govulncheck. The pinned golangci-lint v2.12.2 was rebuilt with Go 1.27.1 to match the local toolchain.
- Replacing the staging minor numbers with indices fails the new staging assertion.
- Replacing configured visibility minors with indices fails the visibility assertion. Both mutations were reverted.

## Checklist

- [x] Commits are signed off and cryptographically signed.
- [x] Tests pass.
- [x] Linter passes.
- [x] Source files retain their license headers.
- [x] Documentation and changelog reviewed; no user-facing behavior changes.
